### PR TITLE
fix(docs): sweep /specflow-* slash syntax + skip tag-deploys (F2, F6)

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,6 @@ name: Deploy docs to Pages
 on:
   push:
     branches: ["main"]
-    tags: ["v*"]
     paths:
       - "docs/**"
       - "scripts/build-docs.ts"

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -59,10 +59,20 @@ projects** without running `specflow init`, install the Claude Code plugin:
 /plugin install mkrlabs/specflow-plugin
 ```
 
-The plugin ships the same 21 assets the binary scaffolds — 10 slash-command skills, 1 auto-chain
-skill, 1 groom skill, and 9 sub-agents — but at user scope, versioned, and auto-updated via
-`/plugin update`. Slash-commands are namespaced: `/specflow-plugin:specify`,
-`/specflow-plugin:plan`, etc.
+The plugin ships the same 23 assets the binary scaffolds — the consolidated `specflow` router skill
+(with 11 phase docs), the `specflow-review` auto-invoke alias, the `auto-chain` skill, and 9
+sub-agents — but at user scope, versioned, and auto-updated via `/plugin update`. Because the
+plugin's slash-commands are namespaced and the consolidated router itself is named `specflow`,
+you'll see a double-prefix at the call site:
+
+```
+/specflow-plugin:specflow specify "<feature description>"
+/specflow-plugin:specflow plan
+/specflow-plugin:auto-chain specify "<feature description>"
+```
+
+Slightly verbose, but unambiguous. If you scaffold project-local with `specflow init`, you get the
+shorter `/specflow specify "..."` form.
 
 To test a local checkout of the plugin without publishing:
 
@@ -72,13 +82,13 @@ claude --plugin-dir /path/to/specflow/plugin
 
 **Plugin vs `specflow init`** — they complement each other:
 
-| Aspect                             | Binary (`specflow init`)    | Plugin (`/plugin install`)              |
-| ---------------------------------- | --------------------------- | --------------------------------------- |
-| Scope                              | Project-local (`.claude/`)  | User-scope (all projects)               |
-| Slash-command style                | `/specify`, `/plan` (short) | `/specflow-plugin:specify` (namespaced) |
-| Customizable per-project           | Yes                         | No (user-scope, shared)                 |
-| Backlog skill, hooks, `.specflow/` | Yes                         | No (project-stateful — binary-only)     |
-| Kept in sync                       | `specflow upgrade`          | `/plugin update`                        |
+| Aspect                             | Binary (`specflow init`)    | Plugin (`/plugin install`)          |
+| ---------------------------------- | --------------------------- | ----------------------------------- |
+| Scope                              | Project-local (`.claude/`)  | User-scope (all projects)           |
+| Slash-command style                | `/specflow specify` (short) | `/specflow-plugin:specflow specify` |
+| Customizable per-project           | Yes                         | No (user-scope, shared)             |
+| Backlog skill, hooks, `.specflow/` | Yes                         | No (project-stateful — binary-only) |
+| Kept in sync                       | `specflow upgrade`          | `/plugin update`                    |
 
 Most teams use both: the plugin provides discoverability and keeps the agents up-to-date across all
 projects; `specflow init` provides the short slash-commands and project-local customization.
@@ -96,14 +106,14 @@ This scaffolds a tree configured for the **Claude Code** harness by default (`.c
 `.specflow/`, `AGENTS.md`, `.specflow/backlog.md`, …). Open the project in your harness — that's
 where you'll run the rest.
 
-### Step 1 after `init`: run `/specflow-constitution`
+### Step 1 after `init`: run `/specflow constitution`
 
-`/specflow-constitution` is the expected first action after `specflow init`. It scaffolds your
+`/specflow constitution` is the expected first action after `specflow init`. It scaffolds your
 project's guiding principles (architecture, quality gates, ways of working) into
-`.specflow/memory/constitution.md` so the rest of the pipeline (`/specflow-specify`,
-`/specflow-plan`, `/specflow-tasks`, `/specflow-implement`) has something to anchor on. Refine the
+`.specflow/memory/constitution.md` so the rest of the pipeline (`/specflow specify`,
+`/specflow plan`, `/specflow tasks`, `/specflow implement`) has something to anchor on. Refine the
 generated constitution and the root `AGENTS.md` for your stack, then move on to
-`/specflow-specify "<feature description>"` for your first feature.
+`/specflow specify "<feature description>"` for your first feature.
 
 ### Add Specflow to an existing project
 
@@ -246,10 +256,10 @@ marketplace:
 ```
 
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
-sub-agents — no binary, no `specflow init` required. The 21 plugin assets (10 slash-command skills
-
-- auto-chain + groom + 9 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist with
-  project-local copies without collision.
+sub-agents — no binary, no `specflow init` required. The 23 plugin assets (the consolidated
+`specflow` router skill with 11 phase docs, the `specflow-review` auto-invoke alias, the
+`auto-chain` skill, and 9 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist with
+project-local copies without collision.
 
 When both the plugin and the binary are in use, `specflow upgrade` detects the plugin and
 auto-migrates vanilla on-disk agents and command files (backed up, then deleted — the plugin serves

--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow-review.
+description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20

--- a/plugin/agents/qa-tester.md
+++ b/plugin/agents/qa-tester.md
@@ -1,6 +1,6 @@
 ---
 name: qa-tester
-description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow-implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
+description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits

--- a/plugin/agents/review-coordinator.md
+++ b/plugin/agents/review-coordinator.md
@@ -1,6 +1,6 @@
 ---
 name: review-coordinator
-description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow-review is running Phase 1.
+description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 maxTurns: 30
@@ -12,7 +12,7 @@ in parallel and aggregate results.
 ## Inputs
 
 - The list of files changed in the current feature branch (provided by
-  `/specflow-review`).
+  `/specflow review`).
 
 ## Protocol
 

--- a/plugin/agents/security-auditor.md
+++ b/plugin/agents/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow-review.
+description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2318,7 +2318,7 @@ failed, and what decision the next owner needs to make.
     suffix: null,
     content: `---
 name: review-coordinator
-description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow-review is running Phase 1.
+description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 maxTurns: 30
@@ -2330,7 +2330,7 @@ in parallel and aggregate results.
 ## Inputs
 
 - The list of files changed in the current feature branch (provided by
-  \`/specflow-review\`).
+  \`/specflow review\`).
 
 ## Protocol
 
@@ -2374,7 +2374,7 @@ MEDIUM / LOW findings: <N>, list suppressed — see per-agent reports for detail
     suffix: null,
     content: `---
 name: code-reviewer
-description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow-review.
+description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
@@ -2429,7 +2429,7 @@ PASS if zero CRITICAL and zero HIGH findings. Otherwise FAIL.
     suffix: null,
     content: `---
 name: security-auditor
-description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow-review.
+description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
@@ -2507,7 +2507,7 @@ Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
     suffix: null,
     content: `---
 name: qa-tester
-description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow-implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
+description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
@@ -4940,20 +4940,20 @@ fi
 # Validate required directories and files
 if [[ ! -d "\$FEATURE_DIR" ]]; then
     echo "ERROR: Feature directory not found: \$FEATURE_DIR" >&2
-    echo "Run /specflow-specify first to create the feature structure." >&2
+    echo "Run /specflow specify first to create the feature structure." >&2
     exit 1
 fi
 
 if [[ ! -f "\$IMPL_PLAN" ]]; then
     echo "ERROR: plan.md not found in \$FEATURE_DIR" >&2
-    echo "Run /specflow-plan first to create the implementation plan." >&2
+    echo "Run /specflow plan first to create the implementation plan." >&2
     exit 1
 fi
 
 # Check for tasks.md if required
 if \$REQUIRE_TASKS && [[ ! -f "\$TASKS" ]]; then
     echo "ERROR: tasks.md not found in \$FEATURE_DIR" >&2
-    echo "Run /specflow-tasks first to create the task list." >&2
+    echo "Run /specflow tasks first to create the task list." >&2
     exit 1
 fi
 
@@ -5233,7 +5233,7 @@ get_feature_paths() {
 
     # Resolve feature directory.  Priority:
     #   1. SPECIFY_FEATURE_DIRECTORY env var (explicit override)
-    #   2. .specflow/feature.json "feature_directory" key (persisted by /specflow-specify)
+    #   2. .specflow/feature.json "feature_directory" key (persisted by /specflow specify)
     #   3. Branch-name-based prefix lookup (legacy fallback)
     local feature_dir
     if [[ -n "\${SPECIFY_FEATURE_DIRECTORY:-}" ]]; then
@@ -7398,7 +7398,7 @@ team's needs.
 
 - **Periodic maintenance** — \`/loop 1h\` runs the prompt in
   \`.claude/loop.md\` every hour. The bundled default delegates to the
-  \`/specflow-groom\` skill (groom backlog, surface stale PRs, list orphan
+  \`/specflow groom\` skill (groom backlog, surface stale PRs, list orphan
   specs); edit \`loop.md\` freely to add project-specific checks. See
   https://code.claude.com/docs/fr/scheduled-tasks.
 
@@ -7584,7 +7584,7 @@ this project's hygiene needs.
 
 Run a hygiene pass on this Specflow project:
 
-1. Invoke the \`/specflow-groom\` skill — it grooms the backlog, surfaces
+1. Invoke the \`/specflow groom\` skill — it grooms the backlog, surfaces
    stale PRs, and flags orphan specs.
 2. If anything actionable came out of the pass, summarize it concisely
    so the human reading the loop output can decide what to do.
@@ -7595,7 +7595,7 @@ Run a hygiene pass on this Specflow project:
 
 - **Active development**: \`/loop 1h\` — frequent grooming during a sprint.
 - **Quiet projects**: \`/loop 12h\` or \`/loop 24h\` — daily cadence.
-- **One-off check**: just \`/specflow-groom\` (no loop) — runs once and exits.
+- **One-off check**: just \`/specflow groom\` (no loop) — runs once and exits.
 
 ## Customizing further
 
@@ -7822,16 +7822,16 @@ clarifications needed) STOP #2 (pre-merge validation)
 
 ## Skills available
 
-- \`/specflow-specify\` — scaffold a new feature spec from a description
-- \`/specflow-clarify\` — resolve outstanding questions in \`spec.md\`
-- \`/specflow-plan\` — produce the implementation plan
-- \`/specflow-tasks\` — break the plan into tasks
-- \`/specflow-analyze\` — cross-artefact consistency check
-- \`/specflow-implement\` — run the developer → review-coordinator → qa-tester pipeline
-- \`/specflow-review\` — architecture + quality gates
-- \`/specflow-merge\` — merge the feature branch to main
+- \`/specflow specify\` — scaffold a new feature spec from a description
+- \`/specflow clarify\` — resolve outstanding questions in \`spec.md\`
+- \`/specflow plan\` — produce the implementation plan
+- \`/specflow tasks\` — break the plan into tasks
+- \`/specflow analyze\` — cross-artefact consistency check
+- \`/specflow implement\` — run the developer → review-coordinator → qa-tester pipeline
+- \`/specflow review\` — architecture + quality gates
+- \`/specflow merge\` — merge the feature branch to main
 - \`/specflow-backlog\` — manage the product backlog (via the PO agent)
-- \`/specflow-auto-chain\` — auto-chain dispatcher invoked by \`/specflow-specify\`
+- \`/specflow-auto-chain\` — auto-chain dispatcher invoked by \`/specflow specify\`
 
 ## Agent roles (invocable manually as skills)
 

--- a/templates/core/agents/code-reviewer.md
+++ b/templates/core/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow-review.
+description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20

--- a/templates/core/agents/qa-tester.md
+++ b/templates/core/agents/qa-tester.md
@@ -1,6 +1,6 @@
 ---
 name: qa-tester
-description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow-implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
+description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits

--- a/templates/core/agents/review-coordinator.md
+++ b/templates/core/agents/review-coordinator.md
@@ -1,6 +1,6 @@
 ---
 name: review-coordinator
-description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow-review is running Phase 1.
+description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 maxTurns: 30
@@ -12,7 +12,7 @@ in parallel and aggregate results.
 ## Inputs
 
 - The list of files changed in the current feature branch (provided by
-  `/specflow-review`).
+  `/specflow review`).
 
 ## Protocol
 

--- a/templates/core/agents/security-auditor.md
+++ b/templates/core/agents/security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: security-auditor
-description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow-review.
+description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20

--- a/templates/core/specflow/scripts/bash/check-prerequisites.sh
+++ b/templates/core/specflow/scripts/bash/check-prerequisites.sh
@@ -115,20 +115,20 @@ fi
 # Validate required directories and files
 if [[ ! -d "$FEATURE_DIR" ]]; then
     echo "ERROR: Feature directory not found: $FEATURE_DIR" >&2
-    echo "Run /specflow-specify first to create the feature structure." >&2
+    echo "Run /specflow specify first to create the feature structure." >&2
     exit 1
 fi
 
 if [[ ! -f "$IMPL_PLAN" ]]; then
     echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
-    echo "Run /specflow-plan first to create the implementation plan." >&2
+    echo "Run /specflow plan first to create the implementation plan." >&2
     exit 1
 fi
 
 # Check for tasks.md if required
 if $REQUIRE_TASKS && [[ ! -f "$TASKS" ]]; then
     echo "ERROR: tasks.md not found in $FEATURE_DIR" >&2
-    echo "Run /specflow-tasks first to create the task list." >&2
+    echo "Run /specflow tasks first to create the task list." >&2
     exit 1
 fi
 

--- a/templates/core/specflow/scripts/bash/common.sh
+++ b/templates/core/specflow/scripts/bash/common.sh
@@ -209,7 +209,7 @@ get_feature_paths() {
 
     # Resolve feature directory.  Priority:
     #   1. SPECIFY_FEATURE_DIRECTORY env var (explicit override)
-    #   2. .specflow/feature.json "feature_directory" key (persisted by /specflow-specify)
+    #   2. .specflow/feature.json "feature_directory" key (persisted by /specflow specify)
     #   3. Branch-name-based prefix lookup (legacy fallback)
     local feature_dir
     if [[ -n "${SPECIFY_FEATURE_DIRECTORY:-}" ]]; then

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -16,7 +16,7 @@ team's needs.
 
 - **Periodic maintenance** — `/loop 1h` runs the prompt in
   `.claude/loop.md` every hour. The bundled default delegates to the
-  `/specflow-groom` skill (groom backlog, surface stale PRs, list orphan
+  `/specflow groom` skill (groom backlog, surface stale PRs, list orphan
   specs); edit `loop.md` freely to add project-specific checks. See
   https://code.claude.com/docs/fr/scheduled-tasks.
 

--- a/templates/harness-specific/claude/loop.md
+++ b/templates/harness-specific/claude/loop.md
@@ -8,7 +8,7 @@ this project's hygiene needs.
 
 Run a hygiene pass on this Specflow project:
 
-1. Invoke the `/specflow-groom` skill — it grooms the backlog, surfaces
+1. Invoke the `/specflow groom` skill — it grooms the backlog, surfaces
    stale PRs, and flags orphan specs.
 2. If anything actionable came out of the pass, summarize it concisely
    so the human reading the loop output can decide what to do.
@@ -19,7 +19,7 @@ Run a hygiene pass on this Specflow project:
 
 - **Active development**: `/loop 1h` — frequent grooming during a sprint.
 - **Quiet projects**: `/loop 12h` or `/loop 24h` — daily cadence.
-- **One-off check**: just `/specflow-groom` (no loop) — runs once and exits.
+- **One-off check**: just `/specflow groom` (no loop) — runs once and exits.
 
 ## Customizing further
 

--- a/templates/harness-specific/cursor/specify-rules.mdc
+++ b/templates/harness-specific/cursor/specify-rules.mdc
@@ -20,16 +20,16 @@ clarifications needed) STOP #2 (pre-merge validation)
 
 ## Skills available
 
-- `/specflow-specify` — scaffold a new feature spec from a description
-- `/specflow-clarify` — resolve outstanding questions in `spec.md`
-- `/specflow-plan` — produce the implementation plan
-- `/specflow-tasks` — break the plan into tasks
-- `/specflow-analyze` — cross-artefact consistency check
-- `/specflow-implement` — run the developer → review-coordinator → qa-tester pipeline
-- `/specflow-review` — architecture + quality gates
-- `/specflow-merge` — merge the feature branch to main
+- `/specflow specify` — scaffold a new feature spec from a description
+- `/specflow clarify` — resolve outstanding questions in `spec.md`
+- `/specflow plan` — produce the implementation plan
+- `/specflow tasks` — break the plan into tasks
+- `/specflow analyze` — cross-artefact consistency check
+- `/specflow implement` — run the developer → review-coordinator → qa-tester pipeline
+- `/specflow review` — architecture + quality gates
+- `/specflow merge` — merge the feature branch to main
 - `/specflow-backlog` — manage the product backlog (via the PO agent)
-- `/specflow-auto-chain` — auto-chain dispatcher invoked by `/specflow-specify`
+- `/specflow-auto-chain` — auto-chain dispatcher invoked by `/specflow specify`
 
 ## Agent roles (invocable manually as skills)
 


### PR DESCRIPTION
## Summary

QA dogfood pass after v1.1.0 surfaced post-v1.0.0 syntax drift in user-facing docs and ~10 template files. Most still referenced the old \`/specflow-<phase>\` slash-command form even though v1.0.0 (#127) consolidated all phases into a single \`/specflow\` router.

This sweep:

- **\`docs/llms.md\`** — quickstart rewritten to \`/specflow <phase>\`. Plugin section updated to the v1.0.0 double-prefix form (\`/specflow-plugin:specflow specify\`) and the asset count (23, was 21).
- **4 sub-agent description fields** (code-reviewer, qa-tester, review-coordinator, security-auditor): \`/specflow-review\` → \`/specflow review\`. Plugin copies re-synced.
- **\`.specflow/scripts/bash/check-prerequisites.sh\` + \`common.sh\`**: printed user hints rewritten.
- **\`.claude/CLAUDE.md\` + \`.claude/loop.md\` + \`.cursor/specify-rules.mdc\`**: \`/specflow-groom\` → \`/specflow groom\`.

**Bonus** — drop \`tags: ["v*"]\` from \`.github/workflows/static.yml\`. The \`github-pages\` environment policy only allows \`main\` deployments, so every release tag has been failing the docs deploy step with "Tag X not allowed". The same release commit on \`main\` deploys successfully via the branch-push path, so docs are always current before the tag run starts. Removing the tag trigger eliminates the red ❌ on every release CI dashboard. Verified by devops-sre advisory: no cross-workflow dependency on the tag-triggered deploy.

## Out of scope

- Historical specs/plans under \`docs/superpowers/\` are intentionally left untouched — they're snapshots of decisions at the time, not user-facing docs.

## Test plan

- [x] \`deno task test\` — 449 passed (plugin agent copies re-synced after the source rewrite)
- [x] smoke-features + smoke-all-harnesses — green
- [x] curl https://specflow.makerlabs.dev/llms.txt — confirmed F1 site is live (Kevin's Cloudflare CNAME landed earlier this turn). Will re-verify post-merge that the deploy fires and serves the corrected content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)