### PR TITLE
feat(init): make conflict error message lock-aware

### DIFF
--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -21,7 +21,16 @@ export type InitResult =
     backups: string[];
     lockWritten: boolean;
   }
-  | { status: "conflicts"; conflicts: string[] };
+  | {
+    status: "conflicts";
+    conflicts: string[];
+    /**
+     * True when a `.specflow/installed.lock` already exists at the target —
+     * lets the CLI suggest `specflow upgrade` instead of `--force` for
+     * projects that were previously initialised by Specflow.
+     */
+    lockExists: boolean;
+  };
 
 export type InitProjectDeps = {
   writer: FsWriter;
@@ -55,7 +64,12 @@ export class InitProjectUseCase {
     if (!input.force) {
       const conflicts = await writer.detectConflicts(bundle, input.targetDir);
       if (conflicts.length > 0) {
-        return { status: "conflicts", conflicts };
+        const existingLock = await lockStore.read(input.targetDir);
+        return {
+          status: "conflicts",
+          conflicts,
+          lockExists: existingLock !== null,
+        };
       }
     }
 

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -104,19 +104,23 @@ export async function runInit(intent: InitIntent): Promise<number> {
   });
 
   if (result.status === "conflicts") {
-    console.error(
-      red(`error: target already contains ${result.conflicts.length} specflow-managed file(s):`),
-    );
+    const n = result.conflicts.length;
+    const noun = n === 1 ? "file" : "files";
+    console.error(red(`error: ${n} ${noun} would be overwritten:`));
     for (const c of result.conflicts) console.error(red(`  - ${c}`));
-    console.error("\nTo proceed:");
-    console.error(
-      `  • Run ${bold("specflow init --here --force")} to re-initialise in place ` +
-        "(existing files are backed up to *.specflow.bak).",
-    );
-    console.error(
-      `  • Or run ${bold("specflow upgrade")} if this project was previously ` +
-        "initialised by Specflow.",
-    );
+    console.error("");
+    if (result.lockExists) {
+      console.error(
+        `This project was previously initialised by Specflow — run ${
+          bold("specflow upgrade")
+        } to update the managed files in place.`,
+      );
+    } else {
+      console.error(
+        `Re-run with ${bold("specflow init --here --force")} to overwrite ` +
+          "(existing files are backed up to *.specflow.bak).",
+      );
+    }
     return 3;
   }
 

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -4,13 +4,15 @@ import type { FsWriter, GitAdapter, Harness, LockStore } from "../../src/applica
 import type { InstalledLock } from "../../src/domain/installed_lock.ts";
 import type { CoreBundle } from "../../src/domain/core_bundle.ts";
 
-function fakeLockStore(): LockStore & { lastWritten: InstalledLock | null } {
+function fakeLockStore(
+  opts: { existing?: InstalledLock | null } = {},
+): LockStore & { lastWritten: InstalledLock | null } {
   const state: { lastWritten: InstalledLock | null } = { lastWritten: null };
   return {
     get lastWritten() {
       return state.lastWritten;
     },
-    read: () => Promise.resolve(null),
+    read: () => Promise.resolve(opts.existing ?? null),
     write: (_d, lock) => {
       state.lastWritten = lock;
       return Promise.resolve();
@@ -111,7 +113,39 @@ Deno.test("InitProjectUseCase fails with 'conflicts' when target already has spe
     force: false,
   });
   assertEquals(result.status, "conflicts");
-  if (result.status === "conflicts") assertEquals(result.conflicts, ["CLAUDE.md"]);
+  if (result.status === "conflicts") {
+    assertEquals(result.conflicts, ["CLAUDE.md"]);
+    assertEquals(result.lockExists, false);
+  }
+});
+
+Deno.test("InitProjectUseCase reports lockExists=true when conflicts hit a previously-initialised project", async () => {
+  const writer = fakeFsWriter(["CLAUDE.md"]);
+  const existingLock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    templatesVersion: "0.0.0",
+    entries: new Map(),
+  };
+  const useCase = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore: fakeLockStore({ existing: existingLock }),
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    core: SAMPLE_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  const result = await useCase.execute({
+    targetDir: "/tmp/demo",
+    initGit: true,
+    force: false,
+  });
+  assertEquals(result.status, "conflicts");
+  if (result.status === "conflicts") {
+    assertEquals(result.lockExists, true);
+  }
 });
 
 Deno.test("InitProjectUseCase calls git.init when repo not initialized and initGit=true", async () => {

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -172,7 +172,7 @@ Deno.test("specflow init --here writes into cwd", async () => {
   });
 });
 
-Deno.test("specflow init refuses to overwrite a pre-existing .claude/", async () => {
+Deno.test("specflow init on a fresh project recommends --force (no lock present)", async () => {
   await withTempDir(async (dir) => {
     // specflow.specify now scaffolds as a skill folder (.claude/skills/...).
     await Deno.mkdir(join(dir, "demo/.claude/skills/specflow.specify"), {
@@ -185,9 +185,48 @@ Deno.test("specflow init refuses to overwrite a pre-existing .claude/", async ()
     const { code, stderr } = await runSpecflow(["init", "demo", "--no-git"], { cwd: dir });
     assertEquals(code, 3);
     assertStringIncludes(stderr, ".claude/skills/specflow.specify/SKILL.md");
+    assertStringIncludes(stderr, "would be overwritten");
     assertStringIncludes(stderr, "specflow init --here --force");
-    assertStringIncludes(stderr, "specflow upgrade");
+    assertEquals(
+      stderr.includes("specflow upgrade"),
+      false,
+      "must not suggest upgrade when no lock is present",
+    );
     assertEquals(stderr.includes("v0.1"), false, "error message must not hardcode a version");
+  });
+});
+
+Deno.test("specflow init on a previously-initialised project recommends upgrade (lock present)", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.mkdir(join(dir, "demo/.claude/skills/specflow.specify"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      join(dir, "demo/.claude/skills/specflow.specify/SKILL.md"),
+      "custom",
+    );
+    // Drop a stub lock so the conflict path treats this as a re-init.
+    await Deno.mkdir(join(dir, "demo/.specflow"), { recursive: true });
+    await Deno.writeTextFile(
+      join(dir, "demo/.specflow/installed.lock"),
+      [
+        "version: 2",
+        "harness: claude",
+        "backlog_backend: local",
+        "templates_version: 0.0.0",
+        "entries: {}",
+        "",
+      ].join("\n"),
+    );
+    const { code, stderr } = await runSpecflow(["init", "demo", "--no-git"], { cwd: dir });
+    assertEquals(code, 3);
+    assertStringIncludes(stderr, "would be overwritten");
+    assertStringIncludes(stderr, "specflow upgrade");
+    assertEquals(
+      stderr.includes("specflow init --here --force"),
+      false,
+      "must not suggest --force when a lock is present",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

When `specflow init` aborts on existing files, the previous error message suggested both `--force` and `specflow upgrade` as parallel options, but only one is right per project. The wording also called the conflicts "specflow-managed file(s)" — misleading, since those paths aren't managed yet.

The handler now reads `.specflow/installed.lock` after a conflict and branches the recommendation:

- **No lock** (e.g. brownfield project that happens to already have `.claude/settings.json`):

  ```
  error: 1 file would be overwritten:
    - .claude/settings.json

  Re-run with specflow init --here --force to overwrite (existing
  files are backed up to *.specflow.bak).
  ```

- **Lock present** (project was previously initialised by Specflow):

  ```
  error: 1 file would be overwritten:
    - .claude/settings.json

  This project was previously initialised by Specflow — run
  specflow upgrade to update the managed files in place.
  ```

## Implementation

- `InitResult.conflicts` variant gains `lockExists: boolean`, populated by `lockStore.read()` only when conflicts are found (no extra I/O on the happy path).
- The CLI handler renders one suggestion based on `lockExists`.

## Test plan

- [x] `tests/application/init_project_test.ts` — asserts `lockExists` flips correctly between fresh and pre-initialised targets
- [x] `tests/integration/init_test.ts` — splits the old "refuses to overwrite" test into two end-to-end runs (no-lock recommends `--force`, lock-present recommends `upgrade`)
- [x] Smoke-tested against a real `~/.claude/settings.json`-only project (the scenario that triggered this fix) — output matches the design above
- [x] `deno task test` — 349 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)