### PR TITLE
docs: surface the specflow-plugin distribution channel (#100 followup)

### DIFF
--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -16,3 +16,4 @@ treatment is now part of normal conventions).
 - [Architect handoff pattern](architect-handoff-pattern.md) — when architect has already designed a solution, wire AC directly from the spec without re-deriving strategy
 - [Docs domain](docs-domain.md) — Specflow docs are at https://specflow.makerlabs.dev (custom domain on GH Pages); use this URL in docs-related issues and AC.
 - [GitHub labels](github-labels.md) — only the 9 default GitHub labels exist; do not use ux/docs/friction slugs
+- [Plugin distribution](plugin-distribution.md) — install command, slash-command namespace, 21 assets, 3 install paths, upgrade migration, check --project gap warn

--- a/.claude/agents/product-owner/memory/plugin-distribution.md
+++ b/.claude/agents/product-owner/memory/plugin-distribution.md
@@ -1,0 +1,73 @@
+---
+name: plugin-distribution
+description: Canonical facts about the specflow-plugin Claude Code plugin — install command, slash-command namespace, what it contains, the three install paths, and the upgrade/check integration.
+type: reference
+---
+
+## Plugin identity
+
+- **Plugin name**: `specflow-plugin`
+- **Manifest**: `plugin/.claude-plugin/plugin.json`
+- **Versioning**: tracks `specflow` binary version (same as templates version); both were at `0.12.1` when the plugin shipped in v0.12.0/v0.12.1.
+- **Homepage**: https://specflow.makerlabs.dev
+- **Repo**: https://github.com/mkrlabs/specflow (the `plugin/` subtree is what the plugin registry sees as `mkrlabs/specflow-plugin`)
+
+## Install command
+
+```
+/plugin install mkrlabs/specflow-plugin
+```
+
+This is the Claude Code marketplace UX. No binary needed.
+
+## Slash-command namespace
+
+Plugin skills are namespaced: `/specflow-plugin:specify`, `/specflow-plugin:plan`, etc.
+Binary-scaffolded project copies use the short form: `/specify`, `/plan`, etc.
+
+## What the plugin contains (21 assets)
+
+- 10 specflow.* slash-command skills (`specify`, `plan`, `tasks`, `implement`, `analyze`, `review`, `merge`, `constitution`, `checklist`, `clarify`) — in `plugin/skills/`
+- 1 auto-chain skill — `plugin/skills/auto-chain/SKILL.md`
+- 1 groom skill — `plugin/skills/specflow.groom/SKILL.md`
+- 9 sub-agents (`code-reviewer`, `developer`, `devops-sre`, `product-owner`, `qa-tester`, `review-coordinator`, `security-auditor`, `test-reviewer`, `workflow-manager`) — in `plugin/agents/`
+
+**Not in the plugin** (binary-owned, project-stateful): backlog skill, backlog scripts, hooks, settings.json, CLAUDE.md, AGENTS.md, .specflow/ tree, architect agent.
+
+## Three install paths
+
+| Path | How | Scope | Slash-command style |
+|------|-----|-------|---------------------|
+| `/plugin install mkrlabs/specflow-plugin` | Claude Code marketplace | User-scope (all projects) | `/specflow-plugin:specify` |
+| `specflow init` | Binary CLI | Project-scope (.claude/) | `/specify` |
+| `claude --plugin-dir /path/to/specflow/plugin` | Local dev only | Session-scope | `/specflow-plugin:specify` |
+
+## Plugin coverage predicate
+
+`src/domain/plugin_coverage.ts` — `isPluginCoveredPath(harness, dest)`:
+- Claude harness only.
+- Covers: `.claude/agents/<name>.md` (all except `architect.md`) + `.claude/skills/specflow.*/SKILL.md` (10 files) + `.claude/skills/auto-chain/SKILL.md` + `.claude/skills/specflow.groom/SKILL.md`.
+- Total: 21 covered paths (`PLUGIN_COVERED_PATHS_CLAUDE` array).
+
+## upgrade-time migration behavior
+
+When `specflow upgrade` runs AND harness is `claude` AND plugin is installed:
+- **Vanilla file on disk** (SHA matches lock) → `migrate-to-plugin`: backed up + deleted from disk; plugin serves it going forward. File is dropped from the lock.
+- **Customized file on disk** (SHA differs) → `preserve` with `pluginAvailable: true` flag; user sees `[plugin available — reconcile manually]` warning in upgrade output.
+- **File already missing** (plugin owns it, nothing on disk) → `defer-to-plugin`: noted in plan, no action needed.
+
+Plugin install detection: `src/infrastructure/fs_plugin_detector.ts` checks `~/.claude/plugins/cache/specflow-plugin/` existence via `Deno.stat`.
+
+## check --project warn: "plugin gap"
+
+`specflow check --project` runs `checkPluginGap`:
+- Only for claude-harness projects.
+- Only when plugin is NOT installed.
+- For each of the 21 PLUGIN_COVERED_PATHS, if the file is missing on disk → warn:
+  > "missing — restore via `specflow upgrade` or install the plugin (`/plugin install specflow-plugin`)"
+
+This fires when a user previously ran `specflow upgrade` with the plugin installed (files got migrated away) and then uninstalled the plugin — the covered files are now silently absent.
+
+## Known caveat (as of v0.12.1)
+
+Handoff IDs in plugin skill SKILL.md files reference binary-scaffolded IDs (`specflow.plan`, etc.), not plugin-namespaced IDs (`specflow-plugin:plan`). Clickable handoff buttons may not resolve in plugin scope. Tracked in issue #73.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ harness (same as upstream).
 
 Specflow scaffolds for one AI harness per invocation:
 
-- **Claude Code** (default) — `specflow init <name>` or `--ai claude`
-- **Cursor** — `specflow init <name> --ai cursor`
-
-Additional harnesses (Codex CLI, GitHub Copilot, Gemini CLI, Windsurf, …) are planned for later
-releases. See `AGENTS.md` for the roadmap.
+| Flag                    | Harness            |
+| ----------------------- | ------------------ |
+| `--ai claude` (default) | Claude Code        |
+| `--ai cursor`           | Cursor             |
+| `--ai codex`            | Codex CLI          |
+| `--ai gemini`           | Gemini CLI         |
+| `--ai windsurf`         | Windsurf           |
+| `--ai copilot`          | GitHub Copilot CLI |
+| `--ai opencode`         | OpenCode           |
+| `--ai antigravity`      | Antigravity        |
 
 ## Installation
 
@@ -59,6 +64,26 @@ On macOS, you may need to clear the quarantine attribute after download:
 xattr -d com.apple.quarantine /path/to/specflow
 ```
 
+## Claude Code plugin
+
+If you use Claude Code, you can also install Specflow as a user-scope plugin — no binary required,
+available across all your projects:
+
+```
+/plugin install mkrlabs/specflow-plugin
+```
+
+The plugin ships 10 slash-command skills, 1 auto-chain skill, 1 groom skill, and 9 sub-agents.
+Slash-commands are namespaced (`/specflow-plugin:specify`, `/specflow-plugin:plan`, etc.) and
+coexist with project-local copies from `specflow init`.
+
+**When to use the plugin vs the binary:**
+
+- Plugin: cross-project, always up-to-date, no `specflow init` needed, namespaced commands.
+- Binary: project-local customization, short slash-commands (`/specify`), backlog + hooks support.
+
+Most teams use both. See [the docs](https://specflow.makerlabs.dev) for the full boundary table.
+
 ## Upgrading an existing project
 
 When you update the `specflow` binary (via `specflow self-update` or Homebrew), the bundled
@@ -72,6 +97,12 @@ specflow upgrade --force      # overwrite customized files (backed up to .specfl
 
 Specflow tracks the SHA256 of each template in `.specflow/installed.lock` so it can detect your
 local edits and avoid overwriting them. Commit this lock file alongside your project.
+
+When the `specflow-plugin` Claude Code plugin is installed and the project harness is `claude`,
+`specflow upgrade` auto-migrates vanilla agent and command files to the plugin (backs them up, then
+removes them from disk — the plugin serves them going forward). Customized files are preserved with
+a warning. If you later uninstall the plugin, `specflow check --project` will warn about any covered
+files that are now missing and tell you how to recover them.
 
 ## Development setup
 

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -50,6 +50,39 @@ Manual download: pick the binary for your OS/arch from
 `$PATH`. On macOS clear the quarantine attribute with
 `xattr -d com.apple.quarantine /path/to/specflow`.
 
+### Install the Claude Code plugin
+
+If you use Claude Code and want Specflow's slash-commands and sub-agents available across **all your
+projects** without running `specflow init`, install the Claude Code plugin:
+
+```
+/plugin install mkrlabs/specflow-plugin
+```
+
+The plugin ships the same 21 assets the binary scaffolds — 10 slash-command skills, 1 auto-chain
+skill, 1 groom skill, and 9 sub-agents — but at user scope, versioned, and auto-updated via
+`/plugin update`. Slash-commands are namespaced: `/specflow-plugin:specify`,
+`/specflow-plugin:plan`, etc.
+
+To test a local checkout of the plugin without publishing:
+
+```bash
+claude --plugin-dir /path/to/specflow/plugin
+```
+
+**Plugin vs `specflow init`** — they complement each other:
+
+| Aspect                             | Binary (`specflow init`)    | Plugin (`/plugin install`)              |
+| ---------------------------------- | --------------------------- | --------------------------------------- |
+| Scope                              | Project-local (`.claude/`)  | User-scope (all projects)               |
+| Slash-command style                | `/specify`, `/plan` (short) | `/specflow-plugin:specify` (namespaced) |
+| Customizable per-project           | Yes                         | No (user-scope, shared)                 |
+| Backlog skill, hooks, `.specflow/` | Yes                         | No (project-stateful — binary-only)     |
+| Kept in sync                       | `specflow upgrade`          | `/plugin update`                        |
+
+Most teams use both: the plugin provides discoverability and keeps the agents up-to-date across all
+projects; `specflow init` provides the short slash-commands and project-local customization.
+
 ## Quickstart
 
 ### Create a new project
@@ -139,7 +172,10 @@ when stdin is a TTY, and falls back to a numeric prompt — or the defaults — 
 ```bash
 specflow check                    # diagnose your environment
 specflow check --project          # also diagnose the current specflow project
+                                  #   (warns if the plugin was uninstalled after migration)
 specflow upgrade                  # update templates to the binary's version
+                                  #   (when specflow-plugin is installed + harness=claude:
+                                  #    vanilla agent/command files are auto-migrated to the plugin)
 specflow upgrade --dry-run        # preview the upgrade plan
 specflow upgrade --force          # apply destructive changes (backs up customizations)
 specflow self-update              # upgrade the binary itself
@@ -167,7 +203,7 @@ frontmatter conventions.
 
 ## What makes Specflow different from upstream Spec Kit
 
-Specflow is a fork of the official `specify` CLI with three additions:
+Specflow is a fork of the official `specify` CLI with four additions:
 
 ### 1. Auto-chained pipeline
 
@@ -199,6 +235,26 @@ A Product Owner agent gates every mutation, and supports three backends:
 
 The user picks one backend per project. The chosen backend is recorded in `.specflow/installed.lock`
 so the PO knows which one to use without auto-detection.
+
+### 4. Claude Code plugin distribution
+
+Specflow ships a first-class Claude Code plugin (`specflow-plugin`) available via the Claude Code
+marketplace:
+
+```
+/plugin install mkrlabs/specflow-plugin
+```
+
+The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
+sub-agents — no binary, no `specflow init` required. The 21 plugin assets (10 slash-command skills
+
+- auto-chain + groom + 9 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist with
+  project-local copies without collision.
+
+When both the plugin and the binary are in use, `specflow upgrade` detects the plugin and
+auto-migrates vanilla on-disk agents and command files (backed up, then deleted — the plugin serves
+them going forward). `specflow check --project` warns when covered files are missing and the plugin
+is not installed, with a recovery hint.
 
 ## Design principles
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -6,18 +6,20 @@ into projects — just as a user-scope plugin instead.
 
 ## What's in here
 
-| Path                                                                                                                                        | Contents                                                          |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specflow-plugin`, v0.0.1 alpha)                 |
-| `skills/auto-chain/SKILL.md`                                                                                                                | Auto-chain skill — `/specflow-plugin:auto-chain`                  |
-| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/specflow-plugin:specify`, etc. |
-| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                  |
-| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specflow-plugin:groom`                            |
+| Path                                                                                                                                        | Contents                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specflow-plugin`, lockstep with the binary version) |
+| `skills/auto-chain/SKILL.md`                                                                                                                | Auto-chain skill — `/specflow-plugin:auto-chain`                      |
+| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/specflow-plugin:specify`, etc.     |
+| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                      |
+| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specflow-plugin:groom`                                |
 
-**Coming in subsequent slices** (tracked in
-[issue #73](https://github.com/mkrlabs/specflow/issues/73)):
-
-- `PluginDetector` port + the v0.x → plugin migration logic in `specflow upgrade`.
+The full plugin migration shipped in v0.12.x (issue
+[#73](https://github.com/mkrlabs/specflow/issues/73)). When the plugin is installed and the project
+harness is `claude`, `specflow upgrade` auto-migrates vanilla on-disk agents to the plugin (backs
+them up, then removes them — the plugin serves them going forward). `specflow check
+--project` warns
+about any plugin-covered files that are missing when the plugin is uninstalled.
 
 ### Known caveat: handoff IDs
 
@@ -41,13 +43,11 @@ discoverability layer, not the polished workflow. Handoff rewriting is a known f
 See [the design doc](../docs/superpowers/specs/2026-05-08-claude-plugin-design.md) for the full
 plugin / binary boundary and the v0.x → plugin migration logic.
 
-## Install (when ready)
+## Install
 
 ```bash
 /plugin install mkrlabs/specflow-plugin
 ```
-
-(The plugin is currently `0.0.1` — pre-release. Wait for v0.1.0 before relying on it in production.)
 
 ## Local development
 
@@ -61,5 +61,6 @@ Then invoke any plugin skill: `/specflow-plugin:auto-chain specify "…"`.
 
 ## Versioning
 
-The plugin is on `0.0.1` and will move to lockstep with the `specflow` binary once the migration
-logic (slices 4–6 in #73) lands. Until then, treat it as alpha — bumps may be breaking.
+The plugin's `version` field in `.claude-plugin/plugin.json` is kept in lockstep with the `specflow`
+binary by `scripts/bump-version.ts`, which is run as part of every `/release`. The release pipeline
+(`.github/workflows/release.yml`) hard-fails on any drift between the two.


### PR DESCRIPTION
Docs-upkeep audit caught the gap: v0.12.0 + v0.12.1 introduced the **specflow-plugin** Claude Code distribution channel, but **zero** mentions of it landed in any of the four user-facing doc surfaces.

Found by Kevin asking "on a une doc en place pour l'utilisation du plugin sur le site et le llms.txt ? le @.claude/agents/product-owner/ est au courant ?". Dispatched the PO in docs-upkeep mode (the #100 pattern); it confirmed both gaps and proposed concrete patches.

## What's in

### `docs/llms.md` (the canonical website page)
- New **"Install the Claude Code plugin"** subsection with the install command, 21-asset summary, `--plugin-dir` dev path, and a plugin-vs-binary boundary table
- Annotations on `specflow upgrade` and `specflow check --project` in "Other commands" highlighting plugin-aware behaviors
- New **4th differentiator**: "Claude Code plugin distribution"

### `README.md`
- Replaced the **stale "Supported AI harnesses" list** (claimed Codex/Copilot/Gemini/Windsurf were planned — they shipped weeks ago) with a current 8-row table
- New **"Claude Code plugin"** section after Installation
- Extended **"Upgrading an existing project"** with the plugin-aware migration behavior

### `plugin/README.md`
- Dropped the "Coming in subsequent slices" placeholder (#73 is fully shipped)
- Tightened the install + versioning sections to reflect the lockstep bump + release.yml pre-flight

### PO memory
- New `plugin-distribution.md` captures canonical facts (plugin name, install command, slash-command namespace, install-path matrix) so future docs-upkeep dispatches don't re-derive

## Test plan

- [x] `deno task test` — 437 passed (no source changes)
- [x] `deno task fmt` — clean
- [x] All 4 doc surfaces now reference the plugin where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)