### PR TITLE
chore: rename test/ scratch dir to sandbox/

### DIFF
--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -132,7 +132,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
   ```bash
   bash .claude/skills/test-specflow/scripts/bootstrap-vite.sh qa-<stamp>
   ```
-- **Expected:** non-zero `test/qa-<stamp>/` with `.gitignore`,
+- **Expected:** non-zero `sandbox/qa-<stamp>/` with `.gitignore`,
   `package.json`, `vite.config.ts`, etc. Original `.gitignore` size is
   in the 200–300 byte range.
 - **Abort-BLOCKER:** script fails or directory missing afterwards.
@@ -146,7 +146,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
   directory (do NOT use `run-init.sh` — that runs `deno run` against
   the working tree, which is not what we're testing).
   ```bash
-  cd test/qa-<stamp> && specflow init --here --no-git --ai claude
+  cd sandbox/qa-<stamp> && specflow init --here --no-git --ai claude
   ```
 - **Expected:** exit 0; stdout includes "Initializing into …" and
   "✓ wrote N files (+ merged: .gitignore)" (N around 38–40); a
@@ -163,7 +163,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
 
 - **Command:**
   ```bash
-  cat test/qa-<stamp>/.gitignore
+  cat sandbox/qa-<stamp>/.gitignore
   ```
 - **Expected:**
   - The original Vite gitignore content (`# Logs`, `node_modules`,
@@ -180,7 +180,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
 
 - **Command:**
   ```bash
-  cd test/qa-<stamp> && specflow init --here --no-git --ai claude
+  cd sandbox/qa-<stamp> && specflow init --here --no-git --ai claude
   ```
 - **Expected:** non-zero exit (currently 3); error names the existing
   files; the count printed (`target already contains N specflow-managed
@@ -208,7 +208,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
 
 - **Command:**
   ```bash
-  cd test/qa-<stamp> && specflow check --project
+  cd sandbox/qa-<stamp> && specflow check --project
   ```
 - **Expected:** identifies `.specflow/` as present; harness as `claude`;
   flags constitution as placeholder; flags `backlog config` as missing
@@ -222,7 +222,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
 - **Commands:**
   ```bash
   specflow --help
-  cd test/qa-<stamp> && specflow upgrade --dry-run
+  cd sandbox/qa-<stamp> && specflow upgrade --dry-run
   specflow self-update --check
   ```
   (`--version` was already captured in T0; no need to re-run.)
@@ -247,7 +247,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
 ## Workflow on every dispatch
 
 1. Pick a stamp: `date -u +%Y%m%d-%H%M%S`. All artefacts live under
-   `test/qa-<stamp>/` and the report at `test/qa-report-<stamp>.md`.
+   `sandbox/qa-<stamp>/` and the report at `sandbox/qa-report-<stamp>.md`.
 2. Pre-read your memory (see "Pre-read" section above).
 3. Run **T0** first — refresh the binary and capture the version. Stop
    the run on abort-BLOCKER (no `specflow` binary on PATH means there's
@@ -266,7 +266,7 @@ abort-BLOCKERs vs finding-BLOCKERs.
 # Specflow QA Report — <ISO timestamp>
 
 **Harness:** claude
-**Scenario:** Vite React-TS brownfield (`test/qa-<stamp>/`)
+**Scenario:** Vite React-TS brownfield (`sandbox/qa-<stamp>/`)
 **Source:** released binary `specflow` on PATH (refreshed via T0)
 **Specflow version under test:** `specflow X.Y.Z (templates A.B.C)` (from T0)
 **Docs:** https://specflow.makerlabs.dev/llms.txt
@@ -338,14 +338,14 @@ abort-BLOCKERs vs finding-BLOCKERs.
 
 - **Do not modify the codebase.** No edits to `src/`, `templates/`,
   `manifest.json`, harness files, or the test-specflow scripts. The
-  only files you write are `test/qa-report-<stamp>.md` and your own
+  only files you write are `sandbox/qa-report-<stamp>.md` and your own
   memory under `.claude/agents/qa-tester/memory/`.
-- **Do not commit anything.** `test/` is gitignored; reports stay
+- **Do not commit anything.** `sandbox/` is gitignored; reports stay
   local. No `git add`, `git commit`, `git push`, `gh pr ...`,
   `gh issue ...`. Reads (`git status`, `git log`, `gh release view`)
   are fine.
 - **Do not delete previous reports.** Multiple runs accumulate as
-  `test/qa-report-*.md` so trends are visible.
+  `sandbox/qa-report-*.md` so trends are visible.
 - **Follow the docs literally.** When reality diverges from docs →
   that's the finding. Don't paper over it by adjusting the command.
 - **Do not read implementation source to explain a bug.** If you need
@@ -406,7 +406,7 @@ index under 200 lines.
 
 ## Scope
 
-Read-only on the codebase. Write-only on `test/qa-report-*.md` and
+Read-only on the codebase. Write-only on `sandbox/qa-report-*.md` and
 your own memory directory. No `git commit|push`, no `gh pr|issue`
 writes, no `gh release create`, no `git tag`. If a question requires
 a destructive command, refuse and say so in the report.

--- a/.claude/skills/test-specflow/SKILL.md
+++ b/.claude/skills/test-specflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-specflow
-description: Spin up controlled test environments (Vite, Next-style brownfield, empty greenfield) under the gitignored `test/` directory and run Specflow against them using the current source tree (not the installed binary). Use whenever you need to manually validate the UX of `specflow init` / `upgrade` / `check` on a real-world project shape, reproduce a brownfield bug, or eyeball cross-harness output side-by-side. Each script is idempotent.
+description: Spin up controlled test environments (Vite, Next-style brownfield, empty greenfield) under the gitignored `sandbox/` directory and run Specflow against them using the current source tree (not the installed binary). Use whenever you need to manually validate the UX of `specflow init` / `upgrade` / `check` on a real-world project shape, reproduce a brownfield bug, or eyeball cross-harness output side-by-side. Each script is idempotent.
 allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*.sh) Bash(${CLAUDE_SKILL_DIR}/scripts/*.sh *) Bash(deno *) Bash(ls *) Bash(find *) Bash(cat *) Bash(diff *) Bash(rm *) Bash(npm *) Bash(git *)
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*.sh) Bash(${CLAUDE_SKILL_DIR}/s
 
 When you need to verify how `specflow init`, `specflow upgrade`, etc. behave on real-world project shapes — without recompiling the binary or installing it system-wide — use this skill.
 
-Each script bootstraps a controlled scenario inside `test/<name>/` (the `test/` dir is gitignored at the repo root, so nothing leaks to commits), then optionally runs Specflow against it from the current source tree (`deno run --allow-all src/main.ts ...`). That way you're testing the working-tree behaviour, not the released binary.
+Each script bootstraps a controlled scenario inside `sandbox/<name>/` (the `sandbox/` dir is gitignored at the repo root, so nothing leaks to commits), then optionally runs Specflow against it from the current source tree (`deno run --allow-all src/main.ts ...`). That way you're testing the working-tree behaviour, not the released binary.
 
 ## When to use
 
@@ -22,9 +22,9 @@ Each script bootstraps a controlled scenario inside `test/<name>/` (the `test/` 
 .claude/skills/test-specflow/scripts/bootstrap-vite.sh <name>      # Vite React-TS scaffold
 .claude/skills/test-specflow/scripts/bootstrap-empty.sh <name>     # empty greenfield (git init + stub package.json)
 .claude/skills/test-specflow/scripts/run-init.sh <name> <harness>  # specflow init --here --ai <harness> (uses current source)
-.claude/skills/test-specflow/scripts/inspect.sh <name>             # summarize specflow output paths in test/<name>/
+.claude/skills/test-specflow/scripts/inspect.sh <name>             # summarize specflow output paths in sandbox/<name>/
 .claude/skills/test-specflow/scripts/compare-harnesses.sh <name>   # bootstrap once + run all 8 harnesses on copies, print summaries
-.claude/skills/test-specflow/scripts/clean.sh [<name>]             # wipe one test dir or the whole test/ tree
+.claude/skills/test-specflow/scripts/clean.sh [<name>]             # wipe one scenario or the whole sandbox/ tree
 ```
 
 `<harness>` ∈ `claude` (default) | `cursor` | `codex` | `gemini` | `windsurf` | `copilot` | `opencode` | `antigravity`.
@@ -37,21 +37,21 @@ Each script bootstraps a controlled scenario inside `test/<name>/` (the `test/` 
 bash .claude/skills/test-specflow/scripts/bootstrap-vite.sh demo
 bash .claude/skills/test-specflow/scripts/run-init.sh demo claude
 bash .claude/skills/test-specflow/scripts/inspect.sh demo
-cat test/demo/.gitignore                       # eyeball the merged result
+cat sandbox/demo/.gitignore                       # eyeball the merged result
 ```
 
 ### Reproduce an issue across all harnesses
 
 ```bash
 bash .claude/skills/test-specflow/scripts/compare-harnesses.sh demo
-ls test/                                       # demo, demo-claude, demo-cursor, …
+ls sandbox/                                       # demo, demo-claude, demo-cursor, …
 ```
 
 ### Reset between runs
 
 ```bash
 bash .claude/skills/test-specflow/scripts/clean.sh demo            # one project
-bash .claude/skills/test-specflow/scripts/clean.sh                 # everything under test/
+bash .claude/skills/test-specflow/scripts/clean.sh                 # everything under sandbox/
 ```
 
 ### Hands-off UX pass — dispatch the QA agent
@@ -61,14 +61,14 @@ running each script yourself, dispatch the `qa-tester` subagent (defined
 at `.claude/agents/qa-tester.md`). It reads the public docs at
 `specflow.makerlabs.dev/llms.txt`, runs Specflow against a clean Vite
 scenario as a brand-new user would, and writes a checklist report to
-`test/qa-report-<stamp>.md` listing every blocker / friction / nit. The
+`sandbox/qa-report-<stamp>.md` listing every blocker / friction / nit. The
 agent never modifies the codebase — it only reports.
 
 ## Conventions
 
-- Test projects always live under `test/<name>/`. The `test/` directory is gitignored at the repo root — never commit anything from it.
+- Sandbox scenarios always live under `sandbox/<name>/`. The `sandbox/` directory is gitignored at the repo root — never commit anything from it.
 - Scripts run `deno run --allow-all` on `src/main.ts` so you're testing the working tree, **not** the installed `specflow` binary. To test the released binary instead, run `specflow` directly without going through this skill.
-- All scripts are idempotent. Re-running is always safe; pre-existing `test/<name>/` is wiped before re-bootstrapping.
+- All scripts are idempotent. Re-running is always safe; pre-existing `sandbox/<name>/` is wiped before re-bootstrapping.
 - Bootstrap scripts skip `npm install` — Specflow's filesystem ops don't depend on `node_modules` being populated, and skipping the install keeps each scenario fast and small.
 
 ## When NOT to use

--- a/.claude/skills/test-specflow/scripts/bootstrap-empty.sh
+++ b/.claude/skills/test-specflow/scripts/bootstrap-empty.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Bootstrap an empty greenfield project under test/<name>/ for Specflow UX
+# Bootstrap an empty greenfield project under sandbox/<name>/ for Specflow UX
 # testing. Stub package.json so it looks like a real (just-created) project.
 # Usage: bootstrap-empty.sh <name>
 set -euo pipefail
 
 NAME="${1:?usage: bootstrap-empty.sh <name>}"
 ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
-TEST_DIR="$ROOT/test/$NAME"
+SANDBOX_DIR="$ROOT/sandbox/$NAME"
 
-rm -rf "$TEST_DIR"
-mkdir -p "$TEST_DIR"
-cd "$TEST_DIR"
+rm -rf "$SANDBOX_DIR"
+mkdir -p "$SANDBOX_DIR"
+cd "$SANDBOX_DIR"
 git init -q
 cat >package.json <<EOF
 {
@@ -20,4 +20,4 @@ cat >package.json <<EOF
 }
 EOF
 
-echo "✓ bootstrapped empty greenfield project at test/$NAME/"
+echo "✓ bootstrapped empty greenfield project at sandbox/$NAME/"

--- a/.claude/skills/test-specflow/scripts/bootstrap-vite.sh
+++ b/.claude/skills/test-specflow/scripts/bootstrap-vite.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bootstrap a Vite React-TS project under test/<name>/ for Specflow UX testing.
+# Bootstrap a Vite React-TS project under sandbox/<name>/ for Specflow UX testing.
 # Skips `npm install` — deps are not needed to test specflow's filesystem ops,
 # and skipping keeps the scenario fast and small.
 # Usage: bootstrap-vite.sh <name>
@@ -7,13 +7,13 @@ set -euo pipefail
 
 NAME="${1:?usage: bootstrap-vite.sh <name>}"
 ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
-TEST_DIR="$ROOT/test/$NAME"
+SANDBOX_DIR="$ROOT/sandbox/$NAME"
 
-rm -rf "$TEST_DIR"
-mkdir -p "$ROOT/test"
-cd "$ROOT/test"
+rm -rf "$SANDBOX_DIR"
+mkdir -p "$ROOT/sandbox"
+cd "$ROOT/sandbox"
 
 npm create vite@latest "$NAME" -- --template react-ts >/dev/null
 
-echo "✓ bootstrapped Vite React-TS at test/$NAME/"
+echo "✓ bootstrapped Vite React-TS at sandbox/$NAME/"
 echo "  (skipped npm install — not needed for specflow UX tests)"

--- a/.claude/skills/test-specflow/scripts/clean.sh
+++ b/.claude/skills/test-specflow/scripts/clean.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Wipe a single test scenario or the entire test/ tree.
+# Wipe a single sandbox scenario or the entire sandbox/ tree.
 # Usage:
-#   clean.sh           # removes the whole test/ tree
-#   clean.sh <name>    # removes just test/<name>/
+#   clean.sh           # removes the whole sandbox/ tree
+#   clean.sh <name>    # removes just sandbox/<name>/
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
 
 if [ $# -eq 0 ]; then
-  rm -rf "$ROOT/test"
-  echo "✓ wiped test/"
+  rm -rf "$ROOT/sandbox"
+  echo "✓ wiped sandbox/"
 else
-  rm -rf "$ROOT/test/$1"
-  echo "✓ removed test/$1"
+  rm -rf "$ROOT/sandbox/$1"
+  echo "✓ removed sandbox/$1"
 fi

--- a/.claude/skills/test-specflow/scripts/compare-harnesses.sh
+++ b/.claude/skills/test-specflow/scripts/compare-harnesses.sh
@@ -14,8 +14,8 @@ bash "$SCRIPT_DIR/bootstrap-vite.sh" "$NAME"
 
 for h in "${HARNESSES[@]}"; do
   variant="$NAME-$h"
-  rm -rf "$ROOT/test/$variant"
-  cp -R "$ROOT/test/$NAME" "$ROOT/test/$variant"
+  rm -rf "$ROOT/sandbox/$variant"
+  cp -R "$ROOT/sandbox/$NAME" "$ROOT/sandbox/$variant"
   echo
   echo "=== init --ai $h ==="
   bash "$SCRIPT_DIR/run-init.sh" "$variant" "$h"

--- a/.claude/skills/test-specflow/scripts/inspect.sh
+++ b/.claude/skills/test-specflow/scripts/inspect.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# Summarize the specflow-output paths inside test/<name>/.
+# Summarize the specflow-output paths inside sandbox/<name>/.
 # Usage: inspect.sh <name>
 set -euo pipefail
 
 NAME="${1:?usage: inspect.sh <name>}"
 ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
-TEST_DIR="$ROOT/test/$NAME"
+SANDBOX_DIR="$ROOT/sandbox/$NAME"
 
-if [ ! -d "$TEST_DIR" ]; then
-  echo "error: test/$NAME does not exist" >&2
+if [ ! -d "$SANDBOX_DIR" ]; then
+  echo "error: sandbox/$NAME does not exist" >&2
   exit 1
 fi
 
-cd "$TEST_DIR"
+cd "$SANDBOX_DIR"
 
-echo "=== test/$NAME ==="
+echo "=== sandbox/$NAME ==="
 for path in .claude .cursor .codex .gemini .windsurf .opencode .agent .agents \
   .github/instructions .specflow tasks AGENTS.md CLAUDE.md .gitignore; do
   if [ -e "$path" ]; then

--- a/.claude/skills/test-specflow/scripts/run-init.sh
+++ b/.claude/skills/test-specflow/scripts/run-init.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run `specflow init --here --no-git --ai <harness>` against test/<name>/ using
+# Run `specflow init --here --no-git --ai <harness>` against sandbox/<name>/ using
 # the current source tree (deno run on src/main.ts) — NOT the installed binary.
 # That way you're validating what's on the working branch.
 # Usage: run-init.sh <name> <harness>
@@ -8,12 +8,12 @@ set -euo pipefail
 NAME="${1:?usage: run-init.sh <name> <harness>}"
 HARNESS="${2:?usage: run-init.sh <name> <harness>}"
 ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
-TEST_DIR="$ROOT/test/$NAME"
+SANDBOX_DIR="$ROOT/sandbox/$NAME"
 
-if [ ! -d "$TEST_DIR" ]; then
-  echo "error: test/$NAME does not exist — run bootstrap-vite.sh or bootstrap-empty.sh first" >&2
+if [ ! -d "$SANDBOX_DIR" ]; then
+  echo "error: sandbox/$NAME does not exist — run bootstrap-vite.sh or bootstrap-empty.sh first" >&2
   exit 1
 fi
 
-cd "$TEST_DIR"
+cd "$SANDBOX_DIR"
 deno run --allow-all "$ROOT/src/main.ts" init --here --no-git --ai "$HARNESS"

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ node_modules/
 /tmp/
 spec-kit/
 .claude/scheduled_tasks.lock
-test/
+sandbox/
 docs-dist/


### PR DESCRIPTION
## Summary

Disambiguates against `tests/` (the actual unit/integration test suite). The gitignored scratch directory used by the `test-specflow` skill and the `qa-tester` agent — where Vite/empty/brownfield scenarios get bootstrapped and where QA reports land — is now `sandbox/`.

Same purpose, same gitignore, same ephemerality. Just a path token rename.

## Why

`tests/` (with S) holds the real Deno test suite, layered to mirror `src/`. `test/` (no S) was an ephemeral scratch directory for manual UX validation. The two had nothing in common but the name, and "is it `test/` or `tests/`?" was a recurring source of confusion. `sandbox/` reads as throwaway-by-design and pairs cleanly with `tests/`.

## What changed

- `.gitignore` — `test/` → `sandbox/`
- `.claude/skills/test-specflow/SKILL.md` — every `test/<name>/` reference becomes `sandbox/<name>/`; minor prose tweaks ("Test projects always live under" → "Sandbox scenarios always live under").
- `.claude/skills/test-specflow/scripts/{bootstrap-empty,bootstrap-vite,inspect,run-init,clean,compare-harnesses}.sh` — `TEST_DIR` → `SANDBOX_DIR`, every path string updated, comments brought in line.
- `.claude/agents/qa-tester.md` — every workflow step + the report schema now points at `sandbox/`.

No product code touched. The skill name (`test-specflow`) stays — it's about testing Specflow, the sandbox is just the workspace it uses.

## Test plan

- [x] `deno task test` — 333 passed / 0 failed.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.
- [x] `git grep test/` returns no remaining hits in skill/agent/scripts/gitignore (excluding `tests/`).
- [ ] Next qa-tester dispatch will exercise the renamed paths end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)