### PR TITLE
docs: dispatch devops-sre subagent before pipeline / release changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,6 +23,13 @@ project vision; this file only encodes how Kevin wants to be collaborated with.
 - **Every backlog mutation goes through the `product-owner` subagent** — don't run `add.sh` /
   `move.sh` / `gh issue {create,close,edit}` inline. Dispatch the PO and let it execute. (See
   `.claude/skills/backlog/SKILL.md`.)
+- **Every release / pipeline / distribution change goes through the `devops-sre` subagent
+  first** — before editing `.github/workflows/*.yml`, `install.sh`, `scripts/build.ts`,
+  `scripts/bump-tap-formula.ts`, anything in `mkrlabs/homebrew-tap`, or running `/release`,
+  dispatch `devops-sre` for an advisory pass. The agent is read-only (same pattern as the
+  architect): it returns findings + recommendations; the main session executes the change.
+  Skip the dispatch only for trivial doc tweaks inside the same area (e.g. typo in a comment).
+  (See `.claude/agents/devops-sre.md`.)
 
 ## Implementation defaults
 


### PR DESCRIPTION
## Summary

Adds a working-contract directive to `.claude/CLAUDE.md` so the main Claude Code session in this repo always dispatches the new `.claude/agents/devops-sre.md` subagent before touching the release pipeline. Mirrors the existing `product-owner` dispatch rule.

Without this, the agent shipped in PR #65 risks going unused — the main session would happily keep editing `release.yml` and `install.sh` inline, defeating the point of having a dedicated advisor.

## What triggers the dispatch

The directive lists explicit triggers:

- `.github/workflows/*.yml`
- `install.sh`
- `scripts/build.ts` or `scripts/bump-tap-formula.ts`
- Anything in `mkrlabs/homebrew-tap`
- Invoking `/release`

Trivial in-area edits (typo in a comment, doc-only change inside an unrelated section) are exempt.

## Why `.claude/CLAUDE.md` and not `AGENTS.md`

The existing working contract already lives there ("Every backlog mutation goes through PO"). `AGENTS.md` is the project vision doc; `.claude/CLAUDE.md` is the runtime directive file Claude Code auto-loads. Keeping working-contract rules in one place avoids drift.

## Test plan

- [x] No code changed; doc-only edit.
- [x] Pre-commit hook (fmt + lint + bundle + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)