### PR TITLE
docs: explain installed.lock + recommend committing it

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -74,6 +74,19 @@ Specflow merges its `.gitignore` block into your existing file (non-destructivel
 `# --- Specflow: gitignore ---` markers). Other specflow-managed files use upgrade-aware semantics:
 if you customize a generated file, `specflow upgrade` will preserve it unless you pass `--force`.
 
+### What's in `.specflow/installed.lock` and should I commit it?
+
+`specflow init` writes a small YAML file at `.specflow/installed.lock`. It records the harness you
+chose, the templates version installed, and a SHA-256 + install timestamp for every file Specflow
+emitted. It contains no secrets — only file paths, content hashes, and version strings.
+
+**Commit it.** `specflow upgrade` reads this lock to know which harness to map templates to, to
+detect files you have customized (so it doesn't clobber them), and to drop orphaned files that are
+no longer part of the bundle. `specflow check --project` also surfaces the harness and templates
+version from this file. Without the lock, both commands degrade gracefully but cannot do their real
+job — `specflow upgrade` will refuse and ask you to re-run `specflow init --here --force` to rebuild
+the lock from scratch.
+
 ### Pick a different harness
 
 ```bash


### PR DESCRIPTION
## Summary

Investigation outcome for #46. The `.specflow/installed.lock` file is essential — `specflow upgrade` cannot work without it (harness key resolution, per-file SHA diffing for customisation detection, orphan removal), and `specflow check --project` reads it to surface harness + templates version. Contains zero secrets. Should be committed.

Adds a short subsection to the public docs (`docs/llms.md`) so users running into the file have an answer without having to read the source. No code change required.

### Investigation summary

| Question | Answer |
|---|---|
| Written by | `InitProjectUseCase` (`src/application/init_project.ts`) |
| Read by | `UpgradeProjectUseCase` (`src/application/upgrade_project.ts`); `FsProjectInspector` (`src/infrastructure/fs_project_inspector.ts`) |
| Stores | format version, harness key, templates version, per-file `{ sha256, installed_at, templates_version }` |
| Commit it? | Yes — required across teammates' machines for `specflow upgrade` to work |
| Without it | `specflow upgrade` refuses with clear message; `specflow check --project` shows graceful warn row |

### Verdict

Keep as-is. No follow-up issue. No code change needed.

Closes #46.

## Test plan

- [x] `deno task test` green (345 passed) — includes `build_docs_test` which re-renders the modified `llms.md`.
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)