### PR TITLE
fix(check): don't crash when deno (or git/gh) missing from PATH

### DIFF
--- a/src/infrastructure/deno_environment_probe.ts
+++ b/src/infrastructure/deno_environment_probe.ts
@@ -43,7 +43,7 @@ export class DenoEnvironmentProbe implements EnvironmentProbe {
       return {
         name: "deno",
         status: "warn",
-        message: "deno not in PATH (optional — only needed for dev)",
+        message: "deno not found in PATH (optional — only needed for Specflow development)",
       };
     }
     const v = extractVersion(res.stdout) ?? "unknown";

--- a/src/infrastructure/deno_subprocess.ts
+++ b/src/infrastructure/deno_subprocess.ts
@@ -15,17 +15,26 @@ export class DenoSubprocessRunner implements SubprocessRunner {
       stderr: "piped",
     });
 
-    const child = p.spawn();
-    if (opts?.stdin) {
-      const writer = child.stdin.getWriter();
-      await writer.write(new TextEncoder().encode(opts.stdin));
-      await writer.close();
+    try {
+      const child = p.spawn();
+      if (opts?.stdin) {
+        const writer = child.stdin.getWriter();
+        await writer.write(new TextEncoder().encode(opts.stdin));
+        await writer.close();
+      }
+      const { code, stdout, stderr } = await child.output();
+      return {
+        code,
+        stdout: new TextDecoder().decode(stdout),
+        stderr: new TextDecoder().decode(stderr),
+      };
+    } catch (err) {
+      // Binary missing from PATH: return a synthetic 127 instead of throwing,
+      // so probes (probeGit/probeGh/probeDeno) can render a clean check row.
+      if (err instanceof Deno.errors.NotFound) {
+        return { code: 127, stdout: "", stderr: `${cmd}: command not found` };
+      }
+      throw err;
     }
-    const { code, stdout, stderr } = await child.output();
-    return {
-      code,
-      stdout: new TextDecoder().decode(stdout),
-      stderr: new TextDecoder().decode(stderr),
-    };
   }
 }

--- a/tests/infrastructure/deno_environment_probe_test.ts
+++ b/tests/infrastructure/deno_environment_probe_test.ts
@@ -76,4 +76,8 @@ Deno.test("probeDeno returns warn when missing (not required)", async () => {
   const probe = new DenoEnvironmentProbe(runner);
   const outcome = await probe.probeDeno();
   assertEquals(outcome.status, "warn");
+  assertEquals(
+    outcome.message,
+    "deno not found in PATH (optional — only needed for Specflow development)",
+  );
 });

--- a/tests/infrastructure/deno_subprocess_test.ts
+++ b/tests/infrastructure/deno_subprocess_test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "@std/assert";
+import { DenoSubprocessRunner } from "../../src/infrastructure/deno_subprocess.ts";
+
+Deno.test("DenoSubprocessRunner returns code 127 (not throw) when binary is missing", async () => {
+  const runner = new DenoSubprocessRunner();
+  const result = await runner.run("specflow-this-binary-does-not-exist-xyz", ["--version"]);
+  assertEquals(result.code, 127);
+  assertEquals(result.stdout, "");
+  assertEquals(result.stderr.includes("command not found"), true);
+});
+
+Deno.test("DenoSubprocessRunner returns real exit code when binary exists", async () => {
+  // `true` is POSIX-standard; on Windows CI we'd skip — but specflow is Unix-first.
+  const runner = new DenoSubprocessRunner();
+  const result = await runner.run("true", []);
+  assertEquals(result.code, 0);
+});


### PR DESCRIPTION
## Summary

- `Deno.Command.spawn()` throws `Deno.errors.NotFound` when the binary is missing — it never returns a non-zero exit code. Result: a user running the compiled `specflow` binary on a machine without Deno gets an uncaught `NotFound` exception from `specflow check` instead of a clean `warn` row.
- Catch `NotFound` in `DenoSubprocessRunner` and synthesise a `code: 127` result so all three probes (`probeGit` / `probeGh` / `probeDeno`) render their normal `fail`/`warn` paths. Fix at the runner level so any future probe benefits too.
- Tighten `probeDeno`'s message wording per #39 AC: `deno not found in PATH (optional — only needed for Specflow development)`.

Closes #39.

## Test plan

- [x] Existing `deno_environment_probe_test.ts` updated to assert the exact AC message wording for `probeDeno`.
- [x] New `deno_subprocess_test.ts` regression test: running a non-existent binary returns `{ code: 127, stderr: "...command not found" }` instead of throwing.
- [x] All 341 tests green locally (`deno task test`).
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)