### PR TITLE
fix(init): merge .gitignore with user content instead of overwriting (#6)

### DIFF
--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -11,5 +11,4 @@ treatment is now part of normal conventions).
 
 ## Entries
 
-_(empty — populate as user preferences, item-category patterns, and triage
-rationales accumulate)_
+- [Architect handoff pattern](architect-handoff-pattern.md) — when architect has already designed a solution, wire AC directly from the spec without re-deriving strategy

--- a/.claude/agents/product-owner/memory/architect-handoff-pattern.md
+++ b/.claude/agents/product-owner/memory/architect-handoff-pattern.md
@@ -1,0 +1,17 @@
+---
+name: architect-handoff-pattern
+description: How to handle issue promotion when the architect has already produced a design call — skip autonomous design, trust the spec, wire AC directly from it.
+type: pattern
+---
+
+When the user dispatches "promote #N to Ready, architect's design is X", the workflow is:
+
+1. Read the architect's design from the dispatch message AND from `.claude/agents/architect/memory/` for the relevant slug.
+2. Do NOT re-derive the implementation strategy — the architect owns that. Wire AC bullets directly from the architect's stated behavior and file list.
+3. Reference the architect's spec file (e.g. `docs/superpowers/specs/YYYY-MM-DD-slug.md`) in the Notes section so future readers can trace the design rationale.
+4. List the concrete files the implementation must touch (as given by the architect) in Notes — this gives the implementing session a checklist without needing to re-read the design.
+5. Out-of-scope bullets should echo what the architect explicitly ruled out, not what you infer.
+
+**Why:** The architect's design call is the authoritative source. The PO's job at this stage is faithful transcription into testable AC + scoping guardrails, not independent design.
+
+**How to apply:** AC bullets must be observable (exit codes, file content, SHA semantics, count of duplicates). Avoid AC that says "the implementation uses X approach" — say what the *user/test* observes, not how the code works.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /tmp/
 spec-kit/
 .claude/scheduled_tasks.lock
+test/

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -3,6 +3,7 @@ import { sha256Hex } from "../domain/sha256.ts";
 import type { InstalledLock, KnownHarness, LockEntry } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
 import { TEMPLATES_VERSION } from "../templates_bundle.ts";
+import { canonicalBlockBody } from "../domain/merge_block.ts";
 
 export type InitResult =
   | {
@@ -57,8 +58,14 @@ export class InitProjectUseCase {
     const now = (this.deps.now ?? (() => new Date()))().toISOString();
     const lockEntries = new Map<string, LockEntry>();
     for (const [dest, file] of Object.entries(bundle)) {
+      // For mergeable files the lock holds the SHA of the *block body in
+      // canonical form* (no leading/trailing newlines) so it stays
+      // comparable against the body extracted from disk on upgrade reads.
+      const shaInput = file.mergeBlock !== undefined
+        ? canonicalBlockBody(file.content)
+        : file.content;
       lockEntries.set(dest, {
-        sha256: await sha256Hex(file.content),
+        sha256: await sha256Hex(shaInput),
         installedAt: now,
         templatesVersion: TEMPLATES_VERSION,
       });

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -4,6 +4,7 @@ import { sha256Hex } from "../domain/sha256.ts";
 import type { InstalledLock, LockEntry } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
 import { computeUpgradePlan, type UpgradePlan } from "../domain/upgrade_plan.ts";
+import { canonicalBlockBody, extractBlock } from "../domain/merge_block.ts";
 
 export type UpgradeProjectInput = {
   projectDir: string;
@@ -62,12 +63,25 @@ export class UpgradeProjectUseCase {
     const diskShas = new Map<string, string>();
     for (const dest of destPaths) {
       const content = await reader.readText(input.projectDir, dest);
-      if (content !== null) diskShas.set(dest, await sha256Hex(content));
+      if (content === null) continue;
+      // For mergeable files we hash the *block content only* (not the whole
+      // user-owned file) so the SHA is comparable against the lock entry,
+      // which also stores only the block content.
+      const file = bundle[dest];
+      if (file?.mergeBlock !== undefined) {
+        const block = extractBlock(content, file.mergeBlock) ?? "";
+        diskShas.set(dest, await sha256Hex(block));
+      } else {
+        diskShas.set(dest, await sha256Hex(content));
+      }
     }
 
     const newShas = new Map<string, string>();
     for (const [dest, file] of Object.entries(bundle)) {
-      newShas.set(dest, await sha256Hex(file.content));
+      const shaInput = file.mergeBlock !== undefined
+        ? canonicalBlockBody(file.content)
+        : file.content;
+      newShas.set(dest, await sha256Hex(shaInput));
     }
 
     const plan = computeUpgradePlan(diskShas, lock, newShas);

--- a/src/domain/core_bundle.ts
+++ b/src/domain/core_bundle.ts
@@ -4,7 +4,8 @@ export type CoreCategory =
   | "skill"
   | "spec-root"
   | "project-root"
-  | "backlog-cmd";
+  | "backlog-cmd"
+  | "mergeable-project-root";
 
 export type CoreEntry = {
   readonly category: CoreCategory;

--- a/src/domain/merge_block.ts
+++ b/src/domain/merge_block.ts
@@ -1,0 +1,94 @@
+/**
+ * Append-block helpers for `mergeable-project-root` files (e.g. `.gitignore`).
+ *
+ * A merge block is a labeled section in an otherwise user-owned file that
+ * Specflow can write, replace, or read back without touching surrounding
+ * lines. The fence markers are stable so future runs (init re-run, upgrade)
+ * can find and replace the block in place.
+ *
+ * Pure — no IO, no Deno globals. Safe to import from domain or application.
+ */
+
+const FENCE_PREFIX = "# --- Specflow: ";
+const FENCE_SUFFIX = " ---";
+const END_PREFIX = "# --- End Specflow: ";
+const END_SUFFIX = " ---";
+
+/**
+ * Normalize a block body to its canonical form (no leading or trailing
+ * newlines). Used so the lock SHA stored at init time matches the SHA of
+ * the body extracted from disk on subsequent reads — the extraction also
+ * trims, so both sides operate on the same canonical bytes.
+ */
+export function canonicalBlockBody(body: string): string {
+  return body.replace(/^\n+/, "").replace(/\n+$/, "");
+}
+
+export function startFence(label: string): string {
+  return `${FENCE_PREFIX}${label}${FENCE_SUFFIX}`;
+}
+
+export function endFence(label: string): string {
+  return `${END_PREFIX}${label}${END_SUFFIX}`;
+}
+
+/** Wraps `body` in fence markers so the result is a self-delimited block. */
+export function wrapInBlock(body: string, label: string): string {
+  const trimmed = body.replace(/\n+$/, "");
+  return `${startFence(label)}\n${trimmed}\n${endFence(label)}`;
+}
+
+/**
+ * Extracts the body of a previously-written block, or `null` if no block
+ * with the given label is present in `content`. The body is returned without
+ * the fence markers and without trailing newlines.
+ */
+export function extractBlock(content: string, label: string): string | null {
+  const start = startFence(label);
+  const end = endFence(label);
+  const startIdx = content.indexOf(start);
+  if (startIdx === -1) return null;
+  const afterStart = startIdx + start.length;
+  const endIdx = content.indexOf(end, afterStart);
+  if (endIdx === -1) return null;
+  const between = content.slice(afterStart, endIdx);
+  return between.replace(/^\n+/, "").replace(/\n+$/, "");
+}
+
+/**
+ * Returns `existing` with the merge block for `label` replaced (if present)
+ * or appended (if absent). Idempotent: calling this twice with the same
+ * `body` produces the same result.
+ *
+ * Greenfield (no `existing` content): returns just the wrapped block.
+ */
+export function mergeIntoFile(
+  existing: string | null,
+  body: string,
+  label: string,
+): string {
+  const block = wrapInBlock(body, label);
+  if (existing === null || existing.length === 0) return `${block}\n`;
+
+  const start = startFence(label);
+  const end = endFence(label);
+  const startIdx = existing.indexOf(start);
+  if (startIdx !== -1) {
+    const endIdx = existing.indexOf(end, startIdx + start.length);
+    if (endIdx !== -1) {
+      const before = existing.slice(0, startIdx).replace(/\n+$/, "");
+      const afterBlockEnd = endIdx + end.length;
+      // Skip the newline that follows the end fence, if any.
+      const restStart = existing[afterBlockEnd] === "\n" ? afterBlockEnd + 1 : afterBlockEnd;
+      const after = existing.slice(restStart);
+      const middle = before.length > 0 ? `${before}\n\n${block}` : block;
+      const trailingNewline = after.length === 0 || after.endsWith("\n") ? "" : "\n";
+      const tail = after.length > 0 ? `\n${after.replace(/^\n+/, "")}${trailingNewline}` : "\n";
+      return `${middle}${tail}`;
+    }
+  }
+
+  // No existing block: append to the end.
+  const trimmedExisting = existing.replace(/\n+$/, "");
+  return `${trimmedExisting}\n\n${block}\n`;
+}

--- a/src/domain/template.ts
+++ b/src/domain/template.ts
@@ -3,6 +3,16 @@ import { isAbsolute, normalize, SEPARATOR } from "@std/path";
 export type TemplateFile = {
   content: string;
   executable: boolean;
+  /**
+   * When set, the file is written as an *append-block* into any pre-existing
+   * file at the destination. The string is the human-readable label used in
+   * the fence markers. `content` carries the body of the block only (no
+   * markers — those are injected by the adapter).
+   *
+   * Idempotent across re-runs: if a block with the same label already exists
+   * on disk, it is replaced; otherwise it is appended to the end.
+   */
+  mergeBlock?: string;
 };
 
 export type Bundle = Record<string, TemplateFile>;

--- a/src/infrastructure/deno_fs_writer.ts
+++ b/src/infrastructure/deno_fs_writer.ts
@@ -1,5 +1,6 @@
 import { dirname, join, resolve } from "@std/path";
 import { assertSafeDestination, type Bundle } from "../domain/template.ts";
+import { mergeIntoFile } from "../domain/merge_block.ts";
 import type { BackupReport, FsWriter } from "../application/ports.ts";
 
 const BACKUP_SUFFIX = ".specflow.bak";
@@ -14,12 +15,24 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+async function readIfExists(path: string): Promise<string | null> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return null;
+    throw err;
+  }
+}
+
 export class DenoFsWriter implements FsWriter {
   async detectConflicts(bundle: Bundle, targetDir: string): Promise<string[]> {
     const conflicts: string[] = [];
     const resolved = resolve(targetDir);
-    for (const dest of Object.keys(bundle)) {
+    for (const [dest, file] of Object.entries(bundle)) {
       assertSafeDestination(dest);
+      // Mergeable files merge non-destructively into any pre-existing content,
+      // so they are never conflicts.
+      if (file.mergeBlock !== undefined) continue;
       const abs = join(resolved, dest);
       if (await fileExists(abs)) conflicts.push(dest);
     }
@@ -52,6 +65,16 @@ export class DenoFsWriter implements FsWriter {
     for (const [dest, file] of Object.entries(bundle)) {
       const abs = join(resolved, dest);
       await Deno.mkdir(dirname(abs), { recursive: true });
+
+      // Mergeable files are never backed up: merge is non-destructive and
+      // writing a backup of an unchanged user file is noisy. They also
+      // bypass the overwrite/conflict path entirely.
+      if (file.mergeBlock !== undefined) {
+        const existing = await readIfExists(abs);
+        const merged = mergeIntoFile(existing, file.content, file.mergeBlock);
+        await Deno.writeTextFile(abs, merged);
+        continue;
+      }
 
       if (backupExisting && (await fileExists(abs))) {
         const backupAbs = `${abs}${BACKUP_SUFFIX}`;

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -45,7 +45,8 @@ function destinationFor(entry: CoreEntry): string {
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
     case "project-root":
-      if (!entry.suffix) throw new Error(`project-root needs suffix`);
+    case "mergeable-project-root":
+      if (!entry.suffix) throw new Error(`${entry.category} needs suffix`);
       return entry.suffix;
   }
 }
@@ -73,7 +74,11 @@ export class AntigravityHarness implements Harness {
         default:
           content = entry.content;
       }
-      out[dest] = { content, executable: entry.executable };
+      out[dest] = {
+        content,
+        executable: entry.executable,
+        ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+      };
     }
     return out;
   }

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -17,7 +17,8 @@ function destinationFor(entry: CoreEntry): string {
       if (!entry.suffix) throw new Error(`spec-root entry needs suffix: ${entry.name}`);
       return `.specflow/${entry.suffix}`;
     case "project-root":
-      if (!entry.suffix) throw new Error(`project-root entry needs suffix: ${entry.name}`);
+    case "mergeable-project-root":
+      if (!entry.suffix) throw new Error(`${entry.category} needs suffix: ${entry.name}`);
       return entry.suffix;
   }
 }
@@ -32,6 +33,7 @@ export class ClaudeHarness implements Harness {
       out[destinationFor(entry)] = {
         content: entry.content,
         executable: entry.executable,
+        ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
       };
     }
     const staticFiles = HARNESS_STATIC[this.key] ?? {};

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -61,6 +61,14 @@ export class CodexHarness implements Harness {
             executable: entry.executable,
           };
           break;
+        case "mergeable-project-root":
+          if (!entry.suffix) throw new Error(`mergeable-project-root needs suffix`);
+          out[entry.suffix] = {
+            content: entry.content,
+            executable: entry.executable,
+            mergeBlock: "gitignore",
+          };
+          break;
       }
     }
     return out;

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -21,7 +21,8 @@ function destinationFor(entry: CoreEntry): string {
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
     case "project-root":
-      if (!entry.suffix) throw new Error(`project-root needs suffix`);
+    case "mergeable-project-root":
+      if (!entry.suffix) throw new Error(`${entry.category} needs suffix`);
       return entry.suffix;
   }
 }
@@ -41,6 +42,7 @@ export class CopilotHarness implements Harness {
       out[dest] = {
         content: isInstruction ? toCopilotInstructionMarkdown(entry) : entry.content,
         executable: entry.executable,
+        ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
       };
     }
     return out;

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -15,7 +15,8 @@ function destinationFor(entry: CoreEntry): string {
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
     case "project-root":
-      if (!entry.suffix) throw new Error(`project-root needs suffix`);
+    case "mergeable-project-root":
+      if (!entry.suffix) throw new Error(`${entry.category} needs suffix`);
       return entry.suffix;
   }
 }
@@ -36,7 +37,11 @@ export class CursorHarness implements Harness {
       if (isSkillFile) {
         content = ensureSkillFrontmatter(content, skillFolderName(entry));
       }
-      out[dest] = { content, executable: entry.executable } satisfies TemplateFile;
+      out[dest] = {
+        content,
+        executable: entry.executable,
+        ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+      } satisfies TemplateFile;
     }
     const staticFiles = HARNESS_STATIC[this.key] ?? {};
     for (const [dest, file] of Object.entries(staticFiles)) {

--- a/src/infrastructure/harness/gemini_harness.ts
+++ b/src/infrastructure/harness/gemini_harness.ts
@@ -69,6 +69,14 @@ export class GeminiHarness implements Harness {
             executable: entry.executable,
           };
           break;
+        case "mergeable-project-root":
+          if (!entry.suffix) throw new Error(`mergeable-project-root needs suffix`);
+          out[entry.suffix] = {
+            content: entry.content,
+            executable: entry.executable,
+            mergeBlock: "gitignore",
+          };
+          break;
       }
     }
     return out;

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -108,7 +108,8 @@ function destinationFor(entry: CoreEntry): string {
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
     case "project-root":
-      if (!entry.suffix) throw new Error(`project-root needs suffix`);
+    case "mergeable-project-root":
+      if (!entry.suffix) throw new Error(`${entry.category} needs suffix`);
       return entry.suffix;
   }
 }
@@ -136,7 +137,11 @@ export class OpenCodeHarness implements Harness {
         default:
           content = entry.content;
       }
-      out[dest] = { content, executable: entry.executable };
+      out[dest] = {
+        content,
+        executable: entry.executable,
+        ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+      };
     }
     return out;
   }

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -23,7 +23,8 @@ function destinationFor(entry: CoreEntry): string {
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
     case "project-root":
-      if (!entry.suffix) throw new Error(`project-root needs suffix`);
+    case "mergeable-project-root":
+      if (!entry.suffix) throw new Error(`${entry.category} needs suffix`);
       return entry.suffix;
   }
 }
@@ -38,6 +39,7 @@ export class WindsurfHarness implements Harness {
       out[destinationFor(entry)] = {
         content: entry.content,
         executable: entry.executable,
+        ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
       };
     }
     return out;

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5655,11 +5655,10 @@ _No tasks yet._
     executable: false,
   },
   {
-    category: "project-root",
+    category: "mergeable-project-root",
     name: "root",
     suffix: ".gitignore",
-    content: `# Specflow
-*.specflow.bak
+    content: `*.specflow.bak
 .specflow/config.yml.local
 `,
     executable: false,

--- a/templates/core/root/.gitignore
+++ b/templates/core/root/.gitignore
@@ -1,3 +1,2 @@
-# Specflow
 *.specflow.bak
 .specflow/config.yml.local

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -42,7 +42,7 @@
 
     { "category": "project-root", "name": "root", "suffix": "AGENTS.md", "source": "core/root/AGENTS.md" },
     { "category": "project-root", "name": "root", "suffix": "tasks/backlog.md", "source": "core/root/tasks/backlog.md" },
-    { "category": "project-root", "name": "root", "suffix": ".gitignore", "source": "core/root/.gitignore" }
+    { "category": "mergeable-project-root", "name": "root", "suffix": ".gitignore", "source": "core/root/.gitignore" }
   ],
   "harness_static": [
     { "harness": "claude", "destination": "CLAUDE.md", "source": "harness-specific/claude/CLAUDE.md" },

--- a/tests/integration/init_brownfield_gitignore_test.ts
+++ b/tests/integration/init_brownfield_gitignore_test.ts
@@ -1,0 +1,125 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+const VITE_GITIGNORE = `# Logs
+logs
+*.log
+npm-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+`;
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-init-brownfield-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("init --here on a Vite-style project preserves the user .gitignore via merge block", async () => {
+  await withTempDir(async (parent) => {
+    const root = join(parent, "vite-demo");
+    await Deno.mkdir(root, { recursive: true });
+    await Deno.writeTextFile(join(root, ".gitignore"), VITE_GITIGNORE);
+    // Plausible Vite scaffold so the test reflects the brownfield case.
+    await Deno.writeTextFile(join(root, "package.json"), `{"name":"vite-demo"}`);
+
+    const { code, stderr } = await runSpecflow(
+      ["init", "--here", "--no-git"],
+      { cwd: root },
+    );
+    assertEquals(code, 0, `expected init to succeed without --force; got ${code}: ${stderr}`);
+
+    const merged = await Deno.readTextFile(join(root, ".gitignore"));
+    // User's lines preserved verbatim.
+    assertStringIncludes(merged, "node_modules");
+    assertStringIncludes(merged, "dist-ssr");
+    assertStringIncludes(merged, ".DS_Store");
+    // Specflow block is fenced and at the end.
+    assertStringIncludes(merged, "# --- Specflow: gitignore ---");
+    assertStringIncludes(merged, "*.specflow.bak");
+    assertStringIncludes(merged, ".specflow/config.yml.local");
+    assertStringIncludes(merged, "# --- End Specflow: gitignore ---");
+    // No backup created — merge is non-destructive.
+    assertEquals(await exists(join(root, ".gitignore.specflow.bak")), false);
+  });
+});
+
+Deno.test("init --here twice does not duplicate the merge block (idempotency)", async () => {
+  await withTempDir(async (parent) => {
+    const root = join(parent, "demo");
+    await Deno.mkdir(root, { recursive: true });
+    await Deno.writeTextFile(join(root, ".gitignore"), VITE_GITIGNORE);
+
+    const first = await runSpecflow(["init", "--here", "--no-git"], { cwd: root });
+    assertEquals(first.code, 0, `first init failed: ${first.stderr}`);
+
+    const second = await runSpecflow(["init", "--here", "--no-git", "--force"], { cwd: root });
+    assertEquals(second.code, 0, `second init failed: ${second.stderr}`);
+
+    const merged = await Deno.readTextFile(join(root, ".gitignore"));
+    const fenceCount = (merged.match(/# --- Specflow: gitignore ---/g) ?? []).length;
+    assertEquals(fenceCount, 1, "specflow block must appear exactly once");
+    // User content still present.
+    assertStringIncludes(merged, "node_modules");
+  });
+});
+
+Deno.test("init --here greenfield writes the .gitignore wrapped in fence markers", async () => {
+  await withTempDir(async (parent) => {
+    const root = join(parent, "demo");
+    // No pre-existing .gitignore; test the greenfield merge shape.
+    const { code, stderr } = await runSpecflow(
+      ["init", "demo", "--no-git"],
+      { cwd: parent },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+
+    const content = await Deno.readTextFile(join(root, ".gitignore"));
+    assertStringIncludes(content, "# --- Specflow: gitignore ---");
+    assertStringIncludes(content, "*.specflow.bak");
+    assertStringIncludes(content, ".specflow/config.yml.local");
+    assertStringIncludes(content, "# --- End Specflow: gitignore ---");
+  });
+});


### PR DESCRIPTION
Closes #6.

## Summary

Brownfield projects (Vite, Next, Astro, etc.) all ship a `.gitignore`. Before this change, `specflow init --here` reported it as a conflict and `--force` then **backed up the user file and wrote specflow's stub** — silently losing all framework ignores.

The fix introduces a new `mergeable-project-root` bundle category and an append-block strategy: specflow's `.gitignore` is wrapped in fence markers and merged into any existing user file, non-destructively, idempotently, and without `--force`.

## Before / After

```diff
 # Logs
 logs
 *.log
 ...
 node_modules
 dist
 .DS_Store
 .vscode/*
+
+# --- Specflow: gitignore ---
+*.specflow.bak
+.specflow/config.yml.local
+# --- End Specflow: gitignore ---
```

User file fully preserved. No `.gitignore.specflow.bak`. No `--force` required.

## Architectural shape

- New `CoreCategory` value `mergeable-project-root` (currently only `.gitignore` uses it).
- New `TemplateFile.mergeBlock?: string` field carrying the fence label.
- `DenoFsWriter.detectConflicts` skips entries with `mergeBlock` set.
- `DenoFsWriter.writeBundle` reads any pre-existing file and merges via `mergeIntoFile()` from the new `src/domain/merge_block.ts` helper.
- Lock SHA for mergeable files stores the canonical block body (trimmed) so it stays comparable against the body extracted from disk on upgrade reads.
- All 8 harnesses route `mergeable-project-root` to the same destination as `project-root` and stamp `mergeBlock: \"gitignore\"`. No harness-specific divergence.

## Test plan

- [x] `deno task test` — 316 / 316 pass (was 313 before; +3 new brownfield tests).
- [x] New integration tests in `tests/integration/init_brownfield_gitignore_test.ts`:
  - Brownfield: pre-existing Vite-style `.gitignore` → init succeeds without `--force`, both user lines and specflow block present, no `.bak` file created.
  - Idempotency: running init twice with `--force` does not duplicate the specflow block.
  - Greenfield: fresh init writes the `.gitignore` wrapped in fence markers (same shape regardless of whether merge was needed).
- [x] End-to-end smoke against a real `npm create vite@latest` project — Vite's 24-line `.gitignore` (logs, node_modules, dist, .DS_Store, .vscode, etc.) preserved verbatim with the specflow block appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)