### PR TITLE
fix: clarify check --project templates-version phrasing (#20)

### DIFF
--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -14,11 +14,11 @@ re-flag a regression on their own).
 ## Tracked in backlog (re-flag once the ticket closes)
 
 - [Tracked findings](tracked-findings.md) — symptoms covered by open
-  tickets #15 (self-update --check), #16 (init file-count discrepancy),
-  #20 (check --project version phrasing). Suppress these in reports until
-  the matching ticket closes. (#18 closed by PR #22, #19 closed by PR #24,
-  #17 closed by PR for init-next-steps-align-docs — sections removed; the
-  next QA run will re-verify those fixes from a fresh-eyes perspective.)
+  tickets #15 (self-update --check), #16 (init file-count discrepancy).
+  Suppress these in reports until the matching ticket closes. (#18 closed
+  by PR #22, #19 closed by PR #24, #17 closed by PR #25, #20 closed by
+  PR for check-project-version-phrasing — sections removed; the next QA
+  run will re-verify those fixes from a fresh-eyes perspective.)
 
 ## Patterns
 

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -48,18 +48,3 @@ entry, written but excluded from the collision count).
 the gap grows beyond 1 (e.g. wrote 40 / contains 38), that's a new
 discrepancy — flag it.
 
----
-
-## Issue #20 — `check --project` template-version phrasing reads as if binary is the templates version
-
-**Symptom to suppress:** `specflow check --project` prints a line of the
-form `templates version  ✓ matches binary (X.Y.Z)`, where `X.Y.Z` is the
-templates version. `--version` shows the binary version separately as
-`specflow A.B.C (templates X.Y.Z)`. The two surfaces look like they
-contradict each other.
-
-**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/20.
-
-**How to apply:** if the wording is `matches binary (...)`, do not flag.
-If the wording changes (e.g. `matches bundled (...)`, `lock matches bundled`,
-or split into two lines), the ticket is fixed — stop suppressing.

--- a/src/infrastructure/fs_project_inspector.ts
+++ b/src/infrastructure/fs_project_inspector.ts
@@ -73,7 +73,7 @@ export class FsProjectInspector implements ProjectInspector {
 
   private async checkTemplatesVersion(
     projectDir: string,
-    binaryVersion: string,
+    bundledTemplatesVersion: string,
   ): Promise<CheckOutcome> {
     const path = join(projectDir, ".specflow/installed.lock");
     if (!(await exists(path))) {
@@ -87,18 +87,18 @@ export class FsProjectInspector implements ProjectInspector {
     try {
       const raw = await Deno.readTextFile(path);
       const lock = parseLock(raw);
-      if (lock.templatesVersion === binaryVersion) {
+      if (lock.templatesVersion === bundledTemplatesVersion) {
         return {
           name: "templates version",
           status: "pass",
-          message: `matches binary (${binaryVersion})`,
+          message: `lock matches bundled (${bundledTemplatesVersion})`,
         };
       }
       return {
         name: "templates version",
         status: "warn",
         message:
-          `project on ${lock.templatesVersion}, binary on ${binaryVersion} — run 'specflow upgrade'`,
+          `project on ${lock.templatesVersion}, bundled on ${bundledTemplatesVersion} — run 'specflow upgrade'`,
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -129,7 +129,7 @@ Deno.test("inspect warns when .specflow/config.yml is missing (optional)", async
   );
 });
 
-Deno.test("inspect passes when lock templates_version matches binary", async () => {
+Deno.test("inspect passes when lock templates_version matches bundled", async () => {
   await withProjectDir(
     async (dir) => {
       await Deno.mkdir(join(dir, ".specflow"), { recursive: true });
@@ -150,7 +150,7 @@ entries: {}
   );
 });
 
-Deno.test("inspect warns when lock templates_version differs from binary", async () => {
+Deno.test("inspect warns when lock templates_version differs from bundled", async () => {
   await withProjectDir(
     async (dir) => {
       await Deno.mkdir(join(dir, ".specflow"), { recursive: true });


### PR DESCRIPTION
## Summary

The `matches binary (X.Y.Z)` line in `specflow check --project` was confusing because `(X.Y.Z)` is the templates version, not the binary version. Users running `--version` (which prints `specflow A.B.C (templates X.Y.Z)`) saw the two outputs apparently contradict each other.

Renames the misleading parameter (`binaryVersion` → `bundledTemplatesVersion`) and rephrases both messages:

**Before:**
```
templates version  ✓ matches binary (0.7.0)
templates version  ⚠ project on 0.7.0, binary on 0.7.2 — run 'specflow upgrade'
```

**After:**
```
templates version  ✓ lock matches bundled (0.7.0)
templates version  ⚠ project on 0.7.0, bundled on 0.7.2 — run 'specflow upgrade'
```

Drops `#20` from `.claude/agents/qa-tester/memory/tracked-findings.md` so the next QA run re-verifies. Test descriptions updated to match new wording.

Closes #20.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [x] Smoke test: `bash .claude/skills/test-specflow/scripts/run-init.sh smoke-20 claude && cd test/smoke-20 && deno run --allow-all .../src/main.ts check --project` → outputs `templates version  ✓ lock matches bundled (0.7.0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)