### PR TITLE
fix(init): replace stale "v0.1" conflict error with actionable message

### DIFF
--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -57,9 +57,14 @@ export async function runInit(intent: InitIntent): Promise<number> {
       red(`error: target already contains ${result.conflicts.length} specflow-managed file(s):`),
     );
     for (const c of result.conflicts) console.error(red(`  - ${c}`));
+    console.error("\nTo proceed:");
     console.error(
-      "\nSpecflow v0.1 does not yet support upgrading an existing project. " +
-        "Remove these files or run init into a clean directory.",
+      `  • Run ${bold("specflow init --here --force")} to re-initialise in place ` +
+        "(existing files are backed up to *.specflow.bak).",
+    );
+    console.error(
+      `  • Or run ${bold("specflow upgrade")} if this project was previously ` +
+        "initialised by Specflow.",
     );
     return 3;
   }

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -85,6 +85,9 @@ Deno.test("specflow init refuses to overwrite a pre-existing .claude/", async ()
     const { code, stderr } = await runSpecflow(["init", "demo", "--no-git"], { cwd: dir });
     assertEquals(code, 3);
     assertStringIncludes(stderr, ".claude/commands/specflow.specify.md");
+    assertStringIncludes(stderr, "specflow init --here --force");
+    assertStringIncludes(stderr, "specflow upgrade");
+    assertEquals(stderr.includes("v0.1"), false, "error message must not hardcode a version");
   });
 });
 


### PR DESCRIPTION
Closes #3.

## Summary

- Replace hardcoded `"Specflow v0.1 does not yet support upgrading an existing project."` with a version-agnostic, actionable message.
- New message lists both escape hatches: `specflow init --here --force` (re-init in place with backups) and `specflow upgrade` (incremental update when a lock already exists).
- Exit code 3, stderr routing, and the conflict file list are unchanged.

## Before

```
error: target already contains 1 specflow-managed file(s):
  - .claude/commands/specflow.specify.md

Specflow v0.1 does not yet support upgrading an existing project. Remove these files or run init into a clean directory.
```

## After

```
error: target already contains 1 specflow-managed file(s):
  - .claude/commands/specflow.specify.md

To proceed:
  • Run specflow init --here --force to re-initialise in place (existing files are backed up to *.specflow.bak).
  • Or run specflow upgrade if this project was previously initialised by Specflow.
```

## Test plan

- [x] `deno task test` — 312 / 312 pass.
- [x] Existing test `specflow init refuses to overwrite a pre-existing .claude/` extended with three assertions: stderr now mentions `specflow init --here --force`, mentions `specflow upgrade`, and contains no `v0.1` substring (regression guard against another stale version sneaking in).
- [x] Manual smoke run reproducing the exact conflict scenario — output matches the "After" block above with exit code 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)