### PR TITLE
fix(check): parse gh auth status from stdout (gh 2.7+)

### DIFF
--- a/src/infrastructure/deno_environment_probe.ts
+++ b/src/infrastructure/deno_environment_probe.ts
@@ -28,7 +28,10 @@ export class DenoEnvironmentProbe implements EnvironmentProbe {
         message: `gh version ${v} (not authenticated — run 'gh auth login')`,
       };
     }
-    const loginMatch = auth.stderr.match(/account\s+(\S+)/);
+    // gh 2.7+ writes `gh auth status` output to stdout; older versions
+    // wrote it to stderr. Search both so the probe works across versions.
+    const combined = `${auth.stdout}\n${auth.stderr}`;
+    const loginMatch = combined.match(/account\s+(\S+)/);
     const login = loginMatch ? loginMatch[1] : "unknown";
     return {
       name: "gh",

--- a/tests/infrastructure/deno_environment_probe_test.ts
+++ b/tests/infrastructure/deno_environment_probe_test.ts
@@ -33,7 +33,7 @@ Deno.test("probeGit returns fail when binary missing", async () => {
   assertEquals(outcome.status, "fail");
 });
 
-Deno.test("probeGh returns pass with authenticated login", async () => {
+Deno.test("probeGh parses login from stderr (legacy gh < 2.7)", async () => {
   const runner = fakeRunner((_cmd, args) => {
     if (args[0] === "--version") {
       return { code: 0, stdout: "gh version 2.50.0", stderr: "" };
@@ -49,6 +49,31 @@ Deno.test("probeGh returns pass with authenticated login", async () => {
   assertEquals(outcome.status, "pass");
   assertEquals(outcome.message.includes("2.50.0"), true);
   assertEquals(outcome.message.includes("kevinraimbaud"), true);
+});
+
+Deno.test("probeGh parses login from stdout (gh 2.7+ — real 2.92.0 output)", async () => {
+  const runner = fakeRunner((_cmd, args) => {
+    if (args[0] === "--version") {
+      return { code: 0, stdout: "gh version 2.92.0 (2026-04-15)", stderr: "" };
+    }
+    // Verbatim shape of `gh auth status` on gh 2.92.0
+    return {
+      code: 0,
+      stdout: "github.com\n" +
+        "  ✓ Logged in to github.com account kevinkod (keyring)\n" +
+        "  - Active account: true\n" +
+        "  - Git operations protocol: ssh\n" +
+        "  - Token: gho_************************************\n" +
+        "  - Token scopes: 'admin:public_key', 'gist', 'project'\n",
+      stderr: "",
+    };
+  });
+  const probe = new DenoEnvironmentProbe(runner);
+  const outcome = await probe.probeGh();
+  assertEquals(outcome.status, "pass");
+  assertEquals(outcome.message.includes("2.92.0"), true);
+  assertEquals(outcome.message.includes("kevinkod"), true);
+  assertEquals(outcome.message.includes("unknown"), false);
 });
 
 Deno.test("probeGh returns warn when installed but not authenticated", async () => {


### PR DESCRIPTION
## Summary

- Closes #146.
- `specflow check` now reports `gh version 2.92.0 (authenticated as <login>)` correctly on gh 2.7+ (which writes `gh auth status` output to stdout, not stderr as in older versions).
- 1-line code fix + test coverage refresh — no behavior change for any other path.

## Root cause

`src/infrastructure/deno_environment_probe.ts:31` searched `auth.stderr` for the username regex. gh 2.7+ writes auth-status output to stdout, so the match never fired and the message fell through to "unknown" — producing the user-visible contradiction:

\`\`\`
gh    ✓ gh version 2.92.0 (authenticated as unknown)
\`\`\`

## Fix

Combine both streams before regex match:

\`\`\`ts
const combined = \`\${auth.stdout}\n\${auth.stderr}\`;
const loginMatch = combined.match(/account\s+(\S+)/);
\`\`\`

Backward-compatible with legacy gh <2.7 — same regex, just runs against both streams.

## Tests

- Renamed existing test to `probeGh parses login from stderr (legacy gh < 2.7)` to make the implicit version assumption explicit.
- New test `probeGh parses login from stdout (gh 2.7+ — real 2.92.0 output)` uses the verbatim 6-line stdout shape from real gh 2.92.0 output, including the `(keyring)` suffix. Asserts the message contains the actual login AND that `unknown` never appears.

## Test plan

- [x] \`deno task test\` — 489 passed / 0 failed
- [x] \`deno run --allow-all src/main.ts check\` on host with gh 2.92.0 — output now reads \`gh version 2.92.0 (authenticated as kevinkod)\` (was: \`authenticated as unknown\`)