### PR TITLE
feat(po): docs-upkeep mode + Stop hook (closes #100)

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -36,6 +36,10 @@ You exclusively control:
 - **Closing items** — `gh issue close <num> --repo mkrlabs/specflow
   --reason {completed|not_planned}`. Always close the issue, don't just
   move to Done — closing is the audit trail.
+- **Docs upkeep** — verifying that the four user-facing doc surfaces
+  stay in sync with what the binary actually does whenever a development
+  changes user-visible behavior. See "Docs upkeep mode" below for the
+  trigger, the surfaces you own, and the definition of "user-visible".
 
 The main session and other agents call you to perform these mutations.
 They never run `add.sh`, `move.sh`, `clarify-comment.sh`, or `gh issue
@@ -220,3 +224,103 @@ issue history, or git log — those are authoritative.
 - Cross-repo backlog management — this role is hard-wired to
   `mkrlabs/specflow` and Project #4. If asked about another repo,
   decline and point at the user.
+- **Editing docs yourself in docs-upkeep mode.** You audit and propose;
+  the main session writes the patches. Same read-only pattern as
+  architect / devops-sre.
+
+## Docs upkeep mode
+
+You are also the owner of Specflow's documentation upkeep — making sure
+the binary's behavior never silently drifts away from what the docs
+describe. This is a separate dispatch mode from backlog mutations; the
+trigger and the workflow are different.
+
+### Trigger
+
+The `.claude/hooks/check-docs-drift.sh` hook fires on every `Stop`
+event in the main session. When it detects that user-visible CLI source
+changed in the working tree but no doc surface was touched in the same
+batch, it emits a `hookSpecificOutput.additionalContext` JSON payload
+that recommends dispatching you in this mode. The next turn, the main
+session reads that recommendation and dispatches you.
+
+You can also be dispatched manually with a brief like "check docs drift
+on the current working tree" or "audit docs against the latest changes
+on `feat/X`".
+
+### Doc surfaces you own
+
+Four files / file groups, in priority order:
+
+1. **`docs/llms.md`** — the canonical website at
+   `specflow.makerlabs.dev` and the LLM-consumption page at `/llms.txt`.
+   This is the highest-priority surface — it's what new users land on.
+2. **`README.md`** — the repo root README. The first thing a developer
+   sees on GitHub. Less detailed than `llms.md`, but flag references
+   and the install snippet must match reality.
+3. **`templates/core/commands/specflow.*.md`** — the slash-command
+   sources (`specflow.specify`, `specflow.plan`, `specflow.tasks`,
+   `specflow.implement`, `specflow.analyze`, `specflow.review`,
+   `specflow.merge`, `specflow.constitution`, `specflow.checklist`,
+   `specflow.clarify`). These ship into every user project — drift
+   here means every harness gets the wrong help text.
+4. **`templates/core/skills/*/SKILL.md`** — the auto-chain, backlog,
+   and specflow.groom skill sources. Same mechanism as the commands.
+
+### Definition of "user-visible"
+
+A change to `src/` is user-visible if it adds, removes, or changes:
+
+- A CLI flag (any `parsed.<flag>` in `src/cli/parser.ts`).
+- A command branch (any `if (command === "X")` branch in `parser.ts`).
+- The `--help` output (`src/cli/help.ts`).
+- The output of any handler in `src/cli/handlers/*.ts` — stdout lines,
+  error messages, prompt strings, exit-code semantics.
+- The interactive prompt UX (`src/cli/select.ts`,
+  `src/cli/harness_picker.ts`, `src/cli/backlog_picker.ts`).
+
+Internal refactors that don't change any of the above are NOT
+user-visible — note that explicitly in your report when relevant.
+
+### Workflow when dispatched in this mode
+
+1. **Read the diff.** Run `git diff HEAD` and `git diff --cached` on
+   the working tree to see what's currently uncommitted. If the user
+   pointed at a specific branch or PR, use `git diff main...<branch>`
+   or `gh pr diff <num>` instead.
+2. **Classify the changes.** Identify which changes are user-visible
+   per the definition above. Refactors / internal renames / test-only
+   changes are not user-visible — say so explicitly and stop.
+3. **Audit each doc surface.** For each user-visible change, grep the
+   four surfaces for the affected concept (flag name, command name,
+   error message, etc.) and check whether the surface still matches.
+   Be specific: cite line numbers.
+4. **Report.** Return a structured table:
+
+   ```
+   | Surface | Status | Drift / suggestion |
+   |---------|--------|--------------------|
+   | docs/llms.md | drift | Line 167: still says "supports two backends" — should say "three" after #70. Suggested patch: …
+   | README.md | in sync | … |
+   | templates/core/commands/specflow.specify.md | n/a | not affected by this change |
+   | templates/core/skills/auto-chain/SKILL.md | drift | … |
+   ```
+
+   For drift rows, include a concrete suggested patch (a small unified
+   diff or a "before / after" snippet). The main session writes the
+   actual edit; you only propose.
+
+5. **No mutations.** You do not run `gh issue edit`, you do not write
+   to disk, you do not create a follow-up ticket. Reporting is the
+   entire job in this mode. The main session decides what to do with
+   your report.
+
+### When NOT to recommend a docs change
+
+- Refactors with no behavior change (rename of internal helper,
+  extracted function, test reorganisation).
+- Changes that touch a doc surface in the same batch (the hook won't
+  fire, so this case shouldn't reach you — but flag it as "already
+  in sync, no further action" if it does).
+- Changes that affect dev-time behavior only (e.g. `scripts/`,
+  `tests/`, `deno.json` task definitions) — those are not user-facing.

--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -11,6 +11,8 @@ treatment is now part of normal conventions).
 
 ## Entries
 
+- [Docs upkeep pattern](docs-upkeep-pattern.md) — PO owns docs on 3 surfaces (llms.md, README, SKILL.md); hook-driven, no separate doc-writer agent; established in #100
+
 - [Architect handoff pattern](architect-handoff-pattern.md) — when architect has already designed a solution, wire AC directly from the spec without re-deriving strategy
 - [Docs domain](docs-domain.md) — Specflow docs are at https://specflow.makerlabs.dev (custom domain on GH Pages); use this URL in docs-related issues and AC.
 - [GitHub labels](github-labels.md) — only the 9 default GitHub labels exist; do not use ux/docs/friction slugs

--- a/.claude/agents/product-owner/memory/docs-upkeep-pattern.md
+++ b/.claude/agents/product-owner/memory/docs-upkeep-pattern.md
@@ -1,0 +1,30 @@
+---
+name: docs-upkeep-pattern
+description: PO owns docs upkeep on four user-visible surfaces, driven by a Stop-event hook in the Specflow repo — pattern established in issue #100
+type: pattern
+---
+
+The product-owner agent (not a separate doc-writer agent) owns docs upkeep on
+four surfaces, in priority order:
+
+1. `docs/llms.md` — canonical website + `/llms.txt`
+2. `README.md` — repo root
+3. `templates/core/commands/specflow.*.md` — slash-command sources (specify, plan, tasks, implement, analyze, review, merge, constitution, checklist, clarify)
+4. `templates/core/skills/*/SKILL.md` — auto-chain, backlog, specflow.groom skills
+
+**Rule:** When clarifying any ticket that touches user-visible surfaces (CLI
+flags, command branches, `--help` output, handler stdout / error messages, prompt
+UX), include an AC bullet requiring docs-upkeep verification before merge.
+
+**Why:** Kevin chose Option B (extend PO scope) over a standalone doc-writer
+agent in issue #100. The trigger is hook-driven — a Stop-event hook at
+`.claude/hooks/check-docs-drift.sh` (in the Specflow repo itself, NOT in the
+bundled templates) fires after every turn and emits
+`hookSpecificOutput.additionalContext` recommending PO dispatch when CLI source
+changed but no doc surface did.
+
+**How to apply:** For future tickets that change user-visible surfaces, add to
+the AC: "The docs-upkeep hook fires and the PO confirms all four surfaces are
+in sync (or proposes patches for any drift) before the PR is merged." The PO is
+read-only in this mode — it audits and proposes patches; the main session
+writes the actual edits.

--- a/.claude/hooks/check-docs-drift.sh
+++ b/.claude/hooks/check-docs-drift.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Stop-event hook: warn when user-visible CLI source changed but no doc
+# surface was touched. Soft warn-only — exits 0 always; emits a
+# `hookSpecificOutput.additionalContext` JSON payload only when drift is
+# detected so the next turn can dispatch the product-owner subagent in
+# its "docs upkeep" mode.
+#
+# This hook lives in the SPECFLOW REPO ITSELF (not in the bundled
+# templates) — its job is to catch drift between the binary's behavior
+# and the docs that describe it (docs/llms.md, README.md, slash-command
+# help, SKILL.md files).
+set -euo pipefail
+
+# Files Claude Code touched in this turn — staged, unstaged, and
+# untracked. Empty diff = nothing to check; exit silently.
+changed=$(
+  {
+    git diff --name-only HEAD 2>/dev/null
+    git ls-files --others --exclude-standard 2>/dev/null
+  } | sort -u
+) || exit 0
+
+[ -z "$changed" ] && exit 0
+
+# User-visible source: anything that affects what the user sees when
+# they run the binary. Slash-command source is intentionally excluded
+# here — those files are themselves a doc surface and editing one is
+# self-documenting.
+uv_pat='^(src/cli/parser\.ts|src/cli/handlers/.*\.ts|src/cli/help\.ts)$'
+
+# Doc surfaces we expect to be kept in sync with the binary.
+ds_pat='^(docs/llms\.md|README\.md|templates/core/commands/specflow\.[a-z]+\.md|templates/core/skills/[^/]+/SKILL\.md)$'
+
+uv_changed=$(echo "$changed" | grep -E "$uv_pat" || true)
+ds_changed=$(echo "$changed" | grep -E "$ds_pat" || true)
+
+# Warn only when CLI source changed but NO doc surface was touched.
+if [ -z "$uv_changed" ] || [ -n "$ds_changed" ]; then
+  exit 0
+fi
+
+# Build a comma-joined list of changed user-visible files for the
+# message — keeps the additionalContext concise.
+uv_list=$(echo "$uv_changed" | paste -sd, -)
+
+cat <<JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "docs-drift watch: user-visible CLI source changed but no doc surface was updated. Changed files: ${uv_list}. If this is a real user-visible change (new/removed CLI flag, new/changed handler output, new/changed error message, new/changed public command), dispatch the product-owner subagent in its docs-upkeep mode (it owns docs/llms.md, README.md, templates/core/commands/specflow.*.md, and templates/core/skills/*/SKILL.md). The PO will report drift with a concrete patch suggestion or confirm docs are in sync. If the change is purely internal refactor with no user-facing impact, ignore this watch."
+  }
+}
+JSON

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,6 +84,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-docs-drift.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Closes #100. Extends the product-owner agent's scope to also own docs upkeep on **four** user-facing surfaces, driven by a Stop-event hook in the Specflow repo itself.

## Behavior

- **Hook**: `.claude/hooks/check-docs-drift.sh`. Fires on every \`Stop\` event. Diffs the working tree (staged + unstaged + untracked) and detects when user-visible CLI source changed but no doc surface was touched in the same batch. Emits a \`hookSpecificOutput.additionalContext\` JSON payload that recommends dispatching the PO in docs-upkeep mode. Soft warn-only — exits 0 always.
- **PO agent**: `.claude/agents/product-owner.md` gains a "Docs upkeep mode" section that defines the trigger, the four surfaces, the definition of "user-visible", and the audit workflow. The PO is read-only in this mode (audits + proposes; main session writes).

## Divergences from the AC sketch (intentional)

1. **Four surfaces, not three.** The AC listed `templates/core/skills/specflow.*/SKILL.md` as one bucket — that's only `specflow.groom`. The actual user-facing doc surfaces split cleanly: `templates/core/commands/specflow.*.md` (slash-command sources, 10 files) AND `templates/core/skills/*/SKILL.md` (auto-chain, backlog, specflow.groom — 3 files). Both are bundled into every user project.
2. **Hook lives in the repo's own `.claude/hooks/`, not in `templates/harness-specific/claude/hooks/`.** The AC suggested the bundled location, but docs-upkeep is for the Specflow repo itself (catching drift between binary and docs at dev time) — not something user projects need. Bundled hooks fire in user projects; this hook fires in the Specflow dev session.

## Test plan

- [x] `deno task test` — 374 passed
- [x] Smoke-tested both hook branches manually (positive: emits drift warning; negative: silent when both CLI source and a doc surface change in same batch; baseline: silent when only docs change)
- [ ] Real-world validation will arrive automatically: the hook fires on every Stop event from now on. Next time CLI source changes without a docs touch, the additionalContext lands in the model's view, and the main session dispatches the PO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)