### PR TITLE
feat(backlog): local backend column model + size/priority frontmatter (#130)

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3376,6 +3376,7 @@ BODY="\${2:-}"
 ROOT="\$(cd "\$(dirname "\$0")/../../.." && pwd)"
 BACKLOG_DIR="\$ROOT/.specflow/backlog"
 INDEX="\$ROOT/.specflow/backlog.md"
+RENDER="\$(dirname "\$0")/render-index.sh"
 mkdir -p "\$BACKLOG_DIR"
 
 # Next free number
@@ -3400,18 +3401,16 @@ cat > "\$FILE" <<EOF
 number: \$NEXT
 title: \$TITLE
 status: Backlog
+size:
+priority:
 created: \$NOW
 ---
 
 \$BODY
 EOF
 
-# Append to (or create) the index
-if [ ! -f "\$INDEX" ]; then
-  echo "# Backlog" > "\$INDEX"
-  echo "" >> "\$INDEX"
-fi
-echo "- [#\$NEXT](backlog/\$NEXT-\$SLUG.md) Backlog — \$TITLE" >> "\$INDEX"
+# Regenerate the column-organised index from the file tree.
+bash "\$RENDER" "\$ROOT"
 
 echo "✓ created #\$NEXT — \$TITLE"
 echo "  \$FILE"
@@ -3426,7 +3425,7 @@ echo "  \$FILE"
     suffix: "move.sh",
     content: `#!/usr/bin/env bash
 # Move a backlog item to a new status. Updates the file's frontmatter and
-# the line in the index.
+# regenerates the column-organised index.
 # Usage: move.sh <number> <Status>
 set -euo pipefail
 
@@ -3448,7 +3447,7 @@ esac
 
 ROOT="\$(cd "\$(dirname "\$0")/../../.." && pwd)"
 BACKLOG_DIR="\$ROOT/.specflow/backlog"
-INDEX="\$ROOT/.specflow/backlog.md"
+RENDER="\$(dirname "\$0")/render-index.sh"
 
 shopt -s nullglob
 matches=("\$BACKLOG_DIR/\$NUM-"*.md)
@@ -3467,18 +3466,8 @@ awk -v new="\$STATUS" '
   END {if (!updated) exit 3}
 ' "\$FILE" > "\$FILE.tmp" && mv "\$FILE.tmp" "\$FILE"
 
-# Update the matching index line
-if [ -f "\$INDEX" ]; then
-  awk -v num="\$NUM" -v new="\$STATUS" '
-    {
-      if (\$0 ~ "\\\\[#" num "\\\\]") {
-        # Replace the status word: format is "...) <Status> — title"
-        sub(/\\) [A-Za-z][^—]*—/, ") " new " —")
-      }
-      print
-    }
-  ' "\$INDEX" > "\$INDEX.tmp" && mv "\$INDEX.tmp" "\$INDEX"
-fi
+# Regenerate the column-organised index from the file tree.
+bash "\$RENDER" "\$ROOT"
 
 echo "✓ #\$NUM → \$STATUS"
 `,
@@ -3522,6 +3511,115 @@ cat >> "\$FILE" <<EOF
 EOF
 
 echo "✓ added clarification on #\$NUM"
+`,
+    executable: true,
+    backend: "local",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
+    name: "render-index",
+    suffix: "render-index.sh",
+    content: `#!/usr/bin/env bash
+# Regenerate .specflow/backlog.md from the per-item files in
+# .specflow/backlog/. Items are grouped by their \`status:\` frontmatter
+# field into the 5 standard columns.
+# Usage: render-index.sh [<project-root>]
+set -euo pipefail
+
+ROOT="\${1:-\$(cd "\$(dirname "\$0")/../../.." && pwd)}"
+BACKLOG_DIR="\$ROOT/.specflow/backlog"
+INDEX="\$ROOT/.specflow/backlog.md"
+
+# Collect (status \\t line) pairs by reading each item's frontmatter.
+# Sort by item number within each status by relying on filename order.
+LINES_BACKLOG=""
+LINES_READY=""
+LINES_INPROG=""
+LINES_INREV=""
+LINES_DONE=""
+
+shopt -s nullglob
+for f in \$(printf "%s\\n" "\$BACKLOG_DIR"/*.md | sort); do
+  base=\$(basename "\$f")
+  num=\$(echo "\$base" | cut -d- -f1)
+  title=\$(awk '/^---\$/{n++; next} n==1 && /^title:/ {sub(/^title:[[:space:]]*/, ""); print; exit}' "\$f")
+  status=\$(awk '/^---\$/{n++; next} n==1 && /^status:/ {sub(/^status:[[:space:]]*/, ""); print; exit}' "\$f")
+  size=\$(awk '/^---\$/{n++; next} n==1 && /^size:/ {sub(/^size:[[:space:]]*/, ""); print; exit}' "\$f")
+  priority=\$(awk '/^---\$/{n++; next} n==1 && /^priority:/ {sub(/^priority:[[:space:]]*/, ""); print; exit}' "\$f")
+
+  badge=""
+  [ -n "\$size" ] && badge="\$badge \\\`size:\$size\\\`"
+  [ -n "\$priority" ] && badge="\$badge \\\`priority:\$priority\\\`"
+  line="- [#\$num](backlog/\$base)\$badge — \$title"
+
+  case "\$status" in
+    Backlog)        LINES_BACKLOG="\$LINES_BACKLOG\$line"\$'\\n' ;;
+    Ready)          LINES_READY="\$LINES_READY\$line"\$'\\n' ;;
+    "In progress")  LINES_INPROG="\$LINES_INPROG\$line"\$'\\n' ;;
+    "In review")    LINES_INREV="\$LINES_INREV\$line"\$'\\n' ;;
+    Done)           LINES_DONE="\$LINES_DONE\$line"\$'\\n' ;;
+    *)              LINES_BACKLOG="\$LINES_BACKLOG\$line  <!-- unknown status: \$status -->"\$'\\n' ;;
+  esac
+done
+
+emit_section() {
+  local header="\$1"
+  local lines="\$2"
+  echo "## \$header"
+  echo
+  if [ -z "\$lines" ]; then
+    echo "_No tasks yet._"
+  else
+    printf "%s" "\$lines"
+  fi
+  echo
+}
+
+{
+  cat <<'HEADER'
+# Backlog
+
+> Managed by the Product Owner agent (\`/backlog\`). Each task is one
+> file under \`.specflow/backlog/NNN-slug.md\` with frontmatter; this
+> index lists items grouped by status column.
+
+The 5 status columns mirror the GitHub Projects "kanban" model:
+
+- **Backlog** — needs more info, sizing, or prioritisation. The PO
+  works these on \`/specflow groom\` until they're ready.
+- **Ready** — clarified, sized, prioritised. The PO proposes these
+  for development when asked "what's next".
+- **In progress** — actively being worked on (a branch is open).
+- **In review** — implementation done, PR open, awaiting merge.
+- **Done** — closed / shipped (kept here for the recent audit trail;
+  prune as needed).
+
+Size and priority live in each item's frontmatter (see
+\`.specflow/backlog/NNN-*.md\`):
+
+\`\`\`yaml
+---
+number: NNN
+title: ...
+status: Backlog | Ready | "In progress" | "In review" | Done
+size: XS | S | M | L | XL
+priority: P0 | P1 | P2 | P3
+created: ...
+---
+\`\`\`
+
+The PO assigns size + priority during the \`/specflow groom\` pass.
+
+---
+
+HEADER
+  emit_section "Backlog" "\$LINES_BACKLOG"
+  emit_section "Ready" "\$LINES_READY"
+  emit_section "In progress" "\$LINES_INPROG"
+  emit_section "In review" "\$LINES_INREV"
+  emit_section "Done" "\$LINES_DONE"
+} > "\$INDEX"
 `,
     executable: true,
     backend: "local",
@@ -4009,56 +4107,58 @@ glab issue note "\$1" --repo "\$PROJECT_ID" --message "\$2"
     suffix: "backlog.md",
     content: `# Backlog
 
-> Managed by the Product Owner agent (\`/backlog\`). Each task lives in
-> \`.specflow/backlog/NNN-slug.md\` with structured frontmatter.
+> Managed by the Product Owner agent (\`/backlog\`). Each task is one
+> file under \`.specflow/backlog/NNN-slug.md\` with frontmatter; this
+> index lists items grouped by status column.
 
-## Scoring
+The 5 status columns mirror the GitHub Projects "kanban" model:
 
-- **Complexity**: Fibonacci (1, 2, 3, 5, 8, 13, 21) — story points
-- **Priority**: critical > high > medium > low
-- **Status**: \`todo\` | \`in_progress\` | \`done\` | \`deferred\` | \`blocked\`
+- **Backlog** — needs more info, sizing, or prioritisation. The PO
+  works these on \`/specflow groom\` until they're ready.
+- **Ready** — clarified, sized, prioritised. The PO proposes these
+  for development when asked "what's next".
+- **In progress** — actively being worked on (a branch is open).
+- **In review** — implementation done, PR open, awaiting merge.
+- **Done** — closed / shipped (kept here for the recent audit trail;
+  prune as needed).
+
+Size and priority live in each item's frontmatter (see
+\`.specflow/backlog/NNN-*.md\`):
+
+\`\`\`yaml
+---
+number: NNN
+title: ...
+status: Backlog | Ready | "In progress" | "In review" | Done
+size: XS | S | M | L | XL
+priority: P0 | P1 | P2 | P3
+created: ...
+---
+\`\`\`
+
+The PO assigns size + priority during the \`/specflow groom\` pass.
 
 ---
 
-## Critical
+## Backlog
 
 _No tasks yet._
 
-## High Priority
+## Ready
 
 _No tasks yet._
 
-## Medium Priority
+## In progress
 
 _No tasks yet._
 
-## Low Priority
-
-_No tasks yet._
-
-## Deferred
+## In review
 
 _No tasks yet._
 
 ## Done
 
 _No tasks yet._
-
----
-
-## Summary
-
-| Metric             | Value |
-|--------------------|-------|
-| Total tasks        | 0     |
-| Critical           | 0     |
-| High               | 0     |
-| Medium             | 0     |
-| Low                | 0     |
-| Deferred           | 0     |
-| Done               | 0     |
-| Total story points | 0     |
-| Done points        | 0     |
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/backlog/scripts/local/add.sh
+++ b/templates/core/skills/backlog/scripts/local/add.sh
@@ -13,6 +13,7 @@ BODY="${2:-}"
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 BACKLOG_DIR="$ROOT/.specflow/backlog"
 INDEX="$ROOT/.specflow/backlog.md"
+RENDER="$(dirname "$0")/render-index.sh"
 mkdir -p "$BACKLOG_DIR"
 
 # Next free number
@@ -37,18 +38,16 @@ cat > "$FILE" <<EOF
 number: $NEXT
 title: $TITLE
 status: Backlog
+size:
+priority:
 created: $NOW
 ---
 
 $BODY
 EOF
 
-# Append to (or create) the index
-if [ ! -f "$INDEX" ]; then
-  echo "# Backlog" > "$INDEX"
-  echo "" >> "$INDEX"
-fi
-echo "- [#$NEXT](backlog/$NEXT-$SLUG.md) Backlog — $TITLE" >> "$INDEX"
+# Regenerate the column-organised index from the file tree.
+bash "$RENDER" "$ROOT"
 
 echo "✓ created #$NEXT — $TITLE"
 echo "  $FILE"

--- a/templates/core/skills/backlog/scripts/local/move.sh
+++ b/templates/core/skills/backlog/scripts/local/move.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Move a backlog item to a new status. Updates the file's frontmatter and
-# the line in the index.
+# regenerates the column-organised index.
 # Usage: move.sh <number> <Status>
 set -euo pipefail
 
@@ -22,7 +22,7 @@ esac
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 BACKLOG_DIR="$ROOT/.specflow/backlog"
-INDEX="$ROOT/.specflow/backlog.md"
+RENDER="$(dirname "$0")/render-index.sh"
 
 shopt -s nullglob
 matches=("$BACKLOG_DIR/$NUM-"*.md)
@@ -41,17 +41,7 @@ awk -v new="$STATUS" '
   END {if (!updated) exit 3}
 ' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
 
-# Update the matching index line
-if [ -f "$INDEX" ]; then
-  awk -v num="$NUM" -v new="$STATUS" '
-    {
-      if ($0 ~ "\\[#" num "\\]") {
-        # Replace the status word: format is "...) <Status> — title"
-        sub(/\) [A-Za-z][^—]*—/, ") " new " —")
-      }
-      print
-    }
-  ' "$INDEX" > "$INDEX.tmp" && mv "$INDEX.tmp" "$INDEX"
-fi
+# Regenerate the column-organised index from the file tree.
+bash "$RENDER" "$ROOT"
 
 echo "✓ #$NUM → $STATUS"

--- a/templates/core/skills/backlog/scripts/local/render-index.sh
+++ b/templates/core/skills/backlog/scripts/local/render-index.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regenerate .specflow/backlog.md from the per-item files in
+# .specflow/backlog/. Items are grouped by their `status:` frontmatter
+# field into the 5 standard columns.
+# Usage: render-index.sh [<project-root>]
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+BACKLOG_DIR="$ROOT/.specflow/backlog"
+INDEX="$ROOT/.specflow/backlog.md"
+
+# Collect (status \t line) pairs by reading each item's frontmatter.
+# Sort by item number within each status by relying on filename order.
+LINES_BACKLOG=""
+LINES_READY=""
+LINES_INPROG=""
+LINES_INREV=""
+LINES_DONE=""
+
+shopt -s nullglob
+for f in $(printf "%s\n" "$BACKLOG_DIR"/*.md | sort); do
+  base=$(basename "$f")
+  num=$(echo "$base" | cut -d- -f1)
+  title=$(awk '/^---$/{n++; next} n==1 && /^title:/ {sub(/^title:[[:space:]]*/, ""); print; exit}' "$f")
+  status=$(awk '/^---$/{n++; next} n==1 && /^status:/ {sub(/^status:[[:space:]]*/, ""); print; exit}' "$f")
+  size=$(awk '/^---$/{n++; next} n==1 && /^size:/ {sub(/^size:[[:space:]]*/, ""); print; exit}' "$f")
+  priority=$(awk '/^---$/{n++; next} n==1 && /^priority:/ {sub(/^priority:[[:space:]]*/, ""); print; exit}' "$f")
+
+  badge=""
+  [ -n "$size" ] && badge="$badge \`size:$size\`"
+  [ -n "$priority" ] && badge="$badge \`priority:$priority\`"
+  line="- [#$num](backlog/$base)$badge — $title"
+
+  case "$status" in
+    Backlog)        LINES_BACKLOG="$LINES_BACKLOG$line"$'\n' ;;
+    Ready)          LINES_READY="$LINES_READY$line"$'\n' ;;
+    "In progress")  LINES_INPROG="$LINES_INPROG$line"$'\n' ;;
+    "In review")    LINES_INREV="$LINES_INREV$line"$'\n' ;;
+    Done)           LINES_DONE="$LINES_DONE$line"$'\n' ;;
+    *)              LINES_BACKLOG="$LINES_BACKLOG$line  <!-- unknown status: $status -->"$'\n' ;;
+  esac
+done
+
+emit_section() {
+  local header="$1"
+  local lines="$2"
+  echo "## $header"
+  echo
+  if [ -z "$lines" ]; then
+    echo "_No tasks yet._"
+  else
+    printf "%s" "$lines"
+  fi
+  echo
+}
+
+{
+  cat <<'HEADER'
+# Backlog
+
+> Managed by the Product Owner agent (`/backlog`). Each task is one
+> file under `.specflow/backlog/NNN-slug.md` with frontmatter; this
+> index lists items grouped by status column.
+
+The 5 status columns mirror the GitHub Projects "kanban" model:
+
+- **Backlog** — needs more info, sizing, or prioritisation. The PO
+  works these on `/specflow groom` until they're ready.
+- **Ready** — clarified, sized, prioritised. The PO proposes these
+  for development when asked "what's next".
+- **In progress** — actively being worked on (a branch is open).
+- **In review** — implementation done, PR open, awaiting merge.
+- **Done** — closed / shipped (kept here for the recent audit trail;
+  prune as needed).
+
+Size and priority live in each item's frontmatter (see
+`.specflow/backlog/NNN-*.md`):
+
+```yaml
+---
+number: NNN
+title: ...
+status: Backlog | Ready | "In progress" | "In review" | Done
+size: XS | S | M | L | XL
+priority: P0 | P1 | P2 | P3
+created: ...
+---
+```
+
+The PO assigns size + priority during the `/specflow groom` pass.
+
+---
+
+HEADER
+  emit_section "Backlog" "$LINES_BACKLOG"
+  emit_section "Ready" "$LINES_READY"
+  emit_section "In progress" "$LINES_INPROG"
+  emit_section "In review" "$LINES_INREV"
+  emit_section "Done" "$LINES_DONE"
+} > "$INDEX"

--- a/templates/core/specflow/backlog.md
+++ b/templates/core/specflow/backlog.md
@@ -1,52 +1,54 @@
 # Backlog
 
-> Managed by the Product Owner agent (`/backlog`). Each task lives in
-> `.specflow/backlog/NNN-slug.md` with structured frontmatter.
+> Managed by the Product Owner agent (`/backlog`). Each task is one
+> file under `.specflow/backlog/NNN-slug.md` with frontmatter; this
+> index lists items grouped by status column.
 
-## Scoring
+The 5 status columns mirror the GitHub Projects "kanban" model:
 
-- **Complexity**: Fibonacci (1, 2, 3, 5, 8, 13, 21) — story points
-- **Priority**: critical > high > medium > low
-- **Status**: `todo` | `in_progress` | `done` | `deferred` | `blocked`
+- **Backlog** — needs more info, sizing, or prioritisation. The PO
+  works these on `/specflow groom` until they're ready.
+- **Ready** — clarified, sized, prioritised. The PO proposes these
+  for development when asked "what's next".
+- **In progress** — actively being worked on (a branch is open).
+- **In review** — implementation done, PR open, awaiting merge.
+- **Done** — closed / shipped (kept here for the recent audit trail;
+  prune as needed).
+
+Size and priority live in each item's frontmatter (see
+`.specflow/backlog/NNN-*.md`):
+
+```yaml
+---
+number: NNN
+title: ...
+status: Backlog | Ready | "In progress" | "In review" | Done
+size: XS | S | M | L | XL
+priority: P0 | P1 | P2 | P3
+created: ...
+---
+```
+
+The PO assigns size + priority during the `/specflow groom` pass.
 
 ---
 
-## Critical
+## Backlog
 
 _No tasks yet._
 
-## High Priority
+## Ready
 
 _No tasks yet._
 
-## Medium Priority
+## In progress
 
 _No tasks yet._
 
-## Low Priority
-
-_No tasks yet._
-
-## Deferred
+## In review
 
 _No tasks yet._
 
 ## Done
 
 _No tasks yet._
-
----
-
-## Summary
-
-| Metric             | Value |
-|--------------------|-------|
-| Total tasks        | 0     |
-| Critical           | 0     |
-| High               | 0     |
-| Medium             | 0     |
-| Low                | 0     |
-| Deferred           | 0     |
-| Done               | 0     |
-| Total story points | 0     |
-| Done points        | 0     |

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -40,6 +40,7 @@
     { "category": "backlog-script", "name": "add", "suffix": "add.sh", "source": "core/skills/backlog/scripts/local/add.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "move", "suffix": "move.sh", "source": "core/skills/backlog/scripts/local/move.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "clarify-comment", "suffix": "clarify-comment.sh", "source": "core/skills/backlog/scripts/local/clarify-comment.sh", "executable": true, "backend": "local" },
+    { "category": "backlog-script", "name": "render-index", "suffix": "render-index.sh", "source": "core/skills/backlog/scripts/local/render-index.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "_config", "suffix": "_config.sh", "source": "core/skills/backlog/scripts/github/_config.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/github/list.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "view", "suffix": "view.sh", "source": "core/skills/backlog/scripts/github/view.sh", "executable": true, "backend": "github" },


### PR DESCRIPTION
## Summary

Closes #130. Aligns the local-markdown backlog backend with the 5-column Kanban model the GitHub/GitLab backends already use. Picks **option 3** from the architect's discussion — turns out the on-disk layout (file-per-item under \`.specflow/backlog/NNN-slug.md\`) was already option-3-shaped; only the **index file** + scripts needed alignment.

## Changes

- **Index template** (\`templates/core/specflow/backlog.md\`): 5 status sections (Backlog / Ready / In progress / In review / Done). Drops the old 4 priority sections and the obsolete \`todo|in_progress|done|deferred|blocked\` status enum.
- **New \`render-index.sh\`**: regenerates the index from the per-item files (source of truth = frontmatter). add.sh and move.sh call it after each mutation. Eliminates the in-place awk-edit drift the old move.sh had.
- **add.sh**: writes \`size:\` and \`priority:\` frontmatter slots (PO fills them via \`/specflow groom\`).
- **move.sh**: relocates items between columns by re-rendering, not by string-substituting the status word.
- **Line format**: drops the redundant status word (section header carries it). Adds \`\\\`size:M\\\` \\\`priority:P2\\\`\` badges when frontmatter is set.

Local backend now matches the column model the PO + groom phase already use.

## Test plan

- [x] \`deno task test\` — 449 passed
- [x] smoke-backlog-local — round-trip add/list/move/view/clarify green
- [x] smoke-features — green
- [x] smoke-all-harnesses — all 8 green
- [x] Manual sandbox round-trip: 3 \`add.sh\` calls + 2 \`move.sh\` calls produce a clean column-organised index with no orphan blank lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)