### PR TITLE
feat(init): /specflow slash command + better re-init guidance (F3, F4)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -48,8 +48,10 @@ check "no orphan END markers" \
 
 echo
 echo "═══ v1.0.0  consolidated specflow router ═══"
-check ".claude/commands/ has only 1 file (backlog)" \
-  '[ "$(find .claude/commands -maxdepth 1 -type f -name "*.md" | wc -l | tr -d " ")" = "1" ]'
+check ".claude/commands/ has 2 files (backlog + specflow)" \
+  '[ "$(find .claude/commands -maxdepth 1 -type f -name "*.md" | wc -l | tr -d " ")" = "2" ]'
+check ".claude/commands/specflow.md present (slash-command shim, post-F3)" \
+  '[ -f .claude/commands/specflow.md ]'
 check "router .claude/skills/specflow/SKILL.md present" \
   '[ -f .claude/skills/specflow/SKILL.md ]'
 for phase in specify constitution clarify plan tasks analyze implement merge review checklist groom; do

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -73,7 +73,12 @@ function printConflictsError(
     console.error(
       `This project was previously initialised by Specflow — run ${
         bold("specflow upgrade")
-      } to update the managed files in place.`,
+      } to update the managed files in place,`,
+    );
+    console.error(
+      `or re-run with ${
+        bold("specflow init --here --force")
+      } to overwrite (existing files are backed up to *.specflow.bak).`,
     );
   } else {
     console.error(

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -7424,6 +7424,27 @@ team's needs.
 `,
       executable: false,
     },
+    ".claude/commands/specflow.md": {
+      content: `---
+description: Specflow workflow router — dispatches to the specflow skill (router phases live at .claude/skills/specflow/phases/<phase>.md). \`/specflow <phase> [args]\` runs a single phase.
+---
+
+## User Input
+
+\`\`\`text
+\$ARGUMENTS
+\`\`\`
+
+## Dispatch
+
+Invoke the **specflow** skill (at \`.claude/skills/specflow/SKILL.md\`) using the \`Skill\` tool, passing \`\$ARGUMENTS\` through verbatim. The skill's body parses the first token as the phase name (\`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`, \`implement\`, \`review\`, \`merge\`, \`constitution\`, \`checklist\`, \`groom\`) and reads the corresponding \`phases/<phase>.md\` to execute the procedure.
+
+Empty \`\$ARGUMENTS\` → the skill prints the workflow overview and stops.
+
+This command is a thin slash-command shim so users can type \`/specflow specify "..."\` directly. The skill itself has \`disable-model-invocation: true\`; this command makes the explicit \`/\` form available alongside the \`specflow-review\` auto-invoke alias.
+`,
+      executable: false,
+    },
     ".claude/scripts/dispatch-agent.sh": {
       content: `#!/usr/bin/env bash
 # Dispatch a Claude Code subagent in headless mode.

--- a/templates/harness-specific/claude/commands/specflow.md
+++ b/templates/harness-specific/claude/commands/specflow.md
@@ -1,0 +1,17 @@
+---
+description: Specflow workflow router — dispatches to the specflow skill (router phases live at .claude/skills/specflow/phases/<phase>.md). `/specflow <phase> [args]` runs a single phase.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Dispatch
+
+Invoke the **specflow** skill (at `.claude/skills/specflow/SKILL.md`) using the `Skill` tool, passing `$ARGUMENTS` through verbatim. The skill's body parses the first token as the phase name (`specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`, `merge`, `constitution`, `checklist`, `groom`) and reads the corresponding `phases/<phase>.md` to execute the procedure.
+
+Empty `$ARGUMENTS` → the skill prints the workflow overview and stops.
+
+This command is a thin slash-command shim so users can type `/specflow specify "..."` directly. The skill itself has `disable-model-invocation: true`; this command makes the explicit `/` form available alongside the `specflow-review` auto-invoke alias.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -76,6 +76,7 @@
   ],
   "harness_static": [
     { "harness": "claude", "destination": ".claude/CLAUDE.md", "source": "harness-specific/claude/CLAUDE.md" },
+    { "harness": "claude", "destination": ".claude/commands/specflow.md", "source": "harness-specific/claude/commands/specflow.md" },
     { "harness": "claude", "destination": ".claude/scripts/dispatch-agent.sh", "source": "harness-specific/claude/scripts/dispatch-agent.sh", "executable": true },
     { "harness": "claude", "destination": ".claude/loop.md", "source": "harness-specific/claude/loop.md" },
     { "harness": "claude", "destination": ".claude/settings.json", "source": "harness-specific/claude/settings.json" },

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -79,17 +79,20 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
       await exists(join(root, ".claude/skills/specflow-groom/SKILL.md")),
       false,
     );
-    // The /backlog command (different category) keeps the flat-file format.
+    // The /backlog command keeps the flat-file format. The /specflow
+    // command is a thin slash-command shim added post-v1.0.0 so users
+    // can type `/specflow specify ...` literally (Claude-only — see F3).
     assertEquals(await exists(join(root, ".claude/commands/backlog.md")), true);
+    assertEquals(await exists(join(root, ".claude/commands/specflow.md")), true);
     assertEquals(await exists(join(root, ".claude/agents/product-owner.md")), true);
     assertEquals(await exists(join(root, ".claude/agents/devops-sre.md")), true);
     assertEquals(await exists(join(root, ".claude/skills/auto-chain/SKILL.md")), true);
 
-    // Only the backlog command stays in .claude/commands/
+    // Two commands ship at the moment: backlog + specflow router.
     const commandsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".claude/commands")),
     )).length;
-    assertEquals(commandsCount, 1);
+    assertEquals(commandsCount, 2);
     // 9 agent .md files + 5 memory subfolders (product-owner, developer,
     // qa-tester, devops-sre, security-auditor)
     const agentDirEntries = await Array.fromAsync(
@@ -267,11 +270,9 @@ Deno.test("specflow init on a previously-initialised project recommends upgrade 
     assertEquals(code, 3);
     assertStringIncludes(stderr, "would be overwritten");
     assertStringIncludes(stderr, "specflow upgrade");
-    assertEquals(
-      stderr.includes("specflow init --here --force"),
-      false,
-      "must not suggest --force when a lock is present",
-    );
+    // Post-#129/F4: --force is also offered as an escape hatch (e.g. for
+    // switching harness or backlog backend). Both options surface.
+    assertStringIncludes(stderr, "specflow init --here --force");
   });
 });
 


### PR DESCRIPTION
## Summary

Two findings from the v1.1.0 QA dogfood pass.

**F3** — `/specflow` was a skill (with \`disable-model-invocation: true\`), so users typing \`/specflow specify "..."\` in Claude Code's slash-command picker found nothing. The 'Next steps' output advertised a slash that didn't exist. Adds a thin \`.claude/commands/specflow.md\` shim (Claude-only harness-static file) that delegates to the existing skill via the \`Skill\` tool. Other harnesses already trigger the router via skill-folder discovery.

**F4** — re-init error on a project with an existing lock used to suggest only \`specflow upgrade\`. Users wanting to switch harness or backlog backend had no documented escape hatch. Now both \`specflow upgrade\` and \`specflow init --here --force\` are surfaced in the error message.

## Out of scope

- F1 (DNS) — Cloudflare CNAME, requires authenticated access; awaiting OAuth from Kevin.
- F2 + F6 (slash-syntax drift in docs/llms.md and ~8 template files) — separate sweep PR coming next.
- F5 (file-count divergence: wrote 60 vs 58 overwritable) — needs separate ticket; the divergence is from intentional behavior (skipIfExists for AGENTS.md / constitution.md + lock not in conflict set), so the fix is a UX rephrasing rather than a count alignment.

## Test plan

- [x] \`deno task test\` — 449 passed, 0 failed (init test updated to expect 2 commands instead of 1; re-init test updated to assert --force is surfaced)
- [x] smoke-features — green (count check updated)
- [x] smoke-all-harnesses — all 8 green
- [x] Manual sandbox: \`init --here --ai claude\` writes \`.claude/commands/specflow.md\`; re-init prints both upgrade and --force suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)