### PR TITLE
fix(docs): surface version on docs site and redeploy on tags

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,6 +4,7 @@ name: Deploy docs to Pages
 on:
   push:
     branches: ["main"]
+    tags: ["v*"]
     paths:
       - "docs/**"
       - "scripts/build-docs.ts"

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -15,6 +15,14 @@ const OUT_HTML = `${OUT_DIR}/index.html`;
 const OUT_MD = `${OUT_DIR}/llms.txt`;
 const OUT_CNAME = `${OUT_DIR}/CNAME`;
 const TITLE = "Specflow — documentation";
+const REPO_URL = "https://github.com/mkrlabs/specflow";
+
+async function readVersion(denoJsonPath = "deno.json"): Promise<string> {
+  const raw = await Deno.readTextFile(denoJsonPath);
+  const { version } = JSON.parse(raw) as { version?: string };
+  if (!version) throw new Error(`No "version" field in ${denoJsonPath}`);
+  return version;
+}
 
 /**
  * GitHub Pages custom domain. Emitted as `docs-dist/CNAME` so each deploy
@@ -26,7 +34,7 @@ const TITLE = "Specflow — documentation";
  */
 const CUSTOM_DOMAIN = "specflow.makerlabs.dev";
 
-const HTML_TEMPLATE = (body: string) =>
+const HTML_TEMPLATE = (body: string, version: string) =>
   `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -34,6 +42,7 @@ const HTML_TEMPLATE = (body: string) =>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${TITLE}</title>
   <meta name="description" content="Specflow — enhanced spec-kit CLI with auto-chain, review phase, and backlog. Distributed as a single native binary." />
+  <meta name="specflow-version" content="${version}" />
   <link rel="canonical" href="https://specflow.makerlabs.dev/" />
   <link rel="alternate" type="text/markdown" href="./llms.txt" />
   <style>
@@ -72,8 +81,9 @@ const HTML_TEMPLATE = (body: string) =>
 ${body}
   </main>
   <footer class="doc-footer">
-    Raw Markdown for LLMs: <a href="./llms.txt">llms.txt</a>
-    · Source: <a href="https://github.com/mkrlabs/specflow">github.com/mkrlabs/specflow</a>
+    Specflow <a href="${REPO_URL}/releases/tag/v${version}">v${version}</a>
+    · Raw Markdown for LLMs: <a href="./llms.txt">llms.txt</a>
+    · Source: <a href="${REPO_URL}">github.com/mkrlabs/specflow</a>
   </footer>
 </body>
 </html>
@@ -82,27 +92,30 @@ ${body}
 export async function buildDocs(opts: {
   source?: string;
   outDir?: string;
-} = {}): Promise<{ html: string; markdown: string }> {
+  version?: string;
+} = {}): Promise<{ html: string; markdown: string; version: string }> {
   const source = opts.source ?? SOURCE;
   const outDir = opts.outDir ?? OUT_DIR;
+  const version = opts.version ?? await readVersion();
   const outHtml = `${outDir}/index.html`;
   const outMd = `${outDir}/llms.txt`;
 
-  const markdown = await Deno.readTextFile(source);
-  const rendered = render(markdown, { allowIframes: false });
-  const html = HTML_TEMPLATE(rendered);
+  const sourceMarkdown = await Deno.readTextFile(source);
+  const rendered = render(sourceMarkdown, { allowIframes: false });
+  const html = HTML_TEMPLATE(rendered, version);
+  const markdown = `<!-- Specflow v${version} — ${REPO_URL} -->\n\n${sourceMarkdown}`;
 
   await Deno.mkdir(outDir, { recursive: true });
   await Deno.writeTextFile(outHtml, html);
   await Deno.writeTextFile(outMd, markdown);
   await Deno.writeTextFile(`${outDir}/CNAME`, `${CUSTOM_DOMAIN}\n`);
 
-  return { html, markdown };
+  return { html, markdown, version };
 }
 
 if (import.meta.main) {
-  const { html } = await buildDocs();
-  console.log(`✓ wrote ${OUT_HTML} (${html.length} bytes)`);
+  const { html, version } = await buildDocs();
+  console.log(`✓ wrote ${OUT_HTML} (${html.length} bytes, v${version})`);
   console.log(`✓ wrote ${OUT_MD}`);
   console.log(`✓ wrote ${OUT_CNAME} (${CUSTOM_DOMAIN})`);
 }

--- a/tests/scripts/build_docs_test.ts
+++ b/tests/scripts/build_docs_test.ts
@@ -21,7 +21,7 @@ async function withTempSource(
 Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", async () => {
   const md = "# Hello Specflow\n\nThis is a **test** doc.\n";
   await withTempSource(md, async (source, outDir) => {
-    await buildDocs({ source, outDir });
+    await buildDocs({ source, outDir, version: "9.9.9" });
 
     assertEquals(await exists(join(outDir, "index.html")), true);
     assertEquals(await exists(join(outDir, "llms.txt")), true);
@@ -34,14 +34,30 @@ Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", asy
     assertStringIncludes(html, "<!DOCTYPE html>");
     // Raw-markdown alt link is present.
     assertStringIncludes(html, 'href="./llms.txt"');
+    // Version surfaced in footer + meta tag so users can tell which Specflow
+    // release the docs describe.
+    assertStringIncludes(html, '<meta name="specflow-version" content="9.9.9"');
+    assertStringIncludes(html, "v9.9.9");
 
     const txt = await Deno.readTextFile(join(outDir, "llms.txt"));
-    assertEquals(txt, md, "llms.txt must be a verbatim copy of the source markdown");
+    assertStringIncludes(txt, "<!-- Specflow v9.9.9");
+    assertStringIncludes(txt, md, "llms.txt must include the source markdown verbatim");
 
     // CNAME is emitted on every build so the custom-domain config persists
     // across workflow deploys.
     const cname = await Deno.readTextFile(join(outDir, "CNAME"));
     assertEquals(cname.trim(), "specflow.makerlabs.dev");
+  });
+});
+
+Deno.test("buildDocs reads version from deno.json by default", async () => {
+  const md = "# Hello\n";
+  await withTempSource(md, async (source, outDir) => {
+    const result = await buildDocs({ source, outDir });
+    const denoJson = JSON.parse(await Deno.readTextFile("deno.json"));
+    assertEquals(result.version, denoJson.version);
+    assertStringIncludes(result.html, `v${denoJson.version}`);
+    assertStringIncludes(result.markdown, `<!-- Specflow v${denoJson.version}`);
   });
 });
 
@@ -51,6 +67,7 @@ Deno.test("buildDocs renders the actual Specflow docs without error", async () =
     const result = await buildDocs({
       source: "docs/llms.md",
       outDir: root,
+      version: "9.9.9",
     });
     // Sanity: the real docs mention install + harnesses, which are headline
     // sections that should never disappear silently.


### PR DESCRIPTION
Closes #60.

## Summary
- `scripts/build-docs.ts` reads the version from `deno.json` at build time and injects it into the HTML footer, a `<meta name="specflow-version">` tag, and an HTML comment at the top of `llms.txt`. No manual sync.
- `.github/workflows/static.yml` gains `tags: ["v*"]` on the push trigger as belt-and-braces — the release commit's `deno.json` bump already redeploys via the existing paths filter, but the tag trigger covers any flow that tags without a deno.json change.

## Test plan
- [x] `deno task test` (282 passed)
- [x] `deno task docs:build` produces `docs-dist/index.html` with `v0.9.2` in footer + meta and `docs-dist/llms.txt` with `<!-- Specflow v0.9.2 — ... -->` at the top
- [ ] After merge + next release, confirm specflow.makerlabs.dev shows the new version with zero manual steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)