### PR TITLE
feat(docs): pin specflow.makerlabs.dev as the custom Pages domain

### DIFF
--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -13,7 +13,18 @@ const SOURCE = "docs/llms.md";
 const OUT_DIR = "docs-dist";
 const OUT_HTML = `${OUT_DIR}/index.html`;
 const OUT_MD = `${OUT_DIR}/llms.txt`;
+const OUT_CNAME = `${OUT_DIR}/CNAME`;
 const TITLE = "Specflow — documentation";
+
+/**
+ * GitHub Pages custom domain. Emitted as `docs-dist/CNAME` so each deploy
+ * republishes it; without this, GitHub Pages drops the custom domain on
+ * subsequent workflow deploys (build_type=workflow ignores the repo
+ * settings UI alone — the artifact's CNAME file is the source of truth).
+ *
+ * The CNAME on OVH (`specflow → mkrlabs.github.io.`) routes traffic here.
+ */
+const CUSTOM_DOMAIN = "specflow.makerlabs.dev";
 
 const HTML_TEMPLATE = (body: string) =>
   `<!DOCTYPE html>
@@ -23,7 +34,7 @@ const HTML_TEMPLATE = (body: string) =>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${TITLE}</title>
   <meta name="description" content="Specflow — enhanced spec-kit CLI with auto-chain, review phase, and backlog. Distributed as a single native binary." />
-  <link rel="canonical" href="https://mkrlabs.github.io/specflow/" />
+  <link rel="canonical" href="https://specflow.makerlabs.dev/" />
   <link rel="alternate" type="text/markdown" href="./llms.txt" />
   <style>
     ${CSS}
@@ -84,6 +95,7 @@ export async function buildDocs(opts: {
   await Deno.mkdir(outDir, { recursive: true });
   await Deno.writeTextFile(outHtml, html);
   await Deno.writeTextFile(outMd, markdown);
+  await Deno.writeTextFile(`${outDir}/CNAME`, `${CUSTOM_DOMAIN}\n`);
 
   return { html, markdown };
 }
@@ -92,4 +104,5 @@ if (import.meta.main) {
   const { html } = await buildDocs();
   console.log(`✓ wrote ${OUT_HTML} (${html.length} bytes)`);
   console.log(`✓ wrote ${OUT_MD}`);
+  console.log(`✓ wrote ${OUT_CNAME} (${CUSTOM_DOMAIN})`);
 }

--- a/tests/scripts/build_docs_test.ts
+++ b/tests/scripts/build_docs_test.ts
@@ -25,6 +25,7 @@ Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", asy
 
     assertEquals(await exists(join(outDir, "index.html")), true);
     assertEquals(await exists(join(outDir, "llms.txt")), true);
+    assertEquals(await exists(join(outDir, "CNAME")), true);
 
     const html = await Deno.readTextFile(join(outDir, "index.html"));
     assertStringIncludes(html, "<h1");
@@ -36,6 +37,11 @@ Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", asy
 
     const txt = await Deno.readTextFile(join(outDir, "llms.txt"));
     assertEquals(txt, md, "llms.txt must be a verbatim copy of the source markdown");
+
+    // CNAME is emitted on every build so the custom-domain config persists
+    // across workflow deploys.
+    const cname = await Deno.readTextFile(join(outDir, "CNAME"));
+    assertEquals(cname.trim(), "specflow.makerlabs.dev");
   });
 });
 


### PR DESCRIPTION
## Summary

Wires the docs site to the custom domain `specflow.makerlabs.dev`.

DNS is already in place on OVH:
\`\`\`
$ dig +short CNAME specflow.makerlabs.dev
mkrlabs.github.io.
$ dig +short A specflow.makerlabs.dev
185.199.{108,109,110,111}.153
\`\`\`

For workflow-based GH Pages, the artifact's `CNAME` file is the source of truth — without it, repo-settings custom domain gets overwritten on every redeploy. This PR has the build emit `docs-dist/CNAME` on every run.

## Changes

- `scripts/build-docs.ts`: emit `docs-dist/CNAME` with `specflow.makerlabs.dev`. Update HTML canonical link to the custom domain.
- `tests/scripts/build_docs_test.ts`: assert the CNAME file is written with the expected content (regression guard).

## After merge — done by me autonomously

\`gh api -X PUT repos/mkrlabs/specflow/pages -f cname=specflow.makerlabs.dev\` (registers the domain on GitHub side, triggers HTTPS cert provisioning ~10 min). Verify https://specflow.makerlabs.dev/ resolves with a 200 + valid cert.

## Test plan

- [x] DNS verified (`dig` output above).
- [x] `deno task docs:build` produces all 3 files including CNAME.
- [x] 318/318 tests pass.
- [ ] After merge: deploy fires, GitHub sees the CNAME, custom domain provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)