### PR TITLE
feat(antigravity): add Antigravity harness (#2)

### DIFF
--- a/.claude/agents/architect/memory/MEMORY.md
+++ b/.claude/agents/architect/memory/MEMORY.md
@@ -7,8 +7,8 @@ Format: `- [Title](file.md) — one-line hook`
 
 Keep the index under 200 lines. Prune entries that are no longer load-bearing
 (drift items become obsolete once docs are fixed; old decisions become
-obsolete once they're encoded in `AGENTS.md`).
+obsolete once they are encoded in `AGENTS.md`).
 
 ## Entries
 
-_(empty — populate as decisions, drift flags, and feedback accumulate)_
+- [Antigravity Harness Research](antigravity-harness-research.md) — Canonical `.agent/` layout resolved from primary sources; resolves the .agent vs .agents ambiguity in issue #2

--- a/.claude/agents/architect/memory/antigravity-harness-research.md
+++ b/.claude/agents/architect/memory/antigravity-harness-research.md
@@ -1,0 +1,60 @@
+---
+name: antigravity-harness-research
+description: Canonical Antigravity directory layout — confirmed from primary source (antigravity-awesome-skills installer + docs), resolves the .agent vs .agents ambiguity
+type: reference
+---
+
+## Rule
+Antigravity uses `.agent/` (singular) for project-local files. OpenCode uses `.agents/` (plural). These two were confused in issue #2.
+
+## Canonical project-local layout (confirmed from getting-started.md + antigravity-kit repo)
+
+```
+.agent/
+  skills/<folder-name>/SKILL.md   ← SKILL.md file in named subfolder
+  agents/<name>.md                 ← flat markdown with YAML frontmatter (name, description, tools, model, skills)
+  workflows/<name>.md              ← slash-command style markdown with $ARGUMENTS
+  rules/GEMINI.md                  ← behavior rules (equivalent of .cursor/rules or CLAUDE.md)
+```
+
+## Source
+- `sickn33/antigravity-awesome-skills` getting-started.md table: "Workspace: `.agent/skills/`"
+- `vudovn/antigravity-kit` repo tree: confirmed `.agent/{agents,skills,workflows,rules}` with flat `.md` agents and `SKILL.md`-in-folder skills
+- Installer `tools/bin/install.js`: `--antigravity` target is `~/.gemini/antigravity/skills` (global), not project-local
+- `.agent/rules/` contains a single `GEMINI.md` — this is the Antigravity "rules" file, not per-skill
+
+## Agent frontmatter format (from antigravity-kit product-owner.md)
+```yaml
+---
+name: product-owner
+description: …
+tools: Read, Grep, Glob, Bash
+model: inherit
+skills: plan-writing, brainstorming, clean-code
+---
+```
+
+## Skill frontmatter (from architecture/SKILL.md)
+```yaml
+---
+name: architecture
+description: …
+allowed-tools: Read, Glob, Grep
+---
+```
+
+## Workflow/command frontmatter (from plan.md)
+```yaml
+---
+description: Create project plan using project-planner agent.
+---
+```
+
+## How to apply
+When implementing `antigravity_harness.ts`:
+- commands → `.agent/workflows/specflow.<name>.md`
+- backlog-cmd → `.agent/workflows/<name>.md`
+- agents → `.agent/agents/specflow-<name>.md` (frontmatter: name, description, tools stripped to known Antigravity tools)
+- skills → `.agent/skills/specflow-<name>/SKILL.md` (with name + description frontmatter)
+- spec-root → `.specflow/<suffix>` (unchanged)
+- project-root → `<suffix>` (unchanged)

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -12,7 +12,15 @@ export type InitIntent = {
   projectName: string | null;
   here: boolean;
   noGit: boolean;
-  ai: "claude" | "cursor" | "codex" | "gemini" | "windsurf" | "copilot" | "opencode";
+  ai:
+    | "claude"
+    | "cursor"
+    | "codex"
+    | "gemini"
+    | "windsurf"
+    | "copilot"
+    | "opencode"
+    | "antigravity";
   force: boolean;
 };
 

--- a/src/cli/harnesses.ts
+++ b/src/cli/harnesses.ts
@@ -6,6 +6,7 @@ import { GeminiHarness } from "../infrastructure/harness/gemini_harness.ts";
 import { WindsurfHarness } from "../infrastructure/harness/windsurf_harness.ts";
 import { CopilotHarness } from "../infrastructure/harness/copilot_harness.ts";
 import { OpenCodeHarness } from "../infrastructure/harness/opencode_harness.ts";
+import { AntigravityHarness } from "../infrastructure/harness/antigravity_harness.ts";
 
 export const HARNESSES: ReadonlyArray<Harness> = [
   new ClaudeHarness(),
@@ -15,6 +16,7 @@ export const HARNESSES: ReadonlyArray<Harness> = [
   new WindsurfHarness(),
   new CopilotHarness(),
   new OpenCodeHarness(),
+  new AntigravityHarness(),
 ];
 
 export function findHarness(key: string): Harness | null {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -20,7 +20,7 @@ ${bold("Usage:")}
 ${bold("Flags (for init):")}
   --here         Scaffold into the current directory instead of creating a new one
   --no-git       Skip "git init" detection and prompt
-  --ai <name>    Target AI harness: claude (default) | cursor | codex | gemini | windsurf | copilot | opencode
+  --ai <name>    Target AI harness: claude (default) | cursor | codex | gemini | windsurf | copilot | opencode | antigravity
 
 ${bold("Docs:")}  ${cyan("https://github.com/mkrlabs/specflow")}`;
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -8,7 +8,15 @@ export type Intent =
     projectName: string | null;
     here: boolean;
     noGit: boolean;
-    ai: "claude" | "cursor" | "codex" | "gemini" | "windsurf" | "copilot" | "opencode";
+    ai:
+      | "claude"
+      | "cursor"
+      | "codex"
+      | "gemini"
+      | "windsurf"
+      | "copilot"
+      | "opencode"
+      | "antigravity";
     force: boolean;
   }
   | { kind: "self-update"; checkOnly: boolean }
@@ -50,7 +58,8 @@ export function parseArgs(argv: string[]): Intent {
       aiRaw !== "gemini" &&
       aiRaw !== "windsurf" &&
       aiRaw !== "copilot" &&
-      aiRaw !== "opencode"
+      aiRaw !== "opencode" &&
+      aiRaw !== "antigravity"
     ) {
       return { kind: "unknown", received: `init --ai ${aiRaw}` };
     }

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -1,0 +1,80 @@
+import type { Harness } from "../../application/ports.ts";
+import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
+import type { Bundle } from "../../domain/template.ts";
+import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
+import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
+
+function toAntigravityWorkflowMarkdown(entry: CoreEntry): string {
+  const split = splitFrontmatter(entry.content);
+  const body = split ? split.rest.replace(/^\n+/, "") : entry.content;
+  const description = split ? frontmatterField(split.fmBody, "description") : null;
+  const fm = description !== null ? `description: ${description}` : `description: ${entry.name}`;
+  return `---\n${fm}\n---\n\n${body}`;
+}
+
+function toAntigravityAgentMarkdown(entry: CoreEntry): string {
+  const split = splitFrontmatter(entry.content);
+  const fmBody = split?.fmBody ?? "";
+  const body = split ? split.rest.replace(/^\n+/, "") : entry.content;
+  const description = frontmatterField(fmBody, "description") ??
+    `Specflow ${entry.name} agent`;
+  const tools = frontmatterField(fmBody, "tools");
+  const model = frontmatterField(fmBody, "model");
+  const skills = frontmatterField(fmBody, "skills");
+  const lines: string[] = [
+    `name: specflow-${entry.name}`,
+    `description: ${description}`,
+  ];
+  if (tools !== null) lines.push(`tools: ${tools}`);
+  if (model !== null) lines.push(`model: ${model}`);
+  if (skills !== null) lines.push(`skills: ${skills}`);
+  return `---\n${lines.join("\n")}\n---\n\n${body}`;
+}
+
+function destinationFor(entry: CoreEntry): string {
+  switch (entry.category) {
+    case "command":
+      return `.agent/workflows/specflow-${entry.name}.md`;
+    case "backlog-cmd":
+      return `.agent/workflows/${entry.name}.md`;
+    case "agent":
+      return `.agent/agents/specflow-${entry.name}.md`;
+    case "skill":
+      return `.agent/skills/${skillFolderName(entry)}/SKILL.md`;
+    case "spec-root":
+      if (!entry.suffix) throw new Error(`spec-root needs suffix`);
+      return `.specflow/${entry.suffix}`;
+    case "project-root":
+      if (!entry.suffix) throw new Error(`project-root needs suffix`);
+      return entry.suffix;
+  }
+}
+
+export class AntigravityHarness implements Harness {
+  readonly key = "antigravity";
+  readonly displayName = "Antigravity";
+
+  mapBundle(core: CoreBundle): Bundle {
+    const out: Bundle = {};
+    for (const entry of core) {
+      const dest = destinationFor(entry);
+      let content: string;
+      switch (entry.category) {
+        case "command":
+        case "backlog-cmd":
+          content = toAntigravityWorkflowMarkdown(entry);
+          break;
+        case "agent":
+          content = toAntigravityAgentMarkdown(entry);
+          break;
+        case "skill":
+          content = ensureSkillFrontmatter(entry.content, skillFolderName(entry));
+          break;
+        default:
+          content = entry.content;
+      }
+      out[dest] = { content, executable: entry.executable };
+    }
+    return out;
+  }
+}

--- a/tests/integration/init_antigravity_test.ts
+++ b/tests/integration/init_antigravity_test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-init-antigravity-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("specflow init --ai antigravity scaffolds an Antigravity layout", async () => {
+  await withTempDir(async (parent) => {
+    const { code, stderr } = await runSpecflow(
+      ["init", "demo", "--no-git", "--ai", "antigravity"],
+      { cwd: parent },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+
+    const root = join(parent, "demo");
+
+    // Workflows — slash commands carry the specflow- prefix; the backlog
+    // command is intentionally unprefixed so it lands as a first-class
+    // user command.
+    assertEquals(
+      await exists(join(root, ".agent/workflows/specflow-specify.md")),
+      true,
+    );
+    assertEquals(
+      await exists(join(root, ".agent/workflows/backlog.md")),
+      true,
+    );
+    const workflowContent = await Deno.readTextFile(
+      join(root, ".agent/workflows/specflow-specify.md"),
+    );
+    assertEquals(workflowContent.startsWith("---\n"), true);
+    assertEquals(workflowContent.includes("description:"), true);
+
+    // Skill subfolders use the standard SKILL.md filename.
+    assertEquals(
+      await exists(join(root, ".agent/skills/specflow-speckit/SKILL.md")),
+      true,
+    );
+
+    // Agents are flat .md files with the specflow- prefix; passthrough
+    // frontmatter (no permission-map translation).
+    assertEquals(
+      await exists(join(root, ".agent/agents/specflow-product-owner.md")),
+      true,
+    );
+    const agentContent = await Deno.readTextFile(
+      join(root, ".agent/agents/specflow-product-owner.md"),
+    );
+    assertEquals(agentContent.includes("name: specflow-product-owner"), true);
+    assertEquals(agentContent.includes("description:"), true);
+
+    // Shared (cross-harness) project metadata still emitted.
+    assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
+    assertEquals(await exists(join(root, "AGENTS.md")), true);
+    assertEquals(await exists(join(root, "tasks/backlog.md")), true);
+
+    // No other harnesses' output trees.
+    assertEquals(await exists(join(root, ".claude/")), false);
+    assertEquals(await exists(join(root, ".cursor/")), false);
+    assertEquals(await exists(join(root, ".gemini/")), false);
+    assertEquals(await exists(join(root, ".codex/")), false);
+    assertEquals(await exists(join(root, ".opencode/")), false);
+    assertEquals(await exists(join(root, ".agents/")), false); // OpenCode (plural)
+    assertEquals(await exists(join(root, "CLAUDE.md")), false);
+
+    // Specflow must NOT touch the user's behavior rules file.
+    assertEquals(await exists(join(root, ".agent/rules/GEMINI.md")), false);
+
+    // Lock reflects antigravity.
+    const lock = await Deno.readTextFile(join(root, ".specflow/installed.lock"));
+    assertEquals(lock.includes("harness: antigravity"), true);
+  });
+});


### PR DESCRIPTION
Closes #2.

## Summary

8th Specflow harness target. Adds `--ai antigravity` to `specflow init`, scaffolding files into `.agent/` (singular — distinct from OpenCode's `.agents/`).

## Layout produced

```
.agent/workflows/specflow-<name>.md   # slash commands
.agent/workflows/<backlog-name>.md    # backlog command (no prefix per AC)
.agent/agents/specflow-<name>.md      # sub-agents (flat .md, frontmatter passthrough)
.agent/skills/specflow-<name>/SKILL.md
.specflow/                            # standard Specflow metadata
AGENTS.md
tasks/backlog.md
```

## Design notes

- Closest pattern reference: `gemini_harness.ts` (markdown commands + separate agents dir + SKILL.md subfolders).
- Workflow files are plain Markdown with `description:` frontmatter — Antigravity convention, not TOML.
- Agent frontmatter passes `tools:` / `model:` / `skills:` through verbatim. No permission-map translation (that's OpenCode-specific).
- `.agent/rules/GEMINI.md` is intentionally NOT written. That's the user's behavior-rules file and must not be touched by Specflow.
- No harness-specific templates needed; runs on the core bundle alone.

## Path resolution

The architect agent (see `.claude/agents/architect/memory/antigravity-harness-research.md`) confirmed `.agent/` vs `.agents/` ambiguity from primary sources: `sickn33/antigravity-awesome-skills` (community-maintained, 36k+ stars, installer test suite pinning paths) and `vudovn/antigravity-kit`.

## Test plan

- [x] New `tests/integration/init_antigravity_test.ts` asserts the full destination layout, agent prefix, frontmatter shape, and negative checks (no `.claude/`, `.agents/`, `.gemini/`, etc., no `.agent/rules/GEMINI.md`).
- [x] `deno task test` — 313/313 pass (was 312 before this PR).
- [x] Visual smoke via `specflow init demo --ai antigravity` — 38 files written, layout matches AC verbatim.
- [ ] Manual smoke in a real Antigravity IDE — Kevin's gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)