### PR TITLE
test(sandbox): smoke-picker.sh drives the interactive picker over PTY

### DIFF
--- a/.claude/skills/test-sandbox/SKILL.md
+++ b/.claude/skills/test-sandbox/SKILL.md
@@ -37,15 +37,24 @@ These wrap a fresh `init --ai claude --backlog local` and exercise specific feat
 .claude/skills/test-sandbox/scripts/smoke-features.sh <name>      # presence + frontmatter checks for every feature shipped after v0.9
 .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh <name> # add → list → move → view → clarify-comment round-trip on the local backend
 .claude/skills/test-sandbox/scripts/smoke-hooks.sh <name>         # fire each bundled hook with synthetic stdin, verify behavior + soft-warn semantics
+.claude/skills/test-sandbox/scripts/smoke-picker.sh <name>        # drive the interactive arrow-key picker over a real PTY (requires python3)
 ```
 
-Run all three back-to-back for a comprehensive post-refactor smoke:
+Run all four back-to-back for a comprehensive post-refactor smoke:
 
 ```bash
 bash .claude/skills/test-sandbox/scripts/smoke-features.sh feat
 bash .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh backlog
 bash .claude/skills/test-sandbox/scripts/smoke-hooks.sh hooks
+bash .claude/skills/test-sandbox/scripts/smoke-picker.sh picker
 ```
+
+`smoke-picker.sh` uses Python's `pty` module to allocate a real pseudo-TTY for the
+`specflow init` subprocess so `Deno.stdin.isTerminal()` returns true and the
+interactive code path actually runs (a normal piped subprocess would fall back
+to the non-TTY numeric prompt). It scripts arrow-down + enter keystrokes,
+captures the rendered frames, and asserts that the highlight moved correctly
+and the resulting init landed the right harness + backlog backend.
 
 ## Typical workflows
 

--- a/.claude/skills/test-sandbox/scripts/smoke-picker.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-picker.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Drive the interactive arrow-key picker over a real PTY so
+# `Deno.stdin.isTerminal()` returns true and the TUI code path runs.
+# Sends arrow-down + enter sequences to verify navigation + selection
+# render correctly and the resulting init landed the right harness +
+# backlog backend.
+#
+# Usage: smoke-picker.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-picker.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$ROOT/sandbox/$NAME"
+
+bash "$SCRIPT_DIR/bootstrap-empty.sh" "$NAME" >/dev/null
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "❌ python3 not on PATH — needed to allocate a PTY for this test"
+  exit 1
+fi
+
+# Python driver: forks a PTY-attached child running specflow init,
+# scripts arrow-down/enter keystrokes, captures all output.
+out="$(PROJECT_DIR="$DIR" MAIN_TS="$ROOT/src/main.ts" python3 - <<'PYEOF'
+import os, pty, select, sys, time
+
+PROJECT_DIR = os.environ["PROJECT_DIR"]
+MAIN_TS = os.environ["MAIN_TS"]
+ARGS = ["deno", "run", "--allow-all", MAIN_TS, "init", "--here", "--no-git"]
+# 2× down + enter (codex harness), then 1× down + enter (github backend).
+SCRIPT = [
+    (0.5, b"\x1b[B"),
+    (0.2, b"\x1b[B"),
+    (0.3, b"\r"),
+    (0.5, b"\x1b[B"),
+    (0.3, b"\r"),
+]
+
+os.chdir(PROJECT_DIR)
+pid, fd = pty.fork()
+if pid == 0:
+    os.execvp(ARGS[0], ARGS)
+
+captured = bytearray()
+deadline = time.time() + 25.0
+script = list(SCRIPT)
+next_at = time.time() + (script[0][0] if script else 0)
+while time.time() < deadline:
+    r, _, _ = select.select([fd], [], [], 0.1)
+    if r:
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        captured.extend(chunk)
+    if script and time.time() >= next_at:
+        _, payload = script.pop(0)
+        os.write(fd, payload)
+        if script:
+            next_at = time.time() + script[0][0]
+    try:
+        done_pid, _status = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        break
+    if done_pid == pid:
+        break
+
+os.close(fd)
+sys.stdout.buffer.write(bytes(captured))
+PYEOF
+)"
+
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1 — $2"; fails=$((fails + 1)); }
+
+echo "$out" | grep -q "Choose your AI harness" \
+  && pass "harness picker prompt rendered" \
+  || fail "harness prompt missing" "$out"
+
+echo "$out" | grep -q "❯ Codex CLI" \
+  && pass "highlight reached Codex CLI after 2 arrow-downs" \
+  || fail "❯ never reached Codex CLI" "$out"
+
+echo "$out" | grep -q "Choose your backlog backend" \
+  && pass "backlog picker prompt rendered" \
+  || fail "backlog prompt missing" "$out"
+
+echo "$out" | grep -q "❯ GitHub Issues" \
+  && pass "highlight reached GitHub backend after arrow-down" \
+  || fail "❯ never reached GitHub backend" "$out"
+
+echo "$out" | grep -q "Open the project in Codex CLI" \
+  && pass "init resolved harness = Codex CLI (selected harness honored)" \
+  || fail "init did not pick Codex CLI" "$out"
+
+[ -f "$DIR/.specflow/backlog-config.yml" ] \
+  && pass "backlog-config.yml written (github backend honored)" \
+  || fail "backlog-config.yml missing" "$(ls "$DIR/.specflow" 2>&1 || echo none)"
+
+[ -f "$DIR/.specflow/installed.lock" ] \
+  && pass "installed.lock written" \
+  || fail "installed.lock missing" "$(ls "$DIR/.specflow" 2>&1 || echo none)"
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL PICKER CHECKS PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails CHECK(S) FAILED ═══"
+  exit 1
+fi


### PR DESCRIPTION
Adds a sandbox smoke script that actually exercises the interactive picker end-to-end. Without a PTY the picker can't be reached from any subprocess (`Deno.stdin.isTerminal()` would be false and we'd fall through to the numeric path), so this script uses Python's `pty.fork()` to allocate one and scripts the keystroke sequence:

1. Bootstrap an empty greenfield project under `sandbox/<name>/`
2. Fork a PTY, exec `specflow init --here --no-git` in the child
3. Send: `↓ ↓ ↵` (select Codex CLI), then `↓ ↵` (select GitHub)
4. Capture all rendered frames + assert:
   - both prompts rendered with the picker header
   - `❯` reached `Codex CLI` after 2 down arrows
   - `❯` reached `GitHub Issues + Project` after 1 down arrow
   - init landed harness=Codex CLI + backlog backend=github (lock + config stub written)

## Test plan
- [x] `bash .claude/skills/test-sandbox/scripts/smoke-picker.sh picker` — 7/7 ✓ locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)