### PR TITLE
feat(check): validate Claude config in specflow check --project (closes #79)

### DIFF
--- a/src/infrastructure/fs_project_inspector.ts
+++ b/src/infrastructure/fs_project_inspector.ts
@@ -17,6 +17,44 @@ function isEmptyPlaceholderConstitution(text: string): boolean {
   return text.includes("(none defined yet)") || text.trim().length === 0;
 }
 
+/**
+ * Validates the shape of `.claude/settings.json`'s `hooks` field.
+ *
+ * Catches the common "matcher as array" mistake — Claude Code expects
+ * a string with `|` for OR, not a JS array. Other structural checks ensure
+ * each hook entry has the right shape so they don't silently fail at runtime.
+ */
+function validateHooks(hooks: unknown): string[] {
+  const errors: string[] = [];
+  if (typeof hooks !== "object" || hooks === null) {
+    return ["hooks must be an object"];
+  }
+  for (const [event, entries] of Object.entries(hooks as Record<string, unknown>)) {
+    if (!Array.isArray(entries)) {
+      errors.push(`hooks.${event} must be an array`);
+      continue;
+    }
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (typeof entry !== "object" || entry === null) {
+        errors.push(`hooks.${event}[${i}] must be an object`);
+        continue;
+      }
+      const e = entry as Record<string, unknown>;
+      if (e.matcher !== undefined && typeof e.matcher !== "string") {
+        errors.push(
+          `hooks.${event}[${i}].matcher must be a string (got ${typeof e
+            .matcher} — common mistake; use "Edit|Write" not ["Edit","Write"])`,
+        );
+      }
+      if (!Array.isArray(e.hooks)) {
+        errors.push(`hooks.${event}[${i}].hooks must be an array`);
+      }
+    }
+  }
+  return errors;
+}
+
 export class FsProjectInspector implements ProjectInspector {
   async inspect(projectDir: string, templatesVersion: string): Promise<CheckOutcome[]> {
     const outcomes: CheckOutcome[] = [];
@@ -25,8 +63,100 @@ export class FsProjectInspector implements ProjectInspector {
     outcomes.push(await this.checkHarness(projectDir));
     outcomes.push(await this.checkConstitution(projectDir));
     outcomes.push(await this.checkTemplatesVersion(projectDir, templatesVersion));
+    outcomes.push(...await this.checkClaudeConfig(projectDir));
 
     return outcomes;
+  }
+
+  /**
+   * Validates Claude Code-specific config files when the project's harness
+   * is Claude. Catches the most common footguns documented at
+   * https://code.claude.com/docs/fr/hooks-guide and /docs/fr/mcp.
+   *
+   * Returns an empty list for non-Claude harnesses or when no relevant
+   * config files exist.
+   */
+  private async checkClaudeConfig(projectDir: string): Promise<CheckOutcome[]> {
+    const lockPath = join(projectDir, ".specflow/installed.lock");
+    if (!(await exists(lockPath))) return [];
+    let lock;
+    try {
+      lock = parseLock(await Deno.readTextFile(lockPath));
+    } catch {
+      return [];
+    }
+    if (lock.harness !== "claude") return [];
+
+    const outcomes: CheckOutcome[] = [];
+    outcomes.push(...await this.checkSettingsJson(projectDir, ".claude/settings.json"));
+    outcomes.push(...await this.checkSettingsJson(projectDir, ".claude/settings.local.json"));
+    outcomes.push(...await this.checkMcpJson(projectDir));
+    return outcomes;
+  }
+
+  private async checkSettingsJson(
+    projectDir: string,
+    rel: string,
+  ): Promise<CheckOutcome[]> {
+    const path = join(projectDir, rel);
+    if (!(await exists(path))) return [];
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await Deno.readTextFile(path));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return [{ name: rel, status: "fail", message: `invalid JSON — ${msg}` }];
+    }
+
+    if (typeof parsed !== "object" || parsed === null) {
+      return [{ name: rel, status: "fail", message: "must be a JSON object" }];
+    }
+
+    const root = parsed as Record<string, unknown>;
+    if (root.hooks === undefined) {
+      return [{ name: rel, status: "pass", message: "well-formed (no hooks)" }];
+    }
+    const errors = validateHooks(root.hooks);
+    if (errors.length > 0) {
+      return [{ name: `${rel} hooks`, status: "fail", message: errors.join("; ") }];
+    }
+    return [{ name: `${rel} hooks`, status: "pass", message: "well-formed" }];
+  }
+
+  private async checkMcpJson(projectDir: string): Promise<CheckOutcome[]> {
+    const path = join(projectDir, ".mcp.json");
+    if (!(await exists(path))) return [];
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await Deno.readTextFile(path));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return [{ name: ".mcp.json", status: "fail", message: `invalid JSON — ${msg}` }];
+    }
+
+    if (typeof parsed !== "object" || parsed === null) {
+      return [{ name: ".mcp.json", status: "fail", message: "must be a JSON object" }];
+    }
+
+    const errors: string[] = [];
+    const servers = (parsed as Record<string, unknown>).mcpServers;
+    if (typeof servers === "object" && servers !== null) {
+      for (const [name, server] of Object.entries(servers)) {
+        if (typeof server !== "object" || server === null) continue;
+        const cmd = (server as Record<string, unknown>).command;
+        if (typeof cmd === "string" && (cmd.startsWith("./") || cmd.startsWith("../"))) {
+          errors.push(
+            `mcpServers.${name}.command uses relative path '${cmd}' — use absolute paths or 'npx'/'uvx' (relative paths resolve from the directory where Claude Code was launched, not the .mcp.json location)`,
+          );
+        }
+      }
+    }
+    if (errors.length > 0) {
+      return [{ name: ".mcp.json", status: "warn", message: errors.join("; ") }];
+    }
+    return [{ name: ".mcp.json", status: "pass", message: "well-formed" }];
   }
 
   private async checkHarness(projectDir: string): Promise<CheckOutcome> {

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -389,6 +389,205 @@ entries: {}
   );
 });
 
+// Helper: write a Claude-harness lock so checkClaudeConfig kicks in.
+async function writeClaudeLock(dir: string) {
+  await Deno.mkdir(join(dir, ".specflow"), { recursive: true });
+  await Deno.writeTextFile(
+    join(dir, ".specflow/installed.lock"),
+    `version: 2
+harness: claude
+templates_version: 0.7.0
+entries: {}
+`,
+  );
+}
+
+Deno.test("inspect skips Claude-config checks for non-Claude harnesses", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await Deno.mkdir(join(dir, ".cursor"), { recursive: true });
+      await Deno.mkdir(join(dir, ".specflow"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".specflow/installed.lock"),
+        `version: 2
+harness: cursor
+templates_version: 0.7.0
+entries: {}
+`,
+      );
+      // Even with a malformed settings.json sitting around, cursor harness
+      // means we don't lint it.
+      await Deno.mkdir(join(dir, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".claude/settings.json"),
+        `{ "hooks": { "PostToolUse": [ { "matcher": ["Edit"] } ] } }`,
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      assertEquals(
+        outcomes.find((o) => o.name.includes("settings.json")),
+        undefined,
+      );
+    },
+  );
+});
+
+Deno.test("inspect passes when .claude/settings.json has valid hooks", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.mkdir(join(dir, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".claude/settings.json"),
+        JSON.stringify({
+          hooks: {
+            PostToolUse: [
+              { matcher: "Edit|Write", hooks: [{ type: "command", command: "echo" }] },
+            ],
+          },
+        }),
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".claude/settings.json hooks");
+      assertEquals(o?.status, "pass");
+    },
+  );
+});
+
+Deno.test("inspect fails when hooks matcher is an array (common mistake)", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.mkdir(join(dir, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".claude/settings.json"),
+        JSON.stringify({
+          hooks: {
+            PostToolUse: [
+              { matcher: ["Edit", "Write"], hooks: [{ type: "command", command: "echo" }] },
+            ],
+          },
+        }),
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".claude/settings.json hooks");
+      assertEquals(o?.status, "fail");
+      assertEquals(o?.message.includes("matcher must be a string"), true);
+    },
+  );
+});
+
+Deno.test("inspect fails when hooks entries[].hooks is missing", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.mkdir(join(dir, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".claude/settings.json"),
+        JSON.stringify({
+          hooks: {
+            PostToolUse: [{ matcher: "Edit" }], // forgot the inner hooks array
+          },
+        }),
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".claude/settings.json hooks");
+      assertEquals(o?.status, "fail");
+    },
+  );
+});
+
+Deno.test("inspect fails when settings.json is invalid JSON", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.mkdir(join(dir, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".claude/settings.json"),
+        `{ "hooks": [`,
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".claude/settings.json");
+      assertEquals(o?.status, "fail");
+      assertEquals(o?.message.includes("invalid JSON"), true);
+    },
+  );
+});
+
+Deno.test("inspect warns on .mcp.json with relative command path", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.writeTextFile(
+        join(dir, ".mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            github: { command: "./bin/github-mcp", args: [] },
+          },
+        }),
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".mcp.json");
+      assertEquals(o?.status, "warn");
+      assertEquals(o?.message.includes("relative path"), true);
+    },
+  );
+});
+
+Deno.test("inspect passes on .mcp.json with absolute / npx command", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.writeTextFile(
+        join(dir, ".mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            github: { command: "npx", args: ["-y", "@github/mcp"] },
+          },
+        }),
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".mcp.json");
+      assertEquals(o?.status, "pass");
+    },
+  );
+});
+
+Deno.test("inspect fails on invalid JSON in .mcp.json", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await writeClaudeLock(dir);
+      await Deno.writeTextFile(join(dir, ".mcp.json"), `{ broken`);
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((o) => o.name === ".mcp.json");
+      assertEquals(o?.status, "fail");
+    },
+  );
+});
+
 Deno.test("inspect reports pass when opencode harness is set and .opencode/ exists", async () => {
   await withProjectDir(
     async (dir) => {


### PR DESCRIPTION
## Summary

Implements #79. Extends \`specflow check --project\` to lint Claude Code's local config files when the project's harness is \`claude\`. Catches the most common footguns documented at code.claude.com/docs/fr/hooks-guide and /docs/fr/mcp.

## What gets validated

**\`.claude/settings.json\` and \`.claude/settings.local.json\`**
- JSON parses cleanly
- \`hooks.<event>\` is an array of objects
- \`hooks.<event>[].matcher\` is a **string** (not array — common mistake; use \`\"Edit|Write\"\` not \`[\"Edit\", \"Write\"]\`)
- \`hooks.<event>[].hooks\` is an array

**\`.mcp.json\`**
- JSON parses cleanly
- \`mcpServers.<name>.command\` does not start with \`./\` or \`../\` (relative paths resolve from launch directory, not \`.mcp.json\` location — silent footgun per the docs)

## Skip rules

- **Non-Claude harnesses** (cursor, codex, etc.) skip Claude config checks entirely — they have different config shapes.
- **Missing files** are not errors — validation only runs when the file exists.

## Tests

8 new cases covering:
- Happy path (well-formed hooks + well-formed mcp.json)
- Non-Claude harness skip
- Hooks with matcher-as-array (fail)
- Hooks missing inner \`hooks\` array (fail)
- Invalid JSON in settings.json (fail)
- Relative path in .mcp.json command (warn)
- Absolute / npx path in .mcp.json command (pass)
- Invalid JSON in .mcp.json (fail)

**Total: 317 → 325 tests pass.**

## Test plan

- [x] \`deno task test\` green
- [x] Pre-commit hook green (fmt + lint + bundle + check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)