### PR TITLE
chore(qa,po): seed memory entries for tickets #15-#20 + GH labels note

### DIFF
--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -13,3 +13,4 @@ treatment is now part of normal conventions).
 
 - [Architect handoff pattern](architect-handoff-pattern.md) — when architect has already designed a solution, wire AC directly from the spec without re-deriving strategy
 - [Docs domain](docs-domain.md) — Specflow docs are at https://specflow.makerlabs.dev (custom domain on GH Pages); use this URL in docs-related issues and AC.
+- [GitHub labels](github-labels.md) — only the 9 default GitHub labels exist; do not use ux/docs/friction slugs

--- a/.claude/agents/product-owner/memory/github-labels.md
+++ b/.claude/agents/product-owner/memory/github-labels.md
@@ -1,0 +1,12 @@
+---
+name: github-labels
+description: Available labels in mkrlabs/specflow — only use these when creating issues
+type: reference
+---
+
+The repo has only the default GitHub label set. When creating issues, restrict to:
+`bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`.
+
+**Why:** Attempting to assign non-existent labels (e.g., `ux`, `docs`, `friction`) causes `gh issue create` to fail with a label-not-found error. Discovered on 2026-05-01 while creating issues #15–#20.
+
+**How to apply:** Before assigning labels, stay within this list. Do not invent new label slugs. If a label is missing and seems important, surface it in the final report so Kevin can create it — do not block issue creation.

--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -13,7 +13,11 @@ re-flag a regression on their own).
 
 ## Tracked in backlog (re-flag once the ticket closes)
 
-_(empty — add entries here as backlog tickets get opened for QA findings)_
+- [Tracked findings](tracked-findings.md) — symptoms covered by open
+  tickets #15 (self-update --check), #16 (init file-count discrepancy),
+  #17 (init next-steps vs docs), #18 (speckit name leak), #19 (--help
+  docs URL), #20 (check --project version phrasing). Suppress these in
+  reports until the matching ticket closes.
 
 ## Patterns
 

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -1,0 +1,117 @@
+---
+name: tracked-findings
+description: QA findings already tracked in backlog tickets — do not re-flag in reports. One section per ticket. Remove a section when its ticket closes; the next run will then re-verify (and re-flag if regressed).
+type: feedback
+---
+
+When you observe one of the symptoms below during a QA run, **do not record
+it as a finding** and **do not bump the findings counter**. Instead, log it
+under "Suppressed by memory" in the final report with the ticket number and
+section slug shown here.
+
+When a ticket below is closed (the corresponding fix shipped), the matching
+section gets deleted from this file by the dispatching session. The next
+QA run will then have no suppression for that symptom — it'll either confirm
+the fix (no finding) or re-flag a regression.
+
+---
+
+## Issue #15 — `self-update --check` indistinguishable from bare self-update in up-to-date path
+
+**Symptom to suppress:** running `specflow self-update --check` and
+`specflow self-update` (no flag) on a freshly-init'd or up-to-date project
+both print `✓ already up to date (templates X.Y.Z)` and exit 0. The two
+forms produce identical output in the up-to-date path.
+
+**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/15.
+
+**How to apply:** if T8 (or any other test that probes self-update) sees
+this exact behaviour, count it as expected, do not file a finding. If
+the bare form starts behaving differently from `--check` (e.g. starts
+trying to download in the up-to-date path), that's a regression — flag
+it as a BLOCKER.
+
+---
+
+## Issue #16 — init reports "wrote 39 files" but collision guard says "38 specflow-managed file(s)"
+
+**Symptom to suppress:** in T3 the `specflow init --here --ai claude`
+output prints `✓ wrote 39 files`. In T5 the re-init refusal prints
+`target already contains 38 specflow-managed file(s)`. The discrepancy
+of 1 corresponds to `.gitignore` (treated as a `mergeable-project-root`
+entry, written but excluded from the collision count).
+
+**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/16.
+
+**How to apply:** when the difference between T3's "wrote N" and T5's
+"contains N-1 specflow-managed" is exactly 1, treat it as expected. If
+the gap grows beyond 1 (e.g. wrote 40 / contains 38), that's a new
+discrepancy — flag it.
+
+---
+
+## Issue #17 — init "Next steps" steers users to a different command than the docs quickstart
+
+**Symptom to suppress:** in T3 the init output's "Next steps" section
+ends with `Run /backlog add "<first task title>"`. The docs at
+`specflow.makerlabs.dev/llms.txt` say a fresh user should run
+`/specflow.specify` first. The `/specflow.specify` command IS scaffolded
+at `.claude/commands/specflow.specify.md` — only the init message
+diverges.
+
+**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/17.
+
+**How to apply:** if the init output recommends `/backlog add` as the
+first user-facing action, do not flag. If the init output starts
+recommending `/specflow.specify`, the ticket is fixed — flag a
+"unexpected fix detected, please re-verify by reading docs" reminder
+in the report and stop suppressing.
+
+---
+
+## Issue #18 — upstream "speckit" name leaks into the user-facing scaffold
+
+**Symptom to suppress:** after init, two locations contain the upstream
+"Speckit" / "speckit" name:
+
+- `test/qa-<stamp>/.claude/skills/speckit/SKILL.md` — directory named
+  `speckit` (lowercase upstream).
+- `test/qa-<stamp>/CLAUDE.md` contains the line "Speckit commands:
+  custom Speckit commands live in `.claude/commands/`."
+
+**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/18.
+
+**How to apply:** `grep -ri speckit test/qa-<stamp>/` returning hits
+matches the known finding — do not flag. If `grep` returns NO hits,
+the rename has shipped — the ticket can close. If a NEW path containing
+"speckit" appears that wasn't here before, flag it as net-new.
+
+---
+
+## Issue #19 — `specflow --help` footer points at the GitHub repo instead of the canonical docs site
+
+**Symptom to suppress:** `specflow --help` prints
+`Docs:  https://github.com/mkrlabs/specflow` in its footer. The
+canonical docs site is `https://specflow.makerlabs.dev`.
+
+**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/19.
+
+**How to apply:** if the Docs URL line still mentions `github.com`, do
+not flag. If it mentions `specflow.makerlabs.dev`, the ticket is
+fixed — stop suppressing.
+
+---
+
+## Issue #20 — `check --project` template-version phrasing reads as if binary is the templates version
+
+**Symptom to suppress:** `specflow check --project` prints a line of the
+form `templates version  ✓ matches binary (X.Y.Z)`, where `X.Y.Z` is the
+templates version. `--version` shows the binary version separately as
+`specflow A.B.C (templates X.Y.Z)`. The two surfaces look like they
+contradict each other.
+
+**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/20.
+
+**How to apply:** if the wording is `matches binary (...)`, do not flag.
+If the wording changes (e.g. `matches bundled (...)`, `lock matches bundled`,
+or split into two lines), the ticket is fixed — stop suppressing.


### PR DESCRIPTION
## Summary

- **qa-tester memory**: adds `tracked-findings.md` with one section per open ticket (#15–#20). The agent pre-reads `MEMORY.md` on every dispatch and suppresses these symptoms in reports — counted under "Suppressed by memory" rather than as new findings — until each ticket closes. Closing a ticket means deleting its section from this file so the next QA run re-verifies the fix.
- **product-owner memory**: notes that this repo only has the 9 default GitHub labels (no `ux`/`docs`/`friction` etc.); the PO must drop those slugs from `gh issue create` calls unless the labels get explicitly created at https://github.com/mkrlabs/specflow/labels first.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [ ] Next QA dispatch: verify each of #15–#20's symptoms shows up under "Suppressed by memory" and not under "Findings", and that the cap counter is unaffected by them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)