### PR TITLE
fix: differentiate self-update --check from bare self-update in up-to-date path (#15)

### DIFF
--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -14,11 +14,11 @@ re-flag a regression on their own).
 ## Tracked in backlog (re-flag once the ticket closes)
 
 - [Tracked findings](tracked-findings.md) — symptoms covered by open
-  tickets #15 (self-update --check), #16 (init file-count discrepancy).
-  Suppress these in reports until the matching ticket closes. (#18 closed
-  by PR #22, #19 closed by PR #24, #17 closed by PR #25, #20 closed by
-  PR for check-project-version-phrasing — sections removed; the next QA
-  run will re-verify those fixes from a fresh-eyes perspective.)
+  ticket #16 (init file-count discrepancy). Suppress this in reports
+  until the matching ticket closes. (#18 closed by PR #22, #19 closed
+  by PR #24, #17 closed by PR #25, #20 closed by PR #26, #15 closed by
+  PR for self-update-check-differentiate — sections removed; the next
+  QA run will re-verify those fixes from a fresh-eyes perspective.)
 
 ## Patterns
 

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -16,23 +16,6 @@ the fix (no finding) or re-flag a regression.
 
 ---
 
-## Issue #15 — `self-update --check` indistinguishable from bare self-update in up-to-date path
-
-**Symptom to suppress:** running `specflow self-update --check` and
-`specflow self-update` (no flag) on a freshly-init'd or up-to-date project
-both print `✓ already up to date (templates X.Y.Z)` and exit 0. The two
-forms produce identical output in the up-to-date path.
-
-**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/15.
-
-**How to apply:** if T8 (or any other test that probes self-update) sees
-this exact behaviour, count it as expected, do not file a finding. If
-the bare form starts behaving differently from `--check` (e.g. starts
-trying to download in the up-to-date path), that's a regression — flag
-it as a BLOCKER.
-
----
-
 ## Issue #16 — init reports "wrote 39 files" but collision guard says "38 specflow-managed file(s)"
 
 **Symptom to suppress:** in T3 the `specflow init --here --ai claude`

--- a/src/cli/handlers/self_update_handler.ts
+++ b/src/cli/handlers/self_update_handler.ts
@@ -38,7 +38,11 @@ export async function handleSelfUpdate(intent: SelfUpdateIntent): Promise<number
     const result = await useCase.execute({ checkOnly: intent.checkOnly });
     switch (result.status) {
       case "up-to-date":
-        console.log(green(`✓ already up to date (${result.currentVersion})`));
+        if (intent.checkOnly) {
+          console.log(green(`✓ no update available — current ${result.currentVersion}`));
+        } else {
+          console.log(green(`✓ already up to date (${result.currentVersion})`));
+        }
         return 0;
       case "available":
         console.log(


### PR DESCRIPTION
## Summary

Both `specflow self-update --check` and `specflow self-update` (no flag) used to print `✓ already up to date (X.Y.Z)` when no update was available — making `--check` (documented as "reports availability only") indistinguishable from a real (no-op) update from a script's perspective.

**Now:**
```
--check, up-to-date:  ✓ no update available — current X.Y.Z
bare,    up-to-date:  ✓ already up to date (X.Y.Z)   (unchanged)
```

When an update IS available, the two forms already differed (`--check` prints `Run \`specflow self-update\` to install.`, bare proceeds to download) — no change needed there.

Drops `#15` from `.claude/agents/qa-tester/memory/tracked-findings.md` so the next QA run re-verifies.

Closes #15.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [x] Smoke: `deno run --allow-all src/main.ts self-update --check` → "no update available — current 0.7.2"; `deno run --allow-all src/main.ts self-update` → "already up to date (0.7.2)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)