### PR TITLE
chore(v1): drop v0.x transition stubs and stale comments

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,4 @@
-// Compiles specflow for the five v0.1 targets into dist/.
+// Compiles specflow for the five supported targets into dist/.
 // Requires: deno task bundle to have been run first (deno task build does both).
 
 const ROOT = new URL("..", import.meta.url);

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -87,10 +87,10 @@ export interface FsReader {
  * `~/.claude/plugins/cache/<name>/` (per the Claude Code
  * discover-plugins docs); test seams can stub this to return any value.
  *
- * Used by the upgrade use case to drive the v0.x → plugin migration
- * table for issue #73: when the plugin is installed, vanilla on-disk
- * agent files are auto-migrated; customized files are preserved with
- * a warning. See `docs/superpowers/specs/2026-05-08-claude-plugin-design.md`.
+ * Used by the upgrade use case to drive the binary → plugin migration
+ * table: when the plugin is installed, vanilla on-disk agent files are
+ * auto-migrated; customized files are preserved with a warning.
+ * See `docs/superpowers/specs/2026-05-08-claude-plugin-design.md`.
  */
 export interface PluginDetector {
   isPluginInstalled(name: string): Promise<boolean>;

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -40,12 +40,12 @@ export type UpgradeProjectDeps = {
   templatesVersion: string;
   findHarness: (key: string) => Harness | null;
   /**
-   * Optional plugin probe. Drives the v0.x → plugin migration table
-   * for #73 — when the plugin is installed and the harness is
-   * `claude`, vanilla on-disk agent / command files are auto-migrated
-   * (backed up + deleted; plugin serves them going forward) and
-   * customized files are preserved with a "plugin available" warning.
-   * Tests omit this dep to skip migration entirely (legacy behavior).
+   * Optional plugin probe. Drives the binary → plugin migration table —
+   * when the plugin is installed and the harness is `claude`, vanilla
+   * on-disk agent / skill files are auto-migrated (backed up + deleted;
+   * plugin serves them going forward) and customized files are
+   * preserved with a "plugin available" warning. Tests omit this dep
+   * to skip migration entirely.
    */
   pluginDetector?: PluginDetector;
   now?: () => Date;

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -58,7 +58,6 @@ export type Intent =
      */
     backlog: "local" | "github" | "gitlab" | null;
   }
-  | { kind: "backlog-removed" }
   | { kind: "unknown"; received: string };
 
 export function parseArgs(argv: string[]): Intent {
@@ -138,11 +137,6 @@ export function parseArgs(argv: string[]): Intent {
       backlog: backlogResult.value,
     };
   }
-
-  // The `backlog` CLI command (sync + configure) was removed in v0.9.0.
-  // Catch it explicitly so we can emit a friendlier upgrade hint instead
-  // of the generic "Unknown command" + full help dump.
-  if (command === "backlog") return { kind: "backlog-removed" };
 
   return { kind: "unknown", received: command ?? "" };
 }

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -4,7 +4,7 @@ import type { KnownHarness } from "./installed_lock.ts";
  * Pure predicate: does the `specflow-plugin` plugin own a copy of the
  * file at `dest` (relative to the project root)?
  *
- * Used by the upgrade use case to decide whether to apply the v0.x →
+ * Used by the upgrade use case to decide whether to apply the binary →
  * plugin migration table for a given lock-tracked file. When the plugin
  * is installed AND a file is plugin-covered, the upgrade plan
  * branches:

--- a/src/domain/upgrade_plan.ts
+++ b/src/domain/upgrade_plan.ts
@@ -42,8 +42,7 @@ export type UpgradePlan = ReadonlyArray<UpgradeAction>;
  *   - `lock`     : the .specflow/installed.lock
  *   - `newShas`  : SHA of each file in the binary's embedded templates
  *
- * Plus two parameters that drive the v0.x → plugin migration table for
- * issue #73:
+ * Plus two parameters that drive the binary → plugin migration table:
  *   - `pluginInstalled`  : whether the `specflow-plugin` plugin is on
  *                          the host (probed at use-case entry by the
  *                          `PluginDetector` port).

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,15 +31,6 @@ export async function run(argv: string[]): Promise<number> {
       const { runUpgrade } = await import("./cli/handlers/upgrade_handler.ts");
       return await runUpgrade(intent);
     }
-    case "backlog-removed":
-      console.error(
-        red(
-          "error: `specflow backlog` was removed in v0.9.0. " +
-            "Manage the backlog from your AI harness via the /backlog slash-command, " +
-            "which dispatches the product-owner agent.",
-        ),
-      );
-      return 2;
     case "unknown":
       console.error(red(`Unknown command: "${intent.received}"`));
       console.error(HELP);

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -66,12 +66,6 @@ Deno.test("parseArgs returns self-update intent without --check", () => {
   });
 });
 
-Deno.test("parseArgs returns backlog-removed for any backlog invocation (post-v0.9.0)", () => {
-  assertEquals(parseArgs(["backlog"]), { kind: "backlog-removed" });
-  assertEquals(parseArgs(["backlog", "sync"]), { kind: "backlog-removed" });
-  assertEquals(parseArgs(["backlog", "configure"]), { kind: "backlog-removed" });
-});
-
 Deno.test("parseArgs returns check intent without --project", () => {
   assertEquals(parseArgs(["check"]), { kind: "check", projectMode: false });
 });


### PR DESCRIPTION
## Summary

Post-v1.0.0 cleanup of v0.x-era cruft surfaced when Kevin asked whether the unused upgrade scripts had really been deleted.

- Drop the `backlog-removed` parser intent (was a friendly hint for the v0.9.0-removed \`specflow backlog\` CLI command). Falls back to the generic "Unknown command" + help dump.
- Refresh stale "v0.x → plugin migration" comments to "binary → plugin migration" — the migration logic itself is still operative; only the wording was v0-era.
- Update \`scripts/build.ts\` header from "five v0.1 targets" to "five supported targets".

The legacy migrate\* helpers (\`migrateLegacyBacklogPaths\`, \`migrateLegacySpecsPaths\`, \`migrateLegacyDottedSkillFolders\`) were already removed in #127.

## Test plan

- [x] \`deno task test\` — 449 passed (was 450; deleted 1 parser test for the removed intent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)