### PR TITLE
fix(init): detect conflicts before prompting for backlog backend

### DIFF
--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -60,6 +60,29 @@ async function resolveBacklogBackend(
   return picked;
 }
 
+function printConflictsError(
+  conflicts: string[],
+  lockExists: boolean,
+): void {
+  const n = conflicts.length;
+  const noun = n === 1 ? "file" : "files";
+  console.error(red(`error: ${n} ${noun} would be overwritten:`));
+  for (const c of conflicts) console.error(red(`  - ${c}`));
+  console.error("");
+  if (lockExists) {
+    console.error(
+      `This project was previously initialised by Specflow — run ${
+        bold("specflow upgrade")
+      } to update the managed files in place.`,
+    );
+  } else {
+    console.error(
+      `Re-run with ${bold("specflow init --here --force")} to overwrite ` +
+        "(existing files are backed up to *.specflow.bak).",
+    );
+  }
+}
+
 async function writeBacklogConfigStub(
   targetDir: string,
   backend: BacklogBackend,
@@ -102,6 +125,28 @@ export async function runInit(intent: InitIntent): Promise<number> {
     return 2;
   }
 
+  // Pre-flight conflict check — runs BEFORE the backlog-backend picker so
+  // a doomed init doesn't drag the user through a prompt for nothing
+  // (regression #103). The probe-bundle uses the `local` backend as a
+  // placeholder: only `backlog-script` paths differ between backends, so
+  // any existing managed file (CLAUDE.md, settings.json, SKILL.md, …)
+  // shows up in every backend's bundle and is enough to flag the conflict
+  // here. The use case still re-checks after the real backend is picked,
+  // so the path stays correct even if the probe missed something.
+  if (!intent.force) {
+    const writer = new DenoFsWriter();
+    const lockStore = new FsLockStore();
+    const probeBundle = harness.mapBundle(CORE_BUNDLE, {
+      backlogBackend: "local",
+    });
+    const conflicts = await writer.detectConflicts(probeBundle, targetDir);
+    if (conflicts.length > 0) {
+      const lock = await lockStore.read(targetDir);
+      printConflictsError(conflicts, lock !== null);
+      return 3;
+    }
+  }
+
   const backlogBackend = await resolveBacklogBackend(intent.backlog);
 
   console.log(`Initializing into ${bold(targetDir)}`);
@@ -123,23 +168,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
   });
 
   if (result.status === "conflicts") {
-    const n = result.conflicts.length;
-    const noun = n === 1 ? "file" : "files";
-    console.error(red(`error: ${n} ${noun} would be overwritten:`));
-    for (const c of result.conflicts) console.error(red(`  - ${c}`));
-    console.error("");
-    if (result.lockExists) {
-      console.error(
-        `This project was previously initialised by Specflow — run ${
-          bold("specflow upgrade")
-        } to update the managed files in place.`,
-      );
-    } else {
-      console.error(
-        `Re-run with ${bold("specflow init --here --force")} to overwrite ` +
-          "(existing files are backed up to *.specflow.bak).",
-      );
-    }
+    printConflictsError(result.conflicts, result.lockExists);
     return 3;
   }
 

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -196,6 +196,33 @@ Deno.test("specflow init on a fresh project recommends --force (no lock present)
   });
 });
 
+Deno.test("specflow init aborts on conflicts BEFORE prompting for backlog backend (regression #103)", async () => {
+  await withTempDir(async (dir) => {
+    // Pre-seed a managed file to force a conflict on re-init.
+    await Deno.mkdir(join(dir, "demo/.claude/skills/specflow.specify"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      join(dir, "demo/.claude/skills/specflow.specify/SKILL.md"),
+      "custom",
+    );
+    // Pass --ai claude so the harness picker doesn't fire (it's only the
+    // backlog-backend picker we're asserting against). Crucially, we omit
+    // --backlog so the backend would normally be resolved interactively.
+    const { code, stdout, stderr } = await runSpecflow(
+      ["init", "demo", "--no-git", "--ai", "claude"],
+      { cwd: dir },
+    );
+    assertEquals(code, 3);
+    assertStringIncludes(stderr, "would be overwritten");
+    assertEquals(
+      stdout.includes("Choose your backlog backend"),
+      false,
+      "regression #103: backlog-backend picker must not run when init is going to abort on conflicts",
+    );
+  });
+});
+
 Deno.test("specflow init on a previously-initialised project recommends upgrade (lock present)", async () => {
   await withTempDir(async (dir) => {
     await Deno.mkdir(join(dir, "demo/.claude/skills/specflow.specify"), {


### PR DESCRIPTION
Closes #103.

QA pass on v0.11.0 surfaced that re-running \`specflow init --here\` on an already-init'd project shows the backlog-backend picker, accepts user input, **then** aborts with the conflict error — wasted interaction with no recovery.

## Fix

Pre-flight conflict check now runs after harness resolution but **before** the backlog prompt. The check:

1. Builds a probe-bundle from the resolved harness using \`local\` as a placeholder backend. File PATHS are invariant across backends for non-script entries (CLAUDE.md, settings.json, SKILL.md files, …) — any existing managed file shows up in every backend's bundle and is enough to flag the conflict.
2. Runs \`writer.detectConflicts(probeBundle, targetDir)\`.
3. Reads \`.specflow/installed.lock\` to decide which lock-aware recommendation to print (already shipped in #95 / v0.11.0).
4. Emits the error and exits 3 — no prompt fires.

The use case keeps its own conflict check after the real backend is picked, as defense-in-depth. The conflict-rendering block is extracted into a \`printConflictsError\` helper so the two call sites stay in sync.

## Behavior verified locally

\`\`\`
$ mkdir -p /tmp/sf-103/.claude/skills/specflow.specify
$ echo custom > /tmp/sf-103/.claude/skills/specflow.specify/SKILL.md
$ cd /tmp/sf-103 && specflow init --here --no-git --ai claude
error: 1 file would be overwritten:
  - .claude/skills/specflow.specify/SKILL.md

Re-run with specflow init --here --force to overwrite (existing files are backed up to *.specflow.bak).
\`\`\`

No "Choose your backlog backend" header — straight to the error.

## Test plan

- [x] New regression test in \`tests/integration/init_test.ts\` asserts \`stdout\` does NOT contain \"Choose your backlog backend\" when conflicts are detected (test FAILED before the fix, PASSES after)
- [x] \`deno task test\` — 375 passed (was 374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)