### PR TITLE
feat(claude): scaffold specflow.* commands as skill folders (closes #76)

### DIFF
--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -7,7 +7,10 @@ import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 function destinationFor(entry: CoreEntry): string {
   switch (entry.category) {
     case "command":
-      return `.claude/commands/specflow.${entry.name}.md`;
+      // Claude harness uses skill-folder format for specflow.* commands
+      // (per the modern Claude Code convention — flat command files are
+      // deprecated). Other harnesses keep their existing destinations.
+      return `.claude/skills/specflow.${entry.name}/SKILL.md`;
     case "backlog-cmd":
       return `.claude/commands/${entry.name}.md`;
     case "agent":

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -10,6 +10,7 @@ export const CORE_BUNDLE: CoreBundle = [
     name: "specify",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Create or update the feature specification from a natural language feature description.
 handoffs: 
   - label: Build Technical Plan
@@ -219,6 +220,7 @@ Success criteria must be **measurable** (specific metrics), **technology-agnosti
     name: "clarify",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
 handoffs: 
   - label: Build Technical Plan
@@ -392,6 +394,7 @@ Hooks with non-empty \`condition\` are deferred to the HookExecutor.
     name: "plan",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Execute the implementation planning workflow using the plan template to generate design artifacts.
 handoffs: 
   - label: Create Tasks
@@ -552,6 +555,7 @@ You **MUST** consider the user input before proceeding (if not empty).
     name: "tasks",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
 handoffs: 
   - label: Analyze For Consistency
@@ -763,6 +767,7 @@ Every task MUST strictly follow this format:
     name: "analyze",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
@@ -1023,6 +1028,7 @@ After reporting, check if \`.specflow/extensions.yml\` exists in the project roo
     name: "implement",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
@@ -1232,6 +1238,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
     name: "constitution",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
 handoffs: 
   - label: Build Specification
@@ -1567,6 +1574,7 @@ Hooks with non-empty \`condition\` are deferred to the HookExecutor.
     name: "merge",
     suffix: null,
     content: `---
+disable-model-invocation: true
 description: Merge the current feature branch into the base branch after pre-merge validation.
 ---
 

--- a/templates/core/commands/specflow.analyze.md
+++ b/templates/core/commands/specflow.analyze.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks

--- a/templates/core/commands/specflow.clarify.md
+++ b/templates/core/commands/specflow.clarify.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
 handoffs: 
   - label: Build Technical Plan

--- a/templates/core/commands/specflow.constitution.md
+++ b/templates/core/commands/specflow.constitution.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
 handoffs: 
   - label: Build Specification

--- a/templates/core/commands/specflow.implement.md
+++ b/templates/core/commands/specflow.implement.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks

--- a/templates/core/commands/specflow.merge.md
+++ b/templates/core/commands/specflow.merge.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Merge the current feature branch into the base branch after pre-merge validation.
 ---
 

--- a/templates/core/commands/specflow.plan.md
+++ b/templates/core/commands/specflow.plan.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Execute the implementation planning workflow using the plan template to generate design artifacts.
 handoffs: 
   - label: Create Tasks

--- a/templates/core/commands/specflow.specify.md
+++ b/templates/core/commands/specflow.specify.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Create or update the feature specification from a natural language feature description.
 handoffs: 
   - label: Build Technical Plan

--- a/templates/core/commands/specflow.tasks.md
+++ b/templates/core/commands/specflow.tasks.md
@@ -1,4 +1,5 @@
 ---
+disable-model-invocation: true
 description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
 handoffs: 
   - label: Analyze For Consistency

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -17,15 +17,20 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   // .claude/CLAUDE.md + .claude/scripts/dispatch-agent.sh + .claude/loop.md
   // + .claude/settings.json + 3 .claude/hooks/*.sh
   assertEquals(keys.length, 58);
+  // specflow.* commands ship as skill folders (#76)
+  assert(".claude/skills/specflow.specify/SKILL.md" in mapped);
+  assert(".claude/skills/specflow.review/SKILL.md" in mapped);
+  // /backlog stays as a flat command (different category)
+  assert(".claude/commands/backlog.md" in mapped);
+  // Bundled assets unchanged
   assert(".claude/skills/specflow.groom/SKILL.md" in mapped);
   assert(".claude/loop.md" in mapped);
   assert(".claude/settings.json" in mapped);
   assert(".claude/hooks/protect-generated.sh" in mapped);
   assert(".claude/hooks/log-subagent.sh" in mapped);
   assert(".claude/hooks/check-backlog-prereqs.sh" in mapped);
-  // Spot-check canonical paths
-  assert(".claude/commands/specflow.specify.md" in mapped);
-  assert(".claude/commands/backlog.md" in mapped);
+  // Spot-check canonical paths (specflow.* moved to skills/)
+  assert(!(".claude/commands/specflow.specify.md" in mapped));
   assert(".claude/agents/product-owner.md" in mapped);
   assert(".claude/skills/auto-chain/SKILL.md" in mapped);
   assert(".claude/skills/backlog/SKILL.md" in mapped);

--- a/tests/integration/init_force_test.ts
+++ b/tests/integration/init_force_test.ts
@@ -43,10 +43,13 @@ Deno.test(
   "init --force overwrites a pre-existing .claude/ and creates .specflow.bak files",
   async () => {
     await withTempDir(async (dir) => {
-      // Pre-seed a custom .claude/commands/specflow.specify.md so init conflicts without --force
-      await Deno.mkdir(join(dir, "demo/.claude/commands"), { recursive: true });
+      // Pre-seed a custom skill folder so init conflicts without --force
+      // (specflow.* commands now scaffold as skill folders per #76).
+      await Deno.mkdir(join(dir, "demo/.claude/skills/specflow.specify"), {
+        recursive: true,
+      });
       await Deno.writeTextFile(
-        join(dir, "demo/.claude/commands/specflow.specify.md"),
+        join(dir, "demo/.claude/skills/specflow.specify/SKILL.md"),
         "CUSTOM CONTENT FROM USER",
       );
 
@@ -65,13 +68,13 @@ Deno.test(
 
       const bakPath = join(
         dir,
-        "demo/.claude/commands/specflow.specify.md.specflow.bak",
+        "demo/.claude/skills/specflow.specify/SKILL.md.specflow.bak",
       );
       const bakContent = await Deno.readTextFile(bakPath);
       assertEquals(bakContent, "CUSTOM CONTENT FROM USER");
 
       const newContent = await Deno.readTextFile(
-        join(dir, "demo/.claude/commands/specflow.specify.md"),
+        join(dir, "demo/.claude/skills/specflow.specify/SKILL.md"),
       );
       assertEquals(newContent.includes("CUSTOM CONTENT"), false);
 

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -52,17 +52,26 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
     assertEquals(await exists(join(root, ".specflow/backlog.md")), true);
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);
     assertEquals(await exists(join(root, ".specflow/templates/spec-template.md")), true);
-    assertEquals(await exists(join(root, ".claude/commands/specflow.specify.md")), true);
-    assertEquals(await exists(join(root, ".claude/commands/specflow.review.md")), true);
+    // specflow.* commands now scaffold as skill folders (#76).
+    assertEquals(
+      await exists(join(root, ".claude/skills/specflow.specify/SKILL.md")),
+      true,
+    );
+    assertEquals(
+      await exists(join(root, ".claude/skills/specflow.review/SKILL.md")),
+      true,
+    );
+    // The /backlog command (different category) keeps the flat-file format.
     assertEquals(await exists(join(root, ".claude/commands/backlog.md")), true);
     assertEquals(await exists(join(root, ".claude/agents/product-owner.md")), true);
     assertEquals(await exists(join(root, ".claude/agents/devops-sre.md")), true);
     assertEquals(await exists(join(root, ".claude/skills/auto-chain/SKILL.md")), true);
 
+    // Only the backlog command stays in .claude/commands/
     const commandsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".claude/commands")),
     )).length;
-    assertEquals(commandsCount, 11);
+    assertEquals(commandsCount, 1);
     // 9 agent .md files + 5 memory subfolders (product-owner, developer,
     // qa-tester, devops-sre, security-auditor)
     const agentDirEntries = await Array.fromAsync(
@@ -165,14 +174,17 @@ Deno.test("specflow init --here writes into cwd", async () => {
 
 Deno.test("specflow init refuses to overwrite a pre-existing .claude/", async () => {
   await withTempDir(async (dir) => {
-    await Deno.mkdir(join(dir, "demo/.claude/commands"), { recursive: true });
+    // specflow.specify now scaffolds as a skill folder (.claude/skills/...).
+    await Deno.mkdir(join(dir, "demo/.claude/skills/specflow.specify"), {
+      recursive: true,
+    });
     await Deno.writeTextFile(
-      join(dir, "demo/.claude/commands/specflow.specify.md"),
+      join(dir, "demo/.claude/skills/specflow.specify/SKILL.md"),
       "custom",
     );
     const { code, stderr } = await runSpecflow(["init", "demo", "--no-git"], { cwd: dir });
     assertEquals(code, 3);
-    assertStringIncludes(stderr, ".claude/commands/specflow.specify.md");
+    assertStringIncludes(stderr, ".claude/skills/specflow.specify/SKILL.md");
     assertStringIncludes(stderr, "specflow init --here --force");
     assertStringIncludes(stderr, "specflow upgrade");
     assertEquals(stderr.includes("v0.1"), false, "error message must not hardcode a version");


### PR DESCRIPTION
## Summary

Implements #76. Migrates the bundled `specflow.*` commands from flat-file format to skill-folder format **for the Claude harness only**:

- Before: `.claude/commands/specflow.<name>.md`
- After: `.claude/skills/specflow.<name>/SKILL.md`

Per the modern Claude Code convention, flat command files are deprecated; skill folders support companion files and integrate cleanly with the plugin system. The `specflow.` prefix is kept to protect against collision with third-party skills.

## Cross-harness behavior

| Harness | Before | After | Notes |
|---|---|---|---|
| **claude** | `.claude/commands/specflow.<n>.md` | `.claude/skills/specflow.<n>/SKILL.md` | Migration target |
| cursor | `.cursor/skills/specflow-<n>/SKILL.md` | unchanged | Already folder format |
| codex | `.agents/skills/specflow-<n>/SKILL.md` | unchanged | Already folder format |
| gemini | `.gemini/commands/<n>.toml` | unchanged | Different format |
| windsurf | `.windsurf/workflows/<n>.md` | unchanged | Single file |
| copilot | `.github/instructions/<n>.instructions.md` | unchanged | Single file |
| opencode | `.opencode/commands/specflow.<n>.md` | unchanged | Single file |
| antigravity | `.agent/workflows/specflow-<n>.md` | unchanged | Single file |

## Manual-only flags

`disable-model-invocation: true` added to 8 user-driven commands so Claude doesn't auto-spawn them on description matches:

| Command | Auto-trigger | Rationale |
|---|---|---|
| `specflow.specify` | ✗ manual-only | User invokes explicitly per #77 spirit |
| `specflow.constitution` | ✗ manual-only | Same |
| `specflow.clarify` | ✗ manual-only | Sequential flow |
| `specflow.plan` | ✗ manual-only | Sequential flow |
| `specflow.tasks` | ✗ manual-only | Sequential flow |
| `specflow.analyze` | ✗ manual-only | Sequential flow |
| `specflow.implement` | ✗ manual-only | Heavy work |
| `specflow.merge` | ✗ manual-only | Destructive |
| `specflow.checklist` | ✓ auto | Cheap, additive (per AC) |
| `specflow.review` | ✓ auto | Same |

## /backlog command (unchanged)

The `/backlog` command (category `backlog-cmd`, distinct from `command`) keeps its flat-file destination at `.claude/commands/backlog.md`. It's a quick command, not a workflow phase.

## Brownfield migration

Handled by the existing upgrade plan machinery. A user upgrading from a previous Specflow version will see:
- Old `.claude/commands/specflow.*.md` paths flagged as `remove` (with backup if customized)
- New `.claude/skills/specflow.*/SKILL.md` flagged as `add-new`

No new code needed for the migration.

## Resolutions of the open questions

- **Q1 (per-harness compat)**: Claude only — others unchanged.
- **Q2 (skill name prefix)**: keep `specflow.` to protect against collisions.

## Tests

- `claude_harness_test`: assertions updated for new skill paths; old paths asserted absent
- `init_test`: now asserts skill-folder paths and 1 (not 11) commands left in `.claude/commands/`
- `init_force_test`: pre-existing skill folder triggers conflict instead of pre-existing command file
- 325 tests pass
- Validated end-to-end via test-sandbox: scaffold drops `specflow.*` skill folders, only `backlog.md` remains in `.claude/commands/`, frontmatter has `disable-model-invocation: true` on the 8 manual-only commands

## Test plan

- [x] `deno task test` green
- [x] Brownfield-style scenario validated via test-sandbox
- [x] Pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)