### PR TITLE
fix(plugin): rename claude-specflow → specflow-plugin (#116)

### DIFF
--- a/.claude/agents/architect/memory/claude-plugin-boundary.md
+++ b/.claude/agents/architect/memory/claude-plugin-boundary.md
@@ -1,6 +1,6 @@
 ---
 name: claude-plugin-boundary
-description: Which Specflow templates go to the claude-specflow plugin vs stay binary-owned — decision from issue #73 design
+description: Which Specflow templates go to the specflow-plugin plugin vs stay binary-owned — decision from issue #73 design
 type: decision
 ---
 
@@ -19,4 +19,4 @@ $(pwd)/.specflow/installed.lock, and cannot be conditionally rendered.
 - All harness-specific static files (CLAUDE.md, settings.json, loop.md, dispatch-agent.sh): binary only (reference project-local paths)
 - spec-root, agent-memory, project-root files: binary only (project-stateful by definition)
 
-Plugin skills are namespaced (/claude-specflow:specify); binary-scaffolded project skills keep the short form (/specify). Both coexist.
+Plugin skills are namespaced (/specflow-plugin:specify); binary-scaffolded project skills keep the short form (/specify). Both coexist.

--- a/.claude/agents/architect/memory/claude-plugin-compat.md
+++ b/.claude/agents/architect/memory/claude-plugin-compat.md
@@ -1,10 +1,10 @@
 ---
 name: claude-plugin-compat
-description: Backwards-compat strategy for v0.x inline agents when claude-specflow plugin is installed — issue #73
+description: Backwards-compat strategy for v0.x inline agents when specflow-plugin plugin is installed — issue #73
 type: decision
 ---
 
-**Detection method:** SHA comparison against InstalledLock.entries (already implemented in src/domain/installed_lock.ts). Plugin presence detected via Deno.stat on ~/.claude/plugins/cache/claude-specflow/ through a new PluginDetector port + fs_plugin_detector.ts adapter.
+**Detection method:** SHA comparison against InstalledLock.entries (already implemented in src/domain/installed_lock.ts). Plugin presence detected via Deno.stat on ~/.claude/plugins/cache/specflow-plugin/ through a new PluginDetector port + fs_plugin_detector.ts adapter.
 
 **Rule: auto-migrate vanilla files, warn-and-preserve customized files.**
 

--- a/docs/superpowers/specs/2026-05-08-claude-plugin-design.md
+++ b/docs/superpowers/specs/2026-05-08-claude-plugin-design.md
@@ -1,4 +1,4 @@
-# Claude plugin (`claude-specflow`) — boundary and backwards-compat design
+# Claude plugin (`specflow-plugin`) — boundary and backwards-compat design
 
 **Goal.** Define (a) which Specflow template files move to the plugin vs stay binary-owned, and (b)
 how `specflow upgrade` handles v0.x users who have inline on-disk agents once the plugin exists.
@@ -10,7 +10,7 @@ This is the design-only document for issue #73; no code ships until AC are writt
 
 The Claude plugin system (`code.claude.com/docs/en/plugins`) installs a plugin repo's content at
 user scope (cached under `~/.claude/plugins/cache/<name>/`) when the user runs
-`/plugin install claude-specflow`. Plugin skills are **namespaced** (`/claude-specflow:specify`), so
+`/plugin install specflow-plugin`. Plugin skills are **namespaced** (`/specflow-plugin:specify`), so
 they coexist with but do not replace project-level `.claude/skills/` files. Hooks in a plugin live
 in `hooks/hooks.json`, not in `settings.json`. Agents in a plugin live in `agents/`.
 
@@ -24,7 +24,7 @@ Anything that requires project-state stays binary-owned.
 
 | Template path (relative to `templates/`)                 | Category        | Destination                       | Rationale                                                                                                                                                                                                                                                                                                                         |
 | -------------------------------------------------------- | --------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `core/commands/specflow.*.md` (10 files)                 | Skills          | **Both**                          | Plugin ships the generic version (namespaced `/claude-specflow:specify`). Binary continues to scaffold project-local copies in `.claude/skills/specflow.*/SKILL.md` (unlocked, un-namespaced `/specify`). Users get the convenience of the plugin AND the short slash-command. On upgrade, binary version wins for project files. |
+| `core/commands/specflow.*.md` (10 files)                 | Skills          | **Both**                          | Plugin ships the generic version (namespaced `/specflow-plugin:specify`). Binary continues to scaffold project-local copies in `.claude/skills/specflow.*/SKILL.md` (unlocked, un-namespaced `/specify`). Users get the convenience of the plugin AND the short slash-command. On upgrade, binary version wins for project files. |
 | `core/commands/backlog.md`                               | Backlog command | **Binary only**                   | Content varies by backend (conditional-render markers). Plugin cannot pre-render per-backend.                                                                                                                                                                                                                                     |
 | `core/agents/*.md` (9 agents)                            | Agents          | **Both**                          | Plugin ships the canonical latest version. Binary scaffolds the snapshot at init time. See Q4 for migration.                                                                                                                                                                                                                      |
 | `core/agents/*/memory/MEMORY.md` (5 files)               | Agent memory    | **Binary only**                   | These are project-local memory files meant to be mutated per-project. Plugin scope makes no sense.                                                                                                                                                                                                                                |
@@ -52,7 +52,7 @@ hook `command` paths resolve relative to plugin root, keep it binary-owned and r
 
 ### Naming note
 
-Plugin skills are namespaced: `/claude-specflow:specify`, not `/specify`. Binary-scaffolded project
+Plugin skills are namespaced: `/specflow-plugin:specify`, not `/specify`. Binary-scaffolded project
 skills keep the short form. This is the correct UX: the plugin provides discoverability for new
 users; the binary provides the customizable project-local copy with the short slash-command.
 
@@ -67,7 +67,7 @@ users; the binary provides the customizable project-local copy with the short sl
 the two differ. This is already implemented in `src/domain/installed_lock.ts` and used by the
 upgrade path — no new infrastructure needed.
 
-Plugin install detection: check whether `~/.claude/plugins/cache/claude-specflow/` exists (the
+Plugin install detection: check whether `~/.claude/plugins/cache/specflow-plugin/` exists (the
 canonical cache path per the discover-plugins docs). The binary reads this path via a new
 `PluginDetector` port method `isPluginInstalled(name: string): Promise<boolean>` backed by a
 `Deno.stat` check in `src/infrastructure/fs_plugin_detector.ts`.
@@ -78,8 +78,8 @@ canonical cache path per the discover-plugins docs). The binary reads this path 
 | -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Vanilla (SHA matches lock) | Not installed | Normal upgrade: overwrite with latest bundle snapshot.                                                                                                                                                                                                                                                 |
 | Customized (SHA differs)   | Not installed | Normal upgrade: preserve unless `--force`. No change from today.                                                                                                                                                                                                                                       |
-| Vanilla                    | Installed     | **Auto-migrate**: backup the file to `.specflow/backups/<timestamp>/`, delete the on-disk copy, drop the lock entry. Print: `info: agent 'product-owner' removed — now served by the claude-specflow plugin`.                                                                                          |
-| Customized                 | Installed     | **Warn + preserve**: keep the on-disk copy (it wins over plugin per Claude Code loading order). Print: `warn: agent 'product-owner' is customized and the claude-specflow plugin is installed. The on-disk version takes precedence. Reconcile manually or run specflow upgrade --force to overwrite.` |
+| Vanilla                    | Installed     | **Auto-migrate**: backup the file to `.specflow/backups/<timestamp>/`, delete the on-disk copy, drop the lock entry. Print: `info: agent 'product-owner' removed — now served by the specflow-plugin plugin`.                                                                                          |
+| Customized                 | Installed     | **Warn + preserve**: keep the on-disk copy (it wins over plugin per Claude Code loading order). Print: `warn: agent 'product-owner' is customized and the specflow-plugin plugin is installed. The on-disk version takes precedence. Reconcile manually or run specflow upgrade --force to overwrite.` |
 | Missing (user deleted)     | Not installed | Drop lock entry, nothing on disk to act on.                                                                                                                                                                                                                                                            |
 | Missing (user deleted)     | Installed     | Drop lock entry. Plugin serves the agent. No action needed.                                                                                                                                                                                                                                            |
 
@@ -106,8 +106,8 @@ plugin is not installed. It emits:
 
 ```
 warn: .claude/agents/product-owner.md is tracked in the lock but missing from disk.
-      The claude-specflow plugin is not installed. Run `specflow upgrade` to restore
-      the bundled version, or install the plugin: /plugin install claude-specflow.
+      The specflow-plugin plugin is not installed. Run `specflow upgrade` to restore
+      the bundled version, or install the plugin: /plugin install specflow-plugin.
 ```
 
 `specflow upgrade` restores the file from the bundle (same path as `add-new` action). No new action
@@ -123,7 +123,7 @@ kind needed — the existing `add-new` path handles it.
    - customizability) but adds upgrade complexity. Accept this as a first-party first-mover cost, or
      decide the plugin is the only source and force namespaced commands on all users. **Recommend:
      keep both.** The `/specify` short form is a core UX property; namespaced
-     `/claude-specflow:specify` is the discoverability layer.
+     `/specflow-plugin:specify` is the discoverability layer.
 
 2. **`log-subagent.sh` plugin vs binary.** Defer to plugin GA when hook path resolution from plugin
    cache is documented. Until then, binary-owned. **Recommend: defer.**
@@ -134,7 +134,7 @@ kind needed — the existing `add-new` path handles it.
    auto-migrate with backup + explicit `info:` line per file.** The backup path is the safety net;
    the log line is the audit trail. Explicit flag adds friction for the common case.
 
-4. **Plugin install detection path.** `~/.claude/plugins/cache/claude-specflow/` is inferred from
+4. **Plugin install detection path.** `~/.claude/plugins/cache/specflow-plugin/` is inferred from
    docs; the actual path is not formally guaranteed by the Claude Code API surface. If the path
    changes, the detector silently fails (no migration, no warning). Accept this fragility at v0.12,
    revisit once Claude Code publishes a stable plugin query API. **Recommend: accept.** Fallback

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-specflow",
+  "name": "specflow-plugin",
   "description": "Specflow's auto-chain skill, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
   "version": "0.12.0",
   "author": {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,4 +1,4 @@
-# claude-specflow — Claude Code plugin for Specflow
+# specflow-plugin — Claude Code plugin for Specflow
 
 This is the Claude Code plugin distribution of [Specflow](https://specflow.makerlabs.dev). It ships
 the same slash-commands, sub-agents, and the auto-chain skill that the `specflow` binary scaffolds
@@ -8,11 +8,11 @@ into projects — just as a user-scope plugin instead.
 
 | Path                                                                                                                                        | Contents                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`claude-specflow`, v0.0.1 alpha)                 |
-| `skills/auto-chain/SKILL.md`                                                                                                                | Auto-chain skill — `/claude-specflow:auto-chain`                  |
-| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/claude-specflow:specify`, etc. |
+| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specflow-plugin`, v0.0.1 alpha)                 |
+| `skills/auto-chain/SKILL.md`                                                                                                                | Auto-chain skill — `/specflow-plugin:auto-chain`                  |
+| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/specflow-plugin:specify`, etc. |
 | `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                  |
-| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/claude-specflow:groom`                            |
+| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specflow-plugin:groom`                            |
 
 **Coming in subsequent slices** (tracked in
 [issue #73](https://github.com/mkrlabs/specflow/issues/73)):
@@ -23,7 +23,7 @@ into projects — just as a user-scope plugin instead.
 
 The 10 command SKILL.md files include `handoffs:` frontmatter that references peer commands by their
 **binary-scaffolded** IDs (`specflow.plan`, `specflow.clarify`, …). In plugin scope those IDs are
-`claude-specflow:plan` etc., so the clickable handoff buttons may not resolve. For the full handoff
+`specflow-plugin:plan` etc., so the clickable handoff buttons may not resolve. For the full handoff
 UX today, use the binary-scaffolded copies (run `specflow init`) — the plugin versions are the
 discoverability layer, not the polished workflow. Handoff rewriting is a known follow-up task on
 #73.
@@ -34,7 +34,7 @@ discoverability layer, not the polished workflow. Handoff rewriting is a known f
   projects, updates via `/plugin update`.
 - The binary's `specflow init` scaffolds **project-scope** copies — you can customize them
   per-project, and they ship with shorter slash-command names (e.g. `/specify` instead of
-  `/claude-specflow:specify`).
+  `/specflow-plugin:specify`).
 - Backlog skill, hooks, and `.specflow/` files stay binary-owned because they read project-state at
   runtime.
 
@@ -44,7 +44,7 @@ plugin / binary boundary and the v0.x → plugin migration logic.
 ## Install (when ready)
 
 ```bash
-/plugin install mkrlabs/claude-specflow
+/plugin install mkrlabs/specflow-plugin
 ```
 
 (The plugin is currently `0.0.1` — pre-release. Wait for v0.1.0 before relying on it in production.)
@@ -57,7 +57,7 @@ To test changes to the plugin without publishing:
 claude --plugin-dir /path/to/specflow/plugin
 ```
 
-Then invoke any plugin skill: `/claude-specflow:auto-chain specify "…"`.
+Then invoke any plugin skill: `/specflow-plugin:auto-chain specify "…"`.
 
 ## Versioning
 

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -64,7 +64,7 @@ async function writeVersions(next: string): Promise<void> {
   );
   await Deno.writeTextFile(verPath, updatedVer);
 
-  // Lockstep the claude-specflow plugin manifest (#73 slice 8). The
+  // Lockstep the specflow-plugin plugin manifest (#73 slice 8). The
   // release workflow's pre-flight step compares deno.json `version`
   // against this file's `version` and fails fast on drift.
   const pluginManifestPath = "plugin/.claude-plugin/plugin.json";

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -8,7 +8,7 @@ import { canonicalBlockBody, extractBlock } from "../domain/merge_block.ts";
 import { isPluginCoveredPath } from "../domain/plugin_coverage.ts";
 
 /** The plugin name used for both the install probe and the cache directory. */
-export const PLUGIN_NAME = "claude-specflow";
+export const PLUGIN_NAME = "specflow-plugin";
 
 export type UpgradeProjectInput = {
   projectDir: string;

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -227,12 +227,12 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
     console.log();
   }
   if (groups.migrated.length > 0) {
-    console.log(bold("  migrated to claude-specflow plugin (backed up + removed)"));
+    console.log(bold("  migrated to specflow-plugin plugin (backed up + removed)"));
     for (const a of groups.migrated) console.log(cyan(`    → ${a.dest}`));
     console.log();
   }
   if (groups.deferred.length > 0) {
-    console.log(bold("  deferred to claude-specflow plugin (was missing on disk)"));
+    console.log(bold("  deferred to specflow-plugin plugin (was missing on disk)"));
     for (const a of groups.deferred) console.log(dim(`    · ${a.dest}`));
     console.log();
   }

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -1,7 +1,7 @@
 import type { KnownHarness } from "./installed_lock.ts";
 
 /**
- * Pure predicate: does the `claude-specflow` plugin own a copy of the
+ * Pure predicate: does the `specflow-plugin` plugin own a copy of the
  * file at `dest` (relative to the project root)?
  *
  * Used by the upgrade use case to decide whether to apply the v0.x →
@@ -53,7 +53,7 @@ export function isPluginCoveredPath(
 
 /**
  * The canonical list of project-relative paths the binary scaffolds for
- * the Claude harness AND the `claude-specflow` plugin owns. Used by
+ * the Claude harness AND the `specflow-plugin` plugin owns. Used by
  * `check --project` to detect the "plugin uninstalled after migration"
  * gap: each path that is missing on disk AND for which the plugin is
  * not installed is a recoverable hole the user should know about

--- a/src/domain/upgrade_plan.ts
+++ b/src/domain/upgrade_plan.ts
@@ -7,7 +7,7 @@ export type UpgradeAction =
     dest: string;
     reason: "customized";
     /**
-     * True when the `claude-specflow` plugin owns this path AND the
+     * True when the `specflow-plugin` plugin owns this path AND the
      * plugin is installed on the host. The handler surfaces an extra
      * warn line in this case ("plugin version is also available;
      * reconcile manually or pass --force"); the file content stays
@@ -44,7 +44,7 @@ export type UpgradePlan = ReadonlyArray<UpgradeAction>;
  *
  * Plus two parameters that drive the v0.x → plugin migration table for
  * issue #73:
- *   - `pluginInstalled`  : whether the `claude-specflow` plugin is on
+ *   - `pluginInstalled`  : whether the `specflow-plugin` plugin is on
  *                          the host (probed at use-case entry by the
  *                          `PluginDetector` port).
  *   - `isPluginCovered`  : predicate `(dest) => boolean` returning true

--- a/src/infrastructure/fs_project_inspector.ts
+++ b/src/infrastructure/fs_project_inspector.ts
@@ -5,7 +5,7 @@ import type { CheckOutcome } from "../domain/check_result.ts";
 import { type BacklogBackend, type KnownHarness, parseLock } from "../domain/installed_lock.ts";
 import { PLUGIN_COVERED_PATHS_CLAUDE } from "../domain/plugin_coverage.ts";
 
-const PLUGIN_NAME = "claude-specflow";
+const PLUGIN_NAME = "specflow-plugin";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -85,7 +85,7 @@ export class FsProjectInspector implements ProjectInspector {
   /**
    * Detects the "plugin uninstalled after migration" edge case (#73
    * slice 7): when `specflow upgrade` previously migrated vanilla
-   * agent files to the `claude-specflow` plugin (deleted from disk +
+   * agent files to the `specflow-plugin` plugin (deleted from disk +
    * dropped from lock), and the user later uninstalled the plugin,
    * those files are now silently absent. This check warns once per
    * missing path so the user can recover via `specflow upgrade` or
@@ -119,7 +119,7 @@ export class FsProjectInspector implements ProjectInspector {
         name: dest,
         status: "warn",
         message:
-          "missing — restore via `specflow upgrade` or install the plugin (`/plugin install claude-specflow`)",
+          "missing — restore via `specflow upgrade` or install the plugin (`/plugin install specflow-plugin`)",
       });
     }
     return outcomes;

--- a/tests/infrastructure/fs_plugin_detector_test.ts
+++ b/tests/infrastructure/fs_plugin_detector_test.ts
@@ -19,13 +19,13 @@ Deno.test("FsPluginDetector returns true when ~/.claude/plugins/cache/<name>/ ex
   await withFakeHome(
     async (home) => {
       await Deno.mkdir(
-        join(home, ".claude/plugins/cache/claude-specflow"),
+        join(home, ".claude/plugins/cache/specflow-plugin"),
         { recursive: true },
       );
     },
     async (home) => {
       const det = new FsPluginDetector(home);
-      assertEquals(await det.isPluginInstalled("claude-specflow"), true);
+      assertEquals(await det.isPluginInstalled("specflow-plugin"), true);
     },
   );
 });
@@ -35,7 +35,7 @@ Deno.test("FsPluginDetector returns false when the cache dir is missing", async 
     async (_home) => {/* empty home */},
     async (home) => {
       const det = new FsPluginDetector(home);
-      assertEquals(await det.isPluginInstalled("claude-specflow"), false);
+      assertEquals(await det.isPluginInstalled("specflow-plugin"), false);
     },
   );
 });
@@ -50,7 +50,7 @@ Deno.test("FsPluginDetector returns false when a sibling plugin is installed but
     },
     async (home) => {
       const det = new FsPluginDetector(home);
-      assertEquals(await det.isPluginInstalled("claude-specflow"), false);
+      assertEquals(await det.isPluginInstalled("specflow-plugin"), false);
     },
   );
 });
@@ -60,20 +60,20 @@ Deno.test("FsPluginDetector returns false when the cache path exists but is a fi
     async (home) => {
       await Deno.mkdir(join(home, ".claude/plugins/cache"), { recursive: true });
       await Deno.writeTextFile(
-        join(home, ".claude/plugins/cache/claude-specflow"),
+        join(home, ".claude/plugins/cache/specflow-plugin"),
         "oops",
       );
     },
     async (home) => {
       const det = new FsPluginDetector(home);
-      assertEquals(await det.isPluginInstalled("claude-specflow"), false);
+      assertEquals(await det.isPluginInstalled("specflow-plugin"), false);
     },
   );
 });
 
 Deno.test("FsPluginDetector returns false when HOME is not resolvable (null)", async () => {
   const det = new FsPluginDetector(null);
-  assertEquals(await det.isPluginInstalled("claude-specflow"), false);
+  assertEquals(await det.isPluginInstalled("specflow-plugin"), false);
 });
 
 Deno.test("FsPluginDetector default constructor reads HOME from the environment", () => {

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -840,7 +840,7 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specflow upgrade"), true);
-      assertEquals(o.message.includes("/plugin install claude-specflow"), true);
+      assertEquals(o.message.includes("/plugin install specflow-plugin"), true);
     }
   });
 });

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -22,7 +22,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
   },
   // Dual-copy commands: 10 specflow.* sources, each landing as
   // `plugin/skills/<name>/SKILL.md` (the `specflow.` prefix is
-  // dropped because the plugin namespace `claude-specflow:` already
+  // dropped because the plugin namespace `specflow-plugin:` already
   // disambiguates).
   ...[
     "analyze",
@@ -60,8 +60,8 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
   // The groom skill: source folder is `templates/core/skills/specflow.groom/`
   // (binary scaffolds it as a project skill with the namespaced short
   // form), but the plugin folder drops the `specflow.` prefix because
-  // the plugin namespace `claude-specflow:` already disambiguates —
-  // the plugin command becomes `/claude-specflow:groom`.
+  // the plugin namespace `specflow-plugin:` already disambiguates —
+  // the plugin command becomes `/specflow-plugin:groom`.
   {
     plugin: "plugin/skills/groom/SKILL.md",
     source: "templates/core/skills/specflow.groom/SKILL.md",
@@ -89,12 +89,12 @@ for (const pair of SYNC_PAIRS) {
 }
 
 Deno.test(
-  "plugin/.claude-plugin/plugin.json declares name 'claude-specflow'",
+  "plugin/.claude-plugin/plugin.json declares name 'specflow-plugin'",
   async () => {
     const manifest = JSON.parse(
       await Deno.readTextFile(abs("plugin/.claude-plugin/plugin.json")),
     );
-    assertEquals(manifest.name, "claude-specflow");
+    assertEquals(manifest.name, "specflow-plugin");
     assertEquals(typeof manifest.description, "string");
     assertEquals(typeof manifest.version, "string");
   },


### PR DESCRIPTION
Closes #116. Renames the plugin from \`claude-specflow\` to \`specflow-plugin\` per Kevin's reconsideration of Q1 of #73.

## Why now

v0.12.0 (the first release with the plugin) shipped minutes before this rename. **Zero users have installed \`claude-specflow\` yet** — the rename is essentially free at this moment. Waiting would require a deprecation flag, a migration command, and backwards-compat detection on the cache path. Now: search-and-replace + bump.

## Naming rationale

\`specflow-plugin\` reads as "the plugin for Specflow"; \`claude-specflow\` reads as "the Claude version of Specflow". The "leave room for cursor-plugin" argument from the original Q1 choice doesn't really hold — Cursor doesn't have the same plugin system, so there will likely never be a parallel \`cursor-plugin\` repo to keep symmetric with.

## What's in

14 files renamed. Cache path probe changed from \`~/.claude/plugins/cache/claude-specflow/\` to \`~/.claude/plugins/cache/specflow-plugin/\`. Slash-command namespace is now \`/specflow-plugin:specify\`, etc.

## Test plan

- [x] \`grep -rn "claude-specflow"\` — zero remaining references in source/tests/docs
- [x] \`deno task test\` — 437 passed (assertions sed-renamed in lockstep)
- [x] End-to-end smoke: \`init\` → fake-HOME \`upgrade --dry-run\` triggers \`21 migrated, 0 deferred, 37 unchanged\` via the new cache path

## Release plan

v0.12.1 (patch). Zero behavior change for users who don't install the plugin; the rename only affects the plugin name + cache path, which currently has zero installed users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)