### PR TITLE
fix: address v0.9.0 audit findings (C1, C2, I1, I4, M1)

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -29,6 +29,7 @@ export type Intent =
   | { kind: "self-update"; checkOnly: boolean }
   | { kind: "check"; projectMode: boolean }
   | { kind: "upgrade"; dryRun: boolean; force: boolean }
+  | { kind: "backlog-removed" }
   | { kind: "unknown"; received: string };
 
 export function parseArgs(argv: string[]): Intent {
@@ -94,6 +95,11 @@ export function parseArgs(argv: string[]): Intent {
       force: Boolean(parsed.force),
     };
   }
+
+  // The `backlog` CLI command (sync + configure) was removed in v0.9.0.
+  // Catch it explicitly so we can emit a friendlier upgrade hint instead
+  // of the generic "Unknown command" + full help dump.
+  if (command === "backlog") return { kind: "backlog-removed" };
 
   return { kind: "unknown", received: command ?? "" };
 }

--- a/src/infrastructure/deno_subprocess.ts
+++ b/src/infrastructure/deno_subprocess.ts
@@ -29,10 +29,20 @@ export class DenoSubprocessRunner implements SubprocessRunner {
         stderr: new TextDecoder().decode(stderr),
       };
     } catch (err) {
-      // Binary missing from PATH: return a synthetic 127 instead of throwing,
-      // so probes (probeGit/probeGh/probeDeno) can render a clean check row.
+      // Synthesise POSIX-style exit codes for the failure modes that surface
+      // as exceptions on `Deno.Command.spawn()`, so probes can render a clean
+      // fail/warn row instead of crashing with a stack trace.
       if (err instanceof Deno.errors.NotFound) {
+        // 127 — binary missing from PATH.
         return { code: 127, stdout: "", stderr: `${cmd}: command not found` };
+      }
+      if (
+        err instanceof Deno.errors.PermissionDenied ||
+        err instanceof Deno.errors.NotCapable
+      ) {
+        // 126 — binary exists but cannot be executed (chmod 000, --allow-run
+        // denial, SELinux deny, etc.).
+        return { code: 126, stdout: "", stderr: `${cmd}: permission denied` };
       }
       throw err;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,15 @@ export async function run(argv: string[]): Promise<number> {
       const { runUpgrade } = await import("./cli/handlers/upgrade_handler.ts");
       return await runUpgrade(intent);
     }
+    case "backlog-removed":
+      console.error(
+        red(
+          "error: `specflow backlog` was removed in v0.9.0. " +
+            "Manage the backlog from your AI harness via the /backlog slash-command, " +
+            "which dispatches the product-owner agent.",
+        ),
+      );
+      return 2;
     case "unknown":
       console.error(red(`Unknown command: "${intent.received}"`));
       console.error(HELP);

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -1741,22 +1741,11 @@ When the backend is remote (GitHub Issues + Project V2, GitLab, etc.) the
 agent talks to that backend directly — the CLI does not push or pull on
 its own.
 
-## Frontmatter schema (used when the backend is local Markdown)
+## Frontmatter schema
 
-\`\`\`yaml
----
-id: NNN                # zero-padded 3 digits
-title: string
-category: string
-priority: critical | high | medium | low
-complexity: 1 | 2 | 3 | 5 | 8 | 13 | 21    # Fibonacci story points
-status: todo | in_progress | done | deferred | blocked
-depends_on: [string]
-spec: string | null
-tags: [string]
-created: YYYY-MM-DD
----
-\`\`\`
+The product-owner agent owns the canonical schema (see
+\`.claude/agents/product-owner.md\` or the equivalent path for your harness).
+Do not duplicate it here — the dispatcher defers to the agent.
 
 ## Quick reference
 
@@ -5881,7 +5870,8 @@ export const HARNESS_STATIC: Record<string, Record<string, TemplateFile>> = {
 - **Skills**: installed skills live in \`.claude/skills/\`.
 - **Specflow commands**: custom Specflow commands live in \`.claude/commands/\`.
 - **Agents**: specialized agents live in \`.claude/agents/\`.
-- **Backlog**: managed via \`/backlog\` — see \`tasks/backlog.md\`.
+- **Backlog**: managed via \`/backlog\` — when the project uses the local
+  Markdown backend, see \`.specflow/backlog.md\`.
 `,
       executable: false,
     },
@@ -5931,11 +5921,13 @@ clarifications needed) STOP #2 (pre-merge validation)
 - \`/specflow-agent-test-reviewer\` — test coverage review
 - \`/specflow-agent-qa-tester\` — QA + test writing
 - \`/specflow-agent-workflow-manager\` — long-running orchestration
+- \`/specflow-agent-devops-sre\` — cloud infrastructure, CI/CD, observability
 
 ## Project context
 
 - Constitution lives at \`.specflow/memory/constitution.md\` — treat as non-negotiable rules.
-- Product backlog lives at \`tasks/backlog.md\` (index) and \`tasks/backlog/NNN-*.md\` (task files).
+- Product backlog (when local Markdown backend): index at \`.specflow/backlog.md\`,
+  task files at \`.specflow/backlog/NNN-*.md\`.
 - Project conventions: \`AGENTS.md\` at project root.
 
 Read the constitution and AGENTS.md before starting any significant work.

--- a/templates/core/commands/backlog.md
+++ b/templates/core/commands/backlog.md
@@ -45,22 +45,11 @@ When the backend is remote (GitHub Issues + Project V2, GitLab, etc.) the
 agent talks to that backend directly — the CLI does not push or pull on
 its own.
 
-## Frontmatter schema (used when the backend is local Markdown)
+## Frontmatter schema
 
-```yaml
----
-id: NNN                # zero-padded 3 digits
-title: string
-category: string
-priority: critical | high | medium | low
-complexity: 1 | 2 | 3 | 5 | 8 | 13 | 21    # Fibonacci story points
-status: todo | in_progress | done | deferred | blocked
-depends_on: [string]
-spec: string | null
-tags: [string]
-created: YYYY-MM-DD
----
-```
+The product-owner agent owns the canonical schema (see
+`.claude/agents/product-owner.md` or the equivalent path for your harness).
+Do not duplicate it here — the dispatcher defers to the agent.
 
 ## Quick reference
 

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -5,4 +5,5 @@
 - **Skills**: installed skills live in `.claude/skills/`.
 - **Specflow commands**: custom Specflow commands live in `.claude/commands/`.
 - **Agents**: specialized agents live in `.claude/agents/`.
-- **Backlog**: managed via `/backlog` — see `tasks/backlog.md`.
+- **Backlog**: managed via `/backlog` — when the project uses the local
+  Markdown backend, see `.specflow/backlog.md`.

--- a/templates/harness-specific/cursor/specify-rules.mdc
+++ b/templates/harness-specific/cursor/specify-rules.mdc
@@ -41,11 +41,13 @@ clarifications needed) STOP #2 (pre-merge validation)
 - `/specflow-agent-test-reviewer` — test coverage review
 - `/specflow-agent-qa-tester` — QA + test writing
 - `/specflow-agent-workflow-manager` — long-running orchestration
+- `/specflow-agent-devops-sre` — cloud infrastructure, CI/CD, observability
 
 ## Project context
 
 - Constitution lives at `.specflow/memory/constitution.md` — treat as non-negotiable rules.
-- Product backlog lives at `tasks/backlog.md` (index) and `tasks/backlog/NNN-*.md` (task files).
+- Product backlog (when local Markdown backend): index at `.specflow/backlog.md`,
+  task files at `.specflow/backlog/NNN-*.md`.
 - Project conventions: `AGENTS.md` at project root.
 
 Read the constitution and AGENTS.md before starting any significant work.

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -63,10 +63,10 @@ Deno.test("parseArgs returns self-update intent without --check", () => {
   });
 });
 
-Deno.test("parseArgs returns unknown for backlog (sync command removed)", () => {
-  assertEquals(parseArgs(["backlog"]), { kind: "unknown", received: "backlog" });
-  assertEquals(parseArgs(["backlog", "sync"]), { kind: "unknown", received: "backlog" });
-  assertEquals(parseArgs(["backlog", "configure"]), { kind: "unknown", received: "backlog" });
+Deno.test("parseArgs returns backlog-removed for any backlog invocation (post-v0.9.0)", () => {
+  assertEquals(parseArgs(["backlog"]), { kind: "backlog-removed" });
+  assertEquals(parseArgs(["backlog", "sync"]), { kind: "backlog-removed" });
+  assertEquals(parseArgs(["backlog", "configure"]), { kind: "backlog-removed" });
 });
 
 Deno.test("parseArgs returns check intent without --project", () => {

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -70,6 +70,45 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
   });
 });
 
+async function* walkFiles(root: string): AsyncIterable<string> {
+  for await (const entry of Deno.readDir(root)) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory) {
+      yield* walkFiles(full);
+    } else if (entry.isFile) {
+      yield full;
+    }
+  }
+}
+
+Deno.test("no scaffolded file references the legacy tasks/backlog path", async () => {
+  // Drift guard: PR #45 moved the local Markdown backlog under .specflow/.
+  // Several harness-static templates kept hardcoded `tasks/backlog.md`
+  // strings on the v0.9.0 release; this test ensures every harness's
+  // scaffolded output stays consistent on any future template edit.
+  for (const harness of ["claude", "cursor", "codex", "gemini"] as const) {
+    await withTempDir(async (parent) => {
+      const { code } = await runSpecflow(
+        ["init", "demo", "--no-git", "--ai", harness],
+        { cwd: parent },
+      );
+      assertEquals(code, 0);
+      const root = join(parent, "demo");
+      for await (const path of walkFiles(root)) {
+        // The lock file legitimately tracks paths; only flag content drift
+        // in user-facing prompt / rule / workflow files.
+        if (path.endsWith(".specflow/installed.lock")) continue;
+        const content = await Deno.readTextFile(path);
+        assertEquals(
+          content.includes("tasks/backlog"),
+          false,
+          `${path} (harness=${harness}) still references the legacy tasks/backlog path`,
+        );
+      }
+    });
+  }
+});
+
 Deno.test("scaffolded product-owner agent documents epic / sub-task support", async () => {
   await withTempDir(async (dir) => {
     const { code } = await runSpecflow(["init", "demo", "--no-git"], { cwd: dir });


### PR DESCRIPTION
## Summary

Post-release audit by `superpowers:code-reviewer` flagged 2 CRITICAL + several IMPORTANT/MINOR issues against v0.9.0. This PR ships the bug-class fixes; the rest stays for follow-up tickets.

## Findings addressed

### CRITICAL — scaffolded files told the model to read a path that no longer exists

- **C1** — `templates/harness-specific/claude/CLAUDE.md:8` still said `see tasks/backlog.md`. Same in `templates/harness-specific/cursor/specify-rules.mdc:48`. PR #55 moved the backlog under `.specflow/`, but the harness reference cards drifted and bypassed every test (assertions checked file *presence*, not template *content*).
- **C2** — Cursor static-rules card listed only 8 agents; `devops-sre` (added in PR #52) was absent from the prose listing even though file count was right.

### IMPORTANT

- **I1** — `templates/core/commands/backlog.md` carried a duplicate frontmatter schema that drifted from the PO template (missing the new `parent: "#NNN"` key from PR #56). Drop the duplication, defer to the PO agent.
- **I4** — `DenoSubprocessRunner.run()` only caught `Deno.errors.NotFound`. `PermissionDenied` / `NotCapable` (chmod 000 binary, --allow-run denial) still crashed `specflow check`. Now both classes are caught and surfaced as POSIX-style exit 126.

### MINOR

- **M1** — Friendly removed-command message: `specflow backlog ...` now emits `error: 'specflow backlog' was removed in v0.9.0. Manage the backlog from your AI harness via the /backlog slash-command...` instead of the generic `Unknown command` + full help dump.

## Drift guard

New integration test in `tests/integration/init_test.ts` walks the entire scaffold output for `claude` / `cursor` / `codex` / `gemini` and asserts no file references the legacy `tasks/backlog` path. This is exactly the regression the suite was missing.

## Not addressed in this PR

- **I2** — `migrateLegacyBacklogPaths` cross-filesystem rename (`EXDEV`). Needs `Deno.rename` → copy+delete fallback. Substantive; deferred to a follow-up ticket.
- **I3** — Migration error-path tests (target-exists warning, partial-rename rollback). Tied to I2.
- **I5** — OpenCode/Codex permission translation for the broadened `Bash(gh issue *)` whitelist. Cross-harness design decision.
- **M3–M6** — Refactor candidates, not bugs.

## Test plan

- [x] All 282 tests green locally (`deno task test`) — +1 from the new drift-guard integration test.
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.
- [x] Audit's CRITICAL claims independently re-verified before fix (grep'd `templates_bundle.ts` to confirm the bundle did contain the legacy strings, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)