### PR TITLE
feat(agents): bundle memory/ stubs for stateful agents (closes #80)

### DIFF
--- a/src/domain/core_bundle.ts
+++ b/src/domain/core_bundle.ts
@@ -3,6 +3,7 @@ import type { BacklogBackend } from "./installed_lock.ts";
 export type CoreCategory =
   | "command"
   | "agent"
+  | "agent-memory"
   | "skill"
   | "spec-root"
   | "project-root"

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -45,6 +45,8 @@ function destinationFor(entry: CoreEntry): string {
       return `.agent/skills/${skillFolderName(entry)}/SKILL.md`;
     case "backlog-script":
       return backlogScriptDestination(entry);
+    case "agent-memory":
+      throw new Error("agent-memory entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -64,6 +66,8 @@ export class AntigravityHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);
       let content: string;
       switch (entry.category) {

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -12,6 +12,9 @@ function destinationFor(entry: CoreEntry): string {
       return `.claude/commands/${entry.name}.md`;
     case "agent":
       return `.claude/agents/${entry.name}.md`;
+    case "agent-memory":
+      if (!entry.suffix) throw new Error(`agent-memory needs suffix: ${entry.name}`);
+      return `.claude/agents/${entry.name}/memory/${entry.suffix}`;
     case "skill":
     case "backlog-skill":
       return `.claude/skills/${entry.name}/SKILL.md`;

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -33,6 +33,8 @@ export class CodexHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       switch (entry.category) {
         case "agent":
           out[`.codex/agents/${entry.name}.toml`] = {

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -21,6 +21,8 @@ function destinationFor(entry: CoreEntry): string {
       return `.github/instructions/${skillFolderName(entry)}.instructions.md`;
     case "backlog-script":
       return backlogScriptDestination(entry);
+    case "agent-memory":
+      throw new Error("agent-memory entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -40,6 +42,8 @@ export class CopilotHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);
       const isInstruction = entry.category === "command" ||
         entry.category === "backlog-cmd" ||

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -15,6 +15,8 @@ function destinationFor(entry: CoreEntry): string {
       return `.cursor/skills/${skillFolderName(entry)}/SKILL.md`;
     case "backlog-script":
       return backlogScriptDestination(entry);
+    case "agent-memory":
+      throw new Error("agent-memory entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -34,6 +36,8 @@ export class CursorHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);
       let content = entry.content;
       const isSkillFile = entry.category === "command" ||

--- a/src/infrastructure/harness/gemini_harness.ts
+++ b/src/infrastructure/harness/gemini_harness.ts
@@ -34,6 +34,8 @@ export class GeminiHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       switch (entry.category) {
         case "command":
         case "backlog-cmd": {

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -108,6 +108,8 @@ function destinationFor(entry: CoreEntry): string {
       return `.opencode/skills/${skillFolderName(entry)}/SKILL.md`;
     case "backlog-script":
       return backlogScriptDestination(entry);
+    case "agent-memory":
+      throw new Error("agent-memory entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -127,6 +129,8 @@ export class OpenCodeHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);
       let content: string;
       switch (entry.category) {

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -23,6 +23,8 @@ function destinationFor(entry: CoreEntry): string {
       return `.windsurf/workflows/${skillFolderName(entry)}.md`;
     case "backlog-script":
       return backlogScriptDestination(entry);
+    case "agent-memory":
+      throw new Error("agent-memory entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -42,6 +44,8 @@ export class WindsurfHarness implements Harness {
     for (const raw of core) {
       const entry = applyBackend(raw, opts);
       if (entry === null) continue;
+      // agent-memory is Claude-only (folder convention); other harnesses skip.
+      if (entry.category === "agent-memory") continue;
       out[destinationFor(entry)] = {
         content: entry.content,
         executable: entry.executable,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2526,6 +2526,220 @@ End with a single \`VERDICT\` line: \`VERDICT: pass\` or
     backend: null,
   },
   {
+    category: "agent-memory",
+    name: "product-owner",
+    suffix: "MEMORY.md",
+    content: `# Product Owner agent memory
+
+Index of persistent notes for the \`product-owner\` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** \`- [Title](file.md) — one-line hook describing why this is worth remembering\`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a decision is encoded in \`AGENTS.md\` or in a closed
+ticket, the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the PO discovers something that should survive
+across sessions and isn't captured elsewhere:
+
+- Recurring backlog conventions specific to this project (label taxonomy,
+  body shape preferences, escalation patterns).
+- Stakeholder preferences ("Kevin always wants AC bullets to start with
+  testable verbs").
+- Incidents and their resolutions ("when \`gh\` returns 404 on a project
+  command, refresh the auth token with \`gh auth refresh -s project\`").
+- External-tracker quirks (project field IDs that drift, GraphQL
+  endpoints that misbehave in some account contexts).
+
+## When NOT to add an entry
+
+- Project-vision-level facts → those go in \`AGENTS.md\`.
+- One-off facts about a single ticket → those go in the ticket body.
+- Anything derivable from \`gh\` / \`git log\` — the PO can re-query.
+
+## Entries
+
+<!-- (this stub starts empty — the PO populates it as it learns) -->
+`,
+    executable: false,
+    backend: null,
+  },
+  {
+    category: "agent-memory",
+    name: "developer",
+    suffix: "MEMORY.md",
+    content: `# Developer agent memory
+
+Index of persistent notes for the \`developer\` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** \`- [Title](file.md) — one-line hook describing why this is worth remembering\`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a workaround is captured in code or a fix lands
+upstream, the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the developer discovers something that should
+survive across sessions and isn't captured elsewhere:
+
+- Codebase gotchas ("file X has a load-bearing side effect at import time;
+  do not move it").
+- Failed approaches ("we tried Y to solve Z and it didn't work because…").
+- Library quirks specific to the version this project pins.
+- Build / test environment specifics ("Deno 2.x emits a benign warning
+  about exports field; ignore in \`deno run\`, not in compiled binary").
+
+## When NOT to add an entry
+
+- Architecture decisions → those go in \`AGENTS.md\` or \`.specflow/memory/constitution.md\`.
+- One-off bug fixes that are captured in the commit message → no memory
+  needed.
+- Anything the developer can re-derive by reading the current code.
+
+## Entries
+
+<!-- (this stub starts empty — the developer populates it as it learns) -->
+`,
+    executable: false,
+    backend: null,
+  },
+  {
+    category: "agent-memory",
+    name: "qa-tester",
+    suffix: "MEMORY.md",
+    content: `# QA tester agent memory
+
+Index of persistent notes for the \`qa-tester\` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** \`- [Title](file.md) — one-line hook describing why this is worth remembering\`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a flaky test is fixed or a known-good finding is filed
+as a ticket, the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the QA tester discovers something that should
+survive across sessions and isn't captured elsewhere:
+
+- **Tracked findings** — items already filed as tickets that the tester
+  should NOT re-flag in subsequent runs (until the ticket closes and the
+  fix needs verification).
+- **Flaky tests** — ones that fail intermittently for known
+  environment-specific reasons; record the trigger and the workaround.
+- **Test fixture quirks** — load-bearing setup details that aren't obvious
+  from reading the test code.
+- **Caching caveats** — e.g. CDNs, package managers, or third-party APIs
+  whose responses can be stale right after a deploy.
+
+## When NOT to add an entry
+
+- Test failures that map directly to a real bug → file a ticket via the
+  PO, not a memory entry.
+- One-off transient errors that resolve on retry → no memory needed.
+
+## Entries
+
+<!-- (this stub starts empty — the QA tester populates it as it learns) -->
+`,
+    executable: false,
+    backend: null,
+  },
+  {
+    category: "agent-memory",
+    name: "devops-sre",
+    suffix: "MEMORY.md",
+    content: `# DevOps / SRE agent memory
+
+Index of persistent notes for the \`devops-sre\` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** \`- [Title](file.md) — one-line hook describing why this is worth remembering\`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once an incident is post-mortemed and the fix is in IaC,
+the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the devops-sre agent discovers something that
+should survive across sessions and isn't captured elsewhere:
+
+- **Pipeline quirks** — flaky CI steps, runner availability windows,
+  rate-limit gotchas with cloud providers.
+- **Deployment gotchas** — order-of-operations issues ("must apply X
+  migration BEFORE rolling out service Y"), dual-region propagation lags.
+- **Secret / credential locations** — which secrets live where, who
+  rotates them, what breaks when they expire.
+- **Observability blind spots** — metrics or logs that don't capture an
+  important class of incident; pointers to the dashboards that do.
+
+## When NOT to add an entry
+
+- IaC / pipeline definitions → those live in the actual config files.
+- Architecture choices → those go in \`AGENTS.md\` or
+  \`.specflow/memory/constitution.md\`.
+- One-off incidents that are fully resolved with no recurring risk → no
+  memory needed.
+
+## Entries
+
+<!-- (this stub starts empty — the devops-sre populates it as it learns) -->
+`,
+    executable: false,
+    backend: null,
+  },
+  {
+    category: "agent-memory",
+    name: "security-auditor",
+    suffix: "MEMORY.md",
+    content: `# Security auditor agent memory
+
+Index of persistent notes for the \`security-auditor\` subagent. Each entry
+below points to a single-topic Markdown file in this same directory.
+
+**Format:** \`- [Title](file.md) — one-line hook describing why this is worth remembering\`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a class of finding is fully addressed in code (e.g.
+all input validation centralised behind one helper), the memory entry can
+be retired.
+
+## When to add an entry here
+
+Add a new memory file when the security auditor discovers something that
+should survive across sessions and isn't captured elsewhere:
+
+- **Project-specific threat model** — assets, attackers, abuse paths the
+  auditor should weigh more heavily here than in a generic review.
+- **Recurring finding patterns** — e.g. "this repo tends to swallow
+  errors silently in catch blocks; flag any new occurrence".
+- **False-positive patterns** — patterns that LOOK like findings but
+  aren't (e.g. internal-only fields that are intentionally exposed
+  because a downstream service needs them).
+- **Compliance constraints** — data-residency, retention, or
+  encryption requirements specific to this project.
+
+## When NOT to add an entry
+
+- Generic OWASP / CWE knowledge → that's already in the auditor's base
+  prompt.
+- Specific findings on a single PR → those go in the review report.
+
+## Entries
+
+<!-- (this stub starts empty — the security auditor populates it as it learns) -->
+`,
+    executable: false,
+    backend: null,
+  },
+  {
     category: "skill",
     name: "auto-chain",
     suffix: null,

--- a/templates/core/agents/developer/memory/MEMORY.md
+++ b/templates/core/agents/developer/memory/MEMORY.md
@@ -1,0 +1,33 @@
+# Developer agent memory
+
+Index of persistent notes for the `developer` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** `- [Title](file.md) — one-line hook describing why this is worth remembering`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a workaround is captured in code or a fix lands
+upstream, the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the developer discovers something that should
+survive across sessions and isn't captured elsewhere:
+
+- Codebase gotchas ("file X has a load-bearing side effect at import time;
+  do not move it").
+- Failed approaches ("we tried Y to solve Z and it didn't work because…").
+- Library quirks specific to the version this project pins.
+- Build / test environment specifics ("Deno 2.x emits a benign warning
+  about exports field; ignore in `deno run`, not in compiled binary").
+
+## When NOT to add an entry
+
+- Architecture decisions → those go in `AGENTS.md` or `.specflow/memory/constitution.md`.
+- One-off bug fixes that are captured in the commit message → no memory
+  needed.
+- Anything the developer can re-derive by reading the current code.
+
+## Entries
+
+<!-- (this stub starts empty — the developer populates it as it learns) -->

--- a/templates/core/agents/devops-sre/memory/MEMORY.md
+++ b/templates/core/agents/devops-sre/memory/MEMORY.md
@@ -1,0 +1,36 @@
+# DevOps / SRE agent memory
+
+Index of persistent notes for the `devops-sre` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** `- [Title](file.md) — one-line hook describing why this is worth remembering`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once an incident is post-mortemed and the fix is in IaC,
+the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the devops-sre agent discovers something that
+should survive across sessions and isn't captured elsewhere:
+
+- **Pipeline quirks** — flaky CI steps, runner availability windows,
+  rate-limit gotchas with cloud providers.
+- **Deployment gotchas** — order-of-operations issues ("must apply X
+  migration BEFORE rolling out service Y"), dual-region propagation lags.
+- **Secret / credential locations** — which secrets live where, who
+  rotates them, what breaks when they expire.
+- **Observability blind spots** — metrics or logs that don't capture an
+  important class of incident; pointers to the dashboards that do.
+
+## When NOT to add an entry
+
+- IaC / pipeline definitions → those live in the actual config files.
+- Architecture choices → those go in `AGENTS.md` or
+  `.specflow/memory/constitution.md`.
+- One-off incidents that are fully resolved with no recurring risk → no
+  memory needed.
+
+## Entries
+
+<!-- (this stub starts empty — the devops-sre populates it as it learns) -->

--- a/templates/core/agents/product-owner/memory/MEMORY.md
+++ b/templates/core/agents/product-owner/memory/MEMORY.md
@@ -1,0 +1,34 @@
+# Product Owner agent memory
+
+Index of persistent notes for the `product-owner` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** `- [Title](file.md) — one-line hook describing why this is worth remembering`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a decision is encoded in `AGENTS.md` or in a closed
+ticket, the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the PO discovers something that should survive
+across sessions and isn't captured elsewhere:
+
+- Recurring backlog conventions specific to this project (label taxonomy,
+  body shape preferences, escalation patterns).
+- Stakeholder preferences ("Kevin always wants AC bullets to start with
+  testable verbs").
+- Incidents and their resolutions ("when `gh` returns 404 on a project
+  command, refresh the auth token with `gh auth refresh -s project`").
+- External-tracker quirks (project field IDs that drift, GraphQL
+  endpoints that misbehave in some account contexts).
+
+## When NOT to add an entry
+
+- Project-vision-level facts → those go in `AGENTS.md`.
+- One-off facts about a single ticket → those go in the ticket body.
+- Anything derivable from `gh` / `git log` — the PO can re-query.
+
+## Entries
+
+<!-- (this stub starts empty — the PO populates it as it learns) -->

--- a/templates/core/agents/qa-tester/memory/MEMORY.md
+++ b/templates/core/agents/qa-tester/memory/MEMORY.md
@@ -1,0 +1,35 @@
+# QA tester agent memory
+
+Index of persistent notes for the `qa-tester` subagent. Each entry below
+points to a single-topic Markdown file in this same directory.
+
+**Format:** `- [Title](file.md) — one-line hook describing why this is worth remembering`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a flaky test is fixed or a known-good finding is filed
+as a ticket, the memory entry can be retired.
+
+## When to add an entry here
+
+Add a new memory file when the QA tester discovers something that should
+survive across sessions and isn't captured elsewhere:
+
+- **Tracked findings** — items already filed as tickets that the tester
+  should NOT re-flag in subsequent runs (until the ticket closes and the
+  fix needs verification).
+- **Flaky tests** — ones that fail intermittently for known
+  environment-specific reasons; record the trigger and the workaround.
+- **Test fixture quirks** — load-bearing setup details that aren't obvious
+  from reading the test code.
+- **Caching caveats** — e.g. CDNs, package managers, or third-party APIs
+  whose responses can be stale right after a deploy.
+
+## When NOT to add an entry
+
+- Test failures that map directly to a real bug → file a ticket via the
+  PO, not a memory entry.
+- One-off transient errors that resolve on retry → no memory needed.
+
+## Entries
+
+<!-- (this stub starts empty — the QA tester populates it as it learns) -->

--- a/templates/core/agents/security-auditor/memory/MEMORY.md
+++ b/templates/core/agents/security-auditor/memory/MEMORY.md
@@ -1,0 +1,36 @@
+# Security auditor agent memory
+
+Index of persistent notes for the `security-auditor` subagent. Each entry
+below points to a single-topic Markdown file in this same directory.
+
+**Format:** `- [Title](file.md) — one-line hook describing why this is worth remembering`
+
+**Keep the index under 200 lines.** Prune entries that are no longer
+load-bearing — once a class of finding is fully addressed in code (e.g.
+all input validation centralised behind one helper), the memory entry can
+be retired.
+
+## When to add an entry here
+
+Add a new memory file when the security auditor discovers something that
+should survive across sessions and isn't captured elsewhere:
+
+- **Project-specific threat model** — assets, attackers, abuse paths the
+  auditor should weigh more heavily here than in a generic review.
+- **Recurring finding patterns** — e.g. "this repo tends to swallow
+  errors silently in catch blocks; flag any new occurrence".
+- **False-positive patterns** — patterns that LOOK like findings but
+  aren't (e.g. internal-only fields that are intentionally exposed
+  because a downstream service needs them).
+- **Compliance constraints** — data-residency, retention, or
+  encryption requirements specific to this project.
+
+## When NOT to add an entry
+
+- Generic OWASP / CWE knowledge → that's already in the auditor's base
+  prompt.
+- Specific findings on a single PR → those go in the review report.
+
+## Entries
+
+<!-- (this stub starts empty — the security auditor populates it as it learns) -->

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -23,6 +23,12 @@
     { "category": "agent", "name": "workflow-manager", "source": "core/agents/workflow-manager.md" },
     { "category": "agent", "name": "devops-sre", "source": "core/agents/devops-sre.md" },
 
+    { "category": "agent-memory", "name": "product-owner", "suffix": "MEMORY.md", "source": "core/agents/product-owner/memory/MEMORY.md" },
+    { "category": "agent-memory", "name": "developer", "suffix": "MEMORY.md", "source": "core/agents/developer/memory/MEMORY.md" },
+    { "category": "agent-memory", "name": "qa-tester", "suffix": "MEMORY.md", "source": "core/agents/qa-tester/memory/MEMORY.md" },
+    { "category": "agent-memory", "name": "devops-sre", "suffix": "MEMORY.md", "source": "core/agents/devops-sre/memory/MEMORY.md" },
+    { "category": "agent-memory", "name": "security-auditor", "suffix": "MEMORY.md", "source": "core/agents/security-auditor/memory/MEMORY.md" },
+
     { "category": "skill", "name": "auto-chain", "source": "core/skills/auto-chain/SKILL.md" },
 
     { "category": "backlog-skill", "name": "backlog", "source": "core/skills/backlog/SKILL.md" },

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -12,8 +12,9 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
   const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
   const keys = Object.keys(mapped).sort();
-  // 39 base core + 1 backlog skill + 5 local backlog scripts + .claude/CLAUDE.md
-  assertEquals(keys.length, 46);
+  // 39 base core + 1 backlog skill + 5 local backlog scripts + 5 agent
+  // memory stubs (Claude only) + .claude/CLAUDE.md
+  assertEquals(keys.length, 51);
   // Spot-check canonical paths
   assert(".claude/commands/specflow.specify.md" in mapped);
   assert(".claude/commands/backlog.md" in mapped);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -63,10 +63,20 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
       Deno.readDir(join(root, ".claude/commands")),
     )).length;
     assertEquals(commandsCount, 11);
-    const agentsCount = (await Array.fromAsync(
+    // 9 agent .md files + 5 memory subfolders (product-owner, developer,
+    // qa-tester, devops-sre, security-auditor)
+    const agentDirEntries = await Array.fromAsync(
       Deno.readDir(join(root, ".claude/agents")),
-    )).length;
-    assertEquals(agentsCount, 9);
+    );
+    const agentMdCount = agentDirEntries.filter((e) => e.isFile && e.name.endsWith(".md")).length;
+    assertEquals(agentMdCount, 9);
+    const memoryDirCount = agentDirEntries.filter((e) => e.isDirectory).length;
+    assertEquals(memoryDirCount, 5);
+    // Spot-check one memory file
+    assertEquals(
+      await exists(join(root, ".claude/agents/product-owner/memory/MEMORY.md")),
+      true,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Implements #80. Scaffolds `.claude/agents/<agent>/memory/MEMORY.md` stubs for the 5 bundled agents that benefit from cross-session memory, mirroring Specflow's own dogfood pattern.

## Which agents get a memory dir

| Agent | Memory? | Rationale |
|---|---|---|
| `product-owner` | ✓ | Project conventions, escalation patterns |
| `developer` | ✓ | Codebase gotchas, failed approaches |
| `qa-tester` | ✓ | Tracked findings, flaky tests, fixture quirks |
| `devops-sre` | ✓ | Pipeline / deployment quirks, secret locations |
| `security-auditor` | ✓ | Project threat model, false-positive patterns |
| `code-reviewer` | ✗ | Cheap, single-shot review — re-reads code each time |
| `test-reviewer` | ✗ | Same |
| `review-coordinator` | ✗ | Orchestrator — delegates, no own memory |
| `workflow-manager` | ✗ | Orchestrator — same |

## Empty stubs (resolution of the open question)

The MEMORY.md files ship **empty** (no pre-seeded entries). Pre-seeded patterns risk going stale or being project-specific; users decide what's worth memorizing as the agent learns. Each stub explains:
- When to add an entry (with concrete categories per agent)
- When NOT to add an entry (vs. AGENTS.md, constitution, ticket bodies)
- The index format

## Mechanism

- New `CoreCategory` value: `"agent-memory"`
- Manifest entries: `{ category, name, suffix: "MEMORY.md", source }`
- `ClaudeHarness` maps to `.claude/agents/<name>/memory/<suffix>`
- 6 other harnesses skip `agent-memory` entries (Claude-only folder convention)
- `destinationFor` switches in non-Claude harnesses throw on `agent-memory` (defense-in-depth: should be filtered upstream)

## Tests

- `claude_harness_test`: bundle count 46 → 51 (+5 stubs)
- `init_test`: asserts 5 memory subdirs alongside 9 agent `.md` files; spot-checks `product-owner/memory/MEMORY.md`
- Validated end-to-end via test-sandbox: `init --ai claude` scaffolds all 5 memory dirs with their stub content
- 317 tests pass (unchanged count — 2 tests updated, 0 added)

## Test plan

- [x] `deno task test` green
- [x] Brownfield validated via test-sandbox
- [x] Pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)