### PR TITLE
feat(init): add skip-if-exists category for placeholder files (#119)

### DIFF
--- a/scripts/bundle-templates.ts
+++ b/scripts/bundle-templates.ts
@@ -15,6 +15,8 @@ type CoreManifestEntry = {
   executable?: boolean;
   /** When set, the entry only applies if this backend is selected. */
   backend?: "local" | "github" | "gitlab";
+  /** When true, the file is only written if absent (placeholder semantics). */
+  skipIfExists?: boolean;
 };
 
 type HarnessStaticManifestEntry = {
@@ -68,6 +70,7 @@ async function buildCoreEntries(m: Manifest): Promise<string[]> {
     const content = await Deno.readTextFile(abs);
     const suffix = entry.suffix === undefined ? "null" : JSON.stringify(entry.suffix);
     const backend = entry.backend === undefined ? "null" : JSON.stringify(entry.backend);
+    const skipIfExists = entry.skipIfExists === true ? "true" : "false";
     lines.push(
       `  {\n` +
         `    category: ${JSON.stringify(entry.category)},\n` +
@@ -76,6 +79,7 @@ async function buildCoreEntries(m: Manifest): Promise<string[]> {
         `    content: \`${escapeTemplateLiteral(content)}\`,\n` +
         `    executable: ${entry.executable === true},\n` +
         `    backend: ${backend},\n` +
+        `    skipIfExists: ${skipIfExists},\n` +
         `  }`,
     );
   }

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -79,8 +79,13 @@ export class InitProjectUseCase {
     });
 
     const now = (this.deps.now ?? (() => new Date()))().toISOString();
+    // Skip-if-exists files that pre-existed are user-owned, not
+    // Specflow-managed — keep them out of the lock so future upgrades
+    // don't try to reconcile them against the placeholder content.
+    const skippedSet = new Set(report.skippedSkipIfExists);
     const lockEntries = new Map<string, LockEntry>();
     for (const [dest, file] of Object.entries(bundle)) {
+      if (skippedSet.has(dest)) continue;
       // For mergeable files the lock holds the SHA of the *block body in
       // canonical form* (no leading/trailing newlines) so it stays
       // comparable against the body extracted from disk on upgrade reads.

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -19,6 +19,14 @@ export interface FsWriter {
 
 export type BackupReport = {
   readonly backups: ReadonlyArray<{ readonly dest: string; readonly backupPath: string }>;
+  /**
+   * Dests that were silently skipped because the file pre-existed AND the
+   * bundle entry had `skipIfExists: true` (placeholder semantics — the
+   * user's existing content always wins). Always present; empty when no
+   * placeholder skipping happened. The init use case omits these dests
+   * from the lock since they aren't Specflow-managed.
+   */
+  readonly skippedSkipIfExists: ReadonlyArray<string>;
 };
 
 export interface GitAdapter {

--- a/src/domain/core_bundle.ts
+++ b/src/domain/core_bundle.ts
@@ -23,6 +23,13 @@ export type CoreEntry = {
    * Absent or `null` means the entry applies regardless of backend.
    */
   readonly backend?: BacklogBackend | null;
+  /**
+   * When `true`, the harness's `mapBundle` propagates this to the resulting
+   * `TemplateFile.skipIfExists`. Used for placeholder files (`AGENTS.md`,
+   * `.specflow/memory/constitution.md`) where the user's existing content
+   * is always more useful than our empty template — see #119.
+   */
+  readonly skipIfExists?: boolean;
 };
 
 export type CoreBundle = ReadonlyArray<CoreEntry>;

--- a/src/domain/template.ts
+++ b/src/domain/template.ts
@@ -13,6 +13,18 @@ export type TemplateFile = {
    * on disk, it is replaced; otherwise it is appended to the end.
    */
   mergeBlock?: string;
+  /**
+   * When `true`, the file is treated as a placeholder: the bundled `content`
+   * is only written when no file already exists at the destination. If a
+   * file is already there (e.g. brownfield project with an existing
+   * `AGENTS.md`), the binary leaves it untouched, no error, no `--force`
+   * needed. The user's existing content is always more useful than the
+   * empty placeholder we ship.
+   *
+   * Skip-if-exists files that pre-existed are NOT recorded in
+   * `installed.lock` — they are user-owned, not Specflow-managed.
+   */
+  skipIfExists?: true;
 };
 
 export type Bundle = Record<string, TemplateFile>;

--- a/src/infrastructure/deno_fs_writer.ts
+++ b/src/infrastructure/deno_fs_writer.ts
@@ -33,6 +33,9 @@ export class DenoFsWriter implements FsWriter {
       // Mergeable files merge non-destructively into any pre-existing content,
       // so they are never conflicts.
       if (file.mergeBlock !== undefined) continue;
+      // Skip-if-exists files (placeholders like AGENTS.md) silently leave
+      // the user's existing file alone — also never a conflict.
+      if (file.skipIfExists === true) continue;
       const abs = join(resolved, dest);
       if (await fileExists(abs)) conflicts.push(dest);
     }
@@ -61,6 +64,7 @@ export class DenoFsWriter implements FsWriter {
     }
 
     const backups: { dest: string; backupPath: string }[] = [];
+    const skippedSkipIfExists: string[] = [];
 
     for (const [dest, file] of Object.entries(bundle)) {
       const abs = join(resolved, dest);
@@ -76,6 +80,20 @@ export class DenoFsWriter implements FsWriter {
         continue;
       }
 
+      // Skip-if-exists placeholders: only write if the file is absent
+      // AND the caller didn't request overwrite. With overwrite=true
+      // (i.e. `--force` from init or any upgrade call), the placeholder
+      // is treated like an owned file: the existing content is backed
+      // up and the bundle content is written. This preserves the
+      // existing `upgrade --force` semantics for files that init
+      // originally created (lock-tracked → standard upgrade path).
+      if (
+        file.skipIfExists === true && !overwrite && (await fileExists(abs))
+      ) {
+        skippedSkipIfExists.push(dest);
+        continue;
+      }
+
       if (backupExisting && (await fileExists(abs))) {
         const backupAbs = `${abs}${BACKUP_SUFFIX}`;
         await Deno.rename(abs, backupAbs);
@@ -88,7 +106,7 @@ export class DenoFsWriter implements FsWriter {
       }
     }
 
-    return { backups };
+    return { backups, skippedSkipIfExists };
   }
 
   async deletePaths(
@@ -113,6 +131,6 @@ export class DenoFsWriter implements FsWriter {
       }
     }
 
-    return { backups };
+    return { backups, skippedSkipIfExists: [] };
   }
 }

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -89,6 +89,7 @@ export class AntigravityHarness implements Harness {
         content,
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+        ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
     }
     return out;

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -61,6 +61,7 @@ export class ClaudeHarness implements Harness {
         content,
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+        ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
     }
     const staticFiles = HARNESS_STATIC[this.key] ?? {};

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -64,6 +64,7 @@ export class CodexHarness implements Harness {
           out[`.specflow/${entry.suffix}`] = {
             content: entry.content,
             executable: entry.executable,
+            ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
           };
           break;
         case "project-root":
@@ -71,6 +72,7 @@ export class CodexHarness implements Harness {
           out[entry.suffix] = {
             content: entry.content,
             executable: entry.executable,
+            ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
           };
           break;
         case "mergeable-project-root":

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -54,6 +54,7 @@ export class CopilotHarness implements Harness {
         content: isInstruction ? toCopilotInstructionMarkdown(entry) : entry.content,
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+        ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
     }
     return out;

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -52,6 +52,7 @@ export class CursorHarness implements Harness {
         content,
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+        ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       } satisfies TemplateFile;
     }
     const staticFiles = HARNESS_STATIC[this.key] ?? {};

--- a/src/infrastructure/harness/gemini_harness.ts
+++ b/src/infrastructure/harness/gemini_harness.ts
@@ -72,6 +72,7 @@ export class GeminiHarness implements Harness {
           out[`.specflow/${entry.suffix}`] = {
             content: entry.content,
             executable: entry.executable,
+            ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
           };
           break;
         case "project-root":
@@ -79,6 +80,7 @@ export class GeminiHarness implements Harness {
           out[entry.suffix] = {
             content: entry.content,
             executable: entry.executable,
+            ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
           };
           break;
         case "mergeable-project-root":

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -152,6 +152,7 @@ export class OpenCodeHarness implements Harness {
         content,
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+        ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
     }
     return out;

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -50,6 +50,7 @@ export class WindsurfHarness implements Harness {
         content: entry.content,
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
+        ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
     }
     return out;

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -214,6 +214,7 @@ Success criteria must be **measurable** (specific metrics), **technology-agnosti
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -388,6 +389,7 @@ Hooks with non-empty \`condition\` are deferred to the HookExecutor.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -549,6 +551,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -761,6 +764,7 @@ Every task MUST strictly follow this format:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -1022,6 +1026,7 @@ After reporting, check if \`.specflow/extensions.yml\` exists in the project roo
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -1232,6 +1237,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -1391,6 +1397,7 @@ Check if \`.specflow/extensions.yml\` exists in the project root.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -1568,6 +1575,7 @@ Hooks with non-empty \`condition\` are deferred to the HookExecutor.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -1611,6 +1619,7 @@ suggested action (e.g. \`/backlog update <id> --status done\`).
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "command",
@@ -1707,6 +1716,7 @@ STOP #2). If FAIL, stop and report to the user.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "backlog-cmd",
@@ -1781,6 +1791,7 @@ Do not duplicate it here — the dispatcher defers to the agent.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2039,6 +2050,7 @@ missing key as \`parent: null\`.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2115,6 +2127,7 @@ failed, and what decision the next owner needs to make.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2170,6 +2183,7 @@ MEDIUM / LOW findings: <N>, list suppressed — see per-agent reports for detail
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2224,6 +2238,7 @@ PASS if zero CRITICAL and zero HIGH findings. Otherwise FAIL.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2263,6 +2278,7 @@ Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2300,6 +2316,7 @@ Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2358,6 +2375,7 @@ QA SUMMARY
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2419,6 +2437,7 @@ review or QA fails twice on the same issue family, stop and escalate.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent",
@@ -2532,6 +2551,7 @@ End with a single \`VERDICT\` line: \`VERDICT: pass\` or
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent-memory",
@@ -2574,6 +2594,7 @@ across sessions and isn't captured elsewhere:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent-memory",
@@ -2615,6 +2636,7 @@ survive across sessions and isn't captured elsewhere:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent-memory",
@@ -2658,6 +2680,7 @@ survive across sessions and isn't captured elsewhere:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent-memory",
@@ -2702,6 +2725,7 @@ should survive across sessions and isn't captured elsewhere:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "agent-memory",
@@ -2746,6 +2770,7 @@ should survive across sessions and isn't captured elsewhere:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "skill",
@@ -2847,6 +2872,7 @@ them resume manually from the last completed phase.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "skill",
@@ -2943,6 +2969,7 @@ to be a **no-op when the project is healthy**.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "backlog-skill",
@@ -3183,6 +3210,7 @@ The first time the PO runs against this project, it will create the 5
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3213,6 +3241,7 @@ done
 `,
     executable: true,
     backend: "local",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3240,6 +3269,7 @@ cat "\${matches[0]}"
 `,
     executable: true,
     backend: "local",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3302,6 +3332,7 @@ echo "  \$FILE"
 `,
     executable: true,
     backend: "local",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3367,6 +3398,7 @@ echo "✓ #\$NUM → \$STATUS"
 `,
     executable: true,
     backend: "local",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3407,6 +3439,7 @@ echo "✓ added clarification on #\$NUM"
 `,
     executable: true,
     backend: "local",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3453,6 +3486,7 @@ export REPO REPO_OWNER REPO_NAME PROJECT_NUMBER
 `,
     executable: true,
     backend: "github",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3507,6 +3541,7 @@ echo "\$JSON" | jq -r --argjson project "\$PROJECT_NUMBER" --arg filter "\$FILTE
 `,
     executable: true,
     backend: "github",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3529,6 +3564,7 @@ gh issue view "\$1" --repo "\$REPO" --comments
 `,
     executable: true,
     backend: "github",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3563,6 +3599,7 @@ echo "✓ attached to Project #\$PROJECT_NUMBER"
 `,
     executable: true,
     backend: "github",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3623,6 +3660,7 @@ echo "✓ #\$NUM → \$STATUS"
 `,
     executable: true,
     backend: "github",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3645,6 +3683,7 @@ gh issue comment "\$1" --repo "\$REPO" --body "\$2"
 `,
     executable: true,
     backend: "github",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3690,6 +3729,7 @@ export PROJECT_ID
 `,
     executable: true,
     backend: "gitlab",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3722,6 +3762,7 @@ echo "\$JSON" | jq -r --arg filter "\$FILTER" '
 `,
     executable: true,
     backend: "gitlab",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3744,6 +3785,7 @@ glab issue view "\$1" --repo "\$PROJECT_ID" --comments
 `,
     executable: true,
     backend: "gitlab",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3782,6 +3824,7 @@ echo "✓ created: \$URL"
 `,
     executable: true,
     backend: "gitlab",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3829,6 +3872,7 @@ echo "✓ #\$NUM → Status::\$STATUS"
 `,
     executable: true,
     backend: "gitlab",
+    skipIfExists: false,
   },
   {
     category: "backlog-script",
@@ -3851,6 +3895,7 @@ glab issue note "\$1" --repo "\$PROJECT_ID" --message "\$2"
 `,
     executable: true,
     backend: "gitlab",
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -3870,6 +3915,7 @@ glab issue note "\$1" --repo "\$PROJECT_ID" --message "\$2"
 `,
     executable: false,
     backend: null,
+    skipIfExists: true,
   },
   {
     category: "spec-root",
@@ -3930,6 +3976,7 @@ _No tasks yet._
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4066,6 +4113,7 @@ _No tasks yet._
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4178,6 +4226,7 @@ directories captured above]
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4437,6 +4486,7 @@ With multiple developers:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4485,6 +4535,7 @@ With multiple developers:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4543,6 +4594,7 @@ With multiple developers:
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4579,6 +4631,7 @@ Auto-generated from all feature plans. Last updated: [DATE]
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -4777,6 +4830,7 @@ fi
 `,
     executable: true,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -5383,6 +5437,7 @@ except Exception:
 `,
     executable: true,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -5804,6 +5859,7 @@ fi
 `,
     executable: true,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -5885,6 +5941,7 @@ fi
 `,
     executable: true,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -6041,6 +6098,7 @@ if (\$Json) {
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -6623,6 +6681,7 @@ except Exception:
 }`,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -7013,6 +7072,7 @@ if (\$Json) {
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "spec-root",
@@ -7082,6 +7142,7 @@ if (\$Json) {
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
   {
     category: "project-root",
@@ -7115,6 +7176,7 @@ Generated by Specflow. Edit freely.
 `,
     executable: false,
     backend: null,
+    skipIfExists: true,
   },
   {
     category: "mergeable-project-root",
@@ -7125,6 +7187,7 @@ Generated by Specflow. Edit freely.
 `,
     executable: false,
     backend: null,
+    skipIfExists: false,
   },
 ];
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -51,7 +51,7 @@
     { "category": "backlog-script", "name": "move", "suffix": "move.sh", "source": "core/skills/backlog/scripts/gitlab/move.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "clarify-comment", "suffix": "clarify-comment.sh", "source": "core/skills/backlog/scripts/gitlab/clarify-comment.sh", "executable": true, "backend": "gitlab" },
 
-    { "category": "spec-root", "name": "specify", "suffix": "memory/constitution.md", "source": "core/specflow/memory/constitution.md" },
+    { "category": "spec-root", "name": "specify", "suffix": "memory/constitution.md", "source": "core/specflow/memory/constitution.md", "skipIfExists": true },
     { "category": "spec-root", "name": "specify", "suffix": "backlog.md", "source": "core/specflow/backlog.md" },
     { "category": "spec-root", "name": "specify", "suffix": "templates/spec-template.md", "source": "core/specflow/templates/spec-template.md" },
     { "category": "spec-root", "name": "specify", "suffix": "templates/plan-template.md", "source": "core/specflow/templates/plan-template.md" },
@@ -68,7 +68,7 @@
     { "category": "spec-root", "name": "specify", "suffix": "scripts/powershell/create-new-feature.ps1", "source": "core/specflow/scripts/powershell/create-new-feature.ps1" },
     { "category": "spec-root", "name": "specify", "suffix": "scripts/powershell/setup-plan.ps1", "source": "core/specflow/scripts/powershell/setup-plan.ps1" },
 
-    { "category": "project-root", "name": "root", "suffix": "AGENTS.md", "source": "core/root/AGENTS.md" },
+    { "category": "project-root", "name": "root", "suffix": "AGENTS.md", "source": "core/root/AGENTS.md", "skipIfExists": true },
     { "category": "mergeable-project-root", "name": "root", "suffix": ".gitignore", "source": "core/root/.gitignore" }
   ],
   "harness_static": [

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -28,9 +28,9 @@ function fakeFsWriter(conflicts: string[] = []): FsWriter & { written: string[] 
     detectConflicts: () => Promise.resolve(conflicts),
     writeBundle: (bundle, targetDir) => {
       for (const dest of Object.keys(bundle)) written.push(`${targetDir}:${dest}`);
-      return Promise.resolve({ backups: [] });
+      return Promise.resolve({ backups: [], skippedSkipIfExists: [] });
     },
-    deletePaths: () => Promise.resolve({ backups: [] }),
+    deletePaths: () => Promise.resolve({ backups: [], skippedSkipIfExists: [] }),
   };
 }
 
@@ -221,9 +221,9 @@ Deno.test("InitProjectUseCase with force=true skips conflict detection and reque
     },
     writeBundle: (_b, _t, options) => {
       passedBackupExisting = options?.backupExisting === true;
-      return Promise.resolve({ backups: [] });
+      return Promise.resolve({ backups: [], skippedSkipIfExists: [] });
     },
-    deletePaths: () => Promise.resolve({ backups: [] }),
+    deletePaths: () => Promise.resolve({ backups: [], skippedSkipIfExists: [] }),
   };
   const useCase = new InitProjectUseCase({
     writer,
@@ -251,8 +251,9 @@ Deno.test("InitProjectUseCase returns backups array from writer report", async (
         backups: [
           { dest: ".claude/x.md", backupPath: ".claude/x.md.specflow.bak" },
         ],
+        skippedSkipIfExists: [],
       }),
-    deletePaths: () => Promise.resolve({ backups: [] }),
+    deletePaths: () => Promise.resolve({ backups: [], skippedSkipIfExists: [] }),
   };
   const useCase = new InitProjectUseCase({
     writer,

--- a/tests/application/upgrade_project_test.ts
+++ b/tests/application/upgrade_project_test.ts
@@ -40,12 +40,12 @@ function fakeWriter(): FsWriter & {
       for (const [dest, file] of Object.entries(bundle)) {
         written.set(dest, file.content);
       }
-      return Promise.resolve({ backups: [] } as BackupReport);
+      return Promise.resolve({ backups: [], skippedSkipIfExists: [] } as BackupReport);
     },
     deletePaths: (paths, _t, options) => {
       if (options.backupExisting) deleteBackupsRequested = true;
       for (const p of paths) deleted.push(p);
-      return Promise.resolve({ backups: [] } as BackupReport);
+      return Promise.resolve({ backups: [], skippedSkipIfExists: [] } as BackupReport);
     },
   };
 }

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -305,3 +305,89 @@ Deno.test("specflow bogus returns exit code 2", async () => {
   const { code } = await runSpecflow(["bogus"]);
   assertEquals(code, 2);
 });
+
+// ── Skip-if-exists placeholders (#119) ─────────────────────────────────────
+
+Deno.test("specflow init --here on a project with existing AGENTS.md does NOT error and leaves AGENTS.md untouched", async () => {
+  await withTempDir(async (dir) => {
+    const target = join(dir, "demo");
+    await Deno.mkdir(target, { recursive: true });
+    const userAgents = "# My Project\n\nMy own architecture rules.\nLine 3.\n";
+    await Deno.writeTextFile(join(target, "AGENTS.md"), userAgents);
+
+    const { code, stderr } = await runSpecflow(
+      ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"],
+      { cwd: target },
+    );
+    assertEquals(code, 0);
+    assertEquals(
+      stderr.includes("would be overwritten"),
+      false,
+      "AGENTS.md should NOT trigger the conflict path",
+    );
+
+    // User content preserved verbatim
+    const after = await Deno.readTextFile(join(target, "AGENTS.md"));
+    assertEquals(after, userAgents);
+
+    // Init succeeded → other Specflow files installed
+    assertEquals(await exists(join(target, ".claude/CLAUDE.md")), true);
+    assertEquals(await exists(join(target, ".specflow/installed.lock")), true);
+
+    // Lock should NOT track AGENTS.md (it's user-owned)
+    const lock = await Deno.readTextFile(
+      join(target, ".specflow/installed.lock"),
+    );
+    assertEquals(
+      lock.includes("AGENTS.md"),
+      false,
+      "skip-if-exists files that pre-existed must not be in the lock",
+    );
+  });
+});
+
+Deno.test("specflow init on a fresh project writes AGENTS.md normally and tracks it in the lock", async () => {
+  await withTempDir(async (dir) => {
+    const { code } = await runSpecflow(
+      ["init", "demo", "--no-git", "--ai", "claude", "--backlog", "local"],
+      { cwd: dir },
+    );
+    assertEquals(code, 0);
+
+    const target = join(dir, "demo");
+    const agents = await Deno.readTextFile(join(target, "AGENTS.md"));
+    assertStringIncludes(agents, "AGENTS.md — Project Context");
+
+    const lock = await Deno.readTextFile(
+      join(target, ".specflow/installed.lock"),
+    );
+    assertStringIncludes(
+      lock,
+      "AGENTS.md",
+      "fresh-write skip-if-exists files DO get a lock entry",
+    );
+  });
+});
+
+Deno.test("specflow init --here on a project with existing constitution.md leaves it untouched", async () => {
+  await withTempDir(async (dir) => {
+    const target = join(dir, "demo");
+    await Deno.mkdir(join(target, ".specflow/memory"), { recursive: true });
+    const userConstitution = "# My Project Constitution\n\nMy own principles.\n";
+    await Deno.writeTextFile(
+      join(target, ".specflow/memory/constitution.md"),
+      userConstitution,
+    );
+
+    const { code } = await runSpecflow(
+      ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"],
+      { cwd: target },
+    );
+    assertEquals(code, 0);
+
+    const after = await Deno.readTextFile(
+      join(target, ".specflow/memory/constitution.md"),
+    );
+    assertEquals(after, userConstitution);
+  });
+});


### PR DESCRIPTION
Closes #119. Per Kevin: when running \`init --here\` on a brownfield project with an existing \`AGENTS.md\`, the conflict-error + force-demand was wrong UX. Specflow's bundled AGENTS.md is a 26-line placeholder; the user's existing file is always more useful.

## Behavior

New **skip-if-exists** file category. Complements existing **mergeable** (.gitignore) and **owned** (skills, agents).

| | init (default) | init --force | upgrade |
|---|---|---|---|
| Owned (today) | error if exists | overwrite + backup | normal upgrade plan |
| Mergeable (today) | merge non-destructively | merge | merge |
| **Skip-if-exists (new)** | **write if absent, leave alone if exists** | overwrite + backup | normal (preserves --force semantics) |

Files newly tagged: \`AGENTS.md\` + \`.specflow/memory/constitution.md\`.

## Lock semantics

Skip-if-exists files that **pre-existed** at init time are NOT recorded in \`installed.lock\` — they're user-owned, not Specflow-managed. When init creates them fresh, they ARE in the lock and behave like owned files for upgrade purposes.

## End-to-end verified

```
$ echo "# Existing user AGENTS.md content" > AGENTS.md
$ specflow init --here --no-git --ai claude --backlog local
✓ wrote 57 files (+ merged: .gitignore)
$ cat AGENTS.md
# Existing user AGENTS.md content   # ← preserved verbatim
```

## Test plan

- [x] \`deno task test\` — 440 passed (was 437, **+3 integration scenarios**)
- [x] Brownfield with AGENTS.md → init succeeds, file preserved, no lock entry
- [x] Greenfield → AGENTS.md written, lock tracks it
- [x] Brownfield with constitution.md → preserved
- [x] \`upgrade --force\` on lock-tracked AGENTS.md still overwrites + backs up (existing semantics preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)