### PR TITLE
feat(plugin): mirror groom skill into plugin/skills/groom/ (#73 slice 4)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -12,11 +12,11 @@ into projects — just as a user-scope plugin instead.
 | `skills/auto-chain/SKILL.md`                                                                                                                | Auto-chain skill — `/claude-specflow:auto-chain`                  |
 | `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/claude-specflow:specify`, etc. |
 | `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                  |
+| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/claude-specflow:groom`                            |
 
 **Coming in subsequent slices** (tracked in
 [issue #73](https://github.com/mkrlabs/specflow/issues/73)):
 
-- `skills/specflow.groom/` — the groom skill.
 - `PluginDetector` port + the v0.x → plugin migration logic in `specflow upgrade`.
 
 ### Known caveat: handoff IDs

--- a/plugin/skills/groom/SKILL.md
+++ b/plugin/skills/groom/SKILL.md
@@ -1,0 +1,88 @@
+---
+description: Run a periodic hygiene pass on this Specflow project — groom Backlog items, surface stale PRs, list orphan specs. Designed to be called from `/loop` or as a manual one-off.
+disable-model-invocation: true
+---
+
+# /specflow.groom
+
+A maintenance pass that keeps the project's backlog and review pipeline
+flowing without human intervention. Designed to be invoked manually or
+on a timer via `/loop`.
+
+This skill is **manual-only** (`disable-model-invocation: true`) — it
+should not auto-trigger on casual user prompts. The user invokes it
+explicitly with `/specflow.groom` or schedules it with
+`/loop 1h /specflow.groom`.
+
+## What this skill does
+
+A grooming pass runs three independent checks. Each is delegated to the
+right subagent so this skill stays small and the heavy lifting is owned
+by the agent that has the right tools and prompt for the job.
+
+### 1. Backlog grooming
+
+Dispatch the **`product-owner`** subagent to clarify any items currently
+in the `Backlog` column (i.e. not yet promoted to `Ready`).
+
+The PO will:
+
+- Read each item's body and existing comments.
+- **Skip** items it has already commented on in a previous run (look for
+  the marker `🤖 specflow-groom` at the start of any comment).
+- For each remaining item:
+  - If the body is already clarified (Why / AC / Out of scope all present
+    and concrete), promote to `Ready`.
+  - If 1–3 scope decisions remain, leave a clarification comment marked
+    with the `🤖 specflow-groom` prefix so subsequent runs skip it.
+  - If the item is genuinely stale or duplicates a closed ticket, the PO
+    can recommend closure with `not_planned` (but does not close
+    autonomously — the recommendation lands as a comment).
+
+The PO must respect the standard backlog skill — do not bypass its
+scripts.
+
+### 2. Stale PR surface
+
+For each open PR on this repository, check whether it has been waiting
+on review or CI for more than 48 hours. List them in the report so the
+user can decide whether to ping, close, or merge.
+
+This step is read-only; do not mutate PRs.
+
+### 3. Orphan spec detection
+
+Walk `.specflow/specs/` (if present) and surface any feature directory
+that is missing the next expected artefact:
+
+- Has `spec.md` but no `plan.md` → flag as "needs `/specflow.plan`".
+- Has `plan.md` but no `tasks.md` → flag as "needs `/specflow.tasks`".
+- Has `tasks.md` but no `installed` markers in commits → flag as
+  "needs `/specflow.implement`".
+
+This is also read-only; never delete or modify spec files.
+
+## Output format
+
+End with a single summary block:
+
+```
+specflow.groom report
+─────────────────────
+Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarification
+Stale PRs:  <S> open PRs idle > 48h
+Orphan specs: <O> spec directories missing the next artefact
+
+Next action: <one-line recommendation, or "no action needed">
+```
+
+If nothing needed action, say so explicitly. The point of the skill is
+to be a **no-op when the project is healthy**.
+
+## When NOT to use this skill
+
+- For a single-item backlog clarification → invoke the `product-owner`
+  subagent directly with the item number.
+- For PR review on a specific PR → invoke `code-reviewer` /
+  `security-auditor` directly.
+- For implementing a spec → invoke `/specflow.implement` directly.

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -57,6 +57,15 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: `plugin/agents/${name}.md`,
     source: `templates/core/agents/${name}.md`,
   })),
+  // The groom skill: source folder is `templates/core/skills/specflow.groom/`
+  // (binary scaffolds it as a project skill with the namespaced short
+  // form), but the plugin folder drops the `specflow.` prefix because
+  // the plugin namespace `claude-specflow:` already disambiguates —
+  // the plugin command becomes `/claude-specflow:groom`.
+  {
+    plugin: "plugin/skills/groom/SKILL.md",
+    source: "templates/core/skills/specflow.groom/SKILL.md",
+  },
 ];
 
 function abs(rel: string): string {


### PR DESCRIPTION
Slice 4 of the plugin migration tracked in #73. Completes the **dual-copy assets phase** — every user-facing artifact that ships in both plugin and binary scope is now in place.

## What's in

- `plugin/skills/groom/SKILL.md` — byte-identical to `templates/core/skills/specflow.groom/SKILL.md`. Folder name drops the `specflow.` prefix (binary uses `specflow.groom` because no namespacing; plugin uses `groom` because the `claude-specflow:` namespace already disambiguates) — same pattern as the 10 commands.
- `SYNC_PAIRS` extended — total 21 byte-identical pairs (1 auto-chain + 10 commands + 9 agents + 1 groom).
- README updated.

## Asset migration: complete

After this slice, the plugin contains everything it will ship at v0.1.0:

| Category | Count |
|---|---|
| Skills (auto-chain, groom) | 2 |
| Commands as namespaced skills | 10 |
| Sub-agents | 9 |
| **Total user-facing files** | **21** |

The remaining slices on #73 are all binary-side migration logic:

5. `PluginDetector` port + `fs_plugin_detector.ts` adapter
6. 6-state migration table in the `upgrade` use case
7. `check --project` warn surface for "plugin uninstalled, files missing"
8. `release.yml` extension to publish the plugin sub-folder (gated on `devops-sre` advisory)

## Test plan

- [x] `deno task test` — 405 passed (was 404, +1 pair)
- [x] `deno task fmt` — clean
- [x] `diff plugin/skills/groom/SKILL.md templates/core/skills/specflow.groom/SKILL.md` empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)