### PR TITLE
feat: move CLAUDE.md into .claude/ (#34)

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5667,7 +5667,7 @@ _No tasks yet._
 
 export const HARNESS_STATIC: Record<string, Record<string, TemplateFile>> = {
   "claude": {
-    "CLAUDE.md": {
+    ".claude/CLAUDE.md": {
       content: `# Claude Reference
 
 - **Project documentation and rules**: the primary reference is \`AGENTS.md\` at

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -45,7 +45,7 @@
     { "category": "mergeable-project-root", "name": "root", "suffix": ".gitignore", "source": "core/root/.gitignore" }
   ],
   "harness_static": [
-    { "harness": "claude", "destination": "CLAUDE.md", "source": "harness-specific/claude/CLAUDE.md" },
+    { "harness": "claude", "destination": ".claude/CLAUDE.md", "source": "harness-specific/claude/CLAUDE.md" },
     { "harness": "cursor", "destination": ".cursor/rules/specify-rules.mdc", "source": "harness-specific/cursor/specify-rules.mdc" }
   ]
 }

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -12,7 +12,7 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
   const mapped = h.mapBundle(CORE_BUNDLE);
   const keys = Object.keys(mapped).sort();
-  assertEquals(keys.length, 39); // 38 core + CLAUDE.md
+  assertEquals(keys.length, 39); // 38 core + .claude/CLAUDE.md
   // Spot-check canonical paths
   assert(".claude/commands/specflow.specify.md" in mapped);
   assert(".claude/commands/backlog.md" in mapped);
@@ -20,13 +20,14 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   assert(".claude/skills/auto-chain/SKILL.md" in mapped);
   assert(".specflow/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
-  assert("CLAUDE.md" in mapped);
+  assert(".claude/CLAUDE.md" in mapped);
+  assert(!("CLAUDE.md" in mapped), "CLAUDE.md must not live at project root");
 });
 
-Deno.test("ClaudeHarness includes HARNESS_STATIC claude files (CLAUDE.md)", () => {
+Deno.test("ClaudeHarness includes HARNESS_STATIC claude files (.claude/CLAUDE.md)", () => {
   const h = new ClaudeHarness();
   const mapped = h.mapBundle(CORE_BUNDLE);
-  const claudeMd = mapped["CLAUDE.md"];
-  const staticClaude = HARNESS_STATIC.claude["CLAUDE.md"];
+  const claudeMd = mapped[".claude/CLAUDE.md"];
+  const staticClaude = HARNESS_STATIC.claude[".claude/CLAUDE.md"];
   assertEquals(claudeMd?.content, staticClaude?.content);
 });

--- a/tests/integration/init_cursor_test.ts
+++ b/tests/integration/init_cursor_test.ts
@@ -82,7 +82,8 @@ Deno.test("specflow init (no --ai) still defaults to Claude", async () => {
     assertEquals(code, 0);
     const root = join(parent, "demo");
     assertEquals(await exists(join(root, ".claude/")), true);
-    assertEquals(await exists(join(root, "CLAUDE.md")), true);
+    assertEquals(await exists(join(root, ".claude/CLAUDE.md")), true);
+    assertEquals(await exists(join(root, "CLAUDE.md")), false);
     assertEquals(await exists(join(root, ".cursor/")), false);
   });
 });

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -45,7 +45,8 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
     assertEquals(code, 0, `init failed: ${stderr}`);
 
     const root = join(dir, "demo");
-    assertEquals(await exists(join(root, "CLAUDE.md")), true);
+    assertEquals(await exists(join(root, ".claude/CLAUDE.md")), true);
+    assertEquals(await exists(join(root, "CLAUDE.md")), false);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), true);
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
@@ -71,7 +72,8 @@ Deno.test("specflow init --here writes into cwd", async () => {
   await withTempDir(async (dir) => {
     const { code, stderr } = await runSpecflow(["init", "--here", "--no-git"], { cwd: dir });
     assertEquals(code, 0, `init --here failed: ${stderr}`);
-    assertEquals(await exists(join(dir, "CLAUDE.md")), true);
+    assertEquals(await exists(join(dir, ".claude/CLAUDE.md")), true);
+    assertEquals(await exists(join(dir, "CLAUDE.md")), false);
   });
 });
 


### PR DESCRIPTION
## Summary

- The Claude harness used to write `CLAUDE.md` at the project root **and** `.claude/{commands,agents,skills}` next to it, which left two top-level files (`AGENTS.md` + `CLAUDE.md`) where the second one is essentially a 7-line redirect.
- Claude Code natively auto-discovers `.claude/CLAUDE.md`, so we move the redirect under `.claude/`. The root keeps only `AGENTS.md` — the cross-harness "constitution" file.
- One-line manifest change + bundle regeneration. No application code touched.

## Migration

Handled implicitly by the existing upgrade-plan logic in `src/domain/upgrade_plan.ts`:
- Old root `CLAUDE.md` becomes an orphan lock entry → auto-removed if untouched, preserved if user-customized (standard managed-files contract).
- New `.claude/CLAUDE.md` is added as `add-new`.

## Refs

> **Project-level:** `CLAUDE.md` or `.claude/CLAUDE.md` in your working directory
> — https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts

## Test plan

- [x] Unit + integration tests updated and green (`deno task test` — 333 passed).
- [x] E2E sandbox: bootstrap Vite project + `specflow init --here --ai claude` from working tree → `.claude/CLAUDE.md` present, root `CLAUDE.md` absent, `AGENTS.md` intact, content unchanged.
- [ ] CI green on macOS / Ubuntu / Windows cross-smoke.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)