### PR TITLE
feat(groom): size + priority labels + body rewriting (#129)

### DIFF
--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -17,3 +17,4 @@ treatment is now part of normal conventions).
 - [Docs domain](docs-domain.md) — Specflow docs are at https://specflow.makerlabs.dev (custom domain on GH Pages); use this URL in docs-related issues and AC.
 - [GitHub labels](github-labels.md) — only the 9 default GitHub labels exist; do not use ux/docs/friction slugs
 - [Plugin distribution](plugin-distribution.md) — install command, slash-command namespace, 21 assets, 3 install paths, upgrade migration, check --project gap warn
+- [Size and priority labels](size-priority-labels.md) — T-shirt sizes (size:XS–XL) + P0–P3 priority labels; create-if-absent pattern; confirmed in #129

--- a/.claude/agents/product-owner/memory/size-priority-labels.md
+++ b/.claude/agents/product-owner/memory/size-priority-labels.md
@@ -1,0 +1,22 @@
+---
+name: size-priority-labels
+description: T-shirt size and priority labels for Backlog grooming — scheme confirmed by Kevin in #129
+type: preference
+---
+
+When `/specflow groom` runs, the PO must assign:
+
+**Size labels** (GitHub/GitLab labels, not in body):
+`size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
+
+**Priority labels** (GitHub/GitLab labels):
+`priority:P0` — incident / blocker
+`priority:P1` — next sprint must-have
+`priority:P2` — important but deferrable
+`priority:P3` — nice-to-have / long horizon
+
+**Why:** Kevin confirmed T-shirt sizes via labels in Q1 of #129. Priority scheme P0–P3 is a PO-proposed default (Kevin did not specify one; if he overrides it, update this file).
+
+**How to apply:** These labels do not exist in the repo by default. Before assigning, run `gh label create size:XS --repo mkrlabs/specflow` etc. (or `glab label create` for GitLab). The create-if-absent pattern is required — do not skip creation or the assignment will fail.
+
+**Local markdown:** When the 5-column local backend ships (#130), size and priority go into front-matter or inline markers (convention TBD in that ticket).

--- a/plugin/skills/specflow/phases/groom.md
+++ b/plugin/skills/specflow/phases/groom.md
@@ -21,22 +21,73 @@ by the agent that has the right tools and prompt for the job.
 Dispatch the **`product-owner`** subagent to clarify any items currently
 in the `Backlog` column (i.e. not yet promoted to `Ready`).
 
+The PO must respect the column model: items in `Backlog` need more
+information / sizing / prioritisation; items in `Ready` are picked up by
+development. The PO never auto-promotes from `Ready` to `In progress`.
+
 The PO will:
 
 - Read each item's body and existing comments.
 - **Skip** items it has already commented on in a previous run (look for
   the marker `🤖 specflow-groom` at the start of any comment).
 - For each remaining item:
-  - If the body is already clarified (Why / AC / Out of scope all present
-    and concrete), promote to `Ready`.
-  - If 1–3 scope decisions remain, leave a clarification comment marked
-    with the `🤖 specflow-groom` prefix so subsequent runs skip it.
-  - If the item is genuinely stale or duplicates a closed ticket, the PO
-    can recommend closure with `not_planned` (but does not close
-    autonomously — the recommendation lands as a comment).
+  - **Rewrite the body when it's poorly worded.** If the description is
+    missing, incomplete, or unclear, the PO MUST rewrite it in the
+    standard `## Why` / `## Acceptance criteria` / `## Out of scope` /
+    `## Notes` shape, using correct business and technical vocabulary
+    so the result is readable by a developer or a future PO who has no
+    prior context.
+  - **Assign a size label.** Apply exactly one of `size:XS`, `size:S`,
+    `size:M`, `size:L`, `size:XL`. T-shirt scale rationale:
+    - `XS` — < 1 hour, trivial doc / config tweak
+    - `S` — 1–4 hours, single-file or single-test change
+    - `M` — half-day to a day, one subsystem touched, tests included
+    - `L` — multi-day, crosses subsystems, requires a plan
+    - `XL` — multi-PR effort; consider splitting into sub-tickets
+  - **Assign a priority label.** Apply exactly one of `priority:P0`,
+    `priority:P1`, `priority:P2`, `priority:P3`:
+    - `P0` — incident / blocker; drop everything
+    - `P1` — must-have for the next sprint or release
+    - `P2` — important but deferrable; standard work
+    - `P3` — nice-to-have / long horizon; pick up when slack appears
+  - **Promote to `Ready`** when the body is clear AND both labels are
+    applied AND no scope decisions remain.
+  - **Leave a clarification comment** marked with the `🤖 specflow-groom`
+    prefix when 1–3 scope decisions still need Kevin's input. Apply
+    size + priority anyway (best estimate from available context). The
+    item stays in `Backlog` until Kevin replies.
+  - **Recommend closure** if the item is genuinely stale or duplicates a
+    closed ticket — leave a comment recommending `not_planned`. Do not
+    close autonomously.
 
 The PO must respect the standard backlog skill — do not bypass its
 scripts.
+
+#### Label management
+
+Size and priority labels are scoped to the repo. Before assigning a
+label, the PO MUST ensure it exists:
+
+- **GitHub backend** (`gh`):
+  - `gh label list --repo <owner>/<repo>` to enumerate existing labels.
+  - `gh label create "<name>" --color <hex> --description "<desc>" --repo <owner>/<repo>`
+    to create one if absent. Suggested colors:
+    - `size:XS` `#c2e0c6` · `size:S` `#bfdadc` · `size:M` `#bfd4f2` · `size:L` `#d4c5f9` · `size:XL` `#f9d0c4`
+    - `priority:P0` `#b60205` · `priority:P1` `#d93f0b` · `priority:P2` `#fbca04` · `priority:P3` `#0e8a16`
+  - `gh issue edit <num> --add-label "size:M" --add-label "priority:P2" --repo <owner>/<repo>`
+    to apply (use `--remove-label` to swap a previously-assigned label
+    when re-grooming).
+
+- **GitLab backend** (`glab`): same flow with `glab label list` /
+  `glab label create -n <name> --color "#hex" --description "<desc>"` /
+  `glab issue update <num> --label "size:M,priority:P2"`.
+
+- **Local markdown backend**: when the local backend ships support for
+  the 5-column model (tracked in #130), size and priority will be
+  applied as front-matter or inline markers per that ticket's
+  convention. Until then, the local backend has no column model and
+  this groom phase is a no-op for it (the PO should report
+  "skipped — local backend predates the column model").
 
 ### 2. Stale PR surface
 
@@ -66,6 +117,7 @@ End with a single summary block:
 specflow-groom report
 ─────────────────────
 Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarification
+            <R> body rewrites, <S> sized, <Z> prioritised
 Stale PRs:  <S> open PRs idle > 48h
 Orphan specs: <O> spec directories missing the next artefact
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -1756,22 +1756,73 @@ by the agent that has the right tools and prompt for the job.
 Dispatch the **\`product-owner\`** subagent to clarify any items currently
 in the \`Backlog\` column (i.e. not yet promoted to \`Ready\`).
 
+The PO must respect the column model: items in \`Backlog\` need more
+information / sizing / prioritisation; items in \`Ready\` are picked up by
+development. The PO never auto-promotes from \`Ready\` to \`In progress\`.
+
 The PO will:
 
 - Read each item's body and existing comments.
 - **Skip** items it has already commented on in a previous run (look for
   the marker \`🤖 specflow-groom\` at the start of any comment).
 - For each remaining item:
-  - If the body is already clarified (Why / AC / Out of scope all present
-    and concrete), promote to \`Ready\`.
-  - If 1–3 scope decisions remain, leave a clarification comment marked
-    with the \`🤖 specflow-groom\` prefix so subsequent runs skip it.
-  - If the item is genuinely stale or duplicates a closed ticket, the PO
-    can recommend closure with \`not_planned\` (but does not close
-    autonomously — the recommendation lands as a comment).
+  - **Rewrite the body when it's poorly worded.** If the description is
+    missing, incomplete, or unclear, the PO MUST rewrite it in the
+    standard \`## Why\` / \`## Acceptance criteria\` / \`## Out of scope\` /
+    \`## Notes\` shape, using correct business and technical vocabulary
+    so the result is readable by a developer or a future PO who has no
+    prior context.
+  - **Assign a size label.** Apply exactly one of \`size:XS\`, \`size:S\`,
+    \`size:M\`, \`size:L\`, \`size:XL\`. T-shirt scale rationale:
+    - \`XS\` — < 1 hour, trivial doc / config tweak
+    - \`S\` — 1–4 hours, single-file or single-test change
+    - \`M\` — half-day to a day, one subsystem touched, tests included
+    - \`L\` — multi-day, crosses subsystems, requires a plan
+    - \`XL\` — multi-PR effort; consider splitting into sub-tickets
+  - **Assign a priority label.** Apply exactly one of \`priority:P0\`,
+    \`priority:P1\`, \`priority:P2\`, \`priority:P3\`:
+    - \`P0\` — incident / blocker; drop everything
+    - \`P1\` — must-have for the next sprint or release
+    - \`P2\` — important but deferrable; standard work
+    - \`P3\` — nice-to-have / long horizon; pick up when slack appears
+  - **Promote to \`Ready\`** when the body is clear AND both labels are
+    applied AND no scope decisions remain.
+  - **Leave a clarification comment** marked with the \`🤖 specflow-groom\`
+    prefix when 1–3 scope decisions still need Kevin's input. Apply
+    size + priority anyway (best estimate from available context). The
+    item stays in \`Backlog\` until Kevin replies.
+  - **Recommend closure** if the item is genuinely stale or duplicates a
+    closed ticket — leave a comment recommending \`not_planned\`. Do not
+    close autonomously.
 
 The PO must respect the standard backlog skill — do not bypass its
 scripts.
+
+#### Label management
+
+Size and priority labels are scoped to the repo. Before assigning a
+label, the PO MUST ensure it exists:
+
+- **GitHub backend** (\`gh\`):
+  - \`gh label list --repo <owner>/<repo>\` to enumerate existing labels.
+  - \`gh label create "<name>" --color <hex> --description "<desc>" --repo <owner>/<repo>\`
+    to create one if absent. Suggested colors:
+    - \`size:XS\` \`#c2e0c6\` · \`size:S\` \`#bfdadc\` · \`size:M\` \`#bfd4f2\` · \`size:L\` \`#d4c5f9\` · \`size:XL\` \`#f9d0c4\`
+    - \`priority:P0\` \`#b60205\` · \`priority:P1\` \`#d93f0b\` · \`priority:P2\` \`#fbca04\` · \`priority:P3\` \`#0e8a16\`
+  - \`gh issue edit <num> --add-label "size:M" --add-label "priority:P2" --repo <owner>/<repo>\`
+    to apply (use \`--remove-label\` to swap a previously-assigned label
+    when re-grooming).
+
+- **GitLab backend** (\`glab\`): same flow with \`glab label list\` /
+  \`glab label create -n <name> --color "#hex" --description "<desc>"\` /
+  \`glab issue update <num> --label "size:M,priority:P2"\`.
+
+- **Local markdown backend**: when the local backend ships support for
+  the 5-column model (tracked in #130), size and priority will be
+  applied as front-matter or inline markers per that ticket's
+  convention. Until then, the local backend has no column model and
+  this groom phase is a no-op for it (the PO should report
+  "skipped — local backend predates the column model").
 
 ### 2. Stale PR surface
 
@@ -1801,6 +1852,7 @@ End with a single summary block:
 specflow-groom report
 ─────────────────────
 Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarification
+            <R> body rewrites, <S> sized, <Z> prioritised
 Stale PRs:  <S> open PRs idle > 48h
 Orphan specs: <O> spec directories missing the next artefact
 

--- a/templates/core/skills/specflow/phases/groom.md
+++ b/templates/core/skills/specflow/phases/groom.md
@@ -21,22 +21,73 @@ by the agent that has the right tools and prompt for the job.
 Dispatch the **`product-owner`** subagent to clarify any items currently
 in the `Backlog` column (i.e. not yet promoted to `Ready`).
 
+The PO must respect the column model: items in `Backlog` need more
+information / sizing / prioritisation; items in `Ready` are picked up by
+development. The PO never auto-promotes from `Ready` to `In progress`.
+
 The PO will:
 
 - Read each item's body and existing comments.
 - **Skip** items it has already commented on in a previous run (look for
   the marker `🤖 specflow-groom` at the start of any comment).
 - For each remaining item:
-  - If the body is already clarified (Why / AC / Out of scope all present
-    and concrete), promote to `Ready`.
-  - If 1–3 scope decisions remain, leave a clarification comment marked
-    with the `🤖 specflow-groom` prefix so subsequent runs skip it.
-  - If the item is genuinely stale or duplicates a closed ticket, the PO
-    can recommend closure with `not_planned` (but does not close
-    autonomously — the recommendation lands as a comment).
+  - **Rewrite the body when it's poorly worded.** If the description is
+    missing, incomplete, or unclear, the PO MUST rewrite it in the
+    standard `## Why` / `## Acceptance criteria` / `## Out of scope` /
+    `## Notes` shape, using correct business and technical vocabulary
+    so the result is readable by a developer or a future PO who has no
+    prior context.
+  - **Assign a size label.** Apply exactly one of `size:XS`, `size:S`,
+    `size:M`, `size:L`, `size:XL`. T-shirt scale rationale:
+    - `XS` — < 1 hour, trivial doc / config tweak
+    - `S` — 1–4 hours, single-file or single-test change
+    - `M` — half-day to a day, one subsystem touched, tests included
+    - `L` — multi-day, crosses subsystems, requires a plan
+    - `XL` — multi-PR effort; consider splitting into sub-tickets
+  - **Assign a priority label.** Apply exactly one of `priority:P0`,
+    `priority:P1`, `priority:P2`, `priority:P3`:
+    - `P0` — incident / blocker; drop everything
+    - `P1` — must-have for the next sprint or release
+    - `P2` — important but deferrable; standard work
+    - `P3` — nice-to-have / long horizon; pick up when slack appears
+  - **Promote to `Ready`** when the body is clear AND both labels are
+    applied AND no scope decisions remain.
+  - **Leave a clarification comment** marked with the `🤖 specflow-groom`
+    prefix when 1–3 scope decisions still need Kevin's input. Apply
+    size + priority anyway (best estimate from available context). The
+    item stays in `Backlog` until Kevin replies.
+  - **Recommend closure** if the item is genuinely stale or duplicates a
+    closed ticket — leave a comment recommending `not_planned`. Do not
+    close autonomously.
 
 The PO must respect the standard backlog skill — do not bypass its
 scripts.
+
+#### Label management
+
+Size and priority labels are scoped to the repo. Before assigning a
+label, the PO MUST ensure it exists:
+
+- **GitHub backend** (`gh`):
+  - `gh label list --repo <owner>/<repo>` to enumerate existing labels.
+  - `gh label create "<name>" --color <hex> --description "<desc>" --repo <owner>/<repo>`
+    to create one if absent. Suggested colors:
+    - `size:XS` `#c2e0c6` · `size:S` `#bfdadc` · `size:M` `#bfd4f2` · `size:L` `#d4c5f9` · `size:XL` `#f9d0c4`
+    - `priority:P0` `#b60205` · `priority:P1` `#d93f0b` · `priority:P2` `#fbca04` · `priority:P3` `#0e8a16`
+  - `gh issue edit <num> --add-label "size:M" --add-label "priority:P2" --repo <owner>/<repo>`
+    to apply (use `--remove-label` to swap a previously-assigned label
+    when re-grooming).
+
+- **GitLab backend** (`glab`): same flow with `glab label list` /
+  `glab label create -n <name> --color "#hex" --description "<desc>"` /
+  `glab issue update <num> --label "size:M,priority:P2"`.
+
+- **Local markdown backend**: when the local backend ships support for
+  the 5-column model (tracked in #130), size and priority will be
+  applied as front-matter or inline markers per that ticket's
+  convention. Until then, the local backend has no column model and
+  this groom phase is a no-op for it (the PO should report
+  "skipped — local backend predates the column model").
 
 ### 2. Stale PR surface
 
@@ -66,6 +117,7 @@ End with a single summary block:
 specflow-groom report
 ─────────────────────
 Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarification
+            <R> body rewrites, <S> sized, <Z> prioritised
 Stale PRs:  <S> open PRs idle > 48h
 Orphan specs: <O> spec directories missing the next artefact
 


### PR DESCRIPTION
## Summary

Closes #129. Extends the `/specflow groom` phase (which dispatches the `product-owner` subagent) with the three behaviors Kevin asked for:

- **Size labels** — `size:XS / S / M / L / XL` (t-shirt scale, with rationale documented in the phase doc). Auto-created via `gh label create` (GitHub) or `glab label create` (GitLab) if absent.
- **Priority labels** — `priority:P0 / P1 / P2 / P3` with the standard 4-tier scheme.
- **Body rewriting** — when the description is missing, incomplete, or poorly worded, the PO rewrites it into the standard `## Why` / `## Acceptance criteria` / `## Out of scope` / `## Notes` shape using both business and technical vocabulary, so it's readable by a future dev or a future PO.

The existing clarification-comment fallback is preserved (with best-effort labels still applied). The phase also now explicitly documents the column-model contract: Backlog items need work; Ready items are pickable; the PO never auto-promotes Ready → In progress.

## Out of scope

- Local markdown backend — deferred to #130 (column-model rework). Until that lands, the groom phase explicitly reports "skipped — local backend predates the column model" for local-backend projects.

## Files touched

- `templates/core/skills/specflow/phases/groom.md` — the new behavior
- `plugin/skills/specflow/phases/groom.md` — kept byte-identical (plugin_sync_test)
- `src/templates_bundle.ts` — regenerated from manifest

## Test plan

- [x] `deno task test` — 449 passed
- [x] smoke-features — green
- [ ] Live validation: run `/specflow groom` against this repo's Backlog (#130 currently sits there) and confirm size + priority + label-create behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)