### PR TITLE
feat(init): nudge users toward /specflow.constitution as step 1

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -60,8 +60,17 @@ cd my-project
 ```
 
 This scaffolds a tree configured for the **Claude Code** harness by default (`.claude/`,
-`.specflow/`, `AGENTS.md`, `tasks/backlog.md`, …). Open the project in your harness and run the
-`/specflow.specify` slash-command to start your first feature.
+`.specflow/`, `AGENTS.md`, `tasks/backlog.md`, …). Open the project in your harness — that's where
+you'll run the rest.
+
+### Step 1 after `init`: run `/specflow.constitution`
+
+`/specflow.constitution` is the expected first action after `specflow init`. It scaffolds your
+project's guiding principles (architecture, quality gates, ways of working) into
+`.specflow/memory/constitution.md` so the rest of the pipeline (`/specflow.specify`,
+`/specflow.plan`, `/specflow.tasks`, `/specflow.implement`) has something to anchor on. Refine the
+generated constitution and the root `AGENTS.md` for your stack, then move on to
+`/specflow.specify "<feature description>"` for your first feature.
 
 ### Add Specflow to an existing project
 

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -88,8 +88,16 @@ export async function runInit(intent: InitIntent): Promise<number> {
     : "";
   console.log(green(`✓ wrote ${result.filesWritten} files${mergedSuffix}`));
   console.log("\nNext steps:");
-  console.log(`  1. Edit ${bold("AGENTS.md")} and ${bold(".specflow/memory/constitution.md")}`);
-  console.log(`  2. Open the project in ${harness.displayName}`);
+  console.log(
+    `  1. Open the project in ${harness.displayName}, then run ${
+      bold("/specflow.constitution")
+    } to scaffold your project's guiding principles`,
+  );
+  console.log(
+    `  2. Edit ${bold("AGENTS.md")} and refine ${
+      bold(".specflow/memory/constitution.md")
+    } for your stack`,
+  );
   console.log(
     `  3. Run ${bold('/specflow.specify "<feature description>"')} to scaffold your first feature`,
   );

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -69,6 +69,23 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
   });
 });
 
+Deno.test("specflow init's Next steps nudges towards /specflow.constitution first", async () => {
+  await withTempDir(async (dir) => {
+    const { code, stdout } = await runSpecflow(["init", "demo", "--no-git"], { cwd: dir });
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, "Next steps:");
+    assertStringIncludes(stdout, "/specflow.constitution");
+    // The constitution step must come before /specflow.specify in the rendered list.
+    const constitutionIdx = stdout.indexOf("/specflow.constitution");
+    const specifyIdx = stdout.indexOf("/specflow.specify");
+    assertEquals(
+      constitutionIdx > 0 && constitutionIdx < specifyIdx,
+      true,
+      "constitution step must precede specify step in Next steps",
+    );
+  });
+});
+
 Deno.test("specflow init --here writes into cwd", async () => {
   await withTempDir(async (dir) => {
     const { code, stderr } = await runSpecflow(["init", "--here", "--no-git"], { cwd: dir });


### PR DESCRIPTION
## Summary

- The post-init "Next steps" message used to tell users to edit `constitution.md` by hand. Users skipped it, then wondered why their setup felt incomplete.
- Reword step 1 to instruct running `/specflow.constitution` first — that's the slash-command that actually scaffolds the project's guiding principles. Manual refinement of `AGENTS.md` / `constitution.md` becomes step 2.
- Also add a "Step 1 after `init`" subsection in the public docs (`docs/llms.md`) so users who don't read the CLI output (or land on the docs first) get the same expectation.

Closes #42.

### Before / after — `specflow init` "Next steps" block

**Before**

```
Next steps:
  1. Edit AGENTS.md and .specflow/memory/constitution.md
  2. Open the project in Claude Code
  3. Run /specflow.specify "<feature description>" to scaffold your first feature
  4. Use /backlog add "<task title>" for follow-up work
```

**After**

```
Next steps:
  1. Open the project in Claude Code, then run /specflow.constitution to scaffold your project's guiding principles
  2. Edit AGENTS.md and refine .specflow/memory/constitution.md for your stack
  3. Run /specflow.specify "<feature description>" to scaffold your first feature
  4. Use /backlog add "<task title>" for follow-up work
```

## Test plan

- [x] New integration test asserts the post-init stdout mentions `/specflow.constitution` and that it precedes `/specflow.specify` in the rendered list.
- [x] All 346 tests green locally (`deno task test`).
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)