### PR TITLE
feat(release): auto-bump mkrlabs/homebrew-tap formula on every release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -111,6 +111,19 @@ Specflow repo.
     Report: binary names, sizes, checksum SHA256 of each, and confirm the
     release body shows the **Features / Bug fixes / Internal** sections.
 
+    **Also confirm the homebrew-tap formula bumped automatically.** The
+    release workflow's last step pushes `Formula/specflow.rb` on
+    `mkrlabs/homebrew-tap` to the new version + checksums. Verify with:
+
+    ```bash
+    gh api repos/mkrlabs/homebrew-tap/commits/main --jq '.commit.message'
+    ```
+
+    Expected: `chore: bump specflow to <NEXT>` as the latest commit. If the
+    step was skipped, the workflow log will say `HOMEBREW_TAP_TOKEN not
+    set — skipping ...`. In that case the secret needs to be (re)provisioned
+    — see "Prerequisites" at the bottom of this skill.
+
 11. **Refresh the local binary** — keep `~/.local/bin/specflow` (or
     wherever `command -v specflow` resolves) in sync with what you just
     shipped, so the next qa-tester dispatch and Kevin's day-to-day usage
@@ -171,4 +184,26 @@ If a release goes wrong:
 2. Delete the local tag: `git tag -d v<BAD>`
 3. Delete the GitHub Release via the web UI (tag deletion does not auto-delete
    the release).
-4. Fix the issue, bump again (patch), and re-release.
+4. Revert the homebrew-tap bump if it landed (`gh api -X DELETE` is not
+   exposed for branches; instead push a force-revert commit on
+   `mkrlabs/homebrew-tap` main, or land a new bump from the corrected
+   patch release).
+5. Fix the issue, bump again (patch), and re-release.
+
+## Prerequisites
+
+The release workflow needs one secret on `mkrlabs/specflow` for the
+homebrew-tap bump step to work:
+
+- **`HOMEBREW_TAP_TOKEN`** — fine-grained GitHub Personal Access Token,
+  scoped to `mkrlabs/homebrew-tap` only, with `Contents: Read and write`.
+  Created in GitHub → Settings → Developer settings → Personal access
+  tokens → Fine-grained tokens. Add it under
+  `mkrlabs/specflow` → Settings → Secrets and variables → Actions →
+  New repository secret.
+
+If the secret is missing, the bump step exits 0 with a workflow warning
+(`HOMEBREW_TAP_TOKEN not set — skipping ...`). The release itself still
+ships; only the formula bump is skipped, and `brew upgrade specflow`
+will silently keep serving the previous version until the next release
+that does have the secret.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,9 @@ jobs:
             dist/specflow-windows-x64.exe
             dist/specflow-windows-x64.exe.sha256
           body_path: dist/release-notes.md
+      - name: Bump mkrlabs/homebrew-tap formula
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          deno run --allow-read --allow-write --allow-run --allow-env \
+            scripts/bump-tap-formula.ts

--- a/scripts/bump-tap-formula.ts
+++ b/scripts/bump-tap-formula.ts
@@ -1,0 +1,168 @@
+// Regenerate `Formula/specflow.rb` in `mkrlabs/homebrew-tap` with the
+// version + SHA-256 checksums from the just-built `dist/`. Commit + push.
+//
+// Designed to run as a step in `.github/workflows/release.yml`, after
+// "Compute checksums" and "Create release" — the four `dist/*.sha256`
+// sidecars must already exist.
+//
+// Required env:
+//   GITHUB_REF_NAME      e.g. "v0.9.3" (the tag that triggered the release)
+//   HOMEBREW_TAP_TOKEN   fine-grained PAT with Contents: write on
+//                        mkrlabs/homebrew-tap. If unset, the script logs
+//                        a workflow warning and exits 0 — a one-off
+//                        release with the secret missing should not fail
+//                        the pipeline.
+//
+// Optional env (for local dry-run):
+//   DRY_RUN=1            print the rendered formula to stdout and stop.
+
+import { join } from "@std/path";
+
+const REPO = "mkrlabs/homebrew-tap";
+const FORMULA_PATH = "Formula/specflow.rb";
+
+type RenderInput = {
+  tag: string;
+  version: string;
+  shaMacOsArm: string;
+  shaMacOsX64: string;
+  shaLinuxArm: string;
+  shaLinuxX64: string;
+};
+
+export function renderFormula(opts: RenderInput): string {
+  const baseUrl = `https://github.com/mkrlabs/specflow/releases/download/${opts.tag}`;
+  return `class Specflow < Formula
+  desc "AI project scaffolding CLI with auto-chain, review, and backlog"
+  homepage "https://specflow.makerlabs.dev"
+  version "${opts.version}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "${baseUrl}/specflow-macos-arm64"
+      sha256 "${opts.shaMacOsArm}"
+    end
+    on_intel do
+      url "${baseUrl}/specflow-macos-x64"
+      sha256 "${opts.shaMacOsX64}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${baseUrl}/specflow-linux-arm64"
+      sha256 "${opts.shaLinuxArm}"
+    end
+    on_intel do
+      url "${baseUrl}/specflow-linux-x64"
+      sha256 "${opts.shaLinuxX64}"
+    end
+  end
+
+  def install
+    bin.install Dir["specflow-*"].first => "specflow"
+  end
+
+  test do
+    assert_match(/^specflow #{version}/, shell_output("#{bin}/specflow --version"))
+  end
+end
+`;
+}
+
+async function readSha(distDir: string, asset: string): Promise<string> {
+  const raw = await Deno.readTextFile(join(distDir, `specflow-${asset}.sha256`));
+  // shasum format: "<sha>  <filename>" — first whitespace-separated token.
+  return raw.trim().split(/\s+/)[0];
+}
+
+async function run(cmd: string[], cwd?: string): Promise<void> {
+  const p = new Deno.Command(cmd[0], {
+    args: cmd.slice(1),
+    cwd,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const { code } = await p.output();
+  if (code !== 0) throw new Error(`${cmd.join(" ")} failed with exit ${code}`);
+}
+
+async function captureStdout(cmd: string[], cwd?: string): Promise<string> {
+  const p = new Deno.Command(cmd[0], {
+    args: cmd.slice(1),
+    cwd,
+    stdout: "piped",
+    stderr: "inherit",
+  });
+  const { code, stdout } = await p.output();
+  if (code !== 0) throw new Error(`${cmd.join(" ")} failed with exit ${code}`);
+  return new TextDecoder().decode(stdout);
+}
+
+async function main(): Promise<number> {
+  const tag = Deno.env.get("GITHUB_REF_NAME");
+  if (!tag) throw new Error("GITHUB_REF_NAME is required");
+  if (!tag.startsWith("v")) {
+    throw new Error(`GITHUB_REF_NAME must start with 'v', got '${tag}'`);
+  }
+  const version = tag.slice(1);
+
+  const formula = renderFormula({
+    tag,
+    version,
+    shaMacOsArm: await readSha("dist", "macos-arm64"),
+    shaMacOsX64: await readSha("dist", "macos-x64"),
+    shaLinuxArm: await readSha("dist", "linux-arm64"),
+    shaLinuxX64: await readSha("dist", "linux-x64"),
+  });
+
+  if (Deno.env.get("DRY_RUN") === "1") {
+    console.log(formula);
+    return 0;
+  }
+
+  const token = Deno.env.get("HOMEBREW_TAP_TOKEN");
+  if (!token) {
+    console.log(
+      `::warning::HOMEBREW_TAP_TOKEN not set — skipping ${REPO} bump for ${tag}.`,
+    );
+    return 0;
+  }
+
+  const workdir = await Deno.makeTempDir({ prefix: "homebrew-tap-bump-" });
+  try {
+    const cloneUrl = `https://x-access-token:${token}@github.com/${REPO}.git`;
+    await run(["git", "clone", "--depth", "1", cloneUrl, workdir]);
+    await Deno.writeTextFile(join(workdir, FORMULA_PATH), formula);
+
+    // Idempotency: re-running the same release shouldn't produce empty commits.
+    const dirty = (await captureStdout(["git", "status", "--porcelain"], workdir)).trim();
+    if (!dirty) {
+      console.log(`Formula already at ${version} — nothing to bump.`);
+      return 0;
+    }
+
+    await run(["git", "config", "user.name", "github-actions[bot]"], workdir);
+    await run(
+      [
+        "git",
+        "config",
+        "user.email",
+        "41898282+github-actions[bot]@users.noreply.github.com",
+      ],
+      workdir,
+    );
+    await run(["git", "add", FORMULA_PATH], workdir);
+    await run(["git", "commit", "-m", `chore: bump specflow to ${version}`], workdir);
+    await run(["git", "push", "origin", "HEAD:main"], workdir);
+    console.log(`✓ pushed bump to ${version} on ${REPO}`);
+    return 0;
+  } finally {
+    await Deno.remove(workdir, { recursive: true });
+  }
+}
+
+if (import.meta.main) {
+  Deno.exit(await main());
+}

--- a/tests/scripts/bump_tap_formula_test.ts
+++ b/tests/scripts/bump_tap_formula_test.ts
@@ -1,0 +1,54 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderFormula } from "../../scripts/bump-tap-formula.ts";
+
+Deno.test("renderFormula produces a Ruby Formula class with the right shape", () => {
+  const out = renderFormula({
+    tag: "v1.2.3",
+    version: "1.2.3",
+    shaMacOsArm: "a".repeat(64),
+    shaMacOsX64: "b".repeat(64),
+    shaLinuxArm: "c".repeat(64),
+    shaLinuxX64: "d".repeat(64),
+  });
+  assertStringIncludes(out, "class Specflow < Formula");
+  assertStringIncludes(out, 'version "1.2.3"');
+  assertStringIncludes(out, "v1.2.3/specflow-macos-arm64");
+  assertStringIncludes(out, "v1.2.3/specflow-macos-x64");
+  assertStringIncludes(out, "v1.2.3/specflow-linux-arm64");
+  assertStringIncludes(out, "v1.2.3/specflow-linux-x64");
+  assertStringIncludes(out, `sha256 "${"a".repeat(64)}"`);
+  assertStringIncludes(out, `sha256 "${"d".repeat(64)}"`);
+  assertStringIncludes(out, "on_macos do");
+  assertStringIncludes(out, "on_linux do");
+  assertStringIncludes(out, "test do");
+});
+
+Deno.test("renderFormula leaves no unrendered placeholders in the output", () => {
+  const out = renderFormula({
+    tag: "v0.0.1",
+    version: "0.0.1",
+    shaMacOsArm: "a".repeat(64),
+    shaMacOsX64: "a".repeat(64),
+    shaLinuxArm: "a".repeat(64),
+    shaLinuxX64: "a".repeat(64),
+  });
+  // Catch accidental sed-style markers or shell-style literal substitutions.
+  assertEquals(out.includes("@@"), false);
+  // The Ruby `#{version}` interpolation in the test block is *intentional*
+  // and must be preserved verbatim — so we don't assert on `#{`.
+});
+
+Deno.test("renderFormula keeps Ruby string interpolation in the test block", () => {
+  const out = renderFormula({
+    tag: "v9.9.9",
+    version: "9.9.9",
+    shaMacOsArm: "0".repeat(64),
+    shaMacOsX64: "0".repeat(64),
+    shaLinuxArm: "0".repeat(64),
+    shaLinuxX64: "0".repeat(64),
+  });
+  // The test stub must use Ruby's #{version} (not the literal "9.9.9") so
+  // brew test resolves it from the formula's own version field at install
+  // time.
+  assertStringIncludes(out, "/^specflow #{version}/");
+});


### PR DESCRIPTION
## Summary

Automates the formula bump in `mkrlabs/homebrew-tap` — without this, every Specflow release left `Formula/specflow.rb` stale and `brew upgrade specflow` was a no-op for users.

The release workflow now finishes by:
1. Reading the four `dist/specflow-*.sha256` sidecars (already produced upstream in the same job — no curl, no race).
2. Rendering `Formula/specflow.rb` from a typed pure function (`renderFormula` in `scripts/bump-tap-formula.ts`, unit-tested).
3. Cloning `mkrlabs/homebrew-tap`, writing the formula, and committing + pushing — idempotently (no-ops if the formula is already at the target version).

If `HOMEBREW_TAP_TOKEN` is not set, the step logs a workflow warning and exits 0 — the release itself still succeeds; only the bump is skipped.

Closes #63.

## Action required from you

This PR cannot be exercised until you create the secret:

1. Generate a **fine-grained Personal Access Token** at https://github.com/settings/personal-access-tokens
2. Repository access: **only** `mkrlabs/homebrew-tap`
3. Permissions: **Contents → Read and write** (everything else can stay `No access`)
4. Add it under `mkrlabs/specflow` → Settings → Secrets and variables → Actions → New repository secret, name `HOMEBREW_TAP_TOKEN`

Once added, the next release tag will trigger the bump automatically. The release skill's new **Prerequisites** section documents this; the post-release verification at step 10 now also asserts the bump landed.

## Test plan

- [x] New unit tests for `renderFormula` cover happy path, no-unrendered-placeholders invariant, and "Ruby `#{version}` interpolation in `test do` is preserved verbatim".
- [x] Local dry-run via `DRY_RUN=1 GITHUB_REF_NAME=v1.2.3` against fake SHAs — formula renders cleanly, no shell expansion bugs, no missing fields.
- [x] All 284 tests green locally (`deno task test`) — 281 + 3 new render tests.
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

## Idempotency / safety

- Re-running the same release tag: `git status --porcelain` check skips the commit when the formula already matches.
- Missing secret: clean exit 0 with workflow warning, release proceeds.
- Bad checksums: caught at `brew install` time via SHA mismatch (would manifest as user-side failure on `brew install`, but at that point the GitHub Release itself is already malformed — no different from today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)