### PR TITLE
feat(docs): GitHub Pages site from docs/llms.md (#1)

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,28 +1,29 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# Build the docs site from docs/llms.md and deploy to GitHub Pages.
+name: Deploy docs to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+    paths:
+      - "docs/**"
+      - "scripts/build-docs.ts"
+      - "deno.json"
+      - ".github/workflows/static.yml"
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment, skipping queued runs between an
+# in-progress run and the latest queued. Don't cancel an in-flight production
+# deploy.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -31,13 +32,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Build docs
+        run: deno task docs:build
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: "docs-dist"
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 spec-kit/
 .claude/scheduled_tasks.lock
 test/
+docs-dist/

--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "build": "deno task bundle && deno run --allow-read --allow-write --allow-run scripts/build.ts",
+    "docs:build": "deno run --allow-read --allow-write --allow-env scripts/build-docs.ts",
     "setup": "deno run --allow-read --allow-write --allow-run scripts/install-hooks.ts"
   },
   "imports": {
@@ -19,7 +20,8 @@
     "@std/fmt": "jsr:@std/fmt@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/yaml": "jsr:@std/yaml@^1.0.0",
-    "@std/toml": "jsr:@std/toml@^1.0.0"
+    "@std/toml": "jsr:@std/toml@^1.0.0",
+    "@deno/gfm": "jsr:@deno/gfm@^0.11.0"
   },
   "fmt": {
     "lineWidth": 100,

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@deno/gfm@0.11": "0.11.0",
+    "jsr:@denosaurs/emoji@~0.3.1": "0.3.1",
     "jsr:@std/assert@1": "1.0.18",
     "jsr:@std/cli@1": "1.0.27",
     "jsr:@std/collections@^1.1.3": "1.1.7",
@@ -10,9 +12,36 @@
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/toml@*": "1.0.11",
     "jsr:@std/toml@1": "1.0.11",
-    "jsr:@std/yaml@1": "1.0.11"
+    "jsr:@std/yaml@1": "1.0.11",
+    "npm:github-slugger@2": "2.0.0",
+    "npm:he@^1.2.0": "1.2.0",
+    "npm:katex@0.16": "0.16.28",
+    "npm:marked-alert@2": "2.1.2_marked@12.0.2",
+    "npm:marked-footnote@^1.2.0": "1.4.0_marked@12.0.2",
+    "npm:marked-gfm-heading-id@^3.1.0": "3.2.0_marked@12.0.2",
+    "npm:marked@12": "12.0.2",
+    "npm:prismjs@^1.29.0": "1.30.0",
+    "npm:sanitize-html@^2.13.0": "2.17.3"
   },
   "jsr": {
+    "@deno/gfm@0.11.0": {
+      "integrity": "ddadbfca6c1281729783612e4b0b2166b6543c1c49cc106b80911f4dc4087abc",
+      "dependencies": [
+        "jsr:@denosaurs/emoji",
+        "npm:github-slugger",
+        "npm:he",
+        "npm:katex",
+        "npm:marked",
+        "npm:marked-alert",
+        "npm:marked-footnote",
+        "npm:marked-gfm-heading-id",
+        "npm:prismjs",
+        "npm:sanitize-html"
+      ]
+    },
+    "@denosaurs/emoji@0.3.1": {
+      "integrity": "b0aed5f55dec99e83da7c9637fe0a36d1d6252b7c99deaaa3fc5dea3fcf3da8b"
+    },
     "@std/assert@1.0.18": {
       "integrity": "270245e9c2c13b446286de475131dc688ca9abcd94fc5db41d43a219b34d1c78",
       "dependencies": [
@@ -53,8 +82,135 @@
       "integrity": "bd139ce77f2d06cbed3713c8b26d301d2a2e12ecc7986130a268107e212143ee"
     }
   },
+  "npm": {
+    "commander@8.3.0": {
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+    },
+    "deepmerge@4.3.1": {
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
+    "dom-serializer@2.0.0": {
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": [
+        "domelementtype",
+        "domhandler",
+        "entities@4.5.0"
+      ]
+    },
+    "domelementtype@2.3.0": {
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler@5.0.3": {
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": [
+        "domelementtype"
+      ]
+    },
+    "domutils@3.2.2": {
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": [
+        "dom-serializer",
+        "domelementtype",
+        "domhandler"
+      ]
+    },
+    "entities@4.5.0": {
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "entities@7.0.1": {
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
+    },
+    "escape-string-regexp@4.0.0": {
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
+    "github-slugger@2.0.0": {
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
+    },
+    "he@1.2.0": {
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": true
+    },
+    "htmlparser2@10.1.0": {
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dependencies": [
+        "domelementtype",
+        "domhandler",
+        "domutils",
+        "entities@7.0.1"
+      ]
+    },
+    "is-plain-object@5.0.0": {
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "katex@0.16.28": {
+      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
+      "dependencies": [
+        "commander"
+      ],
+      "bin": true
+    },
+    "marked-alert@2.1.2_marked@12.0.2": {
+      "integrity": "sha512-EFNRZ08d8L/iEIPLTlQMDjvwIsj03gxWCczYTht6DCiHJIZhMk4NK5gtPY9UqAYb09eV5VGT+jD4lp396E0I+w==",
+      "dependencies": [
+        "marked"
+      ]
+    },
+    "marked-footnote@1.4.0_marked@12.0.2": {
+      "integrity": "sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==",
+      "dependencies": [
+        "marked"
+      ]
+    },
+    "marked-gfm-heading-id@3.2.0_marked@12.0.2": {
+      "integrity": "sha512-Xfxpr5lXLDLY10XqzSCA9l2dDaiabQUgtYM9hw8yunyVsB/xYBRpiic6BOiY/EAJw1ik1eWr1ET1HKOAPZBhXg==",
+      "dependencies": [
+        "github-slugger",
+        "marked"
+      ]
+    },
+    "marked@12.0.2": {
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "bin": true
+    },
+    "nanoid@3.3.11": {
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "bin": true
+    },
+    "parse-srcset@1.0.2": {
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
+    "picocolors@1.1.1": {
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "postcss@8.5.6": {
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dependencies": [
+        "nanoid",
+        "picocolors",
+        "source-map-js"
+      ]
+    },
+    "prismjs@1.30.0": {
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
+    },
+    "sanitize-html@2.17.3": {
+      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "dependencies": [
+        "deepmerge",
+        "escape-string-regexp",
+        "htmlparser2",
+        "is-plain-object",
+        "parse-srcset",
+        "postcss"
+      ]
+    },
+    "source-map-js@1.2.1": {
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
+    }
+  },
   "workspace": {
     "dependencies": [
+      "jsr:@deno/gfm@0.11",
       "jsr:@std/assert@1",
       "jsr:@std/cli@1",
       "jsr:@std/fmt@1",

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -1,0 +1,165 @@
+# Specflow
+
+> Specflow is an enhanced fork of the
+> [`specify` CLI from GitHub Spec Kit](https://github.com/github/spec-kit), distributed as a single
+> native binary (no Python prerequisites). It scaffolds the files your AI coding harness consumes —
+> SpecKit slash-commands, spec / plan / tasks templates, a constitution, agents, and a backlog
+> system — directly into an existing project, in one command.
+
+Specflow does **not** call any LLM and does **not** orchestrate any agent at runtime. Your AI
+harness (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot CLI, Windsurf, OpenCode,
+Antigravity) is what reads the generated files and acts on them.
+
+This page is the canonical documentation. The same content is available as raw Markdown at
+[`/llms.txt`](./llms.txt) for LLM consumption — see [llmstxt.org](https://llmstxt.org/) for the
+convention.
+
+## Install
+
+The fastest path on macOS or Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mkrlabs/specflow/main/install.sh | bash
+```
+
+The installer downloads the platform binary, verifies the SHA256 checksum, and places it in
+`/usr/local/bin` (auto-elevating via `sudo` if needed). On non-writable prefixes with no terminal it
+falls back to `~/.local/bin`.
+
+Pin a specific version:
+
+```bash
+curl -fsSL https://.../install.sh | VERSION=v0.7.1 bash
+```
+
+Custom install dir:
+
+```bash
+curl -fsSL https://.../install.sh | PREFIX=$HOME/.local/bin bash
+```
+
+Or via Homebrew (macOS / Linux):
+
+```bash
+brew tap mkrlabs/tap
+brew install specflow
+```
+
+Manual download: pick the binary for your OS/arch from
+[GitHub Releases](https://github.com/mkrlabs/specflow/releases), `chmod +x`, place it on your
+`$PATH`. On macOS clear the quarantine attribute with
+`xattr -d com.apple.quarantine /path/to/specflow`.
+
+## Quickstart
+
+### Create a new project
+
+```bash
+specflow init my-project
+cd my-project
+```
+
+This scaffolds a tree configured for the **Claude Code** harness by default (`.claude/`,
+`.specflow/`, `AGENTS.md`, `tasks/backlog.md`, …). Open the project in your harness and run the
+`/specflow.specify` slash-command to start your first feature.
+
+### Add Specflow to an existing project
+
+```bash
+cd my-existing-project
+specflow init --here
+```
+
+Specflow merges its `.gitignore` block into your existing file (non-destructively, fenced with
+`# --- Specflow: gitignore ---` markers). Other specflow-managed files use upgrade-aware semantics:
+if you customize a generated file, `specflow upgrade` will preserve it unless you pass `--force`.
+
+### Pick a different harness
+
+```bash
+specflow init my-project --ai cursor
+specflow init my-project --ai antigravity
+specflow init my-project --ai gemini
+# … etc.
+```
+
+Eight harness targets are supported: `claude` (default), `cursor`, `codex`, `gemini`, `windsurf`,
+`copilot`, `opencode`, `antigravity`. Each emits files in the convention that harness expects.
+
+### Other commands
+
+```bash
+specflow check                    # diagnose your environment
+specflow check --project          # also diagnose the current specflow project
+specflow upgrade                  # update templates to the binary's version
+specflow upgrade --dry-run        # preview the upgrade plan
+specflow upgrade --force          # apply destructive changes (backs up customizations)
+specflow self-update              # upgrade the binary itself
+specflow self-update --check      # only report whether an update is available
+specflow backlog configure        # wire the backlog to a remote (GitHub Issues + Project V2)
+specflow backlog sync             # push backlog mutations to the remote
+specflow --version                # print version
+specflow --help                   # full usage
+```
+
+## Available harnesses
+
+| Key           | Display name       | Output root             |
+| ------------- | ------------------ | ----------------------- |
+| `claude`      | Claude Code        | `.claude/`              |
+| `cursor`      | Cursor             | `.cursor/`              |
+| `codex`       | Codex CLI          | `.codex/`, `.agents/`   |
+| `gemini`      | Gemini CLI         | `.gemini/`              |
+| `windsurf`    | Windsurf           | `.windsurf/`            |
+| `copilot`     | GitHub Copilot CLI | `.github/instructions/` |
+| `opencode`    | OpenCode           | `.opencode/`            |
+| `antigravity` | Antigravity        | `.agent/`               |
+
+All harnesses share the same source-of-truth content in `templates/core/`. The per-harness adapters
+in `src/infrastructure/harness/` map that core bundle to each harness's directory layout and
+frontmatter conventions.
+
+## What makes Specflow different from upstream Spec Kit
+
+Specflow is a fork of the official `specify` CLI with three additions:
+
+### 1. Auto-chained pipeline
+
+The generated `specify` skill chains `clarify → plan → tasks → analyze → implement → review → merge`
+in a single session. Upstream stops at every step and asks the human to invoke the next one.
+Specflow only stops twice: when clarification is genuinely required, and once before merging.
+
+### 2. `review` phase post-implement
+
+After `implement`, the generated workflow runs a dedicated `review` phase that checks structure
+(architecture boundaries, silent error swallowing, leaked internal IDs, cache layering, test
+coverage) and the quality gates (format, lint, typecheck, tests). If `review` flags something, the
+loop is `implement → review → fix → re-review` — also automatic.
+
+### 3. Backlog as product source of truth
+
+The generated project ships with a `tasks/backlog.md` index plus per-task files under
+`tasks/backlog/NNN-slug.md` (typed frontmatter: id, title, category, priority, complexity, status,
+depends_on, spec, tags, created). A Product Owner agent gates every mutation.
+`specflow backlog sync` pushes the backlog to a remote (GitHub Issues + Project V2 in v1; GitLab and
+Bitbucket planned for later).
+
+## Design principles
+
+- **Agnostic of the user project's language** — Python, TypeScript, Go, PHP, Rust… your project,
+  your stack.
+- **Agnostic of the LLM** — Claude, OpenAI, Gemini, local models, anything your harness supports.
+- **Agnostic of the AI harness** — eight first-class targets today, with the same core content for
+  all.
+- **Agnostic of the backlog source** — local Markdown is the source of truth, with one-way sync to
+  the remote of your choice.
+- **Single binary** — distributed via `deno compile` for macOS arm64/x64, Linux arm64/x64, and
+  Windows x64. No Python, no `pip`, no extra runtimes on the user's machine.
+
+## Repository
+
+Source, releases, and issue tracker:
+**[github.com/mkrlabs/specflow](https://github.com/mkrlabs/specflow)**.
+
+The `AGENTS.md` file at the repo root is the canonical context document for any future Claude Code,
+Codex, or other agent session contributing to the project itself.

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -1,0 +1,95 @@
+/**
+ * Builds the GitHub Pages site from `docs/llms.md`:
+ *
+ *   docs/llms.md → docs-dist/index.html  (HTML rendering, GFM + embedded CSS)
+ *                → docs-dist/llms.txt    (raw markdown copy, llmstxt.org convention)
+ *
+ * Wired up via `deno task docs:build`. Invoked by the `Deploy static content
+ * to Pages` workflow on every push to main.
+ */
+import { CSS, render } from "@deno/gfm";
+
+const SOURCE = "docs/llms.md";
+const OUT_DIR = "docs-dist";
+const OUT_HTML = `${OUT_DIR}/index.html`;
+const OUT_MD = `${OUT_DIR}/llms.txt`;
+const TITLE = "Specflow — documentation";
+
+const HTML_TEMPLATE = (body: string) =>
+  `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${TITLE}</title>
+  <meta name="description" content="Specflow — enhanced spec-kit CLI with auto-chain, review phase, and backlog. Distributed as a single native binary." />
+  <link rel="canonical" href="https://mkrlabs.github.io/specflow/" />
+  <link rel="alternate" type="text/markdown" href="./llms.txt" />
+  <style>
+    ${CSS}
+
+    body {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 2rem 1.25rem 4rem;
+      color-scheme: light dark;
+      background: var(--color-canvas-default);
+    }
+    .markdown-body {
+      box-sizing: border-box;
+      min-width: 200px;
+      padding: 0;
+    }
+    @media (max-width: 768px) {
+      body { padding: 1rem 0.75rem 3rem; }
+    }
+    .doc-footer {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--color-border-muted);
+      font-size: 0.875rem;
+      color: var(--color-fg-muted);
+    }
+    .doc-footer a {
+      color: inherit;
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <main class="markdown-body">
+${body}
+  </main>
+  <footer class="doc-footer">
+    Raw Markdown for LLMs: <a href="./llms.txt">llms.txt</a>
+    · Source: <a href="https://github.com/mkrlabs/specflow">github.com/mkrlabs/specflow</a>
+  </footer>
+</body>
+</html>
+`;
+
+export async function buildDocs(opts: {
+  source?: string;
+  outDir?: string;
+} = {}): Promise<{ html: string; markdown: string }> {
+  const source = opts.source ?? SOURCE;
+  const outDir = opts.outDir ?? OUT_DIR;
+  const outHtml = `${outDir}/index.html`;
+  const outMd = `${outDir}/llms.txt`;
+
+  const markdown = await Deno.readTextFile(source);
+  const rendered = render(markdown, { allowIframes: false });
+  const html = HTML_TEMPLATE(rendered);
+
+  await Deno.mkdir(outDir, { recursive: true });
+  await Deno.writeTextFile(outHtml, html);
+  await Deno.writeTextFile(outMd, markdown);
+
+  return { html, markdown };
+}
+
+if (import.meta.main) {
+  const { html } = await buildDocs();
+  console.log(`✓ wrote ${OUT_HTML} (${html.length} bytes)`);
+  console.log(`✓ wrote ${OUT_MD}`);
+}

--- a/tests/scripts/build_docs_test.ts
+++ b/tests/scripts/build_docs_test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { join } from "@std/path";
+import { buildDocs } from "../../scripts/build-docs.ts";
+
+async function withTempSource(
+  markdown: string,
+  fn: (source: string, outDir: string) => Promise<void>,
+) {
+  const root = await Deno.makeTempDir({ prefix: "specflow-build-docs-" });
+  try {
+    const source = join(root, "input.md");
+    const outDir = join(root, "out");
+    await Deno.writeTextFile(source, markdown);
+    await fn(source, outDir);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+}
+
+Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", async () => {
+  const md = "# Hello Specflow\n\nThis is a **test** doc.\n";
+  await withTempSource(md, async (source, outDir) => {
+    await buildDocs({ source, outDir });
+
+    assertEquals(await exists(join(outDir, "index.html")), true);
+    assertEquals(await exists(join(outDir, "llms.txt")), true);
+
+    const html = await Deno.readTextFile(join(outDir, "index.html"));
+    assertStringIncludes(html, "<h1");
+    assertStringIncludes(html, "Hello Specflow");
+    assertStringIncludes(html, "<strong>test</strong>");
+    assertStringIncludes(html, "<!DOCTYPE html>");
+    // Raw-markdown alt link is present.
+    assertStringIncludes(html, 'href="./llms.txt"');
+
+    const txt = await Deno.readTextFile(join(outDir, "llms.txt"));
+    assertEquals(txt, md, "llms.txt must be a verbatim copy of the source markdown");
+  });
+});
+
+Deno.test("buildDocs renders the actual Specflow docs without error", async () => {
+  const root = await Deno.makeTempDir({ prefix: "specflow-build-docs-real-" });
+  try {
+    const result = await buildDocs({
+      source: "docs/llms.md",
+      outDir: root,
+    });
+    // Sanity: the real docs mention install + harnesses, which are headline
+    // sections that should never disappear silently.
+    assertStringIncludes(result.markdown, "## Install");
+    assertStringIncludes(result.markdown, "harnesses");
+    assertStringIncludes(result.html, "Install");
+    assertStringIncludes(result.html, "harnesses");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #1.

## Summary

Single-page Specflow doc site, built from `docs/llms.md` and deployed to GitHub Pages. Same content also exposed as raw markdown at `/llms.txt` for LLM consumption ([llmstxt.org](https://llmstxt.org/) convention).

## What ships

- `docs/llms.md` — single source of truth (install, quickstart, harness list, the 3 differences from upstream, design principles, repo link).
- `scripts/build-docs.ts` — Deno build script using `@deno/gfm` (GitHub-flavored markdown rendering with embedded CSS).
- `.github/workflows/static.yml` — replaces the placeholder workflow. Sets up Deno, runs `deno task docs:build`, uploads `docs-dist/` only, deploys via `actions/deploy-pages@v4`. Path-filtered: only fires on changes to `docs/`, the build script, the workflow itself, or `deno.json`.
- `tests/scripts/build_docs_test.ts` — unit tests on the build path. 318/318 tests pass total.
- `docs-dist/` is gitignored.

## After merge — required one-time human step

GitHub Pages must be enabled in the repo settings with **Source = GitHub Actions** before the workflow can deploy. To flip it:

> **Repo settings → Pages → Build and deployment → Source: GitHub Actions**

Without this, the first deploy will fail with a 403 (`actions/deploy-pages` cannot create a Pages deployment until Pages is enabled in the right mode). One-time only.

## After deploy — URLs

- https://mkrlabs.github.io/specflow/         (HTML rendering)
- https://mkrlabs.github.io/specflow/llms.txt (raw markdown)

## Test plan

- [x] `deno task test` — 318 / 318 pass (was 316 before; +2 new build_docs tests).
- [x] `deno task docs:build` runs locally and produces `docs-dist/index.html` (~70KB with embedded CSS) + `docs-dist/llms.txt` (verbatim markdown).
- [x] Visual check on the rendered HTML — sections, code blocks, tables, lists all render with @deno/gfm's GitHub-style CSS.
- [ ] After merge: flip Pages Source to GitHub Actions, verify https://mkrlabs.github.io/specflow/ and /llms.txt resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)