### PR TITLE
feat(claude): bundle dispatch-agent.sh helper for headless invocation (closes #78)

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -6730,7 +6730,9 @@ team's needs.
 
 - **Headless / CI invocation** — \`claude -p "<prompt>"\` runs Claude Code
   non-interactively, useful for CI gates, pre-commit hooks, and cron jobs
-  that dispatch a specific agent. See
+  that dispatch a specific agent. Specflow ships a wrapper at
+  \`.claude/scripts/dispatch-agent.sh <agent-name> "<prompt>"\` that auto-
+  derives the right \`--allowedTools\` from the agent's frontmatter. See
   https://code.claude.com/docs/fr/headless.
 
 - **Deep links** — a \`claude-cli://open?repo=<owner>/<repo>&q=<prompt>\` URL
@@ -6742,6 +6744,87 @@ team's needs.
   via \`.mcp.json\`. See https://code.claude.com/docs/fr/mcp.
 `,
       executable: false,
+    },
+    ".claude/scripts/dispatch-agent.sh": {
+      content: `#!/usr/bin/env bash
+# Dispatch a Claude Code subagent in headless mode.
+#
+# Reads the agent's \`tools:\` frontmatter from .claude/agents/<name>.md and
+# passes it through to \`claude -p --allowedTools\`. The user prompt is
+# wrapped with a directive that loads the agent's full definition (so the
+# headless session adopts the agent's persona + system prompt).
+#
+# Useful for CI gates, pre-commit hooks, cron jobs, and any non-interactive
+# context where you want a specific agent to act without opening a terminal.
+#
+# Usage:
+#   .claude/scripts/dispatch-agent.sh <agent-name> "<prompt>"
+#
+# Environment variables:
+#   MODEL          Override the model (e.g. "claude-sonnet-4-6").
+#                  Defaults to whatever the agent or claude binary picks.
+#   OUTPUT_FORMAT  json | text | stream-json. Defaults to text.
+#
+# Examples:
+#   .claude/scripts/dispatch-agent.sh code-reviewer "Review the diff in /tmp/pr.diff"
+#   .claude/scripts/dispatch-agent.sh product-owner "Open a backlog item titled X"
+#   OUTPUT_FORMAT=json .claude/scripts/dispatch-agent.sh qa-tester "Run the suite"
+set -euo pipefail
+
+if [ "\$#" -lt 2 ]; then
+  cat >&2 <<USAGE
+usage: dispatch-agent.sh <agent-name> "<prompt>"
+
+Dispatches a bundled Claude Code subagent in headless mode (\\\`claude -p\\\`)
+with the right tool allowlist, derived from the agent's frontmatter.
+
+Examples:
+  dispatch-agent.sh code-reviewer "Review /tmp/pr.diff"
+  dispatch-agent.sh product-owner "Open a backlog item titled Foo"
+USAGE
+  exit 2
+fi
+
+AGENT="\$1"
+USER_PROMPT="\$2"
+
+ROOT="\$(cd "\$(dirname "\$0")/.." && pwd)"
+AGENT_FILE="\$ROOT/agents/\$AGENT.md"
+
+if [ ! -f "\$AGENT_FILE" ]; then
+  echo "error: agent file not found at \$AGENT_FILE" >&2
+  echo "       run from the project root, or check the agent name." >&2
+  exit 1
+fi
+
+# Extract the \`tools:\` line from the agent's frontmatter (between the first
+# two \`---\` delimiters). Comma-separated tool names map directly onto
+# claude's --allowedTools.
+TOOLS=\$(awk '/^---\$/{n++; next} n==1 && /^tools:/ {sub(/^tools:[[:space:]]*/, ""); print; exit}' "\$AGENT_FILE")
+
+WRAPPED_PROMPT="You are the \\\`\$AGENT\\\` subagent for this project. Read your full definition at \\\`.claude/agents/\$AGENT.md\\\` (frontmatter + body) before doing anything. Then perform the task below.
+
+---
+
+\$USER_PROMPT"
+
+ARGS=("-p" "\$WRAPPED_PROMPT")
+
+if [ -n "\$TOOLS" ]; then
+  ARGS+=("--allowedTools" "\$TOOLS")
+fi
+
+if [ -n "\${MODEL:-}" ]; then
+  ARGS+=("--model" "\$MODEL")
+fi
+
+if [ -n "\${OUTPUT_FORMAT:-}" ]; then
+  ARGS+=("--output-format" "\$OUTPUT_FORMAT")
+fi
+
+exec claude "\${ARGS[@]}"
+`,
+      executable: true,
     },
   },
   "cursor": {

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -26,7 +26,9 @@ team's needs.
 
 - **Headless / CI invocation** — `claude -p "<prompt>"` runs Claude Code
   non-interactively, useful for CI gates, pre-commit hooks, and cron jobs
-  that dispatch a specific agent. See
+  that dispatch a specific agent. Specflow ships a wrapper at
+  `.claude/scripts/dispatch-agent.sh <agent-name> "<prompt>"` that auto-
+  derives the right `--allowedTools` from the agent's frontmatter. See
   https://code.claude.com/docs/fr/headless.
 
 - **Deep links** — a `claude-cli://open?repo=<owner>/<repo>&q=<prompt>` URL

--- a/templates/harness-specific/claude/scripts/dispatch-agent.sh
+++ b/templates/harness-specific/claude/scripts/dispatch-agent.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Dispatch a Claude Code subagent in headless mode.
+#
+# Reads the agent's `tools:` frontmatter from .claude/agents/<name>.md and
+# passes it through to `claude -p --allowedTools`. The user prompt is
+# wrapped with a directive that loads the agent's full definition (so the
+# headless session adopts the agent's persona + system prompt).
+#
+# Useful for CI gates, pre-commit hooks, cron jobs, and any non-interactive
+# context where you want a specific agent to act without opening a terminal.
+#
+# Usage:
+#   .claude/scripts/dispatch-agent.sh <agent-name> "<prompt>"
+#
+# Environment variables:
+#   MODEL          Override the model (e.g. "claude-sonnet-4-6").
+#                  Defaults to whatever the agent or claude binary picks.
+#   OUTPUT_FORMAT  json | text | stream-json. Defaults to text.
+#
+# Examples:
+#   .claude/scripts/dispatch-agent.sh code-reviewer "Review the diff in /tmp/pr.diff"
+#   .claude/scripts/dispatch-agent.sh product-owner "Open a backlog item titled X"
+#   OUTPUT_FORMAT=json .claude/scripts/dispatch-agent.sh qa-tester "Run the suite"
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  cat >&2 <<USAGE
+usage: dispatch-agent.sh <agent-name> "<prompt>"
+
+Dispatches a bundled Claude Code subagent in headless mode (\`claude -p\`)
+with the right tool allowlist, derived from the agent's frontmatter.
+
+Examples:
+  dispatch-agent.sh code-reviewer "Review /tmp/pr.diff"
+  dispatch-agent.sh product-owner "Open a backlog item titled Foo"
+USAGE
+  exit 2
+fi
+
+AGENT="$1"
+USER_PROMPT="$2"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AGENT_FILE="$ROOT/agents/$AGENT.md"
+
+if [ ! -f "$AGENT_FILE" ]; then
+  echo "error: agent file not found at $AGENT_FILE" >&2
+  echo "       run from the project root, or check the agent name." >&2
+  exit 1
+fi
+
+# Extract the `tools:` line from the agent's frontmatter (between the first
+# two `---` delimiters). Comma-separated tool names map directly onto
+# claude's --allowedTools.
+TOOLS=$(awk '/^---$/{n++; next} n==1 && /^tools:/ {sub(/^tools:[[:space:]]*/, ""); print; exit}' "$AGENT_FILE")
+
+WRAPPED_PROMPT="You are the \`$AGENT\` subagent for this project. Read your full definition at \`.claude/agents/$AGENT.md\` (frontmatter + body) before doing anything. Then perform the task below.
+
+---
+
+$USER_PROMPT"
+
+ARGS=("-p" "$WRAPPED_PROMPT")
+
+if [ -n "$TOOLS" ]; then
+  ARGS+=("--allowedTools" "$TOOLS")
+fi
+
+if [ -n "${MODEL:-}" ]; then
+  ARGS+=("--model" "$MODEL")
+fi
+
+if [ -n "${OUTPUT_FORMAT:-}" ]; then
+  ARGS+=("--output-format" "$OUTPUT_FORMAT")
+fi
+
+exec claude "${ARGS[@]}"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -66,6 +66,7 @@
   ],
   "harness_static": [
     { "harness": "claude", "destination": ".claude/CLAUDE.md", "source": "harness-specific/claude/CLAUDE.md" },
+    { "harness": "claude", "destination": ".claude/scripts/dispatch-agent.sh", "source": "harness-specific/claude/scripts/dispatch-agent.sh", "executable": true },
     { "harness": "cursor", "destination": ".cursor/rules/specify-rules.mdc", "source": "harness-specific/cursor/specify-rules.mdc" }
   ]
 }

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -13,8 +13,9 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
   const keys = Object.keys(mapped).sort();
   // 39 base core + 1 backlog skill + 5 local backlog scripts + 5 agent
-  // memory stubs (Claude only) + .claude/CLAUDE.md
-  assertEquals(keys.length, 51);
+  // memory stubs (Claude only) + .claude/CLAUDE.md +
+  // .claude/scripts/dispatch-agent.sh
+  assertEquals(keys.length, 52);
   // Spot-check canonical paths
   assert(".claude/commands/specflow.specify.md" in mapped);
   assert(".claude/commands/backlog.md" in mapped);


### PR DESCRIPTION
## Summary

Implements #78. Bundles `.claude/scripts/dispatch-agent.sh` for the Claude harness — a wrapper around `claude -p` that auto-derives the `--allowedTools` allowlist from the target agent's frontmatter and prefixes the prompt with a directive that loads the agent's persona.

## Use cases

- **CI gates** running `code-reviewer` / `security-auditor` on a PR diff
- **Pre-commit hooks** dispatching the `test-reviewer`
- **Cron jobs** dispatching the `product-owner` to groom the backlog

## Usage

```bash
.claude/scripts/dispatch-agent.sh <agent-name> "<prompt>"
```

**Examples**:
```bash
.claude/scripts/dispatch-agent.sh code-reviewer "Review the diff in /tmp/pr.diff"
.claude/scripts/dispatch-agent.sh product-owner "Open a backlog item titled X"
OUTPUT_FORMAT=json .claude/scripts/dispatch-agent.sh qa-tester "Run the suite"
```

**Env overrides**:
- `MODEL` — override the model (e.g. `claude-sonnet-4-6`)
- `OUTPUT_FORMAT` — `json` / `text` / `stream-json`

## Mechanism

- New `harness_static` manifest entry for the Claude harness with `executable: true` — leverages the existing harness-specific delivery (same path as the bundled CLAUDE.md)
- Other harnesses unaffected (they get their own static files via the same mechanism)

## Documentation

The bundled `CLAUDE.md` "Optional integrations" section now mentions the helper alongside the headless docs link, so users discover it without having to read source.

## Tests

- `claude_harness_test` bundle count: 51 → 52
- Validated end-to-end via test-sandbox: file is scaffolded at `.claude/scripts/dispatch-agent.sh` with the `+x` bit set
- 317 tests pass

## Test plan

- [x] `deno task test` green
- [x] Validated via test-sandbox (Vite scaffold + claude harness)
- [x] Pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)