### PR TITLE
fix: init next-steps recommends /specflow.specify first (#17)

### DIFF
--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -15,9 +15,9 @@ re-flag a regression on their own).
 
 - [Tracked findings](tracked-findings.md) — symptoms covered by open
   tickets #15 (self-update --check), #16 (init file-count discrepancy),
-  #17 (init next-steps vs docs), #20 (check --project version phrasing).
-  Suppress these in reports until the matching ticket closes. (#18 closed
-  by PR #22, #19 closed by PR for help-docs-url — sections removed; the
+  #20 (check --project version phrasing). Suppress these in reports until
+  the matching ticket closes. (#18 closed by PR #22, #19 closed by PR #24,
+  #17 closed by PR for init-next-steps-align-docs — sections removed; the
   next QA run will re-verify those fixes from a fresh-eyes perspective.)
 
 ## Patterns

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -50,25 +50,6 @@ discrepancy — flag it.
 
 ---
 
-## Issue #17 — init "Next steps" steers users to a different command than the docs quickstart
-
-**Symptom to suppress:** in T3 the init output's "Next steps" section
-ends with `Run /backlog add "<first task title>"`. The docs at
-`specflow.makerlabs.dev/llms.txt` say a fresh user should run
-`/specflow.specify` first. The `/specflow.specify` command IS scaffolded
-at `.claude/commands/specflow.specify.md` — only the init message
-diverges.
-
-**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/17.
-
-**How to apply:** if the init output recommends `/backlog add` as the
-first user-facing action, do not flag. If the init output starts
-recommending `/specflow.specify`, the ticket is fixed — flag a
-"unexpected fix detected, please re-verify by reading docs" reminder
-in the report and stop suppressing.
-
----
-
 ## Issue #20 — `check --project` template-version phrasing reads as if binary is the templates version
 
 **Symptom to suppress:** `specflow check --project` prints a line of the

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -83,6 +83,9 @@ export async function runInit(intent: InitIntent): Promise<number> {
   console.log("\nNext steps:");
   console.log(`  1. Edit ${bold("AGENTS.md")} and ${bold(".specflow/memory/constitution.md")}`);
   console.log(`  2. Open the project in ${harness.displayName}`);
-  console.log(`  3. Run ${bold('/backlog add "<first task title>"')}`);
+  console.log(
+    `  3. Run ${bold('/specflow.specify "<feature description>"')} to scaffold your first feature`,
+  );
+  console.log(`  4. Use ${bold('/backlog add "<task title>"')} for follow-up work`);
   return 0;
 }


### PR DESCRIPTION
## Summary

- Aligns the init handler's `Next steps` output with the docs quickstart at `specflow.makerlabs.dev/llms.txt`, which says a fresh user should run `/specflow.specify` first to scaffold a feature, not `/backlog add`.
- The `/backlog add` command stays mentioned for follow-up work — it's still the right tool for that, just not the first thing to run.
- Drops `#17` from `.claude/agents/qa-tester/memory/tracked-findings.md` so the next QA run re-verifies the fix from a fresh-eyes perspective.

**Before:**
```
3. Run /backlog add "<first task title>"
```

**After:**
```
3. Run /specflow.specify "<feature description>" to scaffold your first feature
4. Use /backlog add "<task title>" for follow-up work
```

Closes #17.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [x] Smoke test: `bash .claude/skills/test-specflow/scripts/run-init.sh smoke-17 claude` → output matches expected.
- [ ] Post-merge: next qa-tester dispatch re-verifies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)