### PR TITLE
fix: split init file count between written and merged (#16)

### DIFF
--- a/.claude/agents/qa-tester/memory/MEMORY.md
+++ b/.claude/agents/qa-tester/memory/MEMORY.md
@@ -13,12 +13,12 @@ re-flag a regression on their own).
 
 ## Tracked in backlog (re-flag once the ticket closes)
 
-- [Tracked findings](tracked-findings.md) — symptoms covered by open
-  ticket #16 (init file-count discrepancy). Suppress this in reports
-  until the matching ticket closes. (#18 closed by PR #22, #19 closed
-  by PR #24, #17 closed by PR #25, #20 closed by PR #26, #15 closed by
-  PR for self-update-check-differentiate — sections removed; the next
-  QA run will re-verify those fixes from a fresh-eyes perspective.)
+- [Tracked findings](tracked-findings.md) — currently empty (no open
+  QA-finding tickets). All six original findings (#15, #17, #18, #19,
+  #20, #16) have shipped: #18 → PR #22, #19 → PR #24, #17 → PR #25,
+  #20 → PR #26, #15 → PR #27, #16 → PR for init-count-mergeable.
+  Sections removed as fixes shipped; the next QA run re-verifies each
+  from a fresh-eyes perspective.
 
 ## Patterns
 

--- a/.claude/agents/qa-tester/memory/tracked-findings.md
+++ b/.claude/agents/qa-tester/memory/tracked-findings.md
@@ -16,18 +16,4 @@ the fix (no finding) or re-flag a regression.
 
 ---
 
-## Issue #16 — init reports "wrote 39 files" but collision guard says "38 specflow-managed file(s)"
-
-**Symptom to suppress:** in T3 the `specflow init --here --ai claude`
-output prints `✓ wrote 39 files`. In T5 the re-init refusal prints
-`target already contains 38 specflow-managed file(s)`. The discrepancy
-of 1 corresponds to `.gitignore` (treated as a `mergeable-project-root`
-entry, written but excluded from the collision count).
-
-**Why suppressed:** tracked in https://github.com/mkrlabs/specflow/issues/16.
-
-**How to apply:** when the difference between T3's "wrote N" and T5's
-"contains N-1 specflow-managed" is exactly 1, treat it as expected. If
-the gap grows beyond 1 (e.g. wrote 40 / contains 38), that's a new
-discrepancy — flag it.
-
+_(currently empty — all six original QA-finding tickets #15, #17, #18, #19, #20, #16 have shipped. Next QA dispatch will re-verify each from a fresh-eyes perspective. Re-add sections here when new tickets get opened for newly-found symptoms.)_

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -8,7 +8,10 @@ import { canonicalBlockBody } from "../domain/merge_block.ts";
 export type InitResult =
   | {
     status: "initialized";
+    /** Count of non-mergeable files written. Matches the collision-guard count. */
     filesWritten: number;
+    /** Paths of mergeable files (e.g. .gitignore) merged into pre-existing user content. */
+    filesMerged: string[];
     warnings: string[];
     backups: string[];
     lockWritten: boolean;
@@ -95,9 +98,20 @@ export class InitProjectUseCase {
       }
     }
 
+    const mergedPaths: string[] = [];
+    let writtenCount = 0;
+    for (const [dest, file] of Object.entries(bundle)) {
+      if (file.mergeBlock !== undefined) {
+        mergedPaths.push(dest);
+      } else {
+        writtenCount++;
+      }
+    }
+
     return {
       status: "initialized",
-      filesWritten: Object.keys(bundle).length,
+      filesWritten: writtenCount,
+      filesMerged: mergedPaths,
       warnings,
       backups: report.backups.map((b) => b.dest),
       lockWritten: true,

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -79,7 +79,10 @@ export async function runInit(intent: InitIntent): Promise<number> {
 
   for (const w of result.warnings) console.error(yellow(`warn: ${w}`));
   for (const b of result.backups) console.log(dim(`↳ backed up ${b} → ${b}.specflow.bak`));
-  console.log(green(`✓ wrote ${result.filesWritten} files`));
+  const mergedSuffix = result.filesMerged.length > 0
+    ? ` (+ merged: ${result.filesMerged.join(", ")})`
+    : "";
+  console.log(green(`✓ wrote ${result.filesWritten} files${mergedSuffix}`));
   console.log("\nNext steps:");
   console.log(`  1. Edit ${bold("AGENTS.md")} and ${bold(".specflow/memory/constitution.md")}`);
   console.log(`  2. Open the project in ${harness.displayName}`);


### PR DESCRIPTION
## Summary

Init was reporting `wrote 39 files` but the re-init collision guard reported `38 specflow-managed file(s)`. The discrepancy of 1 was `.gitignore` being treated as a mergeable entry (written but excluded from the collision count). Both numbers now line up.

**Before:**
```
✓ wrote 39 files
(re-init guard: target already contains 38 specflow-managed file(s))
```

**After:**
```
✓ wrote 38 files (+ merged: .gitignore)
(re-init guard: target already contains 38 specflow-managed file(s))   ← matches
```

`InitResult` now exposes `filesWritten` (non-mergeable count, matches collision logic) and `filesMerged` (paths of mergeable entries merged into pre-existing user content). The handler renders the suffix only when `filesMerged` is non-empty.

Drops `#16` from `.claude/agents/qa-tester/memory/tracked-findings.md` — that file is now empty since all six original QA-finding tickets have shipped.

Closes #16.

## Test plan

- [x] `deno task test` — 318 tests pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [x] Smoke: `bash .claude/skills/test-specflow/scripts/run-init.sh smoke-16 claude` → `✓ wrote 38 files (+ merged: .gitignore)` then re-init → `target already contains 38 specflow-managed file(s)` (matched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)