### PR TITLE
feat(backlog): document GitHub MCP path alongside shell scripts (closes #74)

### DIFF
--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -64,6 +64,11 @@ async function writeBacklogConfigStub(targetDir: string): Promise<void> {
       "↳ wrote .specflow/backlog-config.yml — fill in repo + project_number before running /backlog",
     ),
   );
+  console.log(
+    dim(
+      "  tip: for a richer experience, enable the GitHub MCP connector via `/mcp` in Claude Code",
+    ),
+  );
 }
 
 export async function runInit(intent: InitIntent): Promise<number> {

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3017,7 +3017,50 @@ status_field_id: ""                 # cached on first run
 The PO will refresh \`project_node_id\` / \`status_field_id\` automatically
 on first invocation if they are blank.
 
-### Scripts (preferred path)
+### Two paths to GitHub: MCP (preferred) and shell (always available)
+
+Two ways to talk to GitHub from this project. Pick whichever fits your
+setup; the skill works either way.
+
+#### A. GitHub MCP — preferred when available
+
+If the **GitHub MCP server is wired up in Claude Code**, the PO
+subagent should call its tools directly: \`mcp__github__issue_write\`,
+\`mcp__github__issue_read\`, \`mcp__github__add_issue_comment\`,
+\`mcp__github__list_issues\`, \`mcp__github__search_issues\`, etc. They
+return structured data, no shell parsing needed.
+
+Two ways to enable the GitHub MCP:
+
+1. **Claude Code cloud connector (recommended)** — open a Claude Code
+   session in this project, run \`/mcp\`, choose **GitHub**, and complete
+   the OAuth flow. No file lives in this repo for that — it's stored
+   in your Claude Code account.
+
+2. **Self-hosted MCP** — add the official server to the project's
+   \`.mcp.json\` (creates the file if absent). Specflow does NOT scaffold
+   this for you because it requires Node + a GitHub token; do it
+   manually:
+
+   \`\`\`json
+   {
+     "mcpServers": {
+       "github": {
+         "command": "npx",
+         "args": ["-y", "@modelcontextprotocol/server-github"],
+         "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_TOKEN}" }
+       }
+     }
+   }
+   \`\`\`
+
+   Then restart your Claude Code session.
+
+#### B. Shell scripts — always available
+
+The \`gh\` CLI scripts under \`.specflow/scripts/backlog/\` are scaffolded
+unconditionally and work without MCP. They wrap \`gh issue\` / \`gh
+project\` calls and read configuration from \`backlog-config.yml\`.
 
 \`\`\`bash
 .specflow/scripts/backlog/list.sh [Status]            # all items, optional Status filter
@@ -3027,12 +3070,22 @@ on first invocation if they are blank.
 .specflow/scripts/backlog/clarify-comment.sh <num> "<question>"
 \`\`\`
 
-For closing or editing, just use \`gh\` directly:
+For closing or editing, use \`gh\` directly:
 
 \`\`\`bash
 gh issue close  <num> --repo <repo> --reason completed     # or not_planned
 gh issue edit   <num> --repo <repo> --title "…" --body "…"
 \`\`\`
+
+#### Decision rule for the PO subagent
+
+When dispatched, the PO checks tool availability at runtime:
+
+1. If \`mcp__github__*\` tools are visible in the session, prefer them.
+2. Otherwise fall back to the shell scripts.
+
+This means a project can switch from shell to MCP (or back) without any
+Specflow change — the skill is path-aware.
 
 ### Conventions
 
@@ -3044,8 +3097,11 @@ gh issue edit   <num> --repo <repo> --title "…" --body "…"
 
 ### Prerequisites
 
-The \`gh\` CLI must be authenticated with the \`project\` scope. If
-\`gh project\` returns 404, run \`gh auth refresh -s project\`.
+For the **shell path**: the \`gh\` CLI must be authenticated with the
+\`project\` scope. If \`gh project\` returns 404, run
+\`gh auth refresh -s project\`.
+
+For the **MCP path**: see "Two paths to GitHub" above.
 <!-- END: backend=github -->
 
 ## When NOT to use this skill

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -75,7 +75,50 @@ status_field_id: ""                 # cached on first run
 The PO will refresh `project_node_id` / `status_field_id` automatically
 on first invocation if they are blank.
 
-### Scripts (preferred path)
+### Two paths to GitHub: MCP (preferred) and shell (always available)
+
+Two ways to talk to GitHub from this project. Pick whichever fits your
+setup; the skill works either way.
+
+#### A. GitHub MCP — preferred when available
+
+If the **GitHub MCP server is wired up in Claude Code**, the PO
+subagent should call its tools directly: `mcp__github__issue_write`,
+`mcp__github__issue_read`, `mcp__github__add_issue_comment`,
+`mcp__github__list_issues`, `mcp__github__search_issues`, etc. They
+return structured data, no shell parsing needed.
+
+Two ways to enable the GitHub MCP:
+
+1. **Claude Code cloud connector (recommended)** — open a Claude Code
+   session in this project, run `/mcp`, choose **GitHub**, and complete
+   the OAuth flow. No file lives in this repo for that — it's stored
+   in your Claude Code account.
+
+2. **Self-hosted MCP** — add the official server to the project's
+   `.mcp.json` (creates the file if absent). Specflow does NOT scaffold
+   this for you because it requires Node + a GitHub token; do it
+   manually:
+
+   ```json
+   {
+     "mcpServers": {
+       "github": {
+         "command": "npx",
+         "args": ["-y", "@modelcontextprotocol/server-github"],
+         "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}" }
+       }
+     }
+   }
+   ```
+
+   Then restart your Claude Code session.
+
+#### B. Shell scripts — always available
+
+The `gh` CLI scripts under `.specflow/scripts/backlog/` are scaffolded
+unconditionally and work without MCP. They wrap `gh issue` / `gh
+project` calls and read configuration from `backlog-config.yml`.
 
 ```bash
 .specflow/scripts/backlog/list.sh [Status]            # all items, optional Status filter
@@ -85,12 +128,22 @@ on first invocation if they are blank.
 .specflow/scripts/backlog/clarify-comment.sh <num> "<question>"
 ```
 
-For closing or editing, just use `gh` directly:
+For closing or editing, use `gh` directly:
 
 ```bash
 gh issue close  <num> --repo <repo> --reason completed     # or not_planned
 gh issue edit   <num> --repo <repo> --title "…" --body "…"
 ```
+
+#### Decision rule for the PO subagent
+
+When dispatched, the PO checks tool availability at runtime:
+
+1. If `mcp__github__*` tools are visible in the session, prefer them.
+2. Otherwise fall back to the shell scripts.
+
+This means a project can switch from shell to MCP (or back) without any
+Specflow change — the skill is path-aware.
 
 ### Conventions
 
@@ -102,8 +155,11 @@ gh issue edit   <num> --repo <repo> --title "…" --body "…"
 
 ### Prerequisites
 
-The `gh` CLI must be authenticated with the `project` scope. If
-`gh project` returns 404, run `gh auth refresh -s project`.
+For the **shell path**: the `gh` CLI must be authenticated with the
+`project` scope. If `gh project` returns 404, run
+`gh auth refresh -s project`.
+
+For the **MCP path**: see "Two paths to GitHub" above.
 <!-- END: backend=github -->
 
 ## When NOT to use this skill

--- a/tests/integration/init_backlog_test.ts
+++ b/tests/integration/init_backlog_test.ts
@@ -91,6 +91,11 @@ Deno.test("init --backlog github renders the github skill + writes config stub",
     );
     assertStringIncludes(skill, "Backend: GitHub Issues + Project");
     assertEquals(skill.includes("Backend: local Markdown"), false);
+    // The github skill now documents both MCP and shell paths
+    assertStringIncludes(skill, "GitHub MCP — preferred when available");
+    assertStringIncludes(skill, "mcp__github__issue_write");
+    assertStringIncludes(skill, "Shell scripts — always available");
+    assertStringIncludes(skill, "@modelcontextprotocol/server-github");
 
     // GitHub-flavored scripts present, local ones filtered out
     assertEquals(


### PR DESCRIPTION
## Summary

Implements #74. Enriches the bundled backlog SKILL.md (github backend) so the PO subagent prefers `mcp__github__*` tools when GitHub MCP is wired up, and falls back to the `gh` CLI shell scripts otherwise. The skill is **path-aware at runtime** — no driver flag, no install-time choice.

## What ships

**SKILL.md (github backend section)** — new "Two paths to GitHub" section:

### Path A: GitHub MCP (preferred when available)

Two enable options documented:
1. **Claude Code cloud connector (recommended)** — `/mcp` in Claude Code, choose GitHub, complete OAuth. No file lives in the repo for this.
2. **Self-hosted MCP** — `.mcp.json` snippet ready to copy-paste, wiring `@modelcontextprotocol/server-github` via npx with a `GITHUB_PERSONAL_ACCESS_TOKEN` env var.

### Path B: Shell scripts (always available)

Unchanged from #69 — the `gh`-CLI scripts under `.specflow/scripts/backlog/` always ship and always work without MCP.

### Decision rule for the PO subagent

> 1. If `mcp__github__*` tools are visible in the session, prefer them.
> 2. Otherwise fall back to the shell scripts.

This means a project can switch from shell to MCP (or back) **without any Specflow change** — the skill auto-detects.

**Init handler** — when `--backlog github` is selected, emits an extra tip alongside the existing config-stub message:

```
↳ wrote .specflow/backlog-config.yml — fill in repo + project_number before running /backlog
  tip: for a richer experience, enable the GitHub MCP connector via `/mcp` in Claude Code
```

## Resolutions of the open questions

- **Q1 (default driver)**: no flag — both paths ship; skill is path-aware via runtime tool visibility check.
- **Q2 (MCP server provenance)**: cloud connector is the recommended path (user enables via `/mcp`; not a file). Self-hosted `.mcp.json` snippet documented inline for users who prefer that route.
- **Q3 (scripts coexistence)**: always coexist. The `gh`-CLI scripts ship regardless of MCP availability.

## Deviation from the initial AC

The original AC mandated **auto-scaffolding a `.mcp.json`** at the project root with the GitHub cloud connector entry. After investigation, **cloud connectors are NOT configured in `.mcp.json`** — they're activated in Claude Code's `/mcp` UI and stored in the user's Claude Code account.

The `.mcp.json` would only make sense for the **self-hosted** path, which requires Node + a GitHub PAT — too much config to assume during scaffold. Better to give the user a copy-pasteable snippet and let them opt in.

Net effect: **no `.mcp.json` is written automatically**. The SKILL.md documents both ways to enable; the user picks.

## Tests

- `init_backlog_test` (github backend): now asserts the new MCP section content + the `@modelcontextprotocol/server-github` reference
- Validated end-to-end via test-sandbox: `init --backlog github` emits the MCP tip; rendered SKILL.md contains both paths
- 325 tests pass (no count change — strengthened existing assertions, no new tests added)

## Test plan

- [x] `deno task test` green
- [x] Validated via test-sandbox
- [x] Pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)