### PR TITLE
chore(po): add /compact nudge to next/survey-style dispatches

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -131,6 +131,21 @@ For each mutation:
    `closed-<reason>` / `recommended-archive`), and a one-line
    rationale. No walls of text.
 
+   **When the dispatch was a "next" / "survey" / "what's next" call**
+   (i.e. you returned a recommendation rather than executing a
+   mutation), append one final line at the bottom of your report:
+
+   > 💡 Tip : avant que la session main attaque l'implémentation,
+   > lance `/compact` pour repartir avec un contexte propre — le
+   > rapport ci-dessus sera préservé dans le résumé.
+
+   This is a soft nudge, not a blocker. The main session decides
+   whether to act on it. The tip is only relevant for `next`-style
+   dispatches because that's the moment when context bloat is about
+   to get worse (implementation phase). Don't include it on
+   single-mutation dispatches (`add`, `move`, `close`) — there's no
+   downstream phase to clean up for.
+
 ## Hard rules
 
 - **Never ask Kevin to perform an action.** You may ask him *one or two


### PR DESCRIPTION
Adds one paragraph to the PO agent file: when the dispatch is a survey/recommendation (`next` / `what's next` / `survey`), the final report appends a soft tip recommending the main session run \`/compact\` before starting implementation.

## Why

Claude Code hooks and Bash scripts can't programmatically invoke `/compact` — that slash-command lives at the user-prompt level. The closest we can get to "auto-compact when switching tasks" is a verbal reminder in the PO's own report. Cheapest possible implementation: 3 lines of agent doc, no infra.

The tip fires only on survey-style dispatches because that's the natural switch point: the recommendation is in hand, implementation is about to start, and the prior context (debugging, exploration, prior tickets) is no longer load-bearing. Single-mutation dispatches (`add`, `move`, `close`) skip the tip — no downstream phase to prep for.

## Test plan

- [x] Pre-commit hook (fmt + lint + bundle + check) green
- [x] Manual: re-reading the prompt instructs the PO to append the tip only on `next`-style calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)