### PR TITLE
feat(plugin): scaffold claude-specflow plugin with auto-chain skill (#73 slice 1)

### DIFF
--- a/.claude/agents/architect/memory/MEMORY.md
+++ b/.claude/agents/architect/memory/MEMORY.md
@@ -12,3 +12,5 @@ obsolete once they are encoded in `AGENTS.md`).
 ## Entries
 
 - [Antigravity Harness Research](antigravity-harness-research.md) — Canonical `.agent/` layout resolved from primary sources; resolves the .agent vs .agents ambiguity in issue #2
+- [Claude plugin boundary](claude-plugin-boundary.md) — which templates go to the plugin vs stay binary-owned; the project-state rule
+- [Claude plugin backwards compat](claude-plugin-compat.md) — state table + detection method for v0.x inline agents when plugin is installed

--- a/.claude/agents/architect/memory/claude-plugin-boundary.md
+++ b/.claude/agents/architect/memory/claude-plugin-boundary.md
@@ -1,0 +1,22 @@
+---
+name: claude-plugin-boundary
+description: Which Specflow templates go to the claude-specflow plugin vs stay binary-owned — decision from issue #73 design
+type: decision
+---
+
+Plugin content is user-scoped and project-agnostic. The dividing rule:
+
+**Rule: anything that requires project-state (reads .specflow/installed.lock, has
+conditional-render markers, or is meant to be per-project customized) stays binary-owned.**
+
+**Why:** Plugin hooks and skills cannot vary per backlog backend, cannot reference
+$(pwd)/.specflow/installed.lock, and cannot be conditionally rendered.
+
+**How to apply:**
+- Commands/agents/skills with no backend dependency: "both" (plugin = canonical latest, binary = project snapshot with short slash-command)
+- backlog.md command, backlog SKILL.md, backlog scripts: binary only (conditional render + lock reads)
+- All hooks (protect-generated.sh, check-backlog-prereqs.sh, log-subagent.sh): binary only until plugin hook path resolution is documented
+- All harness-specific static files (CLAUDE.md, settings.json, loop.md, dispatch-agent.sh): binary only (reference project-local paths)
+- spec-root, agent-memory, project-root files: binary only (project-stateful by definition)
+
+Plugin skills are namespaced (/claude-specflow:specify); binary-scaffolded project skills keep the short form (/specify). Both coexist.

--- a/.claude/agents/architect/memory/claude-plugin-compat.md
+++ b/.claude/agents/architect/memory/claude-plugin-compat.md
@@ -1,0 +1,20 @@
+---
+name: claude-plugin-compat
+description: Backwards-compat strategy for v0.x inline agents when claude-specflow plugin is installed — issue #73
+type: decision
+---
+
+**Detection method:** SHA comparison against InstalledLock.entries (already implemented in src/domain/installed_lock.ts). Plugin presence detected via Deno.stat on ~/.claude/plugins/cache/claude-specflow/ through a new PluginDetector port + fs_plugin_detector.ts adapter.
+
+**Rule: auto-migrate vanilla files, warn-and-preserve customized files.**
+
+Why: Claude Code project-scope .claude/agents/ wins over user-scope plugin agents on name collision, so a customized file already takes precedence at runtime. The binary behavior should match the runtime behavior.
+
+**State table summary:**
+- Vanilla on disk + plugin installed → auto-migrate: backup to .specflow/backups/<timestamp>/, delete, drop lock entry, print info
+- Customized on disk + plugin installed → warn + preserve, user reconciles manually (or --force)
+- Any + plugin not installed → normal upgrade path, no change
+
+**Exit ramp:** specflow check --project detects "lock entry exists, file missing from disk, plugin not installed" and recommends specflow upgrade to restore from bundle. The existing add-new action kind handles the restore — no new action kind needed.
+
+**No new CLI flag.** --force extends naturally to mean "overwrite customized files and delete them when plugin is present".

--- a/deno.json
+++ b/deno.json
@@ -33,5 +33,13 @@
   "lint": {
     "rules": { "tags": ["recommended"] }
   },
-  "exclude": ["dist/", "spec-kit/", "examples/", "templates/", ".claude/", "packaging/"]
+  "exclude": [
+    "dist/",
+    "spec-kit/",
+    "examples/",
+    "templates/",
+    ".claude/",
+    "packaging/",
+    "plugin/skills/"
+  ]
 }

--- a/docs/superpowers/specs/2026-05-08-claude-plugin-design.md
+++ b/docs/superpowers/specs/2026-05-08-claude-plugin-design.md
@@ -1,0 +1,141 @@
+# Claude plugin (`claude-specflow`) — boundary and backwards-compat design
+
+**Goal.** Define (a) which Specflow template files move to the plugin vs stay binary-owned, and (b)
+how `specflow upgrade` handles v0.x users who have inline on-disk agents once the plugin exists.
+This is the design-only document for issue #73; no code ships until AC are written.
+
+---
+
+## Summary
+
+The Claude plugin system (`code.claude.com/docs/en/plugins`) installs a plugin repo's content at
+user scope (cached under `~/.claude/plugins/cache/<name>/`) when the user runs
+`/plugin install claude-specflow`. Plugin skills are **namespaced** (`/claude-specflow:specify`), so
+they coexist with but do not replace project-level `.claude/skills/` files. Hooks in a plugin live
+in `hooks/hooks.json`, not in `settings.json`. Agents in a plugin live in `agents/`.
+
+The key constraint: **plugin content is user-scoped and project-agnostic**. It cannot vary by
+backlog backend, cannot reference `.specflow/installed.lock`, and cannot be conditionally rendered.
+Anything that requires project-state stays binary-owned.
+
+---
+
+## Q3 — Path → destination table
+
+| Template path (relative to `templates/`)                 | Category        | Destination                       | Rationale                                                                                                                                                                                                                                                                                                                         |
+| -------------------------------------------------------- | --------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `core/commands/specflow.*.md` (10 files)                 | Skills          | **Both**                          | Plugin ships the generic version (namespaced `/claude-specflow:specify`). Binary continues to scaffold project-local copies in `.claude/skills/specflow.*/SKILL.md` (unlocked, un-namespaced `/specify`). Users get the convenience of the plugin AND the short slash-command. On upgrade, binary version wins for project files. |
+| `core/commands/backlog.md`                               | Backlog command | **Binary only**                   | Content varies by backend (conditional-render markers). Plugin cannot pre-render per-backend.                                                                                                                                                                                                                                     |
+| `core/agents/*.md` (9 agents)                            | Agents          | **Both**                          | Plugin ships the canonical latest version. Binary scaffolds the snapshot at init time. See Q4 for migration.                                                                                                                                                                                                                      |
+| `core/agents/*/memory/MEMORY.md` (5 files)               | Agent memory    | **Binary only**                   | These are project-local memory files meant to be mutated per-project. Plugin scope makes no sense.                                                                                                                                                                                                                                |
+| `core/skills/auto-chain/SKILL.md`                        | Skill           | **Plugin only**                   | No project-state dependency. Shipping in plugin alone is sufficient; binary can stop scaffolding it once plugin is the canonical source.                                                                                                                                                                                          |
+| `core/skills/specflow.groom/SKILL.md`                    | Skill           | **Both** (same logic as commands) | Short-name convenience justifies project-local copy.                                                                                                                                                                                                                                                                              |
+| `core/skills/backlog/SKILL.md`                           | Backlog skill   | **Binary only**                   | Backlog-backend conditional render — plugin cannot do this.                                                                                                                                                                                                                                                                       |
+| `core/skills/backlog/scripts/**`                         | Backlog scripts | **Binary only**                   | Runtime scripts that read `.specflow/installed.lock` for backend discovery. Project-stateful.                                                                                                                                                                                                                                     |
+| `core/specflow/**` (constitution, templates, scripts)    | Spec-root       | **Binary only**                   | Entirely project-stateful (`.specflow/` dir).                                                                                                                                                                                                                                                                                     |
+| `core/root/AGENTS.md`                                    | Project root    | **Binary only**                   | Project-specific constitution.                                                                                                                                                                                                                                                                                                    |
+| `core/root/.gitignore`                                   | Project root    | **Binary only**                   | Mergeable project file.                                                                                                                                                                                                                                                                                                           |
+| `harness-specific/claude/CLAUDE.md`                      | Harness static  | **Binary only**                   | References project-local paths (`.specflow/`, `.claude/commands/`).                                                                                                                                                                                                                                                               |
+| `harness-specific/claude/settings.json`                  | Harness static  | **Binary only**                   | Hook commands use relative project paths (`.claude/hooks/…`). Plugin hooks use `hooks/hooks.json` with different command resolution.                                                                                                                                                                                              |
+| `harness-specific/claude/hooks/protect-generated.sh`     | Hook            | **Binary only**                   | Reads `.specflow/installed.lock` at runtime — project-stateful.                                                                                                                                                                                                                                                                   |
+| `harness-specific/claude/hooks/check-backlog-prereqs.sh` | Hook            | **Binary only**                   | Reads `$(pwd)/.specflow/installed.lock` — project-stateful.                                                                                                                                                                                                                                                                       |
+| `harness-specific/claude/hooks/log-subagent.sh`          | Hook            | **Plugin-only candidate**         | No project-state dependency. Could live in `hooks/hooks.json` of the plugin. Decide below.                                                                                                                                                                                                                                        |
+| `harness-specific/claude/loop.md`                        | Harness static  | **Binary only**                   | Meant to be customized per-project.                                                                                                                                                                                                                                                                                               |
+| `harness-specific/claude/scripts/dispatch-agent.sh`      | Harness static  | **Binary only**                   | References project-local agent paths.                                                                                                                                                                                                                                                                                             |
+
+### Hook split: `log-subagent.sh`
+
+`log-subagent.sh` has no project-state dependency — it just timestamps subagent events. It is a
+candidate for the plugin's `hooks/hooks.json`. However, the plugin's hook commands must be
+path-stable (relative to the plugin cache dir, not the project). Until the plugin SDK specifies how
+hook `command` paths resolve relative to plugin root, keep it binary-owned and revisit at plugin GA.
+
+### Naming note
+
+Plugin skills are namespaced: `/claude-specflow:specify`, not `/specify`. Binary-scaffolded project
+skills keep the short form. This is the correct UX: the plugin provides discoverability for new
+users; the binary provides the customizable project-local copy with the short slash-command.
+
+---
+
+## Q4 — Backwards-compat state table
+
+### Detection method
+
+`InstalledLock.entries` (`.specflow/installed.lock`) records a SHA-256 per managed file. A file is
+**vanilla** when `sha256(disk content) === lock.entries[path].sha256`. A file is **customized** when
+the two differ. This is already implemented in `src/domain/installed_lock.ts` and used by the
+upgrade path — no new infrastructure needed.
+
+Plugin install detection: check whether `~/.claude/plugins/cache/claude-specflow/` exists (the
+canonical cache path per the discover-plugins docs). The binary reads this path via a new
+`PluginDetector` port method `isPluginInstalled(name: string): Promise<boolean>` backed by a
+`Deno.stat` check in `src/infrastructure/fs_plugin_detector.ts`.
+
+### State table
+
+| On-disk state              | Plugin state  | `specflow upgrade` action                                                                                                                                                                                                                                                                              |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Vanilla (SHA matches lock) | Not installed | Normal upgrade: overwrite with latest bundle snapshot.                                                                                                                                                                                                                                                 |
+| Customized (SHA differs)   | Not installed | Normal upgrade: preserve unless `--force`. No change from today.                                                                                                                                                                                                                                       |
+| Vanilla                    | Installed     | **Auto-migrate**: backup the file to `.specflow/backups/<timestamp>/`, delete the on-disk copy, drop the lock entry. Print: `info: agent 'product-owner' removed — now served by the claude-specflow plugin`.                                                                                          |
+| Customized                 | Installed     | **Warn + preserve**: keep the on-disk copy (it wins over plugin per Claude Code loading order). Print: `warn: agent 'product-owner' is customized and the claude-specflow plugin is installed. The on-disk version takes precedence. Reconcile manually or run specflow upgrade --force to overwrite.` |
+| Missing (user deleted)     | Not installed | Drop lock entry, nothing on disk to act on.                                                                                                                                                                                                                                                            |
+| Missing (user deleted)     | Installed     | Drop lock entry. Plugin serves the agent. No action needed.                                                                                                                                                                                                                                            |
+
+### Loading order clarification
+
+Claude Code loads user-scope plugin agents before project-scope `.claude/agents/` files, and
+project-scope wins on name collision. So a customized on-disk file naturally takes precedence over
+the plugin version — the "warn + preserve" policy matches the runtime behavior.
+
+### Migration command UX
+
+No new top-level command. Migration is triggered implicitly by `specflow upgrade` when the plugin is
+detected. The `--force` flag extends its existing semantics: with `--force`, customized agents are
+backed up and deleted, yielding fully plugin-managed operation.
+
+There is no `--migrate-to-plugin` flag — that adds surface area for a rare scenario. The `--force`
+path is sufficient.
+
+### Exit ramp — plugin uninstalled after migration
+
+If the binary deleted vanilla agent files (auto-migrate path) and the user later uninstalls the
+plugin, `specflow check --project` detects the gap: lock entry exists, file is missing from disk,
+plugin is not installed. It emits:
+
+```
+warn: .claude/agents/product-owner.md is tracked in the lock but missing from disk.
+      The claude-specflow plugin is not installed. Run `specflow upgrade` to restore
+      the bundled version, or install the plugin: /plugin install claude-specflow.
+```
+
+`specflow upgrade` restores the file from the bundle (same path as `add-new` action). No new action
+kind needed — the existing `add-new` path handles it.
+
+---
+
+## Trade-offs to decide
+
+1. **Dual-copy for commands and agents.** Recommending "both" means two sources of truth during the
+   transition period. The plugin is authoritative for the user-scope latest; the binary snapshot is
+   authoritative for the project-local customizable copy. This is intentional (short slash-commands
+   - customizability) but adds upgrade complexity. Accept this as a first-party first-mover cost, or
+     decide the plugin is the only source and force namespaced commands on all users. **Recommend:
+     keep both.** The `/specify` short form is a core UX property; namespaced
+     `/claude-specflow:specify` is the discoverability layer.
+
+2. **`log-subagent.sh` plugin vs binary.** Defer to plugin GA when hook path resolution from plugin
+   cache is documented. Until then, binary-owned. **Recommend: defer.**
+
+3. **Auto-migrate threshold.** The state table auto-migrates vanilla files when the plugin is
+   detected. This is a silent deletion (with backup). Consider requiring `--migrate-to-plugin` to
+   gate deletion explicitly rather than auto-migrating on any `specflow upgrade`. **Recommend:
+   auto-migrate with backup + explicit `info:` line per file.** The backup path is the safety net;
+   the log line is the audit trail. Explicit flag adds friction for the common case.
+
+4. **Plugin install detection path.** `~/.claude/plugins/cache/claude-specflow/` is inferred from
+   docs; the actual path is not formally guaranteed by the Claude Code API surface. If the path
+   changes, the detector silently fails (no migration, no warning). Accept this fragility at v0.12,
+   revisit once Claude Code publishes a stable plugin query API. **Recommend: accept.** Fallback
+   behavior (no auto-migration) is safe — the worst case is the user has both copies.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "claude-specflow",
+  "description": "Specflow's auto-chain skill, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
+  "version": "0.0.1",
+  "author": {
+    "name": "MakerLabs"
+  },
+  "homepage": "https://specflow.makerlabs.dev",
+  "repository": "https://github.com/mkrlabs/specflow",
+  "license": "MIT"
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,56 @@
+# claude-specflow — Claude Code plugin for Specflow
+
+This is the Claude Code plugin distribution of [Specflow](https://specflow.makerlabs.dev). It ships
+the same slash-commands, sub-agents, and the auto-chain skill that the `specflow` binary scaffolds
+into projects — just as a user-scope plugin instead.
+
+## What's in here
+
+| Path                         | Contents                                             |
+| ---------------------------- | ---------------------------------------------------- |
+| `.claude-plugin/plugin.json` | Plugin manifest                                      |
+| `skills/auto-chain/SKILL.md` | The auto-chain skill (`/claude-specflow:auto-chain`) |
+
+**Coming in subsequent slices** (tracked in
+[issue #73](https://github.com/mkrlabs/specflow/issues/73)):
+
+- `skills/specify/`, `skills/plan/`, `skills/tasks/`, etc. — the 10 specflow.* slash-commands,
+  namespaced under the plugin (`/claude-specflow:specify`).
+- `agents/` — the 9 sub-agent definitions (architect, product-owner, qa-tester, devops-sre, …).
+- `skills/specflow.groom/` — the groom skill.
+
+## How this differs from `specflow init`
+
+- The plugin is **user-scope** and **versioned** — installed once, available across all your
+  projects, updates via `/plugin update`.
+- The binary's `specflow init` scaffolds **project-scope** copies — you can customize them
+  per-project, and they ship with shorter slash-command names (e.g. `/specify` instead of
+  `/claude-specflow:specify`).
+- Backlog skill, hooks, and `.specflow/` files stay binary-owned because they read project-state at
+  runtime.
+
+See [the design doc](../docs/superpowers/specs/2026-05-08-claude-plugin-design.md) for the full
+plugin / binary boundary and the v0.x → plugin migration logic.
+
+## Install (when ready)
+
+```bash
+/plugin install mkrlabs/claude-specflow
+```
+
+(The plugin is currently `0.0.1` — pre-release. Wait for v0.1.0 before relying on it in production.)
+
+## Local development
+
+To test changes to the plugin without publishing:
+
+```bash
+claude --plugin-dir /path/to/specflow/plugin
+```
+
+Then invoke any plugin skill: `/claude-specflow:auto-chain specify "…"`.
+
+## Versioning
+
+The plugin is on `0.0.1` and will move to lockstep with the `specflow` binary once the migration
+logic (slices 4–6 in #73) lands. Until then, treat it as alpha — bumps may be breaking.

--- a/plugin/skills/auto-chain/SKILL.md
+++ b/plugin/skills/auto-chain/SKILL.md
@@ -5,9 +5,10 @@ description: Auto-chain Specflow workflow — when the user runs /auto-chain spe
 
 # Specflow Auto-Chain
 
-This skill turns the Specflow workflow into a single-command operation. When the user invokes
-`/auto-chain specify "<feature description>"`, you MUST chain every Specflow phase in the same
-session without asking the user between phases, EXCEPT at the two checkpoints defined below.
+This skill turns the Specflow workflow into a single-command operation. When the
+user invokes `/auto-chain specify "<feature description>"`, you MUST chain every
+Specflow phase in the same session without asking the user between phases,
+EXCEPT at the two checkpoints defined below.
 
 ## Default flow
 
@@ -19,35 +20,38 @@ specify → clarify → plan → tasks → analyze → implement → review → 
 
 ## Per-phase behavior
 
-After each phase completes successfully, immediately invoke the next phase via the `Skill` tool (or
-the platform equivalent). Do not emit a user-facing "ready for next step?" prompt. A one-line
-`✓ <phase> complete — proceeding to <next>` log is sufficient.
+After each phase completes successfully, immediately invoke the next phase via
+the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
+for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
+log is sufficient.
 
 ## STOP #1 — Clarification checkpoint
 
 After `/specflow.clarify` finishes:
 
-- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently to
-  `/specflow.plan`.
-- If markers remain, present the top 3 questions to the user (per the `/specflow.clarify` format)
-  and wait for answers. Once the spec is updated, resume the chain automatically.
+- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently
+  to `/specflow.plan`.
+- If markers remain, present the top 3 questions to the user (per the
+  `/specflow.clarify` format) and wait for answers. Once the spec is updated,
+  resume the chain automatically.
 
 ## Silent gates
 
-These phases run without user interruption unless they fail hard or surface CRITICAL findings:
+These phases run without user interruption unless they fail hard or surface
+CRITICAL findings:
 
 - `/specflow.plan` — generates plan + research + data-model + contracts + quickstart.
 - `/specflow.tasks` — generates tasks.md.
-- `/specflow.analyze` — cross-artifact consistency check. On LOW/MEDIUM findings, log a summary and
-  continue. On CRITICAL findings, stop and surface them.
-- `/specflow.implement` — runs the developer → review-coordinator → qa-tester pipeline. Has its own
-  internal fix loop for review findings; do not intercept.
+- `/specflow.analyze` — cross-artifact consistency check. On LOW/MEDIUM findings,
+  log a summary and continue. On CRITICAL findings, stop and surface them.
+- `/specflow.implement` — runs the developer → review-coordinator → qa-tester
+  pipeline. Has its own internal fix loop for review findings; do not intercept.
 - `/specflow.review` — final quality scan.
 
 ## STOP #2 — Pre-merge validation
 
-After `/specflow.review` passes, ALWAYS stop and present a compact summary before invoking
-`/specflow.merge`. The summary must include:
+After `/specflow.review` passes, ALWAYS stop and present a compact summary
+before invoking `/specflow.merge`. The summary must include:
 
 - Feature name and branch
 - Files created / modified (count + key paths)
@@ -56,31 +60,34 @@ After `/specflow.review` passes, ALWAYS stop and present a compact summary befor
 - Open risks / deferred items
 - One-line business outcome
 
-Then ask explicitly: "Ready to merge? (yes to run /specflow.merge, no to stay on the branch)". Wait
-for explicit confirmation. On "yes", invoke `/specflow.merge`. After merge, the chain ends.
+Then ask explicitly: "Ready to merge? (yes to run /specflow.merge, no to stay on
+the branch)". Wait for explicit confirmation. On "yes", invoke
+`/specflow.merge`. After merge, the chain ends.
 
 ## Opt-out
 
-If the user invokes `/auto-chain specify --manual "<description>"`, run `/specflow.specify` only and
-stop. Do not auto-chain. Each subsequent phase must be invoked manually by the user.
+If the user invokes `/auto-chain specify --manual "<description>"`, run
+`/specflow.specify` only and stop. Do not auto-chain. Each subsequent phase must
+be invoked manually by the user.
 
 ## Single-phase invocations
 
-When the user invokes any phase directly (e.g. `/auto-chain clarify 042`, `/auto-chain plan 042`) —
-i.e. NOT via the entry point `/auto-chain specify` — the command is one-shot. Do NOT auto-chain.
-Single-phase invocations exist for re-running phases on an existing feature.
+When the user invokes any phase directly (e.g. `/auto-chain clarify 042`,
+`/auto-chain plan 042`) — i.e. NOT via the entry point `/auto-chain specify` — the
+command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
+re-running phases on an existing feature.
 
 ## Failure handling
 
-- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop, surface the error, ask
-  the user how to proceed. Do not silently retry.
-- Task-level blockers reported by the developer agent during `implement`: the implement workflow has
-  its own fix loop; do not intercept.
-- `clarify` producing more than 5 questions: present the top 3 per the `/specflow.clarify` quota;
-  the rest can be asked later.
+- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
+  surface the error, ask the user how to proceed. Do not silently retry.
+- Task-level blockers reported by the developer agent during `implement`: the
+  implement workflow has its own fix loop; do not intercept.
+- `clarify` producing more than 5 questions: present the top 3 per the
+  `/specflow.clarify` quota; the rest can be asked later.
 
 ## Context budget
 
-Long features (≥13 story points or ≥30 tasks) may exhaust context during `/specflow.implement`. If
-compaction occurs mid-chain, inform the user and let them resume manually from the last completed
-phase.
+Long features (≥13 story points or ≥30 tasks) may exhaust context during
+`/specflow.implement`. If compaction occurs mid-chain, inform the user and let
+them resume manually from the last completed phase.

--- a/plugin/skills/auto-chain/SKILL.md
+++ b/plugin/skills/auto-chain/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: auto-chain
+description: Auto-chain Specflow workflow — when the user runs /auto-chain specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+---
+
+# Specflow Auto-Chain
+
+This skill turns the Specflow workflow into a single-command operation. When the user invokes
+`/auto-chain specify "<feature description>"`, you MUST chain every Specflow phase in the same
+session without asking the user between phases, EXCEPT at the two checkpoints defined below.
+
+## Default flow
+
+```
+specify → clarify → plan → tasks → analyze → implement → review → merge
+          ▲                                                        ▲
+          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+```
+
+## Per-phase behavior
+
+After each phase completes successfully, immediately invoke the next phase via the `Skill` tool (or
+the platform equivalent). Do not emit a user-facing "ready for next step?" prompt. A one-line
+`✓ <phase> complete — proceeding to <next>` log is sufficient.
+
+## STOP #1 — Clarification checkpoint
+
+After `/specflow.clarify` finishes:
+
+- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently to
+  `/specflow.plan`.
+- If markers remain, present the top 3 questions to the user (per the `/specflow.clarify` format)
+  and wait for answers. Once the spec is updated, resume the chain automatically.
+
+## Silent gates
+
+These phases run without user interruption unless they fail hard or surface CRITICAL findings:
+
+- `/specflow.plan` — generates plan + research + data-model + contracts + quickstart.
+- `/specflow.tasks` — generates tasks.md.
+- `/specflow.analyze` — cross-artifact consistency check. On LOW/MEDIUM findings, log a summary and
+  continue. On CRITICAL findings, stop and surface them.
+- `/specflow.implement` — runs the developer → review-coordinator → qa-tester pipeline. Has its own
+  internal fix loop for review findings; do not intercept.
+- `/specflow.review` — final quality scan.
+
+## STOP #2 — Pre-merge validation
+
+After `/specflow.review` passes, ALWAYS stop and present a compact summary before invoking
+`/specflow.merge`. The summary must include:
+
+- Feature name and branch
+- Files created / modified (count + key paths)
+- Tests added and full-suite status
+- Known deviations from tasks.md and rationale
+- Open risks / deferred items
+- One-line business outcome
+
+Then ask explicitly: "Ready to merge? (yes to run /specflow.merge, no to stay on the branch)". Wait
+for explicit confirmation. On "yes", invoke `/specflow.merge`. After merge, the chain ends.
+
+## Opt-out
+
+If the user invokes `/auto-chain specify --manual "<description>"`, run `/specflow.specify` only and
+stop. Do not auto-chain. Each subsequent phase must be invoked manually by the user.
+
+## Single-phase invocations
+
+When the user invokes any phase directly (e.g. `/auto-chain clarify 042`, `/auto-chain plan 042`) —
+i.e. NOT via the entry point `/auto-chain specify` — the command is one-shot. Do NOT auto-chain.
+Single-phase invocations exist for re-running phases on an existing feature.
+
+## Failure handling
+
+- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop, surface the error, ask
+  the user how to proceed. Do not silently retry.
+- Task-level blockers reported by the developer agent during `implement`: the implement workflow has
+  its own fix loop; do not intercept.
+- `clarify` producing more than 5 questions: present the top 3 per the `/specflow.clarify` quota;
+  the rest can be asked later.
+
+## Context budget
+
+Long features (≥13 story points or ≥30 tasks) may exhaust context during `/specflow.implement`. If
+compaction occurs mid-chain, inform the user and let them resume manually from the last completed
+phase.

--- a/tests/plugin/auto_chain_in_sync_test.ts
+++ b/tests/plugin/auto_chain_in_sync_test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+const SOURCE = fromFileUrl(
+  new URL("../../templates/core/skills/auto-chain/SKILL.md", import.meta.url),
+);
+const PLUGIN_COPY = fromFileUrl(
+  new URL("../../plugin/skills/auto-chain/SKILL.md", import.meta.url),
+);
+
+Deno.test(
+  "plugin/skills/auto-chain/SKILL.md is byte-identical to templates/core/skills/auto-chain/SKILL.md",
+  async () => {
+    const [src, plugin] = await Promise.all([
+      Deno.readTextFile(SOURCE),
+      Deno.readTextFile(PLUGIN_COPY),
+    ]);
+    assertEquals(
+      plugin,
+      src,
+      "Plugin copy of auto-chain has drifted from the bundled source. " +
+        "Either: (a) update plugin/skills/auto-chain/SKILL.md to match templates/core/skills/auto-chain/SKILL.md, " +
+        "or (b) if the divergence is intentional, drop this test and document why.",
+    );
+  },
+);
+
+Deno.test(
+  "plugin/.claude-plugin/plugin.json declares name 'claude-specflow'",
+  async () => {
+    const path = fromFileUrl(
+      new URL("../../plugin/.claude-plugin/plugin.json", import.meta.url),
+    );
+    const manifest = JSON.parse(await Deno.readTextFile(path));
+    assertEquals(manifest.name, "claude-specflow");
+    assertEquals(typeof manifest.description, "string");
+    assertEquals(typeof manifest.version, "string");
+  },
+);


### PR DESCRIPTION
First slice of the plugin migration work tracked in #73. Lands the directory layout + the only plugin-only asset (auto-chain skill) so subsequent slices can build on a real plugin tree.

## What's in

- \`plugin/.claude-plugin/plugin.json\` — manifest, **claude-specflow** name, v0.0.1 (alpha)
- \`plugin/skills/auto-chain/SKILL.md\` — byte-identical to \`templates/core/skills/auto-chain/SKILL.md\`
- \`plugin/README.md\` — explains plugin vs binary scope, install path, dev workflow
- \`tests/plugin/auto_chain_in_sync_test.ts\` — guards the byte-identical contract + asserts manifest required fields
- \`deno.json\` — excludes \`plugin/skills/\` from fmt so the byte-identical contract holds (mirrors how \`templates/\` is excluded today)

## What's NOT in (deliberately deferred to subsequent slices on #73)

- 10 specflow.* commands (dual-copy with the binary)
- 9 agent definitions (dual-copy)
- specflow.groom skill (dual-copy)
- \`PluginDetector\` port + \`fs_plugin_detector.ts\` adapter
- 6-state migration table in the upgrade use case
- \`check --project\` warn surface for "plugin uninstalled, files missing"
- \`release.yml\` extension (gated on \`devops-sre\` advisory per the working contract)

## Verifying locally

\`\`\`bash
claude --plugin-dir ./plugin
/claude-specflow:auto-chain specify "your feature"
\`\`\`

Works today.

## Test plan

- [x] \`deno task test\` — 385 passed (was 383, +2 plugin sync tests)
- [x] \`deno task fmt\` — clean, plugin/skills/ correctly excluded
- [x] Verified byte-identical contract: \`diff plugin/skills/auto-chain/SKILL.md templates/core/skills/auto-chain/SKILL.md\` empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)