### PR TITLE
fix: add release-assets.githubusercontent.com to net allowlist

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -15,15 +15,20 @@ const TARGETS: Target[] = [
   { triple: "x86_64-pc-windows-msvc", outName: "specflow-windows-x64.exe" },
 ];
 
-// Permissions baked into the binary. --allow-net is required by
-// `specflow self-update` (Task 15) to reach api.github.com. Scoped to the
-// GitHub API + release download hosts only.
+// Permissions baked into the binary. `--allow-net` is required by
+// `specflow self-update` to reach api.github.com (release lookup) and the
+// release download hosts. github.com 302-redirects release-asset downloads
+// to release-assets.githubusercontent.com — both must be in the allowlist
+// or Deno prompts the user at runtime, defeating the point of a compiled
+// binary. objects.githubusercontent.com / codeload.github.com are kept as
+// belt-and-braces for any redirect path GitHub may use historically or in
+// the future.
 const PERMISSIONS = [
   "--allow-read",
   "--allow-write",
   "--allow-run",
   "--allow-env",
-  "--allow-net=api.github.com,github.com,objects.githubusercontent.com,codeload.github.com",
+  "--allow-net=api.github.com,github.com,release-assets.githubusercontent.com,objects.githubusercontent.com,codeload.github.com",
 ];
 
 async function ensureOutDir(): Promise<void> {


### PR DESCRIPTION
## Summary

- `specflow self-update` was prompting the end user for net access on every release because Deno's compile-time `--allow-net` allowlist in `scripts/build.ts` was missing `release-assets.githubusercontent.com` — the host `github.com` 302-redirects release-asset downloads to.
- Adds the missing host to the allowlist. Keeps `objects.githubusercontent.com` and `codeload.github.com` as belt-and-braces for any historical or future redirect path.
- One-time UX caveat: users on v0.6.1 → 0.7.1 still see the prompt once when they self-update **to** the fixed version (their old binary's permissions are immutable). After they're on the fixed version, future self-updates run silently.

Closes #12.

## Test plan

- [x] Redirect chain confirmed via `curl -I -L` — `github.com/mkrlabs/specflow/releases/download/...` 302s to `release-assets.githubusercontent.com/...` then 200s.
- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [ ] Post-merge: release v0.7.2 and run `specflow self-update --check` from a v0.7.1 binary → expect the prompt **once** (one-time migration), then on a v0.7.2 binary → expect silent operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)