### PR TITLE
feat(plugin): wire migration table into upgrade use case (#73 slice 6)

### DIFF
--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -1,10 +1,14 @@
-import type { FsReader, FsWriter, Harness, LockStore } from "./ports.ts";
+import type { FsReader, FsWriter, Harness, LockStore, PluginDetector } from "./ports.ts";
 import type { Bundle, TemplateFile } from "../domain/template.ts";
 import { sha256Hex } from "../domain/sha256.ts";
 import type { InstalledLock, LockEntry } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
 import { computeUpgradePlan, type UpgradePlan } from "../domain/upgrade_plan.ts";
 import { canonicalBlockBody, extractBlock } from "../domain/merge_block.ts";
+import { isPluginCoveredPath } from "../domain/plugin_coverage.ts";
+
+/** The plugin name used for both the install probe and the cache directory. */
+export const PLUGIN_NAME = "claude-specflow";
 
 export type UpgradeProjectInput = {
   projectDir: string;
@@ -35,6 +39,15 @@ export type UpgradeProjectDeps = {
   core: CoreBundle;
   templatesVersion: string;
   findHarness: (key: string) => Harness | null;
+  /**
+   * Optional plugin probe. Drives the v0.x → plugin migration table
+   * for #73 — when the plugin is installed and the harness is
+   * `claude`, vanilla on-disk agent / command files are auto-migrated
+   * (backed up + deleted; plugin serves them going forward) and
+   * customized files are preserved with a "plugin available" warning.
+   * Tests omit this dep to skip migration entirely (legacy behavior).
+   */
+  pluginDetector?: PluginDetector;
   now?: () => Date;
 };
 
@@ -84,11 +97,21 @@ export class UpgradeProjectUseCase {
       newShas.set(dest, await sha256Hex(shaInput));
     }
 
-    const plan = computeUpgradePlan(diskShas, lock, newShas);
+    const pluginInstalled = this.deps.pluginDetector !== undefined &&
+      await this.deps.pluginDetector.isPluginInstalled(PLUGIN_NAME);
+    const plan = computeUpgradePlan(
+      diskShas,
+      lock,
+      newShas,
+      pluginInstalled,
+      (dest) => isPluginCoveredPath(lock.harness, dest),
+    );
 
     const hasActualWork = plan.some((a) =>
       a.kind === "auto-update" ||
       a.kind === "add-new" ||
+      a.kind === "migrate-to-plugin" ||
+      a.kind === "defer-to-plugin" ||
       (a.kind === "preserve" && input.force) ||
       (a.kind === "remove" && (!a.wasCustomized || input.force))
     );
@@ -147,9 +170,34 @@ export class UpgradeProjectUseCase {
       extraBackups = [...extraBackups, ...r.backups];
     }
 
+    // Plugin migrations: vanilla file on disk + plugin installed →
+    // backup + delete; plugin serves the file going forward. Always
+    // back up (the on-disk copy is exactly what the plugin will serve,
+    // but the user may want to recover it later if they uninstall the
+    // plugin).
+    const pluginMigrations = plan
+      .filter((a): a is Extract<typeof a, { kind: "migrate-to-plugin" }> =>
+        a.kind === "migrate-to-plugin"
+      )
+      .map((a) => a.dest);
+    if (pluginMigrations.length > 0) {
+      const r = await writer.deletePaths(pluginMigrations, input.projectDir, {
+        backupExisting: true,
+      });
+      extraBackups = [...extraBackups, ...r.backups];
+    }
+
     const now = (this.deps.now ?? (() => new Date()))().toISOString();
+    // Dests handed off to the plugin are dropped from the new lock —
+    // the binary is no longer the owner of those files.
+    const droppedToPlugin = new Set<string>(
+      plan
+        .filter((a) => a.kind === "migrate-to-plugin" || a.kind === "defer-to-plugin")
+        .map((a) => a.dest),
+    );
     const updatedEntries = new Map<string, LockEntry>();
     for (const [dest] of newShas) {
+      if (droppedToPlugin.has(dest)) continue;
       const existing = lock.entries.get(dest);
       const sha = await shaOfBundle(bundle[dest]);
       const wrote = toWrite[dest] !== undefined;

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -6,6 +6,7 @@ import { findHarness } from "../harnesses.ts";
 import { DenoFsReader } from "../../infrastructure/fs_reader.ts";
 import { DenoFsWriter } from "../../infrastructure/deno_fs_writer.ts";
 import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
+import { FsPluginDetector } from "../../infrastructure/fs_plugin_detector.ts";
 import { CORE_BUNDLE, TEMPLATES_VERSION } from "../../templates_bundle.ts";
 import { renderUnifiedDiff } from "../../domain/diff.ts";
 import type { UpgradePlan } from "../../domain/upgrade_plan.ts";
@@ -187,6 +188,8 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
     unchanged: plan.filter((a) => a.kind === "unchanged"),
     removed: plan.filter((a) => a.kind === "remove" && !a.wasCustomized),
     orphanPreserved: plan.filter((a) => a.kind === "remove" && a.wasCustomized),
+    migrated: plan.filter((a) => a.kind === "migrate-to-plugin"),
+    deferred: plan.filter((a) => a.kind === "defer-to-plugin"),
   };
 
   console.log(
@@ -205,7 +208,12 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
   }
   if (groups.preserve.length > 0) {
     console.log(bold("  customized locally (not touched)"));
-    for (const a of groups.preserve) console.log(yellow(`    ⚠ ${a.dest}`));
+    for (const a of groups.preserve) {
+      const tag = a.kind === "preserve" && a.pluginAvailable
+        ? ` ${dim("[plugin available — reconcile manually]")}`
+        : "";
+      console.log(yellow(`    ⚠ ${a.dest}${tag}`));
+    }
     console.log();
   }
   if (groups.removed.length > 0) {
@@ -218,12 +226,23 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
     for (const a of groups.orphanPreserved) console.log(yellow(`    ⚠ ${a.dest}`));
     console.log();
   }
+  if (groups.migrated.length > 0) {
+    console.log(bold("  migrated to claude-specflow plugin (backed up + removed)"));
+    for (const a of groups.migrated) console.log(cyan(`    → ${a.dest}`));
+    console.log();
+  }
+  if (groups.deferred.length > 0) {
+    console.log(bold("  deferred to claude-specflow plugin (was missing on disk)"));
+    for (const a of groups.deferred) console.log(dim(`    · ${a.dest}`));
+    console.log();
+  }
 
   console.log(
     dim(
       `  ${groups.auto.length} auto-update, ${groups.preserve.length} preserved, ` +
         `${groups.added.length} added, ${groups.removed.length} removed, ` +
-        `${groups.orphanPreserved.length} orphan-preserved, ${groups.unchanged.length} unchanged`,
+        `${groups.orphanPreserved.length} orphan-preserved, ${groups.migrated.length} migrated, ` +
+        `${groups.deferred.length} deferred, ${groups.unchanged.length} unchanged`,
     ),
   );
 }
@@ -270,6 +289,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     core: CORE_BUNDLE,
     templatesVersion: TEMPLATES_VERSION,
     findHarness,
+    pluginDetector: new FsPluginDetector(),
   });
 
   let result;

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -1,0 +1,52 @@
+import type { KnownHarness } from "./installed_lock.ts";
+
+/**
+ * Pure predicate: does the `claude-specflow` plugin own a copy of the
+ * file at `dest` (relative to the project root)?
+ *
+ * Used by the upgrade use case to decide whether to apply the v0.x →
+ * plugin migration table for a given lock-tracked file. When the plugin
+ * is installed AND a file is plugin-covered, the upgrade plan
+ * branches:
+ *
+ *   - vanilla on disk (SHA matches lock) → `migrate-to-plugin`
+ *   - customized on disk (SHA differs)   → `preserve` with
+ *                                          `pluginAvailable: true`
+ *
+ * When the plugin is NOT installed, this predicate is irrelevant —
+ * upgrade behavior is unchanged.
+ *
+ * Coverage is **Claude-harness only**. The plugin is Claude-specific;
+ * Cursor/Codex/Gemini/etc. projects keep their on-disk files binary-
+ * owned regardless of plugin install state on the host machine.
+ *
+ * Coverage map (per architect's design at
+ * `docs/superpowers/specs/2026-05-08-claude-plugin-design.md`):
+ *
+ *   - `.claude/agents/<name>.md` (excluding `architect.md` — that's a
+ *     contributor-only agent, not bundled into user projects)
+ *   - `.claude/skills/specflow.<name>/SKILL.md` — the 10 slash commands
+ *     scaffolded as skill folders since #76
+ *   - `.claude/skills/auto-chain/SKILL.md`
+ *   - `.claude/skills/specflow.groom/SKILL.md`
+ *
+ * Everything else (project-stateful files in `.specflow/`, harness-
+ * static files like `.claude/settings.json`, hooks, `CLAUDE.md`,
+ * backlog scripts) stays binary-owned and is NOT covered.
+ */
+export function isPluginCoveredPath(
+  harness: KnownHarness,
+  dest: string,
+): boolean {
+  if (harness !== "claude") return false;
+
+  const agentMatch = dest.match(/^\.claude\/agents\/([^/]+)\.md$/);
+  if (agentMatch !== null) return agentMatch[1] !== "architect";
+
+  if (/^\.claude\/skills\/specflow\.[a-z]+\/SKILL\.md$/.test(dest)) return true;
+
+  if (dest === ".claude/skills/auto-chain/SKILL.md") return true;
+  if (dest === ".claude/skills/specflow.groom/SKILL.md") return true;
+
+  return false;
+}

--- a/src/domain/upgrade_plan.ts
+++ b/src/domain/upgrade_plan.ts
@@ -2,9 +2,36 @@ import type { InstalledLock } from "./installed_lock.ts";
 
 export type UpgradeAction =
   | { kind: "auto-update"; dest: string; oldSha: string; newSha: string }
-  | { kind: "preserve"; dest: string; reason: "customized" }
+  | {
+    kind: "preserve";
+    dest: string;
+    reason: "customized";
+    /**
+     * True when the `claude-specflow` plugin owns this path AND the
+     * plugin is installed on the host. The handler surfaces an extra
+     * warn line in this case ("plugin version is also available;
+     * reconcile manually or pass --force"); the file content stays
+     * untouched either way.
+     */
+    pluginAvailable: boolean;
+  }
   | { kind: "add-new"; dest: string }
   | { kind: "unchanged"; dest: string }
+  | {
+    kind: "migrate-to-plugin";
+    dest: string;
+    /** SHA of the file as it sits on disk today — backed up before deletion. */
+    oldSha: string;
+  }
+  | {
+    /**
+     * Plugin-covered dest is missing on disk and the plugin is
+     * installed: do nothing on the filesystem, just drop the lock
+     * entry. The plugin will serve this file from now on.
+     */
+    kind: "defer-to-plugin";
+    dest: string;
+  }
   | { kind: "remove"; dest: string; oldSha: string; wasCustomized: boolean };
 
 export type UpgradePlan = ReadonlyArray<UpgradeAction>;
@@ -15,15 +42,37 @@ export type UpgradePlan = ReadonlyArray<UpgradeAction>;
  *   - `lock`     : the .specflow/installed.lock
  *   - `newShas`  : SHA of each file in the binary's embedded templates
  *
- * Emits one UpgradeAction per destination in the new bundle, plus a `remove`
- * action for each lock entry that is no longer in the new bundle but is
- * still on disk. Orphan entries that are not on disk produce no action — the
- * caller drops them from the new lock implicitly by iterating only `newShas`.
+ * Plus two parameters that drive the v0.x → plugin migration table for
+ * issue #73:
+ *   - `pluginInstalled`  : whether the `claude-specflow` plugin is on
+ *                          the host (probed at use-case entry by the
+ *                          `PluginDetector` port).
+ *   - `isPluginCovered`  : predicate `(dest) => boolean` returning true
+ *                          when the plugin owns a copy of `dest`. See
+ *                          `plugin_coverage.ts` for the canonical map.
+ *
+ * Behavior on plugin-covered dests when the plugin is installed:
+ *   - vanilla on disk (SHA matches lock) → `migrate-to-plugin` (the
+ *     binary backs the file up, deletes the on-disk copy, and drops
+ *     the lock entry; the plugin serves the file going forward).
+ *   - customized on disk (SHA differs from lock) → `preserve` with
+ *     `pluginAvailable: true` (handler surfaces the reconcile warning).
+ *
+ * For uncovered dests, or any dest when the plugin is not installed,
+ * behavior is identical to before the migration table existed.
+ *
+ * Emits one UpgradeAction per destination in the new bundle, plus a
+ * `remove` action for each lock entry that is no longer in the new
+ * bundle but is still on disk. Orphan entries that are not on disk
+ * produce no action — the caller drops them from the new lock
+ * implicitly by iterating only `newShas`.
  */
 export function computeUpgradePlan(
   diskShas: Map<string, string>,
   lock: InstalledLock,
   newShas: Map<string, string>,
+  pluginInstalled: boolean = false,
+  isPluginCovered: (dest: string) => boolean = () => false,
 ): UpgradePlan {
   const actions: UpgradeAction[] = [];
   const sortedDests = [...newShas.keys()].sort();
@@ -33,23 +82,50 @@ export function computeUpgradePlan(
     const diskSha = diskShas.get(dest);
     const lockSha = lock.entries.get(dest)?.sha256;
 
+    const covered = pluginInstalled && isPluginCovered(dest);
+
     if (diskSha === undefined) {
-      actions.push({ kind: "add-new", dest });
+      // File missing on disk. Plugin-covered + plugin installed:
+      // defer to the plugin (drop lock entry, don't re-add). Otherwise,
+      // re-add from the bundle.
+      actions.push(
+        covered ? { kind: "defer-to-plugin", dest } : { kind: "add-new", dest },
+      );
       continue;
     }
+
+    // Vanilla = SHA matches lock entry. With plugin installed and
+    // covered, hand the file off to the plugin regardless of whether
+    // the new bundle's SHA matches.
+    const isVanilla = lockSha !== undefined && diskSha === lockSha;
+    if (covered && isVanilla) {
+      actions.push({ kind: "migrate-to-plugin", dest, oldSha: diskSha });
+      continue;
+    }
+
     if (diskSha === newSha) {
       actions.push({ kind: "unchanged", dest });
       continue;
     }
     if (lockSha === undefined) {
-      actions.push({ kind: "preserve", dest, reason: "customized" });
+      actions.push({
+        kind: "preserve",
+        dest,
+        reason: "customized",
+        pluginAvailable: covered,
+      });
       continue;
     }
     if (diskSha === lockSha) {
       actions.push({ kind: "auto-update", dest, oldSha: lockSha, newSha });
       continue;
     }
-    actions.push({ kind: "preserve", dest, reason: "customized" });
+    actions.push({
+      kind: "preserve",
+      dest,
+      reason: "customized",
+      pluginAvailable: covered,
+    });
   }
 
   // Orphans: lock entries not in newShas. Emit `remove` if still on disk.

--- a/tests/application/upgrade_project_test.ts
+++ b/tests/application/upgrade_project_test.ts
@@ -350,3 +350,158 @@ Deno.test("UpgradeProjectUseCase with --force deletes customized orphan with bac
   assertEquals(writer.deleted, ["orphan.md"]);
   assertEquals(writer.deleteBackupsRequested, true);
 });
+
+// ── Plugin migration end-to-end (#73 slice 6) ──────────────────────────────
+
+const PLUGIN_DEST = ".claude/agents/product-owner.md";
+
+function fakePluginDetector(installed: boolean) {
+  return { isPluginInstalled: (_n: string) => Promise.resolve(installed) };
+}
+
+Deno.test("UpgradeProjectUseCase: vanilla on-disk + plugin installed → backed up + deleted + dropped from lock", async () => {
+  const sha = await sha256Hex("vanilla content");
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    templatesVersion: "0.7.0",
+    entries: new Map([[
+      PLUGIN_DEST,
+      { sha256: sha, installedAt: "2026-05-01T00:00:00Z", templatesVersion: "0.7.0" },
+    ]]),
+  };
+  const writer = fakeWriter();
+  const lockStore = fakeLockStore(lock);
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({ [PLUGIN_DEST]: "vanilla content" }),
+    writer,
+    lockStore,
+    core: coreFromBundle({
+      [PLUGIN_DEST]: { content: "upstream update", executable: false },
+    }),
+    templatesVersion: "0.7.1",
+    findHarness: findFakeHarness,
+    pluginDetector: fakePluginDetector(true),
+  });
+  const result = await uc.execute({ projectDir: "/p", dryRun: false, force: false });
+  assertEquals(result.status, "applied");
+  // File deleted with backup (the on-disk copy must be recoverable)
+  assertEquals(writer.deleted, [PLUGIN_DEST]);
+  assertEquals(writer.deleteBackupsRequested, true);
+  // Lock no longer references the migrated file
+  assertEquals(lockStore.last?.entries.has(PLUGIN_DEST), false);
+  // No write happened — the plugin owns the file now
+  assertEquals(writer.written.has(PLUGIN_DEST), false);
+});
+
+Deno.test("UpgradeProjectUseCase: customized on-disk + plugin installed → preserved with pluginAvailable=true (no delete)", async () => {
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    templatesVersion: "0.7.0",
+    entries: new Map([[
+      PLUGIN_DEST,
+      {
+        sha256: await sha256Hex("original"),
+        installedAt: "2026-05-01T00:00:00Z",
+        templatesVersion: "0.7.0",
+      },
+    ]]),
+  };
+  const writer = fakeWriter();
+  const lockStore = fakeLockStore(lock);
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({ [PLUGIN_DEST]: "user-edited content" }),
+    writer,
+    lockStore,
+    core: coreFromBundle({
+      [PLUGIN_DEST]: { content: "upstream update", executable: false },
+    }),
+    templatesVersion: "0.7.1",
+    findHarness: findFakeHarness,
+    pluginDetector: fakePluginDetector(true),
+  });
+  const result = await uc.execute({ projectDir: "/p", dryRun: false, force: false });
+  assertEquals(result.status, "applied");
+  // File preserved — NOT deleted
+  assertEquals(writer.deleted.includes(PLUGIN_DEST), false);
+  // Lock still tracks it (preserve, not migrate)
+  assertEquals(lockStore.last?.entries.has(PLUGIN_DEST), true);
+  // The plan should mark it as preserve with pluginAvailable=true
+  if (result.status === "applied") {
+    const action = result.plan.find((a) => a.dest === PLUGIN_DEST);
+    assertEquals(action?.kind, "preserve");
+    if (action?.kind === "preserve") {
+      assertEquals(action.pluginAvailable, true);
+    }
+  }
+});
+
+Deno.test("UpgradeProjectUseCase: missing on-disk + plugin installed → deferred (no add-new, no lock entry)", async () => {
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    templatesVersion: "0.7.0",
+    entries: new Map([[
+      PLUGIN_DEST,
+      {
+        sha256: await sha256Hex("original"),
+        installedAt: "2026-05-01T00:00:00Z",
+        templatesVersion: "0.7.0",
+      },
+    ]]),
+  };
+  const writer = fakeWriter();
+  const lockStore = fakeLockStore(lock);
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({}), // user deleted the file
+    writer,
+    lockStore,
+    core: coreFromBundle({
+      [PLUGIN_DEST]: { content: "upstream update", executable: false },
+    }),
+    templatesVersion: "0.7.1",
+    findHarness: findFakeHarness,
+    pluginDetector: fakePluginDetector(true),
+  });
+  const result = await uc.execute({ projectDir: "/p", dryRun: false, force: false });
+  assertEquals(result.status, "applied");
+  // No file written (would have been add-new without plugin)
+  assertEquals(writer.written.has(PLUGIN_DEST), false);
+  // Lock entry dropped
+  assertEquals(lockStore.last?.entries.has(PLUGIN_DEST), false);
+});
+
+Deno.test("UpgradeProjectUseCase: vanilla on-disk + plugin NOT installed → existing auto-update behavior (no delete)", async () => {
+  const sha = await sha256Hex("vanilla content");
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    templatesVersion: "0.7.0",
+    entries: new Map([[
+      PLUGIN_DEST,
+      { sha256: sha, installedAt: "2026-05-01T00:00:00Z", templatesVersion: "0.7.0" },
+    ]]),
+  };
+  const writer = fakeWriter();
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({ [PLUGIN_DEST]: "vanilla content" }),
+    writer,
+    lockStore: fakeLockStore(lock),
+    core: coreFromBundle({
+      [PLUGIN_DEST]: { content: "upstream update", executable: false },
+    }),
+    templatesVersion: "0.7.1",
+    findHarness: findFakeHarness,
+    pluginDetector: fakePluginDetector(false),
+  });
+  const result = await uc.execute({ projectDir: "/p", dryRun: false, force: false });
+  assertEquals(result.status, "applied");
+  // Auto-update: file written with new content, NOT deleted
+  assertEquals(writer.written.get(PLUGIN_DEST), "upstream update");
+  assertEquals(writer.deleted.includes(PLUGIN_DEST), false);
+});

--- a/tests/domain/plugin_coverage_test.ts
+++ b/tests/domain/plugin_coverage_test.ts
@@ -1,0 +1,149 @@
+import { assertEquals } from "@std/assert";
+import { isPluginCoveredPath } from "../../src/domain/plugin_coverage.ts";
+
+// ── Claude harness — covered paths ─────────────────────────────────────────
+
+Deno.test("isPluginCoveredPath: claude + .claude/agents/<name>.md (non-architect) is covered", () => {
+  for (
+    const name of [
+      "code-reviewer",
+      "developer",
+      "devops-sre",
+      "product-owner",
+      "qa-tester",
+      "review-coordinator",
+      "security-auditor",
+      "test-reviewer",
+      "workflow-manager",
+    ]
+  ) {
+    assertEquals(
+      isPluginCoveredPath("claude", `.claude/agents/${name}.md`),
+      true,
+      `agent ${name} should be plugin-covered`,
+    );
+  }
+});
+
+Deno.test("isPluginCoveredPath: claude + architect.md is NOT covered (contributor-only)", () => {
+  assertEquals(
+    isPluginCoveredPath("claude", ".claude/agents/architect.md"),
+    false,
+  );
+});
+
+Deno.test("isPluginCoveredPath: claude + .claude/skills/specflow.<name>/SKILL.md is covered", () => {
+  for (
+    const name of [
+      "specify",
+      "plan",
+      "tasks",
+      "implement",
+      "analyze",
+      "review",
+      "merge",
+      "constitution",
+      "checklist",
+      "clarify",
+    ]
+  ) {
+    assertEquals(
+      isPluginCoveredPath(
+        "claude",
+        `.claude/skills/specflow.${name}/SKILL.md`,
+      ),
+      true,
+      `command ${name} should be plugin-covered`,
+    );
+  }
+});
+
+Deno.test("isPluginCoveredPath: claude + auto-chain skill is covered", () => {
+  assertEquals(
+    isPluginCoveredPath("claude", ".claude/skills/auto-chain/SKILL.md"),
+    true,
+  );
+});
+
+Deno.test("isPluginCoveredPath: claude + specflow.groom skill is covered", () => {
+  assertEquals(
+    isPluginCoveredPath("claude", ".claude/skills/specflow.groom/SKILL.md"),
+    true,
+  );
+});
+
+// ── Claude harness — NOT covered paths ────────────────────────────────────
+
+Deno.test("isPluginCoveredPath: claude + project-stateful paths NOT covered", () => {
+  for (
+    const dest of [
+      ".specflow/installed.lock",
+      ".specflow/memory/constitution.md",
+      ".specflow/backlog.md",
+      ".specflow/backlog-config.yml",
+      ".specflow/scripts/backlog/add.sh",
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".gitignore",
+    ]
+  ) {
+    assertEquals(
+      isPluginCoveredPath("claude", dest),
+      false,
+      `${dest} should NOT be plugin-covered (project-stateful)`,
+    );
+  }
+});
+
+Deno.test("isPluginCoveredPath: claude + harness-static paths NOT covered", () => {
+  for (
+    const dest of [
+      ".claude/settings.json",
+      ".claude/settings.local.json",
+      ".claude/hooks/protect-generated.sh",
+      ".claude/hooks/log-subagent.sh",
+      ".claude/hooks/check-backlog-prereqs.sh",
+      ".claude/loop.md",
+      ".claude/scripts/dispatch-agent.sh",
+    ]
+  ) {
+    assertEquals(
+      isPluginCoveredPath("claude", dest),
+      false,
+      `${dest} should NOT be plugin-covered (harness-static)`,
+    );
+  }
+});
+
+Deno.test("isPluginCoveredPath: claude + backlog skill NOT covered (project-stateful)", () => {
+  assertEquals(
+    isPluginCoveredPath("claude", ".claude/skills/backlog/SKILL.md"),
+    false,
+  );
+});
+
+// ── Other harnesses — never covered ───────────────────────────────────────
+
+Deno.test("isPluginCoveredPath: non-claude harnesses are never covered (plugin is Claude-only)", () => {
+  for (
+    const harness of [
+      "cursor",
+      "codex",
+      "gemini",
+      "windsurf",
+      "copilot",
+      "opencode",
+    ] as const
+  ) {
+    // Even paths that would be covered under claude
+    assertEquals(
+      isPluginCoveredPath(harness, ".claude/agents/product-owner.md"),
+      false,
+      `${harness} should never have plugin-covered files`,
+    );
+    assertEquals(
+      isPluginCoveredPath(harness, ".claude/skills/specflow.specify/SKILL.md"),
+      false,
+    );
+  }
+});

--- a/tests/domain/upgrade_plan_test.ts
+++ b/tests/domain/upgrade_plan_test.ts
@@ -191,3 +191,99 @@ Deno.test("computeUpgradePlan emits no action for orphan-not-on-disk (user alrea
   const plan = computeUpgradePlan(diskShas, lock, newShas);
   assertEquals(plan.find((p) => p.kind === "remove"), undefined);
 });
+
+// ── Plugin migration table (#73) ───────────────────────────────────────────
+//
+// Each test exercises one cell of the 6-state architect spec:
+// (on-disk state) × (plugin state) → action.
+
+const PLUGIN_PATH = ".claude/agents/product-owner.md";
+const isCovered = (dest: string) => dest === PLUGIN_PATH;
+
+Deno.test("plugin migration: vanilla on disk + plugin installed → migrate-to-plugin", async () => {
+  const sha = await sha256Hex("original");
+  const lock = lockWith(PLUGIN_PATH, sha);
+  const diskShas = new Map([[PLUGIN_PATH, sha]]);
+  const newShas = new Map([[PLUGIN_PATH, await sha256Hex("upstream-update")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, true, isCovered);
+  const a = plan.find((p) => p.dest === PLUGIN_PATH);
+  assertEquals(a?.kind, "migrate-to-plugin");
+  if (a?.kind === "migrate-to-plugin") {
+    assertEquals(a.oldSha, sha);
+  }
+});
+
+Deno.test("plugin migration: vanilla on disk + plugin installed (already at latest) → migrate-to-plugin (still hand off)", async () => {
+  // Even when disk SHA already matches new bundle (would normally be
+  // "unchanged"), with plugin installed we still hand the file off.
+  const sha = await sha256Hex("identical-everywhere");
+  const lock = lockWith(PLUGIN_PATH, sha);
+  const diskShas = new Map([[PLUGIN_PATH, sha]]);
+  const newShas = new Map([[PLUGIN_PATH, sha]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, true, isCovered);
+  assertEquals(plan.find((p) => p.dest === PLUGIN_PATH)?.kind, "migrate-to-plugin");
+});
+
+Deno.test("plugin migration: customized on disk + plugin installed → preserve with pluginAvailable=true", async () => {
+  const lockSha = await sha256Hex("original");
+  const lock = lockWith(PLUGIN_PATH, lockSha);
+  const diskShas = new Map([[PLUGIN_PATH, await sha256Hex("user-edits")]]);
+  const newShas = new Map([[PLUGIN_PATH, await sha256Hex("upstream-update")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, true, isCovered);
+  const a = plan.find((p) => p.dest === PLUGIN_PATH);
+  assertEquals(a?.kind, "preserve");
+  if (a?.kind === "preserve") {
+    assertEquals(a.pluginAvailable, true);
+    assertEquals(a.reason, "customized");
+  }
+});
+
+Deno.test("plugin migration: missing on disk + plugin installed → defer-to-plugin", async () => {
+  const lock = lockWith(PLUGIN_PATH, await sha256Hex("original"));
+  const diskShas = new Map<string, string>(); // user deleted it
+  const newShas = new Map([[PLUGIN_PATH, await sha256Hex("upstream-update")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, true, isCovered);
+  assertEquals(plan.find((p) => p.dest === PLUGIN_PATH)?.kind, "defer-to-plugin");
+});
+
+Deno.test("plugin migration: vanilla on disk + plugin NOT installed → existing auto-update behavior", async () => {
+  const sha = await sha256Hex("original");
+  const lock = lockWith(PLUGIN_PATH, sha);
+  const diskShas = new Map([[PLUGIN_PATH, sha]]);
+  const newShas = new Map([[PLUGIN_PATH, await sha256Hex("upstream-update")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, false, isCovered);
+  assertEquals(plan.find((p) => p.dest === PLUGIN_PATH)?.kind, "auto-update");
+});
+
+Deno.test("plugin migration: customized on disk + plugin NOT installed → preserve with pluginAvailable=false", async () => {
+  const lockSha = await sha256Hex("original");
+  const lock = lockWith(PLUGIN_PATH, lockSha);
+  const diskShas = new Map([[PLUGIN_PATH, await sha256Hex("user-edits")]]);
+  const newShas = new Map([[PLUGIN_PATH, await sha256Hex("upstream-update")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, false, isCovered);
+  const a = plan.find((p) => p.dest === PLUGIN_PATH);
+  assertEquals(a?.kind, "preserve");
+  if (a?.kind === "preserve") {
+    assertEquals(a.pluginAvailable, false);
+  }
+});
+
+Deno.test("plugin migration: missing on disk + plugin NOT installed → existing add-new behavior", async () => {
+  const lock = lockWith(PLUGIN_PATH, await sha256Hex("original"));
+  const diskShas = new Map<string, string>();
+  const newShas = new Map([[PLUGIN_PATH, await sha256Hex("upstream")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, false, isCovered);
+  assertEquals(plan.find((p) => p.dest === PLUGIN_PATH)?.kind, "add-new");
+});
+
+Deno.test("plugin migration: uncovered path + plugin installed → existing behavior (covered=false)", async () => {
+  // Even when plugin is installed, a path the plugin doesn't own
+  // (like .claude/settings.json) goes through the normal flow.
+  const UNCOVERED = ".claude/settings.json";
+  const sha = await sha256Hex("hooks: {}");
+  const lock = lockWith(UNCOVERED, sha);
+  const diskShas = new Map([[UNCOVERED, sha]]);
+  const newShas = new Map([[UNCOVERED, await sha256Hex("hooks: { ... }")]]);
+  const plan = computeUpgradePlan(diskShas, lock, newShas, true, isCovered);
+  assertEquals(plan.find((p) => p.dest === UNCOVERED)?.kind, "auto-update");
+});


### PR DESCRIPTION
Slice 6 of the plugin migration tracked in #73. **The biggest slice yet** — implements the architect's 6-state on-disk × plugin migration table.

## What's in

### Domain
- New `src/domain/plugin_coverage.ts` — pure predicate `isPluginCoveredPath(harness, dest): boolean`. Claude-harness only; covers 9 agents (excluding `architect`), 10 specflow.* skill folders, auto-chain, specflow.groom.
- Extended `src/domain/upgrade_plan.ts`:
  - New action `migrate-to-plugin` (vanilla on-disk + plugin installed → backup + delete + drop lock entry)
  - New action `defer-to-plugin` (missing on-disk + plugin installed → drop lock entry, plugin serves it)
  - `preserve` gains `pluginAvailable: boolean` (true → handler shows "[plugin available — reconcile manually]" tag)
  - `computeUpgradePlan` signature gains `pluginInstalled` + `isPluginCovered` (both default to `false` / no-op so existing callers are unaffected)

### Application
- `UpgradeProjectUseCase` gains optional `pluginDetector` dep, probes `claude-specflow` plugin at execute() entry, applies the table:
  - `migrate-to-plugin` → `writer.deletePaths` with `backupExisting: true`
  - `defer-to-plugin` → no FS action, just lock-entry drop
  - Lock-rebuild loop skips dests handed off to the plugin

### CLI
- `upgrade_handler.ts` injects `FsPluginDetector` + renders new groups in the summary:
  - "migrated to claude-specflow plugin (backed up + removed)"
  - "deferred to claude-specflow plugin (was missing on disk)"
  - Customized preserves now annotate with "[plugin available — reconcile manually]" when applicable

## Architect's 6-state table (now implemented)

| On-disk | Plugin | Action |
|---|---|---|
| Vanilla | Not installed | auto-update (existing) |
| Customized | Not installed | preserve, `pluginAvailable: false` |
| Vanilla | Installed | **migrate-to-plugin** ← new |
| Customized | Installed | preserve, `pluginAvailable: true` ← annotated |
| Missing | Not installed | add-new (existing) |
| Missing | Installed | **defer-to-plugin** ← new |

## Test plan

- [x] `deno task test` — 432 passed (was 411, **+21** new tests)
  - 9 in `tests/domain/plugin_coverage_test.ts` covering the predicate
  - 8 in `tests/domain/upgrade_plan_test.ts` covering all 6 cells + 2 unchanged-baseline
  - 4 in `tests/application/upgrade_project_test.ts` end-to-end (delete + lock-drop + defer + non-installed)
- [x] `deno task fmt` — clean
- [x] All existing upgrade tests pass (`pluginDetector` defaults to undefined → legacy behavior)

## Next

- Slice 7: `check --project` warn surface for "plugin uninstalled, files missing" edge case
- Slice 8: `release.yml` extension to publish the plugin sub-folder (gated on `devops-sre` advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)