### PR TITLE
docs: surface optional Claude Code integrations in scaffolded CLAUDE.md (closes #81)

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -6497,6 +6497,35 @@ export const HARNESS_STATIC: Record<string, Record<string, TemplateFile>> = {
 - **Agents**: specialized agents live in \`.claude/agents/\`.
 - **Backlog**: managed via \`/backlog\` — when the project uses the local
   Markdown backend, see \`.specflow/backlog.md\`.
+
+## Optional integrations
+
+These are Claude Code features Specflow does NOT configure by default, but
+that pair well with the scaffolded workflow. Set them up if they fit your
+team's needs.
+
+- **Periodic maintenance** — \`/loop 1h\` runs a recurring prompt every hour
+  (e.g. groom backlog, surface stale PRs, check for orphan specs). Customize
+  the loop prompt by creating \`.claude/loop.md\` in this project. See
+  https://code.claude.com/docs/fr/scheduled-tasks.
+
+- **Async notifications** — install one of the channel plugins (Telegram,
+  Discord, iMessage) so Claude can ping you when a long-running task or
+  agent dispatch finishes. See
+  https://code.claude.com/docs/fr/channels.
+
+- **Headless / CI invocation** — \`claude -p "<prompt>"\` runs Claude Code
+  non-interactively, useful for CI gates, pre-commit hooks, and cron jobs
+  that dispatch a specific agent. See
+  https://code.claude.com/docs/fr/headless.
+
+- **Deep links** — a \`claude-cli://open?repo=<owner>/<repo>&q=<prompt>\` URL
+  opens a fresh Claude Code session in the right project with the prompt
+  pre-filled. Useful in runbooks, dashboards, and Slack messages. See
+  https://code.claude.com/docs/fr/deep-links.
+
+- **MCP servers** — connect external tools (GitHub, GCP, AWS, databases)
+  via \`.mcp.json\`. See https://code.claude.com/docs/fr/mcp.
 `,
       executable: false,
     },

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -7,3 +7,32 @@
 - **Agents**: specialized agents live in `.claude/agents/`.
 - **Backlog**: managed via `/backlog` — when the project uses the local
   Markdown backend, see `.specflow/backlog.md`.
+
+## Optional integrations
+
+These are Claude Code features Specflow does NOT configure by default, but
+that pair well with the scaffolded workflow. Set them up if they fit your
+team's needs.
+
+- **Periodic maintenance** — `/loop 1h` runs a recurring prompt every hour
+  (e.g. groom backlog, surface stale PRs, check for orphan specs). Customize
+  the loop prompt by creating `.claude/loop.md` in this project. See
+  https://code.claude.com/docs/fr/scheduled-tasks.
+
+- **Async notifications** — install one of the channel plugins (Telegram,
+  Discord, iMessage) so Claude can ping you when a long-running task or
+  agent dispatch finishes. See
+  https://code.claude.com/docs/fr/channels.
+
+- **Headless / CI invocation** — `claude -p "<prompt>"` runs Claude Code
+  non-interactively, useful for CI gates, pre-commit hooks, and cron jobs
+  that dispatch a specific agent. See
+  https://code.claude.com/docs/fr/headless.
+
+- **Deep links** — a `claude-cli://open?repo=<owner>/<repo>&q=<prompt>` URL
+  opens a fresh Claude Code session in the right project with the prompt
+  pre-filled. Useful in runbooks, dashboards, and Slack messages. See
+  https://code.claude.com/docs/fr/deep-links.
+
+- **MCP servers** — connect external tools (GitHub, GCP, AWS, databases)
+  via `.mcp.json`. See https://code.claude.com/docs/fr/mcp.


### PR DESCRIPTION
## Summary

Implements #81. Adds an **Optional integrations** section to the bundled `templates/harness-specific/claude/CLAUDE.md` so users scaffolded with `--ai claude` discover features Specflow does not configure by default but that pair well with the workflow.

## What's surfaced

| Feature | Why it matters | Docs link |
|---|---|---|
| `/loop` + `.claude/loop.md` | Periodic backlog grooming, stale PR checks | docs/fr/scheduled-tasks |
| Channels (Telegram/Discord/iMessage) | Async notifications when long agent dispatches finish | docs/fr/channels |
| `claude -p` headless | CI gates, pre-commit hooks, cron-driven agent dispatch | docs/fr/headless |
| Deep links | Runbook / dashboard / Slack URLs that open Claude Code in the right project with a pre-filled prompt | docs/fr/deep-links |
| MCP servers | External tool integration (GitHub, GCP, AWS, databases) via `.mcp.json` | docs/fr/mcp |

Each item is one paragraph; Specflow doesn't try to teach the feature, only nudge users towards it. The canonical docs at `code.claude.com` do the rest.

## Out of scope

Setup helpers / scaffolded configs for any of these — those are the dedicated tickets in the backlog (#72 hooks, #74 GitHub MCP, #75 loop.md skill, #78 dispatch-agent helper). This ticket is **discovery-only**.

## Test plan

- [x] `deno task test` green (317 passing — pure docs change)
- [x] Pre-commit hook green
- [x] No new test required: this content lives in the bundle, the existing scaffold-content tests already verify CLAUDE.md is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)