### PR TITLE
feat(help): drop spec-kit from the help tagline

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -2,7 +2,7 @@ import { bold, cyan, dim } from "@std/fmt/colors";
 
 export const HELP = `${
   bold("specflow")
-} — improved spec-kit CLI with auto-chain, review, and backlog
+} — AI project scaffolding CLI with auto-chain, review, and backlog
 
 ${bold("Usage:")}
   specflow init <project-name>        Bootstrap a new project in ./<project-name>

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -127,6 +127,16 @@ Deno.test("specflow --help advertises -v and -h shortcuts", async () => {
   assertStringIncludes(stdout, "--help, -h");
 });
 
+Deno.test("specflow --help tagline does not mention spec-kit", async () => {
+  const { stdout } = await runSpecflow(["--help"]);
+  assertStringIncludes(stdout, "AI project scaffolding CLI");
+  assertEquals(
+    stdout.toLowerCase().includes("spec-kit"),
+    false,
+    "help tagline must not mention spec-kit (lineage belongs in README/AGENTS.md)",
+  );
+});
+
 Deno.test("specflow bogus returns exit code 2", async () => {
   const { code } = await runSpecflow(["bogus"]);
   assertEquals(code, 2);


### PR DESCRIPTION
## Summary

- The `specflow --help` tagline used to read *"improved spec-kit CLI with auto-chain, review, and backlog"*. New users who don't know spec-kit found it confusing — Specflow is its own product, and the lineage belongs in `README.md`/`AGENTS.md`, not in the runtime CLI surface.
- New tagline: *"AI project scaffolding CLI with auto-chain, review, and backlog"*.
- Audited `src/` and `templates/` for other user-facing mentions. Internal script comments in `templates/.../common.sh` and the lineage line in the cursor `specify-rules.mdc` match the README/AGENTS.md exclusion (lineage docs, not CLI output) and were left untouched per AC.

Closes #41.

## Test plan

- [x] New integration test asserts the new tagline is present **and** that `spec-kit` no longer appears anywhere in the `--help` output.
- [x] All 345 tests green locally (`deno task test`).
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)