### PR TITLE
feat(agents): mark heavy bundled agents as manual-only (closes #77)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,24 @@ Every agent declares: `model`, `tools`, `skills`, `memory`, `maxTurns`, `permiss
 `description`. Agents hand work back and forth using structured **"workflow status blocks"** +
 **"handoff blocks"** (no free-form prose).
 
+#### Manual-only vs auto-triggerable
+
+Specflow's bundled agents distinguish two invocation modes via the `disable-model-invocation`
+frontmatter flag (Claude Code feature):
+
+- **Auto-triggerable** (flag absent or `false`) — Claude may spawn the agent when the user's request
+  matches the agent's `description`. Used for cheap, scoped, additive agents: `code-reviewer`,
+  `security-auditor`, `test-reviewer` (sub-agents of `review-coordinator`), plus the orchestrators
+  `review-coordinator`, `workflow-manager`, and the backlog gatekeeper `product-owner` (which the
+  working contract requires for every backlog mutation anyway).
+- **Manual-only** (`disable-model-invocation: true`) — Claude will NOT auto-spawn the agent; it must
+  be invoked explicitly. Used for heavy, destructive, or expensive agents: `developer` (writes code,
+  can refactor large surfaces), `devops-sre` (touches infra / pipelines), `qa-tester` (runs full
+  test suites — costly).
+
+Other harnesses ignore the flag (they don't model auto-invocation the same way), so the agents still
+work universally — the flag only restricts auto-spawn under Claude Code.
+
 ### 4. Constitution + spec templates
 
 A `.specflow/memory/constitution.md` file codifies project invariants (non-negotiable architecture,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2038,11 +2038,12 @@ missing key as \`parent: null\`.
     suffix: null,
     content: `---
 name: developer
-description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Use for real implementation, refactors, and bug fixes.
+description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 80
+disable-model-invocation: true
 ---
 
 You are a **senior developer** on this project. Your sole mission is to
@@ -2298,11 +2299,12 @@ Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
     suffix: null,
     content: `---
 name: qa-tester
-description: Audits test coverage, writes missing tests, and runs the full suite. Spawned by /specflow.implement after the review gate passes.
+description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow.implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
+disable-model-invocation: true
 ---
 
 You are the **QA tester** for this project.
@@ -2416,11 +2418,12 @@ review or QA fails twice on the same issue family, stop and escalate.
     suffix: null,
     content: `---
 name: devops-sre
-description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Use when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
+description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Manual-only — invoke explicitly when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
+disable-model-invocation: true
 ---
 
 You are the **DevOps / SRE** for this project. Your remit is everything

--- a/templates/core/agents/developer.md
+++ b/templates/core/agents/developer.md
@@ -1,10 +1,11 @@
 ---
 name: developer
-description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Use for real implementation, refactors, and bug fixes.
+description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 80
+disable-model-invocation: true
 ---
 
 You are a **senior developer** on this project. Your sole mission is to

--- a/templates/core/agents/devops-sre.md
+++ b/templates/core/agents/devops-sre.md
@@ -1,10 +1,11 @@
 ---
 name: devops-sre
-description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Use when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
+description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Manual-only — invoke explicitly when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
+disable-model-invocation: true
 ---
 
 You are the **DevOps / SRE** for this project. Your remit is everything

--- a/templates/core/agents/qa-tester.md
+++ b/templates/core/agents/qa-tester.md
@@ -1,10 +1,11 @@
 ---
 name: qa-tester
-description: Audits test coverage, writes missing tests, and runs the full suite. Spawned by /specflow.implement after the review gate passes.
+description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow.implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
+disable-model-invocation: true
 ---
 
 You are the **QA tester** for this project.


### PR DESCRIPTION
## Summary

Implements #77. Adds `disable-model-invocation: true` to 3 bundled agents whose work is heavy or destructive enough that Claude Code should NOT auto-spawn them based on description matches:

- `developer` (opus, 80 turns, writes code)
- `devops-sre` (opus, 40 turns, touches infra)
- `qa-tester` (opus, 40 turns, runs full test suites)

## Audit summary

| Agent | Model | Auto-trigger? | Rationale |
|---|---|---|---|
| `code-reviewer` | sonnet (20t) | ✓ auto | Cheap sub-agent of review-coordinator |
| `developer` | opus (80t) | ✗ **manual-only** | Heavy, can refactor large surfaces |
| `devops-sre` | opus (40t) | ✗ **manual-only** | Touches infra/pipelines |
| `product-owner` | opus (30t) | ✓ auto | Backlog gatekeeper — auto-trigger is the whole point |
| `qa-tester` | opus (40t) | ✗ **manual-only** | Runs full test suites — costly |
| `review-coordinator` | sonnet (30t) | ✓ auto | Orchestrator for /specflow.review |
| `security-auditor` | sonnet (20t) | ✓ auto | Cheap sub-agent |
| `test-reviewer` | sonnet (20t) | ✓ auto | Cheap sub-agent |
| `workflow-manager` | sonnet (60t) | ✓ auto | Orchestrator |

Models all looked appropriate (opus for heavy work, sonnet for review/orchestration) — no model changes.

Description text on the 3 manual-only agents is also tightened to make the intent visible to users reading the agent files (e.g. "Manual-only — invoke explicitly when…").

## Documentation

`AGENTS.md` now documents the manual-only vs auto-triggerable distinction in the "Specialist agent team" section, so users understand the rationale when extending or adding agents.

Other harnesses ignore the flag (they don't model auto-invocation the same way), so the agents still work universally — the flag only restricts auto-spawn under Claude Code.

## Test plan

- [x] `deno task test` green (317 passing — no test changes; pure content tweaks)
- [x] Pre-commit hook green (fmt + lint + bundle + check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)