### PR TITLE
feat(help): advertise -v and -h shortcuts in usage block

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -14,8 +14,8 @@ ${bold("Usage:")}
   specflow check [--project]         Diagnose the environment (and optionally the project)
   specflow upgrade [--dry-run] [--force]
                                      Update project templates to the binary's version
-  specflow --version                  Print version
-  specflow --help                     Show this help
+  specflow --version, -v              Print version
+  specflow --help, -h                 Show this help
 
 ${bold("Flags (for init):")}
   --here         Scaffold into the current directory instead of creating a new one

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -100,11 +100,31 @@ Deno.test("specflow --version prints semver line", async () => {
   assertStringIncludes(stdout, "templates ");
 });
 
+Deno.test("specflow -v matches --version", async () => {
+  const long = await runSpecflow(["--version"]);
+  const short = await runSpecflow(["-v"]);
+  assertEquals(short.code, 0);
+  assertEquals(short.stdout, long.stdout);
+});
+
 Deno.test("specflow --help prints usage", async () => {
   const { code, stdout } = await runSpecflow(["--help"]);
   assertEquals(code, 0);
   assertStringIncludes(stdout, "Usage:");
   assertStringIncludes(stdout, "specflow init");
+});
+
+Deno.test("specflow -h matches --help", async () => {
+  const long = await runSpecflow(["--help"]);
+  const short = await runSpecflow(["-h"]);
+  assertEquals(short.code, 0);
+  assertEquals(short.stdout, long.stdout);
+});
+
+Deno.test("specflow --help advertises -v and -h shortcuts", async () => {
+  const { stdout } = await runSpecflow(["--help"]);
+  assertStringIncludes(stdout, "--version, -v");
+  assertStringIncludes(stdout, "--help, -h");
 });
 
 Deno.test("specflow bogus returns exit code 2", async () => {


### PR DESCRIPTION
## Summary

- The aliases `-v`/`-h` for `--version`/`--help` were already wired in `src/cli/parser.ts` (line 52: `alias: { v: 'version', h: 'help' }`) but invisible in the help output.
- Update `src/cli/help.ts` to surface them — `--version, -v` and `--help, -h` — making them discoverable per Unix convention.
- No parser changes; functionality was already present.

Closes #40.

## Test plan

- [x] New integration tests: `specflow -v` and `specflow -h` produce identical output to their long forms.
- [x] New integration test: `specflow --help` advertises both shortcuts in the usage block.
- [x] All 344 tests green locally (`deno task test`).
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)