### PR TITLE
chore(qa): drop #18 from tracked-findings (closed by PR #22)

### DIFF
--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -15,9 +15,10 @@ re-flag a regression on their own).
 
 - [Tracked findings](tracked-findings.md) — symptoms covered by open
   tickets #15 (self-update --check), #16 (init file-count discrepancy),
-  #17 (init next-steps vs docs), #18 (speckit name leak), #19 (--help
-  docs URL), #20 (check --project version phrasing). Suppress these in
-  reports until the matching ticket closes.
+  #17 (init next-steps vs docs), #19 (--help docs URL), #20 (check
+  --project version phrasing). Suppress these in reports until the
+  matching ticket closes. (#18 closed by PR #22 — section removed; the
+  next QA run will re-verify the rename from a fresh-eyes perspective.)
 
 ## Patterns
 

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -69,25 +69,6 @@ in the report and stop suppressing.
 
 ---
 
-## Issue #18 — upstream "speckit" name leaks into the user-facing scaffold
-
-**Symptom to suppress:** after init, two locations contain the upstream
-"Speckit" / "speckit" name:
-
-- `test/qa-<stamp>/.claude/skills/speckit/SKILL.md` — directory named
-  `speckit` (lowercase upstream).
-- `test/qa-<stamp>/CLAUDE.md` contains the line "Speckit commands:
-  custom Speckit commands live in `.claude/commands/`."
-
-**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/18.
-
-**How to apply:** `grep -ri speckit test/qa-<stamp>/` returning hits
-matches the known finding — do not flag. If `grep` returns NO hits,
-the rename has shipped — the ticket can close. If a NEW path containing
-"speckit" appears that wasn't here before, flag it as net-new.
-
----
-
 ## Issue #19 — `specflow --help` footer points at the GitHub repo instead of the canonical docs site
 
 **Symptom to suppress:** `specflow --help` prints


### PR DESCRIPTION
## Summary

- Removes the `#18` section from `.claude/agents/qa-tester/memory/tracked-findings.md` and updates the `MEMORY.md` index. The speckit → auto-chain rename shipped in PR #22, ticket is closed/Done, suppression no longer needed.
- Next QA run: T4 (.gitignore merge) and T8 (--help/--version) will re-verify cleanly. Any residual leak surfaces as net-new finding.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook green.
- [ ] Next qa-tester dispatch: confirm `grep speckit` test stops appearing under "Suppressed by memory".

🤖 Generated with [Claude Code](https://claude.com/claude-code)