### PR TITLE
feat(skills): add test-specflow skill for manual UX validation

### DIFF
--- a/.claude/skills/test-specflow/SKILL.md
+++ b/.claude/skills/test-specflow/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: test-specflow
+description: Spin up controlled test environments (Vite, Next-style brownfield, empty greenfield) under the gitignored `test/` directory and run Specflow against them using the current source tree (not the installed binary). Use whenever you need to manually validate the UX of `specflow init` / `upgrade` / `check` on a real-world project shape, reproduce a brownfield bug, or eyeball cross-harness output side-by-side. Each script is idempotent.
+allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*.sh) Bash(${CLAUDE_SKILL_DIR}/scripts/*.sh *) Bash(deno *) Bash(ls *) Bash(find *) Bash(cat *) Bash(diff *) Bash(rm *) Bash(npm *) Bash(git *)
+---
+
+# test-specflow skill — Specflow UX testing toolbox
+
+When you need to verify how `specflow init`, `specflow upgrade`, etc. behave on real-world project shapes — without recompiling the binary or installing it system-wide — use this skill.
+
+Each script bootstraps a controlled scenario inside `test/<name>/` (the `test/` dir is gitignored at the repo root, so nothing leaks to commits), then optionally runs Specflow against it from the current source tree (`deno run --allow-all src/main.ts ...`). That way you're testing the working-tree behaviour, not the released binary.
+
+## When to use
+
+- Manual UX validation of a fix or feature before / after merging (e.g. brownfield `.gitignore` merge — that's exactly how PR #7 was caught and validated).
+- Reproducing an issue reported on a real project shape (Vite, Next, etc.) without leaving the repo.
+- Cross-harness comparison: same project, all 8 harnesses, eyeball the output trees side by side.
+
+## Scripts
+
+```bash
+.claude/skills/test-specflow/scripts/bootstrap-vite.sh <name>      # Vite React-TS scaffold
+.claude/skills/test-specflow/scripts/bootstrap-empty.sh <name>     # empty greenfield (git init + stub package.json)
+.claude/skills/test-specflow/scripts/run-init.sh <name> <harness>  # specflow init --here --ai <harness> (uses current source)
+.claude/skills/test-specflow/scripts/inspect.sh <name>             # summarize specflow output paths in test/<name>/
+.claude/skills/test-specflow/scripts/compare-harnesses.sh <name>   # bootstrap once + run all 8 harnesses on copies, print summaries
+.claude/skills/test-specflow/scripts/clean.sh [<name>]             # wipe one test dir or the whole test/ tree
+```
+
+`<harness>` ∈ `claude` (default) | `cursor` | `codex` | `gemini` | `windsurf` | `copilot` | `opencode` | `antigravity`.
+
+## Typical workflows
+
+### Validate a brownfield fix before merging
+
+```bash
+bash .claude/skills/test-specflow/scripts/bootstrap-vite.sh demo
+bash .claude/skills/test-specflow/scripts/run-init.sh demo claude
+bash .claude/skills/test-specflow/scripts/inspect.sh demo
+cat test/demo/.gitignore                       # eyeball the merged result
+```
+
+### Reproduce an issue across all harnesses
+
+```bash
+bash .claude/skills/test-specflow/scripts/compare-harnesses.sh demo
+ls test/                                       # demo, demo-claude, demo-cursor, …
+```
+
+### Reset between runs
+
+```bash
+bash .claude/skills/test-specflow/scripts/clean.sh demo            # one project
+bash .claude/skills/test-specflow/scripts/clean.sh                 # everything under test/
+```
+
+## Conventions
+
+- Test projects always live under `test/<name>/`. The `test/` directory is gitignored at the repo root — never commit anything from it.
+- Scripts run `deno run --allow-all` on `src/main.ts` so you're testing the working tree, **not** the installed `specflow` binary. To test the released binary instead, run `specflow` directly without going through this skill.
+- All scripts are idempotent. Re-running is always safe; pre-existing `test/<name>/` is wiped before re-bootstrapping.
+- Bootstrap scripts skip `npm install` — Specflow's filesystem ops don't depend on `node_modules` being populated, and skipping the install keeps each scenario fast and small.
+
+## When NOT to use
+
+- If you just need to run the existing automated test suite, `deno task test` covers it — no skill needed.
+- If you're doing repo-wide refactors with no UX-facing change (template restructuring, harness internals), this skill won't surface anything the unit tests don't already.
+- Don't use the bootstrapped projects as scratchpads for unrelated work — they're meant to be ephemeral test fixtures, wiped between scenarios.

--- a/.claude/skills/test-specflow/scripts/bootstrap-empty.sh
+++ b/.claude/skills/test-specflow/scripts/bootstrap-empty.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Bootstrap an empty greenfield project under test/<name>/ for Specflow UX
+# testing. Stub package.json so it looks like a real (just-created) project.
+# Usage: bootstrap-empty.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: bootstrap-empty.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+TEST_DIR="$ROOT/test/$NAME"
+
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+git init -q
+cat >package.json <<EOF
+{
+  "name": "$NAME",
+  "version": "0.0.0",
+  "private": true
+}
+EOF
+
+echo "✓ bootstrapped empty greenfield project at test/$NAME/"

--- a/.claude/skills/test-specflow/scripts/bootstrap-vite.sh
+++ b/.claude/skills/test-specflow/scripts/bootstrap-vite.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Bootstrap a Vite React-TS project under test/<name>/ for Specflow UX testing.
+# Skips `npm install` — deps are not needed to test specflow's filesystem ops,
+# and skipping keeps the scenario fast and small.
+# Usage: bootstrap-vite.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: bootstrap-vite.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+TEST_DIR="$ROOT/test/$NAME"
+
+rm -rf "$TEST_DIR"
+mkdir -p "$ROOT/test"
+cd "$ROOT/test"
+
+npm create vite@latest "$NAME" -- --template react-ts >/dev/null
+
+echo "✓ bootstrapped Vite React-TS at test/$NAME/"
+echo "  (skipped npm install — not needed for specflow UX tests)"

--- a/.claude/skills/test-specflow/scripts/clean.sh
+++ b/.claude/skills/test-specflow/scripts/clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Wipe a single test scenario or the entire test/ tree.
+# Usage:
+#   clean.sh           # removes the whole test/ tree
+#   clean.sh <name>    # removes just test/<name>/
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+
+if [ $# -eq 0 ]; then
+  rm -rf "$ROOT/test"
+  echo "✓ wiped test/"
+else
+  rm -rf "$ROOT/test/$1"
+  echo "✓ removed test/$1"
+fi

--- a/.claude/skills/test-specflow/scripts/compare-harnesses.sh
+++ b/.claude/skills/test-specflow/scripts/compare-harnesses.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Bootstrap a Vite project once, copy it into 8 sibling dirs, run
+# `specflow init --here --ai <harness>` on each, then print an inspect summary
+# per harness. Useful for eyeballing layout differences across harnesses.
+# Usage: compare-harnesses.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: compare-harnesses.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HARNESSES=(claude cursor codex gemini windsurf copilot opencode antigravity)
+
+bash "$SCRIPT_DIR/bootstrap-vite.sh" "$NAME"
+
+for h in "${HARNESSES[@]}"; do
+  variant="$NAME-$h"
+  rm -rf "$ROOT/test/$variant"
+  cp -R "$ROOT/test/$NAME" "$ROOT/test/$variant"
+  echo
+  echo "=== init --ai $h ==="
+  bash "$SCRIPT_DIR/run-init.sh" "$variant" "$h"
+done
+
+echo
+echo "=== layout summaries ==="
+for h in "${HARNESSES[@]}"; do
+  bash "$SCRIPT_DIR/inspect.sh" "$NAME-$h"
+done

--- a/.claude/skills/test-specflow/scripts/inspect.sh
+++ b/.claude/skills/test-specflow/scripts/inspect.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Summarize the specflow-output paths inside test/<name>/.
+# Usage: inspect.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: inspect.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+TEST_DIR="$ROOT/test/$NAME"
+
+if [ ! -d "$TEST_DIR" ]; then
+  echo "error: test/$NAME does not exist" >&2
+  exit 1
+fi
+
+cd "$TEST_DIR"
+
+echo "=== test/$NAME ==="
+for path in .claude .cursor .codex .gemini .windsurf .opencode .agent .agents \
+  .github/instructions .specflow tasks AGENTS.md CLAUDE.md .gitignore; do
+  if [ -e "$path" ]; then
+    if [ -d "$path" ]; then
+      count=$(find "$path" -type f | wc -l | tr -d ' ')
+      echo "  $path/  ($count files)"
+    else
+      size=$(wc -c <"$path" | tr -d ' ')
+      echo "  $path  ($size bytes)"
+    fi
+  fi
+done

--- a/.claude/skills/test-specflow/scripts/run-init.sh
+++ b/.claude/skills/test-specflow/scripts/run-init.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run `specflow init --here --no-git --ai <harness>` against test/<name>/ using
+# the current source tree (deno run on src/main.ts) — NOT the installed binary.
+# That way you're validating what's on the working branch.
+# Usage: run-init.sh <name> <harness>
+set -euo pipefail
+
+NAME="${1:?usage: run-init.sh <name> <harness>}"
+HARNESS="${2:?usage: run-init.sh <name> <harness>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+TEST_DIR="$ROOT/test/$NAME"
+
+if [ ! -d "$TEST_DIR" ]; then
+  echo "error: test/$NAME does not exist — run bootstrap-vite.sh or bootstrap-empty.sh first" >&2
+  exit 1
+fi
+
+cd "$TEST_DIR"
+deno run --allow-all "$ROOT/src/main.ts" init --here --no-git --ai "$HARNESS"


### PR DESCRIPTION
## Summary

A pre-baked toolbox for spinning up controlled test environments and running Specflow against them — same pattern that caught the brownfield .gitignore bug (#6) and validated the fix end-to-end.

Each script targets `test/<name>/` (gitignored at the repo root, so nothing leaks to commits) and runs Specflow via \`deno run --allow-all src/main.ts\` against the **working tree**, not the installed binary.

## Scripts

\`\`\`
.claude/skills/test-specflow/scripts/
├── bootstrap-vite.sh <name>      # Vite React-TS scaffold
├── bootstrap-empty.sh <name>     # empty greenfield (git init + stub package.json)
├── run-init.sh <name> <harness>  # specflow init --here --ai <harness>
├── inspect.sh <name>             # summarize specflow output paths in test/<name>/
├── compare-harnesses.sh <name>   # bootstrap once + all 8 harnesses on copies
└── clean.sh [<name>]             # remove one project or the whole test/ tree
\`\`\`

All idempotent (re-running wipes pre-existing \`test/<name>/\` first).

## Typical use

\`\`\`bash
bash .claude/skills/test-specflow/scripts/bootstrap-vite.sh demo
bash .claude/skills/test-specflow/scripts/run-init.sh demo claude
bash .claude/skills/test-specflow/scripts/inspect.sh demo
cat test/demo/.gitignore                       # eyeball the merge
\`\`\`

## Test plan

- [x] Smoke test ran end-to-end on a fresh Vite scaffold:
  - bootstrap → 24-line .gitignore from Vite + standard React-TS files
  - run-init claude → 39 files written, exit 0
  - inspect → \`.claude/\` (20 files), \`.specflow/\` (16 files), \`tasks/\`, AGENTS.md, CLAUDE.md, \`.gitignore\` (360 bytes — Vite + Specflow merged correctly)
- [x] Skill metadata is picked up by Claude Code (visible in available-skills list with the right description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)