### PR TITLE
feat(check): warn on plugin-uninstalled gap (#73 slice 7)

### DIFF
--- a/src/cli/handlers/check_handler.ts
+++ b/src/cli/handlers/check_handler.ts
@@ -4,6 +4,7 @@ import { RunChecksUseCase } from "../../application/run_checks.ts";
 import { DenoSubprocessRunner } from "../../infrastructure/deno_subprocess.ts";
 import { DenoEnvironmentProbe } from "../../infrastructure/deno_environment_probe.ts";
 import { FsProjectInspector } from "../../infrastructure/fs_project_inspector.ts";
+import { FsPluginDetector } from "../../infrastructure/fs_plugin_detector.ts";
 import { TEMPLATES_VERSION } from "../../templates_bundle.ts";
 import { type CheckOutcome, worstStatusOf } from "../../domain/check_result.ts";
 
@@ -31,7 +32,7 @@ function renderSection(title: string, outcomes: ReadonlyArray<CheckOutcome>) {
 export async function runCheck(intent: CheckIntent): Promise<number> {
   const runner = new DenoSubprocessRunner();
   const env = new DenoEnvironmentProbe(runner);
-  const inspector = new FsProjectInspector();
+  const inspector = new FsProjectInspector(new FsPluginDetector());
 
   const projectDir = intent.projectMode ? resolve(Deno.cwd()) : null;
   const uc = new RunChecksUseCase({ env, inspector });

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -50,3 +50,44 @@ export function isPluginCoveredPath(
 
   return false;
 }
+
+/**
+ * The canonical list of project-relative paths the binary scaffolds for
+ * the Claude harness AND the `claude-specflow` plugin owns. Used by
+ * `check --project` to detect the "plugin uninstalled after migration"
+ * gap: each path that is missing on disk AND for which the plugin is
+ * not installed is a recoverable hole the user should know about
+ * (either re-install the plugin or run `specflow upgrade` to restore
+ * the bundled snapshot).
+ *
+ * Kept in sync with `isPluginCoveredPath` above. Total: 21 paths
+ * (9 agents excluding architect + 10 specflow.* commands as skill
+ * folders + auto-chain + specflow.groom).
+ */
+export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
+  ...[
+    "code-reviewer",
+    "developer",
+    "devops-sre",
+    "product-owner",
+    "qa-tester",
+    "review-coordinator",
+    "security-auditor",
+    "test-reviewer",
+    "workflow-manager",
+  ].map((name) => `.claude/agents/${name}.md`),
+  ...[
+    "analyze",
+    "checklist",
+    "clarify",
+    "constitution",
+    "implement",
+    "merge",
+    "plan",
+    "review",
+    "specify",
+    "tasks",
+  ].map((name) => `.claude/skills/specflow.${name}/SKILL.md`),
+  ".claude/skills/auto-chain/SKILL.md",
+  ".claude/skills/specflow.groom/SKILL.md",
+];

--- a/src/infrastructure/fs_project_inspector.ts
+++ b/src/infrastructure/fs_project_inspector.ts
@@ -1,8 +1,11 @@
 import { join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
-import type { ProjectInspector } from "../application/ports.ts";
+import type { PluginDetector, ProjectInspector } from "../application/ports.ts";
 import type { CheckOutcome } from "../domain/check_result.ts";
 import { type BacklogBackend, type KnownHarness, parseLock } from "../domain/installed_lock.ts";
+import { PLUGIN_COVERED_PATHS_CLAUDE } from "../domain/plugin_coverage.ts";
+
+const PLUGIN_NAME = "claude-specflow";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -57,6 +60,14 @@ function validateHooks(hooks: unknown): string[] {
 }
 
 export class FsProjectInspector implements ProjectInspector {
+  /**
+   * `pluginDetector` is optional — when omitted, the "plugin gap"
+   * check (slice 7 of #73) is skipped silently. The check_handler
+   * always injects an `FsPluginDetector` in production; tests opt in
+   * by constructing the inspector with one.
+   */
+  constructor(private readonly pluginDetector: PluginDetector | null = null) {}
+
   async inspect(projectDir: string, templatesVersion: string): Promise<CheckOutcome[]> {
     const outcomes: CheckOutcome[] = [];
 
@@ -66,7 +77,51 @@ export class FsProjectInspector implements ProjectInspector {
     outcomes.push(await this.checkTemplatesVersion(projectDir, templatesVersion));
     outcomes.push(await this.checkBacklogConfig(projectDir));
     outcomes.push(...await this.checkClaudeConfig(projectDir));
+    outcomes.push(...await this.checkPluginGap(projectDir));
 
+    return outcomes;
+  }
+
+  /**
+   * Detects the "plugin uninstalled after migration" edge case (#73
+   * slice 7): when `specflow upgrade` previously migrated vanilla
+   * agent files to the `claude-specflow` plugin (deleted from disk +
+   * dropped from lock), and the user later uninstalled the plugin,
+   * those files are now silently absent. This check warns once per
+   * missing path so the user can recover via `specflow upgrade` or
+   * by re-installing the plugin.
+   *
+   * Returns an empty list when no `pluginDetector` is configured, the
+   * lock is missing or non-claude, or the plugin is currently
+   * installed (no gap can exist).
+   */
+  private async checkPluginGap(projectDir: string): Promise<CheckOutcome[]> {
+    if (this.pluginDetector === null) return [];
+
+    const lockPath = join(projectDir, ".specflow/installed.lock");
+    if (!(await exists(lockPath))) return [];
+    let harness: KnownHarness;
+    try {
+      harness = parseLock(await Deno.readTextFile(lockPath)).harness;
+    } catch {
+      return [];
+    }
+    if (harness !== "claude") return [];
+
+    const installed = await this.pluginDetector.isPluginInstalled(PLUGIN_NAME);
+    if (installed) return [];
+
+    const outcomes: CheckOutcome[] = [];
+    for (const dest of PLUGIN_COVERED_PATHS_CLAUDE) {
+      const present = await exists(join(projectDir, dest));
+      if (present) continue;
+      outcomes.push({
+        name: dest,
+        status: "warn",
+        message:
+          "missing — restore via `specflow upgrade` or install the plugin (`/plugin install claude-specflow`)",
+      });
+    }
     return outcomes;
   }
 

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -793,3 +793,145 @@ project_number: 4
     },
   );
 });
+
+// ── Plugin gap detection (#73 slice 7) ─────────────────────────────────────
+
+import type { PluginDetector } from "../../src/application/ports.ts";
+
+function fakePluginDetector(installed: boolean): PluginDetector {
+  return { isPluginInstalled: (_n: string) => Promise.resolve(installed) };
+}
+
+Deno.test("inspect: plugin gap check skipped when no pluginDetector is configured", async () => {
+  await withProjectDir(filledProject, async (dir) => {
+    const inspector = new FsProjectInspector();
+    const outcomes = await inspector.inspect(dir, "0.2.0");
+    const gapOutcomes = outcomes.filter((o) =>
+      o.name.startsWith(".claude/agents/") || o.name.startsWith(".claude/skills/")
+    );
+    assertEquals(gapOutcomes.length, 0);
+  });
+});
+
+Deno.test("inspect: plugin gap check emits no warnings when plugin IS installed", async () => {
+  await withProjectDir(filledProject, async (dir) => {
+    const inspector = new FsProjectInspector(fakePluginDetector(true));
+    const outcomes = await inspector.inspect(dir, "0.2.0");
+    const gapOutcomes = outcomes.filter((o) =>
+      o.name.startsWith(".claude/agents/") ||
+      o.name.startsWith(".claude/skills/specflow.")
+    );
+    assertEquals(gapOutcomes.length, 0);
+  });
+});
+
+Deno.test("inspect: plugin gap check warns for each missing covered path when plugin NOT installed", async () => {
+  await withProjectDir(filledProject, async (dir) => {
+    const inspector = new FsProjectInspector(fakePluginDetector(false));
+    const outcomes = await inspector.inspect(dir, "0.2.0");
+    const gapOutcomes = outcomes.filter((o) =>
+      (o.name.startsWith(".claude/agents/") ||
+        o.name.startsWith(".claude/skills/specflow.") ||
+        o.name === ".claude/skills/auto-chain/SKILL.md") &&
+      o.status === "warn"
+    );
+    // 9 agents + 10 commands + 2 skills = 21 covered paths, all missing
+    assertEquals(gapOutcomes.length, 21);
+    for (const o of gapOutcomes) {
+      assertEquals(o.message.includes("missing"), true);
+      assertEquals(o.message.includes("specflow upgrade"), true);
+      assertEquals(o.message.includes("/plugin install claude-specflow"), true);
+    }
+  });
+});
+
+Deno.test("inspect: plugin gap check skipped on non-claude harnesses", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await Deno.mkdir(join(dir, ".specflow/memory"), { recursive: true });
+      await Deno.mkdir(join(dir, ".cursor"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".specflow/memory/constitution.md"),
+        CONSTITUTION_FILLED,
+      );
+      await Deno.writeTextFile(
+        join(dir, ".specflow/installed.lock"),
+        `version: 2
+harness: cursor
+templates_version: 0.7.0
+entries: {}
+`,
+      );
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector(fakePluginDetector(false));
+      const outcomes = await inspector.inspect(dir, "0.7.0");
+      const gapOutcomes = outcomes.filter((o) => o.name.startsWith(".claude/"));
+      assertEquals(gapOutcomes.length, 0);
+    },
+  );
+});
+
+Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually deleted", async () => {
+  await withProjectDir(
+    async (dir) => {
+      await filledProject(dir);
+      await Deno.mkdir(join(dir, ".claude/agents"), { recursive: true });
+      // Scaffold all 9 agents EXCEPT product-owner (simulating that
+      // one alone got deleted post-migration).
+      for (
+        const name of [
+          "code-reviewer",
+          "developer",
+          "devops-sre",
+          "qa-tester",
+          "review-coordinator",
+          "security-auditor",
+          "test-reviewer",
+          "workflow-manager",
+        ]
+      ) {
+        await Deno.writeTextFile(join(dir, `.claude/agents/${name}.md`), "stub");
+      }
+      // Scaffold all skills + commands too (only the agent gap should warn)
+      await Deno.mkdir(join(dir, ".claude/skills/auto-chain"), { recursive: true });
+      await Deno.writeTextFile(join(dir, ".claude/skills/auto-chain/SKILL.md"), "stub");
+      await Deno.mkdir(join(dir, ".claude/skills/specflow.groom"), { recursive: true });
+      await Deno.writeTextFile(
+        join(dir, ".claude/skills/specflow.groom/SKILL.md"),
+        "stub",
+      );
+      for (
+        const name of [
+          "analyze",
+          "checklist",
+          "clarify",
+          "constitution",
+          "implement",
+          "merge",
+          "plan",
+          "review",
+          "specify",
+          "tasks",
+        ]
+      ) {
+        await Deno.mkdir(join(dir, `.claude/skills/specflow.${name}`), {
+          recursive: true,
+        });
+        await Deno.writeTextFile(
+          join(dir, `.claude/skills/specflow.${name}/SKILL.md`),
+          "stub",
+        );
+      }
+    },
+    async (dir) => {
+      const inspector = new FsProjectInspector(fakePluginDetector(false));
+      const outcomes = await inspector.inspect(dir, "0.2.0");
+      const gapOutcomes = outcomes.filter((o) =>
+        o.name.startsWith(".claude/agents/") && o.status === "warn"
+      );
+      assertEquals(gapOutcomes.length, 1);
+      assertEquals(gapOutcomes[0].name, ".claude/agents/product-owner.md");
+    },
+  );
+});


### PR DESCRIPTION
Slice 7 of the plugin migration tracked in #73. Closes the architect's "plugin uninstalled after migration" exit-ramp edge case.

## Why

When `specflow upgrade` migrates vanilla agent files to the `claude-specflow` plugin (slice 6), those files are deleted from disk and dropped from the lock — the plugin serves them going forward. If the user later uninstalls the plugin, those files would be silently absent. `specflow check --project` now detects the gap and tells the user how to recover.

## What's in

### Domain
- New constant `PLUGIN_COVERED_PATHS_CLAUDE` in `src/domain/plugin_coverage.ts` — the 21 canonical paths the binary scaffolds for the Claude harness AND the plugin owns. Single source of truth for the inspector to walk.

### Inspector
- `FsProjectInspector` constructor takes optional `pluginDetector` (legacy callers unaffected).
- New `checkPluginGap` private method, runs last in `inspect()`. Skips when: no detector, no lock, non-claude harness, or plugin installed. Otherwise iterates the 21 covered paths and warns once per missing path:
  ```
  missing — restore via `specflow upgrade` or install the plugin (`/plugin install claude-specflow`)
  ```

### Handler
- `check_handler.ts` injects `FsPluginDetector` into the inspector so the gap check fires in production.

## Test plan

- [x] `deno task test` — 437 passed (was 432, **+5**)
- [x] gap check skipped when no detector
- [x] gap check silent when plugin installed
- [x] 21 warnings when plugin uninstalled + all covered paths missing
- [x] gap check skipped on non-claude harnesses
- [x] only actually-deleted paths warn (mixed scenario — 8 agents present, 1 missing → 1 warn)

## Next

Slice 8 (final): `release.yml` extension to publish the plugin sub-folder. Gated on `devops-sre` advisory per the working contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)