### PR TITLE
feat(specs): store feature specs under .specflow/specs/ (closes #67)

### DIFF
--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -52,6 +52,28 @@ export async function migrateLegacyBacklogPaths(
   return moves;
 }
 
+/**
+ * One-shot migration for projects that pre-date #67. Move a top-level
+ * `specs/` directory (the legacy SpecKit-style location) into
+ * `.specflow/specs/`. Idempotent: if the new path already exists, the
+ * old one is left alone.
+ */
+export async function migrateLegacySpecsPaths(
+  projectDir: string,
+): Promise<ReadonlyArray<string>> {
+  const moves: string[] = [];
+
+  const oldDir = join(projectDir, "specs");
+  const newDir = join(projectDir, ".specflow/specs");
+  if ((await exists(oldDir)) && !(await exists(newDir))) {
+    await Deno.mkdir(join(projectDir, ".specflow"), { recursive: true });
+    await Deno.rename(oldDir, newDir);
+    moves.push("specs/ → .specflow/specs/");
+  }
+
+  return moves;
+}
+
 export type UpgradeIntent = {
   kind: "upgrade";
   dryRun: boolean;
@@ -111,8 +133,10 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
   const projectDir = resolve(Deno.cwd());
 
   if (!intent.dryRun) {
-    const moves = await migrateLegacyBacklogPaths(projectDir);
-    for (const m of moves) console.log(dim(`↳ migrated ${m}`));
+    const backlogMoves = await migrateLegacyBacklogPaths(projectDir);
+    for (const m of backlogMoves) console.log(dim(`↳ migrated ${m}`));
+    const specsMoves = await migrateLegacySpecsPaths(projectDir);
+    for (const m of specsMoves) console.log(dim(`↳ migrated ${m}`));
   }
 
   const useCase = new UpgradeProjectUseCase({

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -60,16 +60,16 @@ Given that feature description, do this:
 
 3. **Create the spec feature directory**:
 
-   Specs live under \`specs/\` unless the user provides \`SPECIFY_FEATURE_DIRECTORY\`.
+   Specs live under \`.specflow/specs/\` unless the user provides \`SPECIFY_FEATURE_DIRECTORY\`.
 
    **Resolution order for \`SPECIFY_FEATURE_DIRECTORY\`**:
    1. If the user explicitly provided it, use as-is.
-   2. Otherwise auto-generate under \`specs/\`:
+   2. Otherwise auto-generate under \`.specflow/specs/\`:
       - Check \`.specflow/init-options.json\` for \`branch_numbering\`
       - \`"timestamp"\`: prefix is \`YYYYMMDD-HHMMSS\`
       - \`"sequential"\` or absent: prefix is \`NNN\` (next available 3-digit number)
       - Construct: \`<prefix>-<short-name>\` (e.g., \`003-user-auth\`)
-      - Set \`SPECIFY_FEATURE_DIRECTORY\` to \`specs/<directory-name>\`
+      - Set \`SPECIFY_FEATURE_DIRECTORY\` to \`.specflow/specs/<directory-name>\`
 
    **Create the directory and spec file**:
    - \`mkdir -p SPECIFY_FEATURE_DIRECTORY\`
@@ -79,7 +79,7 @@ Given that feature description, do this:
      \`\`\`json
      { "feature_directory": "<resolved feature dir>" }
      \`\`\`
-     Write the actual resolved path (e.g., \`specs/003-user-auth\`), not the literal string.
+     Write the actual resolved path (e.g., \`.specflow/specs/003-user-auth\`), not the literal string.
      This lets downstream commands (\`__SPECFLOW_COMMAND_PLAN__\`, \`__SPECFLOW_COMMAND_TASKS__\`, etc.) locate the feature directory.
 
    **IMPORTANT**:
@@ -2821,7 +2821,7 @@ _No tasks yet._
     content: `# Implementation Plan: [FEATURE]
 
 **Branch**: \`[###-feature-name]\` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from \`/specs/[###-feature-name]/spec.md\`
+**Input**: Feature specification from \`/.specflow/specs/[###-feature-name]/spec.md\`
 
 **Note**: This template is filled in by the \`__SPECFLOW_COMMAND_PLAN__\` command. See \`.specflow/templates/plan-template.md\` for the execution workflow.
 
@@ -2858,7 +2858,7 @@ _No tasks yet._
 ### Documentation (this feature)
 
 \`\`\`text
-specs/[###-feature]/
+.specflow/specs/[###-feature]/
 ├── plan.md              # This file (__SPECFLOW_COMMAND_PLAN__ command output)
 ├── research.md          # Phase 0 output (__SPECFLOW_COMMAND_PLAN__ command)
 ├── data-model.md        # Phase 1 output (__SPECFLOW_COMMAND_PLAN__ command)
@@ -2936,7 +2936,7 @@ description: "Task list template for feature implementation"
 
 # Tasks: [FEATURE NAME]
 
-**Input**: Design documents from \`/specs/[###-feature-name]/\`
+**Input**: Design documents from \`/.specflow/specs/[###-feature-name]/\`
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
 **Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.
@@ -3586,7 +3586,7 @@ get_current_branch() {
     fi
 
     # For non-git repos, try to find the latest feature directory
-    local specs_dir="\$repo_root/specs"
+    local specs_dir="\$repo_root/.specflow/specs"
 
     if [[ -d "\$specs_dir" ]]; then
         local latest_feature=""
@@ -3684,7 +3684,7 @@ find_feature_dir_by_prefix() {
     local repo_root="\$1"
     local branch_name
     branch_name=\$(spec_kit_effective_branch_name "\$2")
-    local specs_dir="\$repo_root/specs"
+    local specs_dir="\$repo_root/.specflow/specs"
 
     # Extract prefix from branch (e.g., "004" from "004-whatever" or "20260319-143022" from timestamp branches)
     local prefix=""
@@ -3698,7 +3698,7 @@ find_feature_dir_by_prefix() {
         return
     fi
 
-    # Search for directories in specs/ that start with this prefix
+    # Search for directories in .specflow/specs/ that start with this prefix
     local matches=()
     if [[ -d "\$specs_dir" ]]; then
         for dir in "\$specs_dir"/"\$prefix"-*; do
@@ -4333,7 +4333,7 @@ fi
 
 cd "\$REPO_ROOT"
 
-SPECS_DIR="\$REPO_ROOT/specs"
+SPECS_DIR="\$REPO_ROOT/.specflow/specs"
 if [ "\$DRY_RUN" != true ]; then
     mkdir -p "\$SPECS_DIR"
 fi
@@ -4853,7 +4853,7 @@ function Get-CurrentBranch {
     }
 
     # For non-git repos, try to find the latest feature directory
-    \$specsDir = Join-Path \$repoRoot "specs"
+    \$specsDir = Join-Path \$repoRoot ".specflow" "specs"
     
     if (Test-Path \$specsDir) {
         \$latestFeature = ""
@@ -4949,13 +4949,13 @@ function Test-FeatureBranch {
     return \$true
 }
 
-# Resolve specs/<feature-dir> by numeric/timestamp prefix (mirrors scripts/bash/common.sh find_feature_dir_by_prefix).
+# Resolve .specflow/specs/<feature-dir> by numeric/timestamp prefix (mirrors scripts/bash/common.sh find_feature_dir_by_prefix).
 function Find-FeatureDirByPrefix {
     param(
         [Parameter(Mandatory = \$true)][string]\$RepoRoot,
         [Parameter(Mandatory = \$true)][string]\$Branch
     )
-    \$specsDir = Join-Path \$RepoRoot 'specs'
+    \$specsDir = Join-Path \$RepoRoot '.specflow' 'specs'
     \$branchName = Get-SpecflowEffectiveBranchName \$Branch
 
     \$prefix = \$null
@@ -5540,7 +5540,7 @@ function ConvertTo-CleanBranchName {
 
 Set-Location \$repoRoot
 
-\$specsDir = Join-Path \$repoRoot 'specs'
+\$specsDir = Join-Path \$repoRoot '.specflow' 'specs'
 if (-not \$DryRun) {
     New-Item -ItemType Directory -Path \$specsDir -Force | Out-Null
 }

--- a/templates/core/commands/specflow.specify.md
+++ b/templates/core/commands/specflow.specify.md
@@ -49,16 +49,16 @@ Given that feature description, do this:
 
 3. **Create the spec feature directory**:
 
-   Specs live under `specs/` unless the user provides `SPECIFY_FEATURE_DIRECTORY`.
+   Specs live under `.specflow/specs/` unless the user provides `SPECIFY_FEATURE_DIRECTORY`.
 
    **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
    1. If the user explicitly provided it, use as-is.
-   2. Otherwise auto-generate under `specs/`:
+   2. Otherwise auto-generate under `.specflow/specs/`:
       - Check `.specflow/init-options.json` for `branch_numbering`
       - `"timestamp"`: prefix is `YYYYMMDD-HHMMSS`
       - `"sequential"` or absent: prefix is `NNN` (next available 3-digit number)
       - Construct: `<prefix>-<short-name>` (e.g., `003-user-auth`)
-      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `.specflow/specs/<directory-name>`
 
    **Create the directory and spec file**:
    - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
@@ -68,7 +68,7 @@ Given that feature description, do this:
      ```json
      { "feature_directory": "<resolved feature dir>" }
      ```
-     Write the actual resolved path (e.g., `specs/003-user-auth`), not the literal string.
+     Write the actual resolved path (e.g., `.specflow/specs/003-user-auth`), not the literal string.
      This lets downstream commands (`__SPECFLOW_COMMAND_PLAN__`, `__SPECFLOW_COMMAND_TASKS__`, etc.) locate the feature directory.
 
    **IMPORTANT**:

--- a/templates/core/specflow/scripts/bash/common.sh
+++ b/templates/core/specflow/scripts/bash/common.sh
@@ -61,7 +61,7 @@ get_current_branch() {
     fi
 
     # For non-git repos, try to find the latest feature directory
-    local specs_dir="$repo_root/specs"
+    local specs_dir="$repo_root/.specflow/specs"
 
     if [[ -d "$specs_dir" ]]; then
         local latest_feature=""
@@ -159,7 +159,7 @@ find_feature_dir_by_prefix() {
     local repo_root="$1"
     local branch_name
     branch_name=$(spec_kit_effective_branch_name "$2")
-    local specs_dir="$repo_root/specs"
+    local specs_dir="$repo_root/.specflow/specs"
 
     # Extract prefix from branch (e.g., "004" from "004-whatever" or "20260319-143022" from timestamp branches)
     local prefix=""
@@ -173,7 +173,7 @@ find_feature_dir_by_prefix() {
         return
     fi
 
-    # Search for directories in specs/ that start with this prefix
+    # Search for directories in .specflow/specs/ that start with this prefix
     local matches=()
     if [[ -d "$specs_dir" ]]; then
         for dir in "$specs_dir"/"$prefix"-*; do

--- a/templates/core/specflow/scripts/bash/create-new-feature.sh
+++ b/templates/core/specflow/scripts/bash/create-new-feature.sh
@@ -203,7 +203,7 @@ fi
 
 cd "$REPO_ROOT"
 
-SPECS_DIR="$REPO_ROOT/specs"
+SPECS_DIR="$REPO_ROOT/.specflow/specs"
 if [ "$DRY_RUN" != true ]; then
     mkdir -p "$SPECS_DIR"
 fi

--- a/templates/core/specflow/scripts/powershell/common.ps1
+++ b/templates/core/specflow/scripts/powershell/common.ps1
@@ -68,7 +68,7 @@ function Get-CurrentBranch {
     }
 
     # For non-git repos, try to find the latest feature directory
-    $specsDir = Join-Path $repoRoot "specs"
+    $specsDir = Join-Path $repoRoot ".specflow" "specs"
     
     if (Test-Path $specsDir) {
         $latestFeature = ""
@@ -164,13 +164,13 @@ function Test-FeatureBranch {
     return $true
 }
 
-# Resolve specs/<feature-dir> by numeric/timestamp prefix (mirrors scripts/bash/common.sh find_feature_dir_by_prefix).
+# Resolve .specflow/specs/<feature-dir> by numeric/timestamp prefix (mirrors scripts/bash/common.sh find_feature_dir_by_prefix).
 function Find-FeatureDirByPrefix {
     param(
         [Parameter(Mandatory = $true)][string]$RepoRoot,
         [Parameter(Mandatory = $true)][string]$Branch
     )
-    $specsDir = Join-Path $RepoRoot 'specs'
+    $specsDir = Join-Path $RepoRoot '.specflow' 'specs'
     $branchName = Get-SpecflowEffectiveBranchName $Branch
 
     $prefix = $null

--- a/templates/core/specflow/scripts/powershell/create-new-feature.ps1
+++ b/templates/core/specflow/scripts/powershell/create-new-feature.ps1
@@ -174,7 +174,7 @@ $hasGit = Test-HasGit
 
 Set-Location $repoRoot
 
-$specsDir = Join-Path $repoRoot 'specs'
+$specsDir = Join-Path $repoRoot '.specflow' 'specs'
 if (-not $DryRun) {
     New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 }

--- a/templates/core/specflow/templates/plan-template.md
+++ b/templates/core/specflow/templates/plan-template.md
@@ -1,7 +1,7 @@
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+**Input**: Feature specification from `/.specflow/specs/[###-feature-name]/spec.md`
 
 **Note**: This template is filled in by the `__SPECFLOW_COMMAND_PLAN__` command. See `.specflow/templates/plan-template.md` for the execution workflow.
 
@@ -38,7 +38,7 @@
 ### Documentation (this feature)
 
 ```text
-specs/[###-feature]/
+.specflow/specs/[###-feature]/
 ├── plan.md              # This file (__SPECFLOW_COMMAND_PLAN__ command output)
 ├── research.md          # Phase 0 output (__SPECFLOW_COMMAND_PLAN__ command)
 ├── data-model.md        # Phase 1 output (__SPECFLOW_COMMAND_PLAN__ command)

--- a/templates/core/specflow/templates/tasks-template.md
+++ b/templates/core/specflow/templates/tasks-template.md
@@ -5,7 +5,7 @@ description: "Task list template for feature implementation"
 
 # Tasks: [FEATURE NAME]
 
-**Input**: Design documents from `/specs/[###-feature-name]/`
+**Input**: Design documents from `/.specflow/specs/[###-feature-name]/`
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
 **Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.

--- a/tests/integration/upgrade_test.ts
+++ b/tests/integration/upgrade_test.ts
@@ -143,6 +143,34 @@ Deno.test("upgrade migrates legacy tasks/backlog paths into .specflow/", async (
   });
 });
 
+Deno.test("upgrade migrates legacy specs/ into .specflow/specs/", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0);
+
+    const projectDir = join(parent, "demo");
+
+    // Simulate a project that pre-dates #67: a feature directory exists
+    // at the legacy top-level `specs/` path (where SpecKit puts them).
+    await Deno.mkdir(join(projectDir, "specs/001-legacy-feature"), { recursive: true });
+    await Deno.writeTextFile(
+      join(projectDir, "specs/001-legacy-feature/spec.md"),
+      "# Legacy spec\n",
+    );
+
+    const upgrade = await runSpecflow(["upgrade"], { cwd: projectDir });
+    assertEquals(upgrade.code, 0, `upgrade failed: ${upgrade.stderr}`);
+    assertStringIncludes(upgrade.stdout, "specs/ → .specflow/specs/");
+
+    // Old path gone, new path populated with the user's content preserved.
+    assertEquals(await exists(join(projectDir, "specs")), false);
+    const migrated = await Deno.readTextFile(
+      join(projectDir, ".specflow/specs/001-legacy-feature/spec.md"),
+    );
+    assertStringIncludes(migrated, "Legacy spec");
+  });
+});
+
 Deno.test("upgrade auto-deletes a clean orphan and drops it from the lock", async () => {
   await withTempDir(async (parent) => {
     const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });


### PR DESCRIPTION
## Summary

Implements #67 — moves feature spec storage from the SpecKit-style top-level `specs/` to `.specflow/specs/`, so the `.specflow/` directory owns all feature artefacts (specs, plans, tasks, checklists) alongside the existing control files.

## Changes

- **All 7 generated templates updated**:
  - `templates/core/commands/specflow.specify.md` — prose + auto-generation logic
  - `templates/core/specflow/scripts/bash/{common.sh,create-new-feature.sh}`
  - `templates/core/specflow/scripts/powershell/{common.ps1,create-new-feature.ps1}`
  - `templates/core/specflow/templates/{plan-template.md,tasks-template.md}` — input/structure docstrings

- **Brownfield migration** (`src/cli/handlers/upgrade_handler.ts`): new `migrateLegacySpecsPaths` mirrors the existing `migrateLegacyBacklogPaths` pattern from PR #45 — silent, idempotent rename of `specs/` → `.specflow/specs/` on `specflow upgrade`. No domain or port change.

- **Integration test** (`tests/integration/upgrade_test.ts`): asserts the migration moves a planted legacy `specs/001-legacy-feature/spec.md` into `.specflow/specs/...` with content preserved and the migration log line emitted.

## Validation

- `deno task test` — 286 tests pass (with the new one)
- `test-sandbox` brownfield validation:
  - Bootstrapped Vite scenario, planted `specs/001-legacy-from-speckit/spec.md`, ran `specflow upgrade` against the working tree
  - Output: `↳ migrated specs/ → .specflow/specs/`
  - Result: legacy `specs/` removed, content present at `.specflow/specs/001-legacy-from-speckit/spec.md`
- `test-sandbox` greenfield validation:
  - Bootstrapped fresh Vite, ran `init`, then ran the bundled `create-new-feature.sh` script
  - Emitted `SPEC_FILE: <project>/.specflow/specs/001-test-feature/spec.md` ✓

## Out of scope

- `examples/` references (Kevin's reference projects, not generated output)
- `docs/superpowers/specs/` self-references (documentation about Specflow, not Specflow's storage layout)
- Renaming `.specflow/` itself

## Test plan

- [x] `deno task test` green locally (286 passing)
- [x] Brownfield migration validated end-to-end via test-sandbox
- [x] Greenfield path validated via `create-new-feature.sh`
- [x] Pre-commit hook green (fmt + lint + bundle + check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)