### PR TITLE
fix(check): validate backlog-config.yml on github/gitlab backends

### DIFF
--- a/src/infrastructure/fs_project_inspector.ts
+++ b/src/infrastructure/fs_project_inspector.ts
@@ -1,7 +1,8 @@
 import { join } from "@std/path";
+import { parse as parseYaml } from "@std/yaml";
 import type { ProjectInspector } from "../application/ports.ts";
 import type { CheckOutcome } from "../domain/check_result.ts";
-import { type KnownHarness, parseLock } from "../domain/installed_lock.ts";
+import { type BacklogBackend, type KnownHarness, parseLock } from "../domain/installed_lock.ts";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -63,9 +64,96 @@ export class FsProjectInspector implements ProjectInspector {
     outcomes.push(await this.checkHarness(projectDir));
     outcomes.push(await this.checkConstitution(projectDir));
     outcomes.push(await this.checkTemplatesVersion(projectDir, templatesVersion));
+    outcomes.push(await this.checkBacklogConfig(projectDir));
     outcomes.push(...await this.checkClaudeConfig(projectDir));
 
     return outcomes;
+  }
+
+  /**
+   * Surfaces the active backlog backend and validates that the per-backend
+   * config file is wired up enough to actually run. The PO will fail at
+   * runtime if `backlog-config.yml` has empty required fields, so flagging
+   * here saves the user from a confusing first `/backlog add` failure.
+   *
+   * Local backend is zero-config: a single `pass` line, no file lookup.
+   */
+  private async checkBacklogConfig(projectDir: string): Promise<CheckOutcome> {
+    const lockPath = join(projectDir, ".specflow/installed.lock");
+    if (!(await exists(lockPath))) {
+      return {
+        name: "backlog backend",
+        status: "warn",
+        message: "no installed.lock — cannot determine backend",
+      };
+    }
+    let backend: BacklogBackend;
+    try {
+      backend = parseLock(await Deno.readTextFile(lockPath)).backlogBackend;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { name: "backlog backend", status: "fail", message: `corrupt lock — ${msg}` };
+    }
+
+    if (backend === "local") {
+      return {
+        name: "backlog backend",
+        status: "pass",
+        message: "local — zero-config",
+      };
+    }
+
+    const cfgPath = join(projectDir, ".specflow/backlog-config.yml");
+    if (!(await exists(cfgPath))) {
+      return {
+        name: "backlog backend",
+        status: "warn",
+        message:
+          `${backend} — backlog-config.yml missing (run \`specflow upgrade --backlog ${backend}\` to scaffold)`,
+      };
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      const raw = await Deno.readTextFile(cfgPath);
+      parsed = (parseYaml(raw) ?? {}) as Record<string, unknown>;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        name: "backlog backend",
+        status: "fail",
+        message: `${backend} — backlog-config.yml is invalid YAML: ${msg}`,
+      };
+    }
+
+    const requiredFields: Record<"github" | "gitlab", string[]> = {
+      github: ["repo", "project_number"],
+      gitlab: ["project_id"],
+    };
+
+    const missing: string[] = [];
+    for (const field of requiredFields[backend]) {
+      const v = parsed[field];
+      if (v === undefined || v === null || v === "") {
+        missing.push(field);
+      }
+    }
+
+    if (missing.length > 0) {
+      return {
+        name: "backlog backend",
+        status: "warn",
+        message: `${backend} — backlog-config.yml has empty ${
+          missing.join(", ")
+        } (PO will fail at runtime)`,
+      };
+    }
+
+    return {
+      name: "backlog backend",
+      status: "pass",
+      message: `${backend} — backlog-config.yml configured`,
+    };
   }
 
   /**

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -611,3 +611,185 @@ entries: {}
     },
   );
 });
+
+// ── backlog backend (#104) ─────────────────────────────────────────────────
+
+async function backlogProject(
+  dir: string,
+  backend: "local" | "github" | "gitlab",
+  configYml?: string,
+): Promise<void> {
+  await Deno.mkdir(join(dir, ".specflow/memory"), { recursive: true });
+  await Deno.mkdir(join(dir, ".claude"), { recursive: true });
+  await Deno.writeTextFile(
+    join(dir, ".specflow/memory/constitution.md"),
+    CONSTITUTION_FILLED,
+  );
+  await Deno.writeTextFile(
+    join(dir, ".specflow/installed.lock"),
+    `version: 2
+harness: claude
+backlog_backend: ${backend}
+templates_version: 0.7.0
+entries: {}
+`,
+  );
+  if (configYml !== undefined) {
+    await Deno.writeTextFile(
+      join(dir, ".specflow/backlog-config.yml"),
+      configYml,
+    );
+  }
+}
+
+Deno.test("inspect surfaces backlog backend = local with pass status (zero-config)", async () => {
+  await withProjectDir(
+    (dir) => backlogProject(dir, "local"),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "pass");
+      assertEquals(o?.message, "local — zero-config");
+    },
+  );
+});
+
+Deno.test("inspect warns when github backend has empty repo and project_number", async () => {
+  await withProjectDir(
+    (dir) =>
+      backlogProject(
+        dir,
+        "github",
+        `repo: ""
+project_number: ""
+project_node_id: ""
+status_field_id: ""
+`,
+      ),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "warn");
+      assertEquals(o?.message.includes("repo"), true);
+      assertEquals(o?.message.includes("project_number"), true);
+      assertEquals(o?.message.includes("PO will fail at runtime"), true);
+    },
+  );
+});
+
+Deno.test("inspect warns when github backend has only repo filled (project_number still empty)", async () => {
+  await withProjectDir(
+    (dir) =>
+      backlogProject(
+        dir,
+        "github",
+        `repo: myorg/myproject
+project_number: ""
+`,
+      ),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "warn");
+      assertEquals(o?.message.includes("project_number"), true);
+      assertEquals(o?.message.includes("repo"), false);
+    },
+  );
+});
+
+Deno.test("inspect passes when github backend has both required fields filled", async () => {
+  await withProjectDir(
+    (dir) =>
+      backlogProject(
+        dir,
+        "github",
+        `repo: myorg/myproject
+project_number: 4
+`,
+      ),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "pass");
+      assertEquals(o?.message, "github — backlog-config.yml configured");
+    },
+  );
+});
+
+Deno.test("inspect warns when gitlab backend has empty project_id", async () => {
+  await withProjectDir(
+    (dir) =>
+      backlogProject(
+        dir,
+        "gitlab",
+        `host: gitlab.com
+project_id: ""
+`,
+      ),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "warn");
+      assertEquals(o?.message.includes("project_id"), true);
+    },
+  );
+});
+
+Deno.test("inspect passes when gitlab backend has project_id filled", async () => {
+  await withProjectDir(
+    (dir) =>
+      backlogProject(
+        dir,
+        "gitlab",
+        `host: gitlab.com
+project_id: 12345
+`,
+      ),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "pass");
+      assertEquals(o?.message, "gitlab — backlog-config.yml configured");
+    },
+  );
+});
+
+Deno.test("inspect warns when github backend lock is set but backlog-config.yml is missing", async () => {
+  await withProjectDir(
+    (dir) => backlogProject(dir, "github" /* no configYml */),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "warn");
+      assertEquals(o?.message.includes("backlog-config.yml missing"), true);
+      assertEquals(o?.message.includes("specflow upgrade --backlog github"), true);
+    },
+  );
+});
+
+Deno.test("inspect fails when backlog-config.yml is invalid YAML", async () => {
+  await withProjectDir(
+    (dir) =>
+      backlogProject(
+        dir,
+        "github",
+        `repo: "myorg/myproject
+project_number: 4
+`, // unterminated quote
+      ),
+    async (dir) => {
+      const inspector = new FsProjectInspector();
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const o = outcomes.find((x) => x.name === "backlog backend");
+      assertEquals(o?.status, "fail");
+      assertEquals(o?.message.includes("invalid YAML"), true);
+    },
+  );
+});


### PR DESCRIPTION
Closes #104.

QA pass on v0.11.0 surfaced that \`specflow check --project\` passed silently on a fresh \`init --backlog github\` even though the stub had empty \`repo\` and \`project_number\`. Operator believed everything was wired, then \`/backlog add\` failed at runtime with a confusing error.

## Fix

\`FsProjectInspector\` gains a \`backlog backend\` outcome (rendered between \"templates version\" and the Claude-config block):

| Backend | Outcome |
|---|---|
| \`local\` | \`✓ local — zero-config\` |
| \`github\` (config valid) | \`✓ github — backlog-config.yml configured\` |
| \`github\` (\`repo\` or \`project_number\` empty) | \`⚠ github — backlog-config.yml has empty repo, project_number (PO will fail at runtime)\` |
| \`gitlab\` (config valid) | \`✓ gitlab — backlog-config.yml configured\` |
| \`gitlab\` (\`project_id\` empty) | \`⚠ gitlab — backlog-config.yml has empty project_id (PO will fail at runtime)\` |
| Any non-local backend, file missing | \`⚠ <backend> — backlog-config.yml missing (run \\\`specflow upgrade --backlog <backend>\\\` to scaffold)\` |
| Invalid YAML | \`✗ <backend> — backlog-config.yml is invalid YAML: <reason>\` |

Required-field map, by backend:
- **github**: \`repo\`, \`project_number\` (optional cached fields \`project_node_id\`, \`status_field_id\` are intentionally NOT validated — they get filled in on first run).
- **gitlab**: \`project_id\` only (\`host\` defaults to \`gitlab.com\`).

## Test plan

- [x] 8 new unit tests in \`tests/infrastructure/fs_project_inspector_test.ts\` — covers all 8 outcome paths above
- [x] \`deno task test\` — 383 passed (was 375)
- [x] Smoke-tested locally — empty github init shows the warn line, populated github shows pass, local shows zero-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)