### PR TITLE
feat(commands): expose argument-hint frontmatter on user-facing commands

### DIFF
--- a/plugin/skills/specflow-review/SKILL.md
+++ b/plugin/skills/specflow-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: specflow-review
 description: Review the implementation against spec, plan, and tasks before merge — runs the quality gates (functional acceptance, test coverage, constitution checks). Auto-invokable when the user signals readiness to merge or asks for a final review pass.
+argument-hint: [feature-path-or-PR-number]
 when_to_use: |
   Trigger phrases:
   - "review the implementation"

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -2,6 +2,7 @@
 name: specflow
 disable-model-invocation: true
 description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -13,6 +13,7 @@ export const CORE_BUNDLE: CoreBundle = [
 name: specflow
 disable-model-invocation: true
 description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). \`/specflow\` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -1881,6 +1882,7 @@ to be a **no-op when the project is healthy**.
     content: `---
 name: specflow-review
 description: Review the implementation against spec, plan, and tasks before merge — runs the quality gates (functional acceptance, test coverage, constitution checks). Auto-invokable when the user signals readiness to merge or asks for a final review pass.
+argument-hint: [feature-path-or-PR-number]
 when_to_use: |
   Trigger phrases:
   - "review the implementation"
@@ -1907,6 +1909,7 @@ Do not duplicate the review procedure here — it lives in \`phases/review.md\` 
     suffix: null,
     content: `---
 description: Manage the product backlog — list, add, update, groom, and brief tasks. All mutations route through the product-owner agent.
+argument-hint: [list|next|add|update|estimate|status|groom|brief] [args]
 ---
 
 ## User Input
@@ -3064,6 +3067,7 @@ them resume manually from the last completed phase.
     content: `---
 name: backlog
 description: Manage this project's backlog — add, list, view, move, and clarify items. The backend is fixed at init time and recorded in \`.specflow/installed.lock\`. Run \`specflow upgrade --backlog <new>\` to switch.
+argument-hint: [list|next|add|update|estimate|status|groom|brief] [args]
 ---
 
 # Backlog skill
@@ -7427,6 +7431,7 @@ team's needs.
     ".claude/commands/specflow.md": {
       content: `---
 description: Specflow workflow router — dispatches to the specflow skill (router phases live at .claude/skills/specflow/phases/<phase>.md). \`/specflow <phase> [args]\` runs a single phase.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 ---
 
 ## User Input

--- a/templates/core/commands/backlog.md
+++ b/templates/core/commands/backlog.md
@@ -1,5 +1,6 @@
 ---
 description: Manage the product backlog — list, add, update, groom, and brief tasks. All mutations route through the product-owner agent.
+argument-hint: [list|next|add|update|estimate|status|groom|brief] [args]
 ---
 
 ## User Input

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: backlog
 description: Manage this project's backlog — add, list, view, move, and clarify items. The backend is fixed at init time and recorded in `.specflow/installed.lock`. Run `specflow upgrade --backlog <new>` to switch.
+argument-hint: [list|next|add|update|estimate|status|groom|brief] [args]
 ---
 
 # Backlog skill

--- a/templates/core/skills/specflow-review/SKILL.md
+++ b/templates/core/skills/specflow-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: specflow-review
 description: Review the implementation against spec, plan, and tasks before merge — runs the quality gates (functional acceptance, test coverage, constitution checks). Auto-invokable when the user signals readiness to merge or asks for a final review pass.
+argument-hint: [feature-path-or-PR-number]
 when_to_use: |
   Trigger phrases:
   - "review the implementation"

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -2,6 +2,7 @@
 name: specflow
 disable-model-invocation: true
 description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"

--- a/templates/harness-specific/claude/commands/specflow.md
+++ b/templates/harness-specific/claude/commands/specflow.md
@@ -1,5 +1,6 @@
 ---
 description: Specflow workflow router — dispatches to the specflow skill (router phases live at .claude/skills/specflow/phases/<phase>.md). `/specflow <phase> [args]` runs a single phase.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 ---
 
 ## User Input


### PR DESCRIPTION
## Summary

- Closes #143.
- Adds the `argument-hint` frontmatter field to Specflow's 3 user-facing slash commands (`/specflow`, `/backlog`, `/specflow-review`) and their backing skills.
- Claude Code renders the value as a dim grey inline hint after the command name — e.g. typing `/specflow ` now shows `<specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom>` in the input, so phases are discoverable without docs.

## Hints

| Command | Hint |
|---|---|
| `/specflow` | `<specify\|clarify\|plan\|tasks\|analyze\|implement\|review\|merge\|constitution\|checklist\|groom> [args]` |
| `/backlog` | `[list\|next\|add\|update\|estimate\|status\|groom\|brief] [args]` |
| `/specflow-review` | `[feature-path-or-PR-number]` |

Convention per Claude Code docs: `<arg>` for required, `[arg]` for optional.

## Files

Templates + plugin mirror — 8 files total, all frontmatter-only (12 line additions, no behavior change).

## Test plan

- [x] `deno task bundle` — 66 core entries, 9 harness-specific
- [x] `deno task test` — 458 passed, 0 failed
- [x] Smoke via test-sandbox: `specflow init --here --ai claude --backlog local` on a clean greenfield → all 5 scaffolded files (`commands/specflow.md`, `commands/backlog.md`, `skills/specflow/SKILL.md`, `skills/backlog/SKILL.md`, `skills/specflow-review/SKILL.md`) carry the hint intact
- [ ] Visual confirmation in Claude Code after `specflow upgrade` lands the next release