### PR TITLE
feat(release): publish plugin in lockstep with binary (#73 slice 8) — closes #73

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -32,12 +32,15 @@ Specflow repo.
    deno run --allow-read --allow-write scripts/bump-version.ts <kind>
    ```
 
-   This updates `deno.json` and `src/domain/version.ts` in lockstep.
+   This updates `deno.json`, `src/domain/version.ts`, AND
+   `plugin/.claude-plugin/plugin.json` in lockstep. The
+   release.yml pre-flight step fails fast on plugin/binary version
+   drift, so all three must move together.
 
 2. **Review the diff** and confirm with Kevin:
 
    ```bash
-   git diff deno.json src/domain/version.ts
+   git diff deno.json src/domain/version.ts plugin/.claude-plugin/plugin.json
    ```
 
 3. **Regenerate the bundle** in case templates changed since the last release:
@@ -73,7 +76,8 @@ Specflow repo.
 6. **Commit the bump**:
 
    ```bash
-   git add deno.json src/domain/version.ts src/templates_bundle.ts
+   git add deno.json src/domain/version.ts src/templates_bundle.ts \
+           plugin/.claude-plugin/plugin.json
    git commit -m "chore: release v<NEXT>"
    ```
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,23 @@ jobs:
           deno-version: v2.x
       - name: Bundle templates
         run: deno task bundle
+      - name: Plugin pre-flight (version lockstep + scaffold integrity)
+        run: |
+          set -euo pipefail
+          # 1. plugin.json must be parseable JSON
+          jq -e . plugin/.claude-plugin/plugin.json > /dev/null
+          # 2. Plugin scaffold must contain at minimum the auto-chain skill
+          # (catches an accidentally truncated plugin/ directory).
+          test -f plugin/skills/auto-chain/SKILL.md
+          # 3. Hard fail if plugin.json version drifts from deno.json version.
+          # The two are kept in lockstep by scripts/bump-version.ts.
+          BIN_VERSION=$(jq -r .version deno.json)
+          PLUGIN_VERSION=$(jq -r .version plugin/.claude-plugin/plugin.json)
+          if [ "$BIN_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "::error::plugin/.claude-plugin/plugin.json version ($PLUGIN_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
+            exit 1
+          fi
+          echo "✓ plugin manifest valid, scaffold present, version $PLUGIN_VERSION matches binary"
       - name: Cross-compile all targets
         run: deno run --allow-read --allow-write --allow-run --allow-env scripts/build.ts
       - name: Compute checksums

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-specflow",
   "description": "Specflow's auto-chain skill, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
-  "version": "0.0.1",
+  "version": "0.11.1",
   "author": {
     "name": "MakerLabs"
   },

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -63,6 +63,17 @@ async function writeVersions(next: string): Promise<void> {
     `export const VERSION = "${next}"`,
   );
   await Deno.writeTextFile(verPath, updatedVer);
+
+  // Lockstep the claude-specflow plugin manifest (#73 slice 8). The
+  // release workflow's pre-flight step compares deno.json `version`
+  // against this file's `version` and fails fast on drift.
+  const pluginManifestPath = "plugin/.claude-plugin/plugin.json";
+  const pluginRaw = await Deno.readTextFile(pluginManifestPath);
+  const updatedPlugin = pluginRaw.replace(
+    /"version":\s*"[^"]+"/,
+    `"version": "${next}"`,
+  );
+  await Deno.writeTextFile(pluginManifestPath, updatedPlugin);
 }
 
 async function main() {
@@ -77,7 +88,9 @@ async function main() {
   const next = computeNextVersion(version, kind as BumpKind);
   await writeVersions(next);
   console.log(`Bumped ${version} → ${next}`);
-  console.log(`Updated: deno.json, src/domain/version.ts`);
+  console.log(
+    `Updated: deno.json, src/domain/version.ts, plugin/.claude-plugin/plugin.json`,
+  );
 }
 
 if (import.meta.main) await main();


### PR DESCRIPTION
**Final slice of #73.** Closes the gap between the binary's release pipeline and the claude-specflow plugin's distribution model.

## Per devops-sre advisory

No plugin zip artifact is needed today — the plugin is served from the repo at HEAD via \`/plugin install mkrlabs/claude-specflow\`. What IS needed is **version lockstep + a fail-fast pre-flight** so the plugin manifest and the binary always release together.

## Changes

1. **\`scripts/bump-version.ts\`** now writes \`plugin/.claude-plugin/plugin.json\` alongside \`deno.json\` and \`src/domain/version.ts\`. One bump command, three files updated atomically.

2. **\`plugin/.claude-plugin/plugin.json\`** bumped from \`0.0.1\` → \`0.11.1\` to close the existing drift surfaced by the advisory (binary was on v0.11.1 since this morning's release).

3. **\`.github/workflows/release.yml\`** gains a "Plugin pre-flight" step between bundle and build:
   - jq-validates \`plugin.json\` is parseable
   - Asserts \`plugin/skills/auto-chain/SKILL.md\` exists (catches accidentally truncated plugin/ directory)
   - **Hard-fails when deno.json version != plugin.json version**
   - Prints \`✓ plugin manifest valid, scaffold present, version X.Y.Z matches binary\` when green

4. **\`.claude/skills/release/SKILL.md\`** updated for the new staging line — the release recipe now stages all three version files atomically.

## Test plan

- [x] \`deno task test\` — 437 passed (plugin.json sync test only checks shape, not the specific value, so the bump didn't break it)
- [x] Pre-flight commands smoke-tested locally — \`deno=0.11.1 plugin=0.11.1 match=yes ✓\`
- [x] All 5 cross-platform smoke jobs in CI

## Closes #73 — the full v0.x → plugin migration is shipped

| Slice | Result |
|---|---|
| 1 | plugin scaffold + auto-chain |
| 2 | 10 commands as namespaced skills |
| 3 | 9 agents |
| 4 | groom skill (asset migration complete) |
| 5 | PluginDetector port + adapter |
| 6 | 6-state migration table in upgrade use case |
| 7 | check --project warn for plugin-uninstalled gap |
| 8 | Release pipeline lockstep + pre-flight (this PR) |

Total: 8 PRs, 21 dual/plugin assets, +56 tests (404 → 437 + the 19 plan/coverage cells), zero behavior change for users who don't install the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)