### PR TITLE
fix(init): catch ClaudeSettingsParseError at the CLI boundary (#141)

### DIFF
--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -7,6 +7,7 @@ import { pickBacklogBackend, pickBacklogBackendInteractive } from "../backlog_pi
 import { makeStdinSelectIO } from "../select.ts";
 import type { BacklogBackend } from "../../domain/installed_lock.ts";
 import { findBacklogStrategy } from "../../domain/backlog_strategies/registry.ts";
+import { ClaudeSettingsParseError } from "../../domain/claude_settings_merge.ts";
 import { DenoFsWriter } from "../../infrastructure/deno_fs_writer.ts";
 import { DenoGit } from "../../infrastructure/deno_git.ts";
 import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
@@ -203,11 +204,25 @@ export async function runInit(intent: InitIntent): Promise<number> {
     ensureDir: (path) => Deno.mkdir(path, { recursive: true }),
   });
 
-  const result = await useCase.execute({
-    targetDir,
-    initGit: !intent.noGit,
-    force: intent.force,
-  });
+  let result;
+  try {
+    result = await useCase.execute({
+      targetDir,
+      initGit: !intent.noGit,
+      force: intent.force,
+    });
+  } catch (err) {
+    // Surface the actionable first-line message for known structured
+    // errors (currently only the JSON merge of `.claude/settings.json`).
+    // Without this catch, Deno's default top-level handler prints a
+    // 10-line stack trace from inside the compiled binary's cache —
+    // unprofessional and noisy for what is a user-fixable typo.
+    if (err instanceof ClaudeSettingsParseError) {
+      console.error(red(err.message));
+      return 2;
+    }
+    throw err;
+  }
 
   if (result.status === "conflicts") {
     // Re-derive the managed file count for the secondary conflict path


### PR DESCRIPTION
## Summary

Closes #141. QA finding F3 from the v1.1.3 dogfood pass: malformed user `.claude/settings.json` correctly triggered the structured `ClaudeSettingsParseError` with an actionable first-line message, but the error then propagated uncaught — Deno's default top-level handler appended a 10-line stack trace from inside the compiled binary's cache.

**Before** (v1.1.3):

\`\`\`
ClaudeSettingsParseError: .claude/settings.json is not valid JSON: ...
Fix the file (or back it up and re-run with --force) before re-running specflow.
    at mergeClaudeSettings (file:///var/folders/.../deno-compile-specflow/.../claude_settings_merge.ts:94:11)
    at DenoFsWriter.writeBundle (file:///.../deno_fs_writer.ts:103:24)
    ... 8 more frames ...
Caused by: SyntaxError: Expected ',' or '}' ...
\`\`\`

**After** (this PR):

\`\`\`
.claude/settings.json is not valid JSON: Expected ',' or '}' after property value in JSON at position 18 (line 2 column 1)
Fix the file (or back it up and re-run with --force) before re-running specflow.
\`\`\`

Exit 2. No stack trace.

## Implementation

- `init_handler.ts` catches \`ClaudeSettingsParseError\` from \`useCase.execute\`, prints the message via \`console.error(red(...))\`, returns exit 2.
- Other unhandled errors rethrow as before — no behaviour change for the rest of the error surface.
- \`upgrade_handler.ts\` already had a generic message-only catch, so the leak was init-only.

## Test plan

- [x] \`deno task test\` — 458 passed
- [x] smoke-features — green
- [x] Manual sandbox: write a malformed \`.claude/settings.json\` (missing closing brace), run \`init\` → 2-line clean error, exit 2, no stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)