### PR TITLE
refactor(backlog): move local Markdown backlog under .specflow/

### DIFF
--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -1,4 +1,5 @@
-import { resolve } from "@std/path";
+import { join, resolve } from "@std/path";
+import { exists } from "@std/fs/exists";
 import { bold, cyan, dim, green, red, yellow } from "@std/fmt/colors";
 import { UpgradeProjectUseCase } from "../../application/upgrade_project.ts";
 import { findHarness } from "../harnesses.ts";
@@ -8,6 +9,48 @@ import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
 import { CORE_BUNDLE, TEMPLATES_VERSION } from "../../templates_bundle.ts";
 import { renderUnifiedDiff } from "../../domain/diff.ts";
 import type { UpgradePlan } from "../../domain/upgrade_plan.ts";
+
+/**
+ * One-shot migration for projects that pre-date #45. Move
+ * `tasks/backlog.md` and `tasks/backlog/` (the old local-Markdown
+ * backlog locations) into `.specflow/`. Idempotent: if the new path
+ * already exists, the old one is left alone (the user must resolve
+ * the conflict manually).
+ */
+export async function migrateLegacyBacklogPaths(
+  projectDir: string,
+): Promise<ReadonlyArray<string>> {
+  const moves: string[] = [];
+
+  const oldIndex = join(projectDir, "tasks/backlog.md");
+  const newIndex = join(projectDir, ".specflow/backlog.md");
+  if ((await exists(oldIndex)) && !(await exists(newIndex))) {
+    await Deno.mkdir(join(projectDir, ".specflow"), { recursive: true });
+    await Deno.rename(oldIndex, newIndex);
+    moves.push("tasks/backlog.md → .specflow/backlog.md");
+  }
+
+  const oldDir = join(projectDir, "tasks/backlog");
+  const newDir = join(projectDir, ".specflow/backlog");
+  if ((await exists(oldDir)) && !(await exists(newDir))) {
+    await Deno.mkdir(join(projectDir, ".specflow"), { recursive: true });
+    await Deno.rename(oldDir, newDir);
+    moves.push("tasks/backlog/ → .specflow/backlog/");
+  }
+
+  // Tidy up: drop the empty `tasks/` dir if Specflow was its only tenant.
+  const tasksDir = join(projectDir, "tasks");
+  if (await exists(tasksDir)) {
+    let empty = true;
+    for await (const _ of Deno.readDir(tasksDir)) {
+      empty = false;
+      break;
+    }
+    if (empty) await Deno.remove(tasksDir);
+  }
+
+  return moves;
+}
 
 export type UpgradeIntent = {
   kind: "upgrade";
@@ -66,6 +109,11 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
 
 export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
   const projectDir = resolve(Deno.cwd());
+
+  if (!intent.dryRun) {
+    const moves = await migrateLegacyBacklogPaths(projectDir);
+    for (const m of moves) console.log(dim(`↳ migrated ${m}`));
+  }
 
   const useCase = new UpgradeProjectUseCase({
     reader: new DenoFsReader(),

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -1732,9 +1732,14 @@ description: Manage the product backlog — list, add, update, groom, and brief 
 ## Backlog storage
 
 The product-owner agent reads and writes the backlog directly to whichever
-backend the project uses (local Markdown files, GitHub Issues + Project V2,
-GitLab, etc.). The CLI does not push or pull on its own; the agent is
-responsible for talking to the backend.
+backend the project uses. When the backend is local Markdown:
+
+- Index: \`.specflow/backlog.md\`
+- Task files: \`.specflow/backlog/NNN-slug.md\`
+
+When the backend is remote (GitHub Issues + Project V2, GitLab, etc.) the
+agent talks to that backend directly — the CLI does not push or pull on
+its own.
 
 ## Frontmatter schema (used when the backend is local Markdown)
 
@@ -2528,6 +2533,65 @@ them resume manually from the last completed phase.
 ## Principles
 
 (none defined yet)
+`,
+    executable: false,
+  },
+  {
+    category: "spec-root",
+    name: "specify",
+    suffix: "backlog.md",
+    content: `# Backlog
+
+> Managed by the Product Owner agent (\`/backlog\`). Each task lives in
+> \`.specflow/backlog/NNN-slug.md\` with structured frontmatter.
+
+## Scoring
+
+- **Complexity**: Fibonacci (1, 2, 3, 5, 8, 13, 21) — story points
+- **Priority**: critical > high > medium > low
+- **Status**: \`todo\` | \`in_progress\` | \`done\` | \`deferred\` | \`blocked\`
+
+---
+
+## Critical
+
+_No tasks yet._
+
+## High Priority
+
+_No tasks yet._
+
+## Medium Priority
+
+_No tasks yet._
+
+## Low Priority
+
+_No tasks yet._
+
+## Deferred
+
+_No tasks yet._
+
+## Done
+
+_No tasks yet._
+
+---
+
+## Summary
+
+| Metric             | Value |
+|--------------------|-------|
+| Total tasks        | 0     |
+| Critical           | 0     |
+| High               | 0     |
+| Medium             | 0     |
+| Low                | 0     |
+| Deferred           | 0     |
+| Done               | 0     |
+| Total story points | 0     |
+| Done points        | 0     |
 `,
     executable: false,
   },

--- a/templates/core/commands/backlog.md
+++ b/templates/core/commands/backlog.md
@@ -36,9 +36,14 @@ $ARGUMENTS
 ## Backlog storage
 
 The product-owner agent reads and writes the backlog directly to whichever
-backend the project uses (local Markdown files, GitHub Issues + Project V2,
-GitLab, etc.). The CLI does not push or pull on its own; the agent is
-responsible for talking to the backend.
+backend the project uses. When the backend is local Markdown:
+
+- Index: `.specflow/backlog.md`
+- Task files: `.specflow/backlog/NNN-slug.md`
+
+When the backend is remote (GitHub Issues + Project V2, GitLab, etc.) the
+agent talks to that backend directly — the CLI does not push or pull on
+its own.
 
 ## Frontmatter schema (used when the backend is local Markdown)
 

--- a/templates/core/specflow/backlog.md
+++ b/templates/core/specflow/backlog.md
@@ -1,0 +1,52 @@
+# Backlog
+
+> Managed by the Product Owner agent (`/backlog`). Each task lives in
+> `.specflow/backlog/NNN-slug.md` with structured frontmatter.
+
+## Scoring
+
+- **Complexity**: Fibonacci (1, 2, 3, 5, 8, 13, 21) — story points
+- **Priority**: critical > high > medium > low
+- **Status**: `todo` | `in_progress` | `done` | `deferred` | `blocked`
+
+---
+
+## Critical
+
+_No tasks yet._
+
+## High Priority
+
+_No tasks yet._
+
+## Medium Priority
+
+_No tasks yet._
+
+## Low Priority
+
+_No tasks yet._
+
+## Deferred
+
+_No tasks yet._
+
+## Done
+
+_No tasks yet._
+
+---
+
+## Summary
+
+| Metric             | Value |
+|--------------------|-------|
+| Total tasks        | 0     |
+| Critical           | 0     |
+| High               | 0     |
+| Medium             | 0     |
+| Low                | 0     |
+| Deferred           | 0     |
+| Done               | 0     |
+| Total story points | 0     |
+| Done points        | 0     |

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -26,6 +26,7 @@
     { "category": "skill", "name": "auto-chain", "source": "core/skills/auto-chain/SKILL.md" },
 
     { "category": "spec-root", "name": "specify", "suffix": "memory/constitution.md", "source": "core/specflow/memory/constitution.md" },
+    { "category": "spec-root", "name": "specify", "suffix": "backlog.md", "source": "core/specflow/backlog.md" },
     { "category": "spec-root", "name": "specify", "suffix": "templates/spec-template.md", "source": "core/specflow/templates/spec-template.md" },
     { "category": "spec-root", "name": "specify", "suffix": "templates/plan-template.md", "source": "core/specflow/templates/plan-template.md" },
     { "category": "spec-root", "name": "specify", "suffix": "templates/tasks-template.md", "source": "core/specflow/templates/tasks-template.md" },

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -12,7 +12,7 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
   const mapped = h.mapBundle(CORE_BUNDLE);
   const keys = Object.keys(mapped).sort();
-  assertEquals(keys.length, 39); // 38 core + .claude/CLAUDE.md
+  assertEquals(keys.length, 40); // 39 core + .claude/CLAUDE.md
   // Spot-check canonical paths
   assert(".claude/commands/specflow.specify.md" in mapped);
   assert(".claude/commands/backlog.md" in mapped);

--- a/tests/integration/init_antigravity_test.ts
+++ b/tests/integration/init_antigravity_test.ts
@@ -88,6 +88,7 @@ Deno.test("specflow init --ai antigravity scaffolds an Antigravity layout", asyn
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
 
     // No other harnesses' output trees.
     assertEquals(await exists(join(root, ".claude/")), false);

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -78,6 +78,7 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
 
     // NOT emitted for codex
     assertEquals(await exists(join(root, ".claude/")), false);

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -87,6 +87,7 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
 
     // NOT emitted for copilot
     assertEquals(await exists(join(root, ".claude/")), false);

--- a/tests/integration/init_cursor_test.ts
+++ b/tests/integration/init_cursor_test.ts
@@ -66,6 +66,7 @@ Deno.test("specflow init --ai cursor scaffolds a Cursor layout", async () => {
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
     // NOT emitted for cursor
     assertEquals(await exists(join(root, ".claude/")), false);
     assertEquals(await exists(join(root, "CLAUDE.md")), false);

--- a/tests/integration/init_gemini_test.ts
+++ b/tests/integration/init_gemini_test.ts
@@ -94,6 +94,7 @@ Deno.test("specflow init --ai gemini scaffolds a Gemini layout", async () => {
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
 
     // NOT emitted for gemini
     assertEquals(await exists(join(root, ".claude/")), false);

--- a/tests/integration/init_opencode_test.ts
+++ b/tests/integration/init_opencode_test.ts
@@ -84,6 +84,7 @@ Deno.test("specflow init --ai opencode scaffolds a complete OpenCode project lay
     const agentsRoot = await Deno.readTextFile(join(root, "AGENTS.md"));
     assertEquals(agentsRoot.length > 0, true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
 
     // NOT emitted for opencode
     assertEquals(await exists(join(root, ".claude/")), false);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -49,6 +49,7 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
     assertEquals(await exists(join(root, "CLAUDE.md")), false);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, ".specflow/templates/spec-template.md")), true);
     assertEquals(await exists(join(root, ".claude/commands/specflow.specify.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -78,6 +78,7 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, "AGENTS.md")), true);
     assertEquals(await exists(join(root, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
 
     // NOT emitted for windsurf
     assertEquals(await exists(join(root, ".claude/")), false);

--- a/tests/integration/upgrade_test.ts
+++ b/tests/integration/upgrade_test.ts
@@ -102,6 +102,47 @@ Deno.test("upgrade --force overwrites a customized file with backup", async () =
   });
 });
 
+Deno.test("upgrade migrates legacy tasks/backlog paths into .specflow/", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0);
+
+    const projectDir = join(parent, "demo");
+
+    // Simulate a project that pre-dates #45: the new index doesn't exist
+    // yet (the user installed Specflow before the path moved), and the
+    // legacy layout under tasks/ is in place.
+    await Deno.remove(join(projectDir, ".specflow/backlog.md"));
+    await Deno.mkdir(join(projectDir, "tasks/backlog"), { recursive: true });
+    await Deno.writeTextFile(
+      join(projectDir, "tasks/backlog.md"),
+      "# Legacy backlog index\n",
+    );
+    await Deno.writeTextFile(
+      join(projectDir, "tasks/backlog/001-legacy.md"),
+      "# Legacy task\n",
+    );
+
+    const upgrade = await runSpecflow(["upgrade"], { cwd: projectDir });
+    assertEquals(upgrade.code, 0, `upgrade failed: ${upgrade.stderr}`);
+    assertStringIncludes(upgrade.stdout, "tasks/backlog.md → .specflow/backlog.md");
+    assertStringIncludes(upgrade.stdout, "tasks/backlog/ → .specflow/backlog/");
+
+    // Old paths gone, new paths populated with the user's content preserved.
+    assertEquals(await exists(join(projectDir, "tasks/backlog.md")), false);
+    assertEquals(await exists(join(projectDir, "tasks/backlog")), false);
+    assertEquals(await exists(join(projectDir, "tasks")), false); // tidy-up
+    const migratedIndex = await Deno.readTextFile(
+      join(projectDir, ".specflow/backlog.md"),
+    );
+    assertStringIncludes(migratedIndex, "Legacy backlog index");
+    const migratedTask = await Deno.readTextFile(
+      join(projectDir, ".specflow/backlog/001-legacy.md"),
+    );
+    assertStringIncludes(migratedTask, "Legacy task");
+  });
+});
+
 Deno.test("upgrade auto-deletes a clean orphan and drops it from the lock", async () => {
   await withTempDir(async (parent) => {
     const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });


### PR DESCRIPTION
## Summary

Specflow's footprint should be invisible — everything we own lives under `.specflow/`, not at the project root. This move closes the gap for the local-Markdown backlog mode (the only thing still escaping into `tasks/`).

| Before | After |
|---|---|
| `tasks/backlog.md` | `.specflow/backlog.md` |
| `tasks/backlog/NNN-slug.md` | `.specflow/backlog/NNN-slug.md` |

Closes #45. Pairs with the `tasks/` removal that landed in #44.

## Changes

- **Init**: scaffolds `.specflow/backlog.md` (the empty index). Never creates `tasks/`.
- **Upgrade migration**: pre-#45 projects with `tasks/backlog.md` and/or `tasks/backlog/` get them moved into `.specflow/`. Empty `tasks/` is removed afterwards. Migration is idempotent — if the new path already exists, the old one is left alone for the user to resolve.
- **Slash-command template** (`templates/core/commands/backlog.md`): the "Backlog storage" section now documents `.specflow/backlog.md` and `.specflow/backlog/NNN-slug.md`.
- **Manifest**: new `spec-root` entry maps `.specflow/backlog.md` to `templates/core/specflow/backlog.md`.

## Test plan

- [x] All 280 tests green locally (`deno task test`).
- [x] New integration test covers the `tasks/` → `.specflow/` migration end-to-end (legacy paths laid down on disk, `specflow upgrade` runs, contents preserved at the new location, empty `tasks/` removed).
- [x] All 8 harness init tests assert `.specflow/backlog.md` exists and `tasks/backlog.md` does not.
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)