### PR TITLE
fix: --help footer points at docs site, not GitHub repo (#19)

### DIFF
--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -15,10 +15,10 @@ re-flag a regression on their own).
 
 - [Tracked findings](tracked-findings.md) — symptoms covered by open
   tickets #15 (self-update --check), #16 (init file-count discrepancy),
-  #17 (init next-steps vs docs), #19 (--help docs URL), #20 (check
-  --project version phrasing). Suppress these in reports until the
-  matching ticket closes. (#18 closed by PR #22 — section removed; the
-  next QA run will re-verify the rename from a fresh-eyes perspective.)
+  #17 (init next-steps vs docs), #20 (check --project version phrasing).
+  Suppress these in reports until the matching ticket closes. (#18 closed
+  by PR #22, #19 closed by PR for help-docs-url — sections removed; the
+  next QA run will re-verify those fixes from a fresh-eyes perspective.)
 
 ## Patterns
 

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -69,20 +69,6 @@ in the report and stop suppressing.
 
 ---
 
-## Issue #19 — `specflow --help` footer points at the GitHub repo instead of the canonical docs site
-
-**Symptom to suppress:** `specflow --help` prints
-`Docs:  https://github.com/mkrlabs/specflow` in its footer. The
-canonical docs site is `https://specflow.makerlabs.dev`.
-
-**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/19.
-
-**How to apply:** if the Docs URL line still mentions `github.com`, do
-not flag. If it mentions `specflow.makerlabs.dev`, the ticket is
-fixed — stop suppressing.
-
----
-
 ## Issue #20 — `check --project` template-version phrasing reads as if binary is the templates version
 
 **Symptom to suppress:** `specflow check --project` prints a line of the

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -22,7 +22,8 @@ ${bold("Flags (for init):")}
   --no-git       Skip "git init" detection and prompt
   --ai <name>    Target AI harness: claude (default) | cursor | codex | gemini | windsurf | copilot | opencode | antigravity
 
-${bold("Docs:")}  ${cyan("https://github.com/mkrlabs/specflow")}`;
+${bold("Docs:")}    ${cyan("https://specflow.makerlabs.dev")}
+${bold("Source:")}  ${cyan("https://github.com/mkrlabs/specflow")}`;
 
 export function renderVersionLine(
   version: string,


### PR DESCRIPTION
## Summary

- Adds the canonical docs URL (`specflow.makerlabs.dev`, shipped in v0.7.0 via issue #1) to `specflow --help` and demotes the GitHub repo to a separate `Source:` line so users discovering specflow via `--help` land on the curated docs first.
- Also drops the `#19` section from `.claude/agents/qa-tester/memory/tracked-findings.md` so the next QA run re-verifies the fix from a fresh-eyes perspective.

**Before:**
```
Docs:  https://github.com/mkrlabs/specflow
```

**After:**
```
Docs:    https://specflow.makerlabs.dev
Source:  https://github.com/mkrlabs/specflow
```

Closes #19.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [x] `deno run --allow-all src/main.ts --help` shows both URLs.
- [ ] Post-merge: next qa-tester dispatch re-verifies the help footer line cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)