### PR TITLE
feat(claude): bundle loop.md + /specflow.groom skill for periodic hygiene (closes #75)

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2841,6 +2841,102 @@ them resume manually from the last completed phase.
     backend: null,
   },
   {
+    category: "skill",
+    name: "specflow.groom",
+    suffix: null,
+    content: `---
+description: Run a periodic hygiene pass on this Specflow project — groom Backlog items, surface stale PRs, list orphan specs. Designed to be called from \`/loop\` or as a manual one-off.
+disable-model-invocation: true
+---
+
+# /specflow.groom
+
+A maintenance pass that keeps the project's backlog and review pipeline
+flowing without human intervention. Designed to be invoked manually or
+on a timer via \`/loop\`.
+
+This skill is **manual-only** (\`disable-model-invocation: true\`) — it
+should not auto-trigger on casual user prompts. The user invokes it
+explicitly with \`/specflow.groom\` or schedules it with
+\`/loop 1h /specflow.groom\`.
+
+## What this skill does
+
+A grooming pass runs three independent checks. Each is delegated to the
+right subagent so this skill stays small and the heavy lifting is owned
+by the agent that has the right tools and prompt for the job.
+
+### 1. Backlog grooming
+
+Dispatch the **\`product-owner\`** subagent to clarify any items currently
+in the \`Backlog\` column (i.e. not yet promoted to \`Ready\`).
+
+The PO will:
+
+- Read each item's body and existing comments.
+- **Skip** items it has already commented on in a previous run (look for
+  the marker \`🤖 specflow-groom\` at the start of any comment).
+- For each remaining item:
+  - If the body is already clarified (Why / AC / Out of scope all present
+    and concrete), promote to \`Ready\`.
+  - If 1–3 scope decisions remain, leave a clarification comment marked
+    with the \`🤖 specflow-groom\` prefix so subsequent runs skip it.
+  - If the item is genuinely stale or duplicates a closed ticket, the PO
+    can recommend closure with \`not_planned\` (but does not close
+    autonomously — the recommendation lands as a comment).
+
+The PO must respect the standard backlog skill — do not bypass its
+scripts.
+
+### 2. Stale PR surface
+
+For each open PR on this repository, check whether it has been waiting
+on review or CI for more than 48 hours. List them in the report so the
+user can decide whether to ping, close, or merge.
+
+This step is read-only; do not mutate PRs.
+
+### 3. Orphan spec detection
+
+Walk \`.specflow/specs/\` (if present) and surface any feature directory
+that is missing the next expected artefact:
+
+- Has \`spec.md\` but no \`plan.md\` → flag as "needs \`/specflow.plan\`".
+- Has \`plan.md\` but no \`tasks.md\` → flag as "needs \`/specflow.tasks\`".
+- Has \`tasks.md\` but no \`installed\` markers in commits → flag as
+  "needs \`/specflow.implement\`".
+
+This is also read-only; never delete or modify spec files.
+
+## Output format
+
+End with a single summary block:
+
+\`\`\`
+specflow.groom report
+─────────────────────
+Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarification
+Stale PRs:  <S> open PRs idle > 48h
+Orphan specs: <O> spec directories missing the next artefact
+
+Next action: <one-line recommendation, or "no action needed">
+\`\`\`
+
+If nothing needed action, say so explicitly. The point of the skill is
+to be a **no-op when the project is healthy**.
+
+## When NOT to use this skill
+
+- For a single-item backlog clarification → invoke the \`product-owner\`
+  subagent directly with the item number.
+- For PR review on a specific PR → invoke \`code-reviewer\` /
+  \`security-auditor\` directly.
+- For implementing a spec → invoke \`/specflow.implement\` directly.
+`,
+    executable: false,
+    backend: null,
+  },
+  {
     category: "backlog-skill",
     name: "backlog",
     suffix: null,
@@ -6718,9 +6814,10 @@ These are Claude Code features Specflow does NOT configure by default, but
 that pair well with the scaffolded workflow. Set them up if they fit your
 team's needs.
 
-- **Periodic maintenance** — \`/loop 1h\` runs a recurring prompt every hour
-  (e.g. groom backlog, surface stale PRs, check for orphan specs). Customize
-  the loop prompt by creating \`.claude/loop.md\` in this project. See
+- **Periodic maintenance** — \`/loop 1h\` runs the prompt in
+  \`.claude/loop.md\` every hour. The bundled default delegates to the
+  \`/specflow.groom\` skill (groom backlog, surface stale PRs, list orphan
+  specs); edit \`loop.md\` freely to add project-specific checks. See
   https://code.claude.com/docs/fr/scheduled-tasks.
 
 - **Async notifications** — install one of the channel plugins (Telegram,
@@ -6825,6 +6922,44 @@ fi
 exec claude "\${ARGS[@]}"
 `,
       executable: true,
+    },
+    ".claude/loop.md": {
+      content: `# Project loop prompt
+
+This file customizes what \`/loop\` does when invoked without an explicit
+prompt. Specflow ships a sensible default below — edit freely to match
+this project's hygiene needs.
+
+## Default prompt
+
+Run a hygiene pass on this Specflow project:
+
+1. Invoke the \`/specflow.groom\` skill — it grooms the backlog, surfaces
+   stale PRs, and flags orphan specs.
+2. If anything actionable came out of the pass, summarize it concisely
+   so the human reading the loop output can decide what to do.
+3. If everything is healthy, say so in one sentence and stop. Do not
+   manufacture work.
+
+## Recommended schedules
+
+- **Active development**: \`/loop 1h\` — frequent grooming during a sprint.
+- **Quiet projects**: \`/loop 12h\` or \`/loop 24h\` — daily cadence.
+- **One-off check**: just \`/specflow.groom\` (no loop) — runs once and exits.
+
+## Customizing further
+
+Add project-specific checks below the default by appending bullets to the
+prompt above. Examples:
+
+- "Check that the staging deploy from the last \`main\` commit succeeded."
+- "Verify the daily backup ran in the last 24 hours."
+- "Ping if any feature flag is still enabled after its sunset date."
+
+Each loop iteration runs the entire prompt, so keep it focused — long
+prompts cost more tokens and drift out of relevance.
+`,
+      executable: false,
     },
   },
   "cursor": {

--- a/templates/core/skills/specflow.groom/SKILL.md
+++ b/templates/core/skills/specflow.groom/SKILL.md
@@ -1,0 +1,88 @@
+---
+description: Run a periodic hygiene pass on this Specflow project — groom Backlog items, surface stale PRs, list orphan specs. Designed to be called from `/loop` or as a manual one-off.
+disable-model-invocation: true
+---
+
+# /specflow.groom
+
+A maintenance pass that keeps the project's backlog and review pipeline
+flowing without human intervention. Designed to be invoked manually or
+on a timer via `/loop`.
+
+This skill is **manual-only** (`disable-model-invocation: true`) — it
+should not auto-trigger on casual user prompts. The user invokes it
+explicitly with `/specflow.groom` or schedules it with
+`/loop 1h /specflow.groom`.
+
+## What this skill does
+
+A grooming pass runs three independent checks. Each is delegated to the
+right subagent so this skill stays small and the heavy lifting is owned
+by the agent that has the right tools and prompt for the job.
+
+### 1. Backlog grooming
+
+Dispatch the **`product-owner`** subagent to clarify any items currently
+in the `Backlog` column (i.e. not yet promoted to `Ready`).
+
+The PO will:
+
+- Read each item's body and existing comments.
+- **Skip** items it has already commented on in a previous run (look for
+  the marker `🤖 specflow-groom` at the start of any comment).
+- For each remaining item:
+  - If the body is already clarified (Why / AC / Out of scope all present
+    and concrete), promote to `Ready`.
+  - If 1–3 scope decisions remain, leave a clarification comment marked
+    with the `🤖 specflow-groom` prefix so subsequent runs skip it.
+  - If the item is genuinely stale or duplicates a closed ticket, the PO
+    can recommend closure with `not_planned` (but does not close
+    autonomously — the recommendation lands as a comment).
+
+The PO must respect the standard backlog skill — do not bypass its
+scripts.
+
+### 2. Stale PR surface
+
+For each open PR on this repository, check whether it has been waiting
+on review or CI for more than 48 hours. List them in the report so the
+user can decide whether to ping, close, or merge.
+
+This step is read-only; do not mutate PRs.
+
+### 3. Orphan spec detection
+
+Walk `.specflow/specs/` (if present) and surface any feature directory
+that is missing the next expected artefact:
+
+- Has `spec.md` but no `plan.md` → flag as "needs `/specflow.plan`".
+- Has `plan.md` but no `tasks.md` → flag as "needs `/specflow.tasks`".
+- Has `tasks.md` but no `installed` markers in commits → flag as
+  "needs `/specflow.implement`".
+
+This is also read-only; never delete or modify spec files.
+
+## Output format
+
+End with a single summary block:
+
+```
+specflow.groom report
+─────────────────────
+Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarification
+Stale PRs:  <S> open PRs idle > 48h
+Orphan specs: <O> spec directories missing the next artefact
+
+Next action: <one-line recommendation, or "no action needed">
+```
+
+If nothing needed action, say so explicitly. The point of the skill is
+to be a **no-op when the project is healthy**.
+
+## When NOT to use this skill
+
+- For a single-item backlog clarification → invoke the `product-owner`
+  subagent directly with the item number.
+- For PR review on a specific PR → invoke `code-reviewer` /
+  `security-auditor` directly.
+- For implementing a spec → invoke `/specflow.implement` directly.

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -14,9 +14,10 @@ These are Claude Code features Specflow does NOT configure by default, but
 that pair well with the scaffolded workflow. Set them up if they fit your
 team's needs.
 
-- **Periodic maintenance** — `/loop 1h` runs a recurring prompt every hour
-  (e.g. groom backlog, surface stale PRs, check for orphan specs). Customize
-  the loop prompt by creating `.claude/loop.md` in this project. See
+- **Periodic maintenance** — `/loop 1h` runs the prompt in
+  `.claude/loop.md` every hour. The bundled default delegates to the
+  `/specflow.groom` skill (groom backlog, surface stale PRs, list orphan
+  specs); edit `loop.md` freely to add project-specific checks. See
   https://code.claude.com/docs/fr/scheduled-tasks.
 
 - **Async notifications** — install one of the channel plugins (Telegram,

--- a/templates/harness-specific/claude/loop.md
+++ b/templates/harness-specific/claude/loop.md
@@ -1,0 +1,34 @@
+# Project loop prompt
+
+This file customizes what `/loop` does when invoked without an explicit
+prompt. Specflow ships a sensible default below — edit freely to match
+this project's hygiene needs.
+
+## Default prompt
+
+Run a hygiene pass on this Specflow project:
+
+1. Invoke the `/specflow.groom` skill — it grooms the backlog, surfaces
+   stale PRs, and flags orphan specs.
+2. If anything actionable came out of the pass, summarize it concisely
+   so the human reading the loop output can decide what to do.
+3. If everything is healthy, say so in one sentence and stop. Do not
+   manufacture work.
+
+## Recommended schedules
+
+- **Active development**: `/loop 1h` — frequent grooming during a sprint.
+- **Quiet projects**: `/loop 12h` or `/loop 24h` — daily cadence.
+- **One-off check**: just `/specflow.groom` (no loop) — runs once and exits.
+
+## Customizing further
+
+Add project-specific checks below the default by appending bullets to the
+prompt above. Examples:
+
+- "Check that the staging deploy from the last `main` commit succeeded."
+- "Verify the daily backup ran in the last 24 hours."
+- "Ping if any feature flag is still enabled after its sunset date."
+
+Each loop iteration runs the entire prompt, so keep it focused — long
+prompts cost more tokens and drift out of relevance.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -30,6 +30,7 @@
     { "category": "agent-memory", "name": "security-auditor", "suffix": "MEMORY.md", "source": "core/agents/security-auditor/memory/MEMORY.md" },
 
     { "category": "skill", "name": "auto-chain", "source": "core/skills/auto-chain/SKILL.md" },
+    { "category": "skill", "name": "specflow.groom", "source": "core/skills/specflow.groom/SKILL.md" },
 
     { "category": "backlog-skill", "name": "backlog", "source": "core/skills/backlog/SKILL.md" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/local/list.sh", "executable": true, "backend": "local" },
@@ -67,6 +68,7 @@
   "harness_static": [
     { "harness": "claude", "destination": ".claude/CLAUDE.md", "source": "harness-specific/claude/CLAUDE.md" },
     { "harness": "claude", "destination": ".claude/scripts/dispatch-agent.sh", "source": "harness-specific/claude/scripts/dispatch-agent.sh", "executable": true },
+    { "harness": "claude", "destination": ".claude/loop.md", "source": "harness-specific/claude/loop.md" },
     { "harness": "cursor", "destination": ".cursor/rules/specify-rules.mdc", "source": "harness-specific/cursor/specify-rules.mdc" }
   ]
 }

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -12,10 +12,12 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
   const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
   const keys = Object.keys(mapped).sort();
-  // 39 base core + 1 backlog skill + 5 local backlog scripts + 5 agent
-  // memory stubs (Claude only) + .claude/CLAUDE.md +
-  // .claude/scripts/dispatch-agent.sh
-  assertEquals(keys.length, 52);
+  // 40 base core (39 + specflow.groom skill) + 1 backlog skill +
+  // 5 local backlog scripts + 5 agent memory stubs (Claude only) +
+  // .claude/CLAUDE.md + .claude/scripts/dispatch-agent.sh + .claude/loop.md
+  assertEquals(keys.length, 54);
+  assert(".claude/skills/specflow.groom/SKILL.md" in mapped);
+  assert(".claude/loop.md" in mapped);
   // Spot-check canonical paths
   assert(".claude/commands/specflow.specify.md" in mapped);
   assert(".claude/commands/backlog.md" in mapped);

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -68,7 +68,7 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 12);
+    assertEquals(agentsSkillsCount, 13);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -81,7 +81,7 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 21);
+    assertEquals(instructionsCount, 22);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_cursor_test.ts
+++ b/tests/integration/init_cursor_test.ts
@@ -60,7 +60,7 @@ Deno.test("specflow init --ai cursor scaffolds a Cursor layout", async () => {
     const skillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".cursor/skills")),
     )).length;
-    assertEquals(skillsCount, 21);
+    assertEquals(skillsCount, 22);
 
     // Shared
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -72,7 +72,7 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 21);
+    assertEquals(workflowsCount, 22);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);


### PR DESCRIPTION
## Summary

Implements #75. Surfaces Claude Code's `/loop` feature with sensible defaults so users can run periodic hygiene passes without ceremony.

## What ships

**1. New bundled skill: `/specflow.groom`** (`templates/core/skills/specflow.groom/SKILL.md`)

Manual-only (`disable-model-invocation: true`). Runs three independent checks, each delegated to the right subagent:

- **Backlog grooming** → dispatches the `product-owner` to clarify items in the Backlog column. Skip-marker prefix `🤖 specflow-groom` prevents re-commenting on already-clarified items.
- **Stale PR surface** → reads-only, lists open PRs idle > 48 hours.
- **Orphan spec detection** → reads-only, flags spec.md without plan.md, plan.md without tasks.md, etc.

Output ends with a structured report; **no-op when the project is healthy**.

**2. New bundled `loop.md`** (`templates/harness-specific/claude/loop.md`)

Per-project customizable loop prompt. Default delegates to `/specflow.groom`; recommends schedules (1h active, 12h quiet); leaves room for users to append project-specific checks.

## Resolutions of the open questions

- **Q1 (auto-trigger)**: manual-only — `/loop` is already explicit invocation, so double auto-trigger discovery is redundant.
- **Q2 (backend conditional)**: backend-agnostic skill that delegates to the PO subagent. The PO already knows its backend, no need to duplicate that logic in the skill via conditional rendering.

## Cross-harness impact

The new `specflow.groom` skill flows through all 7 harnesses (skills count: 21 → 22 across cursor/copilot/windsurf; codex `.agents/skills/`: 12 → 13). Only Claude gets the `loop.md` — other harnesses don't have an equivalent loop concept.

The CLAUDE.md "Optional integrations" section now references the shipped `loop.md` + `/specflow.groom` directly (more specific than the previous generic "create a loop.md").

## Tests

- `claude_harness_test`: bundle 52 → 54 keys; spot-checks `specflow.groom` + `loop.md`
- 4 cross-harness tests bumped for the new skill count (cursor, copilot, windsurf, codex)
- Validated end-to-end via test-sandbox: both files scaffolded with the expected content
- 325 tests pass (no count change vs before; 5 tests updated in place)

## Test plan

- [x] `deno task test` green
- [x] Brownfield validated via test-sandbox
- [x] Pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)