### PR TITLE
fix(sandbox): smoke-features.sh — sweep stragglers from #123 rename

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -51,18 +51,18 @@ echo "═══ #76  commands → skill folders ═══"
 check ".claude/commands/ has only 1 file (backlog)" \
   '[ "$(find .claude/commands -maxdepth 1 -type f -name "*.md" | wc -l | tr -d " ")" = "1" ]'
 for skill in specify constitution clarify plan tasks analyze implement merge review checklist; do
-  check ".claude/skills/specflow.$skill/SKILL.md present" \
-    "[ -f .claude/skills/specflow.$skill/SKILL.md ]"
+  check ".claude/skills/specflow-$skill/SKILL.md present" \
+    "[ -f .claude/skills/specflow-$skill/SKILL.md ]"
 done
-check "name: injected on specflow.specify SKILL.md (post-#92)" \
-  'head -3 .claude/skills/specflow.specify/SKILL.md | grep -q "name: specflow.specify"'
+check "name: injected on specflow-specify SKILL.md (post-#92)" \
+  'head -3 .claude/skills/specflow-specify/SKILL.md | grep -q "name: specflow-specify"'
 
 echo
-echo "═══ #75  loop.md + /specflow.groom ═══"
+echo "═══ #75  loop.md + /specflow-groom ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
-check "specflow.groom skill present" '[ -f .claude/skills/specflow.groom/SKILL.md ]'
+check "specflow-groom skill present" '[ -f .claude/skills/specflow-groom/SKILL.md ]'
 check "groom skill has name: (post-#92)" \
-  'head -3 .claude/skills/specflow.groom/SKILL.md | grep -q "name: specflow.groom"'
+  'head -3 .claude/skills/specflow-groom/SKILL.md | grep -q "name: specflow-groom"'
 
 echo
 echo "═══ #77  manual-only flags ═══"


### PR DESCRIPTION
Tiny follow-up to PR #124 — \`smoke-features.sh\` had 4 hardcoded paths still using the dotted form (\`specflow.\$skill\` etc.). Caught by running \`/test-sandbox\` after the v0.14.0 release. With this fix:

- All 5 sandbox smoke suites pass green
- All 8 harnesses pass smoke-all-harnesses.sh
- The upgrade migration was independently verified end-to-end: simulating a v0.13 layout (rename folders + lock back to dotted form) then running \`specflow upgrade\` correctly migrated all 11 dotted folders → hyphenated AND rewrote the lock atomically. Zero dotted paths remained post-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)