### PR TITLE
docs(llms): mention backlog backend in check --project description

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -91,10 +91,11 @@ emitted. It contains no secrets — only file paths, content hashes, and version
 
 **Commit it.** `specflow upgrade` reads this lock to know which harness to map templates to, to
 detect files you have customized (so it doesn't clobber them), and to drop orphaned files that are
-no longer part of the bundle. `specflow check --project` also surfaces the harness and templates
-version from this file. Without the lock, both commands degrade gracefully but cannot do their real
-job — `specflow upgrade` will refuse and ask you to re-run `specflow init --here --force` to rebuild
-the lock from scratch.
+no longer part of the bundle. `specflow check --project` also surfaces the harness, templates
+version, and backlog backend from this file (and warns when `backlog-config.yml` has empty required
+fields for the github / gitlab backends). Without the lock, both commands degrade gracefully but
+cannot do their real job — `specflow upgrade` will refuse and ask you to re-run
+`specflow init --here --force` to rebuild the lock from scratch.
 
 ### Pick a different harness
 


### PR DESCRIPTION
Drift surfaced by the docs-upkeep PO audit after v0.11.1.

The sentence describing what `specflow check --project` reads from `.specflow/installed.lock` listed only "harness and templates version". PR #106 added a third outcome (active backlog backend) plus a warning path when `backlog-config.yml` has empty required fields. This PR aligns the prose with reality.

Audit confirmed clean on the other three surfaces (`README.md`, `templates/core/commands/`, `templates/core/skills/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)