### PR TITLE
test(sandbox): add smoke scripts for session features

### DIFF
--- a/.claude/skills/test-sandbox/SKILL.md
+++ b/.claude/skills/test-sandbox/SKILL.md
@@ -29,6 +29,24 @@ Each script bootstraps a controlled scenario inside `sandbox/<name>/` (the `sand
 
 `<harness>` ∈ `claude` (default) | `cursor` | `codex` | `gemini` | `windsurf` | `copilot` | `opencode` | `antigravity`.
 
+### Smoke tests for bundled features
+
+These wrap a fresh `init --ai claude --backlog local` and exercise specific feature surfaces. Each prints a `✓` / `❌` line per check and exits 0 on full pass, 1 on any failure — usable as guard rails in pre-release runs or after a refactor that touches bundled artefacts.
+
+```bash
+.claude/skills/test-sandbox/scripts/smoke-features.sh <name>      # presence + frontmatter checks for every feature shipped after v0.9
+.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh <name> # add → list → move → view → clarify-comment round-trip on the local backend
+.claude/skills/test-sandbox/scripts/smoke-hooks.sh <name>         # fire each bundled hook with synthetic stdin, verify behavior + soft-warn semantics
+```
+
+Run all three back-to-back for a comprehensive post-refactor smoke:
+
+```bash
+bash .claude/skills/test-sandbox/scripts/smoke-features.sh feat
+bash .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh backlog
+bash .claude/skills/test-sandbox/scripts/smoke-hooks.sh hooks
+```
+
 ## Typical workflows
 
 ### Validate a brownfield fix before merging

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Exercise the bundled local-backlog scripts end-to-end on a fresh
+# scaffold: add → list → move → view → clarify-comment, then verify
+# the resulting Markdown files reflect every mutation.
+#
+# Usage: smoke-backlog-local.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-backlog-local.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$ROOT/sandbox/$NAME"
+
+bash "$SCRIPT_DIR/bootstrap-vite.sh" "$NAME" >/dev/null
+(cd "$DIR" && deno run --allow-all "$ROOT/src/main.ts" \
+  init --here --no-git --ai claude --backlog local >/dev/null 2>&1)
+
+cd "$DIR"
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1 — $2"; fails=$((fails + 1)); }
+
+echo "═══ add ═══"
+out=$(bash .specflow/scripts/backlog/add.sh "First item" "## Why\n\nSmoke test")
+echo "$out"
+echo "$out" | grep -q "✓ created #001" \
+  && pass "add prints '✓ created #001'" \
+  || fail "add output" "$out"
+[ -f .specflow/backlog/001-first-item.md ] \
+  && pass "001-first-item.md created" \
+  || fail "expected file at .specflow/backlog/001-first-item.md" "missing"
+
+echo
+echo "═══ list (Backlog) ═══"
+out=$(bash .specflow/scripts/backlog/list.sh)
+echo "$out"
+echo "$out" | grep -q "#001.*Backlog.*First item" \
+  && pass "list shows #001 in Backlog" \
+  || fail "list output" "$out"
+
+echo
+echo "═══ list filtered by Backlog ═══"
+out=$(bash .specflow/scripts/backlog/list.sh Backlog)
+echo "$out" | grep -q "#001" && pass "filter Backlog matches" \
+  || fail "filter mismatch" "$out"
+
+echo
+echo "═══ move 1 → Ready ═══"
+out=$(bash .specflow/scripts/backlog/move.sh 1 Ready)
+echo "$out"
+echo "$out" | grep -q "✓ #001 → Ready" \
+  && pass "move prints transition" \
+  || fail "move output" "$out"
+grep -q "^status: Ready$" .specflow/backlog/001-first-item.md \
+  && pass "frontmatter status updated to Ready" \
+  || fail "frontmatter not updated" "$(head -7 .specflow/backlog/001-first-item.md)"
+
+echo
+echo "═══ list filtered by Backlog (should be empty) ═══"
+out=$(bash .specflow/scripts/backlog/list.sh Backlog)
+[ -z "$out" ] && pass "no Backlog items left" \
+  || fail "expected empty list, got" "$out"
+
+echo
+echo "═══ list filtered by Ready ═══"
+out=$(bash .specflow/scripts/backlog/list.sh Ready)
+echo "$out" | grep -q "#001.*Ready" && pass "Ready filter matches" \
+  || fail "Ready filter mismatch" "$out"
+
+echo
+echo "═══ view 1 ═══"
+out=$(bash .specflow/scripts/backlog/view.sh 1)
+echo "$out" | grep -q "title: First item" && pass "view shows title" \
+  || fail "view missing title" "$out"
+echo "$out" | grep -q "status: Ready" && pass "view shows current status" \
+  || fail "view missing status" "$out"
+
+echo
+echo "═══ clarify-comment ═══"
+out=$(bash .specflow/scripts/backlog/clarify-comment.sh 1 "Need scope decision on X")
+echo "$out"
+echo "$out" | grep -q "✓ added clarification" && pass "clarify prints confirmation" \
+  || fail "clarify output" "$out"
+grep -q "Need scope decision on X" .specflow/backlog/001-first-item.md \
+  && pass "clarification appended to file" \
+  || fail "clarification not in file" "$(tail -10 .specflow/backlog/001-first-item.md)"
+
+echo
+echo "═══ add second item (auto-numbering) ═══"
+bash .specflow/scripts/backlog/add.sh "Second" "" >/dev/null
+[ -f .specflow/backlog/002-second.md ] \
+  && pass "002-second.md created (auto-numbered)" \
+  || fail "expected 002-second.md" "$(ls .specflow/backlog/)"
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL BACKLOG CHECKS PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails CHECK(S) FAILED ═══"
+  exit 1
+fi

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Verify that every Specflow feature shipped after v0.9 is correctly
+# scaffolded into a freshly-init'd Claude project. Walks the bundled
+# layout and checks file presence, frontmatter shape, and a few
+# canonical content snippets.
+#
+# Usage: smoke-features.sh <name>
+#   <name> is the sandbox scenario name (will be created/wiped).
+#
+# Exits 0 on full pass, 1 on any failure. Each check prints a single
+# line: ✓ pass / ❌ fail.
+set -euo pipefail
+
+NAME="${1:?usage: smoke-features.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$ROOT/sandbox/$NAME"
+
+bash "$SCRIPT_DIR/bootstrap-vite.sh" "$NAME" >/dev/null
+(cd "$DIR" && deno run --allow-all "$ROOT/src/main.ts" \
+  init --here --no-git --ai claude --backlog local >/dev/null 2>&1)
+
+cd "$DIR"
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1"; fails=$((fails + 1)); }
+check() { if eval "$2" >/dev/null 2>&1; then pass "$1"; else fail "$1"; fi; }
+
+echo "═══ #67  specs/ → .specflow/specs/ ═══"
+check "no top-level specs/ directory" '[ ! -d specs ]'
+check "create-new-feature.sh writes to .specflow/specs" \
+  'grep -q "\.specflow/specs" .specflow/scripts/bash/create-new-feature.sh'
+
+echo
+echo "═══ #69 + #93  backlog backends + strategy refactor ═══"
+check "lock records local backend" 'grep -q "backlog_backend: local" .specflow/installed.lock'
+check "backlog SKILL.md present" '[ -f .claude/skills/backlog/SKILL.md ]'
+check "SKILL renders local backend section" \
+  'grep -q "Backend: local Markdown" .claude/skills/backlog/SKILL.md'
+check "github section stripped (local backend)" \
+  '! grep -q "Backend: GitHub" .claude/skills/backlog/SKILL.md'
+check "gitlab section stripped (local backend)" \
+  '! grep -q "Backend: GitLab" .claude/skills/backlog/SKILL.md'
+check "no orphan BEGIN markers" \
+  '! grep -q "BEGIN: backend=" .claude/skills/backlog/SKILL.md'
+check "no orphan END markers" \
+  '! grep -q "END: backend=" .claude/skills/backlog/SKILL.md'
+
+echo
+echo "═══ #76  commands → skill folders ═══"
+check ".claude/commands/ has only 1 file (backlog)" \
+  '[ "$(find .claude/commands -maxdepth 1 -type f -name "*.md" | wc -l | tr -d " ")" = "1" ]'
+for skill in specify constitution clarify plan tasks analyze implement merge review checklist; do
+  check ".claude/skills/specflow.$skill/SKILL.md present" \
+    "[ -f .claude/skills/specflow.$skill/SKILL.md ]"
+done
+check "name: injected on specflow.specify SKILL.md (post-#92)" \
+  'head -3 .claude/skills/specflow.specify/SKILL.md | grep -q "name: specflow.specify"'
+
+echo
+echo "═══ #75  loop.md + /specflow.groom ═══"
+check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
+check "specflow.groom skill present" '[ -f .claude/skills/specflow.groom/SKILL.md ]'
+check "groom skill has name: (post-#92)" \
+  'head -3 .claude/skills/specflow.groom/SKILL.md | grep -q "name: specflow.groom"'
+
+echo
+echo "═══ #77  manual-only flags ═══"
+for agent in developer devops-sre qa-tester; do
+  check "$agent has disable-model-invocation: true" \
+    "grep -q 'disable-model-invocation: true' .claude/agents/$agent.md"
+done
+
+echo
+echo "═══ #78 + #92  dispatch-agent.sh + depth-aware splitter ═══"
+check "dispatch-agent.sh executable" '[ -x .claude/scripts/dispatch-agent.sh ]'
+check "depth-aware splitter included" \
+  'grep -q "split_tools" .claude/scripts/dispatch-agent.sh'
+
+echo
+echo "═══ #80  agent memory/ stubs ═══"
+for agent in product-owner developer qa-tester devops-sre security-auditor; do
+  check "$agent/memory/MEMORY.md present" \
+    "[ -f .claude/agents/$agent/memory/MEMORY.md ]"
+done
+
+echo
+echo "═══ #88  hooks bundled ═══"
+check ".claude/settings.json scaffolded" '[ -f .claude/settings.json ]'
+check "PreToolUse hook registered" 'grep -q "PreToolUse" .claude/settings.json'
+check "SubagentStart hook registered" 'grep -q "SubagentStart" .claude/settings.json'
+check "SessionStart hook registered" 'grep -q "SessionStart" .claude/settings.json'
+for hook in protect-generated log-subagent check-backlog-prereqs; do
+  check "$hook.sh executable" "[ -x .claude/hooks/$hook.sh ]"
+done
+check ".specflow/logs/ in bundled .gitignore" \
+  'grep -q "\.specflow/logs/" .gitignore'
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL CHECKS PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails CHECK(S) FAILED ═══"
+  exit 1
+fi

--- a/.claude/skills/test-sandbox/scripts/smoke-hooks.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-hooks.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Fire each bundled Claude hook with a synthetic stdin payload, verify
+# the side effects, and confirm exit codes are 0 (soft warn-only).
+#
+# Usage: smoke-hooks.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-hooks.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$ROOT/sandbox/$NAME"
+
+bash "$SCRIPT_DIR/bootstrap-vite.sh" "$NAME" >/dev/null
+(cd "$DIR" && deno run --allow-all "$ROOT/src/main.ts" \
+  init --here --no-git --ai claude --backlog local >/dev/null 2>&1)
+
+cd "$DIR"
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1 — $2"; fails=$((fails + 1)); }
+
+echo "═══ protect-generated.sh ═══"
+
+# Lock edit → soft warn, exit 0
+out=$(echo '{"tool_input":{"file_path":"/x/.specflow/installed.lock"}}' \
+  | bash .claude/hooks/protect-generated.sh 2>&1)
+ec=$?
+[ "$ec" = "0" ] && pass "exit code 0 on lock edit (soft warn)" \
+  || fail "non-zero exit on lock edit" "ec=$ec"
+echo "$out" | grep -q "warn:" \
+  && pass "warning emitted on lock edit" \
+  || fail "missing warning text" "$out"
+
+# Unrelated file → silent, exit 0
+out=$(echo '{"tool_input":{"file_path":"/x/random.txt"}}' \
+  | bash .claude/hooks/protect-generated.sh 2>&1)
+[ -z "$out" ] && pass "silent on unrelated file" \
+  || fail "unexpected output on unrelated file" "$out"
+
+# Empty stdin → silent, exit 0
+out=$(echo "" | bash .claude/hooks/protect-generated.sh 2>&1; echo "ec=$?")
+echo "$out" | grep -q "ec=0" \
+  && pass "exit 0 on empty stdin" \
+  || fail "non-zero exit on empty stdin" "$out"
+
+echo
+echo "═══ log-subagent.sh ═══"
+
+rm -f .specflow/logs/agents.jsonl
+echo '{"session_id":"sess-A","subagent_name":"product-owner"}' \
+  | bash .claude/hooks/log-subagent.sh start
+[ -f .specflow/logs/agents.jsonl ] \
+  && pass "agents.jsonl created" \
+  || fail "log file not created" "$(ls .specflow/logs/ 2>&1 || echo none)"
+
+line=$(cat .specflow/logs/agents.jsonl)
+echo "$line" | grep -q '"event":"start"' \
+  && pass 'event field = "start"' \
+  || fail "wrong event field" "$line"
+echo "$line" | grep -q '"agent":"product-owner"' \
+  && pass "agent field extracted" \
+  || fail "agent field missing" "$line"
+echo "$line" | grep -q '"session":"sess-A"' \
+  && pass "session field extracted" \
+  || fail "session field missing" "$line"
+
+# Second event appends
+echo '{"session_id":"sess-A","subagent_name":"product-owner"}' \
+  | bash .claude/hooks/log-subagent.sh stop
+count=$(wc -l < .specflow/logs/agents.jsonl | tr -d ' ')
+[ "$count" = "2" ] && pass "stop event appended (2 lines total)" \
+  || fail "expected 2 lines, got $count" "$(cat .specflow/logs/agents.jsonl)"
+
+# Missing payload fields → "unknown" defaults
+echo '{}' | bash .claude/hooks/log-subagent.sh start
+last=$(tail -1 .specflow/logs/agents.jsonl)
+echo "$last" | grep -q '"agent":"unknown"' \
+  && pass "agent defaults to 'unknown' when missing" \
+  || fail "did not default to 'unknown'" "$last"
+
+echo
+echo "═══ check-backlog-prereqs.sh (local backend) ═══"
+
+out=$(echo "{}" | bash .claude/hooks/check-backlog-prereqs.sh 2>&1)
+ec=$?
+[ "$ec" = "0" ] && pass "exit 0 on local backend" \
+  || fail "non-zero exit" "ec=$ec"
+[ -z "$out" ] && pass "silent on local backend (no warn)" \
+  || fail "unexpected output on local backend" "$out"
+
+echo
+echo "═══ check-backlog-prereqs.sh (github backend, gh present) ═══"
+# Patch the lock to simulate the github backend
+sed -i.bak 's/backlog_backend: local/backlog_backend: github/' \
+  .specflow/installed.lock
+out=$(echo "{}" | bash .claude/hooks/check-backlog-prereqs.sh 2>&1)
+ec=$?
+mv .specflow/installed.lock.bak .specflow/installed.lock
+[ "$ec" = "0" ] && pass "exit 0 on github backend" \
+  || fail "non-zero exit" "ec=$ec"
+# If gh is installed + auth'd, no warning. If not, warning. Either is OK
+# as long as exit 0 and no crash.
+echo "(github-backend output: $(echo "$out" | head -1))"
+
+echo
+echo "═══ no lock present (e.g. uninitialised project) ═══"
+mv .specflow/installed.lock /tmp/spec-lock-backup-$$
+out=$(echo '{"tool_input":{"file_path":"/x/.specflow/installed.lock"}}' \
+  | bash .claude/hooks/protect-generated.sh 2>&1; echo "ec=$?")
+echo "$out" | grep -q "ec=0" \
+  && pass "protect-generated exits 0 with no lock" \
+  || fail "protect-generated crashed" "$out"
+out=$(echo "{}" | bash .claude/hooks/check-backlog-prereqs.sh 2>&1; echo "ec=$?")
+echo "$out" | grep -q "ec=0" \
+  && pass "check-backlog-prereqs exits 0 with no lock" \
+  || fail "check-backlog-prereqs crashed" "$out"
+mv /tmp/spec-lock-backup-$$ .specflow/installed.lock
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL HOOK CHECKS PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails CHECK(S) FAILED ═══"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds 3 new \`test-sandbox\` scripts that exercise everything shipped across this session's 13 PRs end-to-end on a fresh Vite scaffold. Each prints ✓ / ❌ per check and exits 0 on full pass, 1 on any failure — usable as pre-release guard rails or quick regression checks after a refactor that touches bundled artefacts.

## What ships

### \`smoke-features.sh\`

Presence + frontmatter checks for every artefact shipped after v0.9:

- **#67** \`specs/\` → \`.specflow/specs/\` migration
- **#69 + #93** 3 backlog backends + strategy refactor (lock, SKILL.md sections, no orphan markers)
- **#76** commands → skill folders (\`.claude/commands/\` has 1 file, 10 \`specflow.*/\` skill folders)
- **#75** \`loop.md\` + \`/specflow.groom\` skill
- **#77** manual-only flags on developer / devops-sre / qa-tester
- **#78 + #92** \`dispatch-agent.sh\` executable + depth-aware splitter included
- **#80** 5 agent memory stubs (PO, dev, QA, devops, security)
- **#88** \`settings.json\` + 3 hook scripts + \`.specflow/logs/\` gitignored

### \`smoke-backlog-local.sh\`

Round-trip on the local backend:

- \`add\` → asserts file created, output format
- \`list\` (full + Status filter) → asserts state visible
- \`move 1 Ready\` → asserts frontmatter \`status:\` updated
- \`list Backlog\` (after move) → asserts empty
- \`view\` → asserts title + status visible
- \`clarify-comment\` → asserts text appended to file
- \`add\` second item → asserts auto-numbering (\`002-...\`)

### \`smoke-hooks.sh\`

Fires each bundled hook with synthetic stdin payloads, verifies the soft warn-only contract:

- **\`protect-generated.sh\`** — warn on lock edit, silent on unrelated file, exit 0 always
- **\`log-subagent.sh\`** — JSONL append, field extraction (event, agent, session), \`unknown\` default when fields missing
- **\`check-backlog-prereqs.sh\`** — silent on local backend, runs on github, exit 0 even with no lock present

### SKILL.md

New "Smoke tests for bundled features" subsection documents the 3 scripts with a copy-paste block to run all 3 back-to-back.

## Validation

All 3 scripts pass end-to-end against the working tree as of commit \`b9551ed\` (current main). Verified:

\`\`\`
═══ ALL CHECKS PASSED ═══         (smoke-features)
═══ ALL BACKLOG CHECKS PASSED ═══ (smoke-backlog-local)
═══ ALL HOOK CHECKS PASSED ═══    (smoke-hooks)
\`\`\`

## Test plan

- [x] All 3 scripts execute cleanly with exit 0
- [x] No new test changes to \`tests/\` (this PR adds developer-facing smoke scripts, not unit tests)
- [x] Pre-commit hook green (no source files touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)