### PR TITLE
test(sandbox): add smoke-all-harnesses.sh — pass/fail across all 8 (#121)

### DIFF
--- a/.claude/skills/test-sandbox/SKILL.md
+++ b/.claude/skills/test-sandbox/SKILL.md
@@ -34,20 +34,30 @@ Each script bootstraps a controlled scenario inside `sandbox/<name>/` (the `sand
 These wrap a fresh `init --ai claude --backlog local` and exercise specific feature surfaces. Each prints a `✓` / `❌` line per check and exits 0 on full pass, 1 on any failure — usable as guard rails in pre-release runs or after a refactor that touches bundled artefacts.
 
 ```bash
-.claude/skills/test-sandbox/scripts/smoke-features.sh <name>      # presence + frontmatter checks for every feature shipped after v0.9
-.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh <name> # add → list → move → view → clarify-comment round-trip on the local backend
-.claude/skills/test-sandbox/scripts/smoke-hooks.sh <name>         # fire each bundled hook with synthetic stdin, verify behavior + soft-warn semantics
-.claude/skills/test-sandbox/scripts/smoke-picker.sh <name>        # drive the interactive arrow-key picker over a real PTY (requires python3)
+.claude/skills/test-sandbox/scripts/smoke-features.sh <name>        # presence + frontmatter checks for every feature shipped after v0.9
+.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh <name>   # add → list → move → view → clarify-comment round-trip on the local backend
+.claude/skills/test-sandbox/scripts/smoke-hooks.sh <name>           # fire each bundled hook with synthetic stdin, verify behavior + soft-warn semantics
+.claude/skills/test-sandbox/scripts/smoke-picker.sh <name>          # drive the interactive arrow-key picker over a real PTY (requires python3)
+.claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh <name>   # init across all 8 harnesses, assert each scaffold is correct (auto-cleans on exit)
 ```
 
-Run all four back-to-back for a comprehensive post-refactor smoke:
+Run all five back-to-back for a comprehensive post-refactor smoke:
 
 ```bash
 bash .claude/skills/test-sandbox/scripts/smoke-features.sh feat
 bash .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh backlog
 bash .claude/skills/test-sandbox/scripts/smoke-hooks.sh hooks
 bash .claude/skills/test-sandbox/scripts/smoke-picker.sh picker
+bash .claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh allharness
 ```
+
+`smoke-all-harnesses.sh` is the cross-harness coverage gate: it bootstraps a
+fresh empty project per harness, runs `specflow init --here --no-git --ai
+<harness> --backlog local`, and asserts the harness-specific output root
+exists AND `.specflow/installed.lock` declares the right harness. Prints
+`✓ <harness>: scaffold ok` on pass and `❌ <harness>: <reason>` on fail. A
+trap on EXIT cleans up every `sandbox/<name>-<harness>/` directory it
+created, success or failure — no orphans.
 
 `smoke-picker.sh` uses Python's `pty` module to allocate a real pseudo-TTY for the
 `specflow init` subprocess so `Deno.stdin.isTerminal()` returns true and the

--- a/.claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Pass/fail smoke across all 8 harnesses.
+#
+# For each harness: bootstrap a fresh empty project, run `specflow init`
+# with that harness, and assert the harness-specific output root + the
+# installed.lock are present and well-formed. Cleans up its own sandbox
+# directories on exit (success OR failure) via a trap.
+#
+# Usage: smoke-all-harnesses.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-all-harnesses.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HARNESSES=(claude cursor codex gemini windsurf copilot opencode antigravity)
+
+# Per-harness expected output root (relative to project dir). The lock
+# declares the same key, which is also asserted. Using a case statement
+# instead of `declare -A` so the script works on macOS's stock bash 3.2.
+expected_root_for() {
+  case "$1" in
+    claude)      echo ".claude" ;;
+    cursor)      echo ".cursor" ;;
+    codex)       echo ".agents" ;;
+    gemini)      echo ".gemini" ;;
+    windsurf)    echo ".windsurf" ;;
+    copilot)     echo ".github/instructions" ;;
+    opencode)    echo ".opencode" ;;
+    antigravity) echo ".agent" ;;
+    *) echo ""; return 1 ;;
+  esac
+}
+
+# Trap-based cleanup: every sandbox/<name>-<harness> dir we create, plus
+# the bootstrap dir if any. Runs on every exit path so a failed assertion
+# never leaves orphans behind.
+cleanup() {
+  for h in "${HARNESSES[@]}"; do
+    bash "$SCRIPT_DIR/clean.sh" "$NAME-$h" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1 — $2"; fails=$((fails + 1)); }
+
+for h in "${HARNESSES[@]}"; do
+  variant="$NAME-$h"
+  bash "$SCRIPT_DIR/bootstrap-empty.sh" "$variant" >/dev/null
+
+  # `init --here` runs against the empty project; backend stays local
+  # (zero-config — no `backlog-config.yml` to worry about per harness).
+  if ! (cd "$ROOT/sandbox/$variant" && deno run --allow-all "$ROOT/src/main.ts" \
+    init --here --no-git --ai "$h" --backlog local >/dev/null 2>&1); then
+    fail "$h" "init exited non-zero"
+    continue
+  fi
+
+  expected="$(expected_root_for "$h")"
+  if [ ! -d "$ROOT/sandbox/$variant/$expected" ]; then
+    fail "$h" "expected root $expected/ missing"
+    continue
+  fi
+
+  lock="$ROOT/sandbox/$variant/.specflow/installed.lock"
+  if [ ! -f "$lock" ]; then
+    fail "$h" ".specflow/installed.lock missing"
+    continue
+  fi
+
+  if ! grep -q "^harness: $h$" "$lock"; then
+    fail "$h" "lock did not declare harness=$h"
+    continue
+  fi
+
+  pass "$h: scaffold ok ($expected/ + lock declares harness=$h)"
+done
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL 8 HARNESSES PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails HARNESS CHECK(S) FAILED ═══"
+  exit 1
+fi


### PR DESCRIPTION
Closes #121. Pass/fail smoke parity across all 8 harnesses (claude, cursor, codex, gemini, windsurf, copilot, opencode, antigravity).

## What's in

\`smoke-all-harnesses.sh\` — bootstraps a fresh empty project per harness, runs \`specflow init\`, asserts:
- harness-specific output root exists (e.g. \`.claude/\` / \`.cursor/\` / \`.agents/\` / \`.github/instructions/\` / etc.)
- \`.specflow/installed.lock\` exists
- lock declares \`harness: <expected>\`

Prints \`✓ <harness>: scaffold ok\` on pass, \`❌ <harness>: <reason>\` on fail. Exit 0 iff all 8 pass.

## Cleanup

Trap on EXIT runs \`clean.sh\` against every \`sandbox/<name>-<harness>/\` directory — success OR failure. No orphans.

## Why a new script vs extending the existing 4

The existing 4 smokes (\`features\`, \`backlog-local\`, \`hooks\`, \`picker\`) are intentionally claude-specific:
- hooks bundle is claude-only
- backlog is harness-agnostic at runtime
- picker UI is the same regardless of pick

This new script is the cross-harness scaffold gate. Different concern, kept separate.

## bash 3.2 compatibility

macOS ships bash 3.2. Used a \`case\` statement instead of \`declare -A\` (associative arrays don't exist in bash 3.x).

## Test plan

- [x] All 8 harnesses pass on local run
- [x] Sandbox cleanup verified — \`ls sandbox/\` returns empty after exit
- [x] SKILL.md updated to document the new script + extended comprehensive-smoke recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)