### PR TITLE
feat(skills): rename /auto-chain to /specflow-auto for namespace consistency

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -60,7 +60,7 @@ projects** without running `specflow init`, install the Claude Code plugin:
 ```
 
 The plugin ships the same 23 assets the binary scaffolds — the consolidated `specflow` router skill
-(with 11 phase docs), the `specflow-review` auto-invoke alias, the `auto-chain` skill, and 9
+(with 11 phase docs), the `specflow-review` auto-invoke alias, the `specflow-auto` skill, and 9
 sub-agents — but at user scope, versioned, and auto-updated via `/plugin update`. Because the
 plugin's slash-commands are namespaced and the consolidated router itself is named `specflow`,
 you'll see a double-prefix at the call site:
@@ -68,7 +68,7 @@ you'll see a double-prefix at the call site:
 ```
 /specflow-plugin:specflow specify "<feature description>"
 /specflow-plugin:specflow plan
-/specflow-plugin:auto-chain specify "<feature description>"
+/specflow-plugin:specflow-auto specify "<feature description>"
 ```
 
 Slightly verbose, but unambiguous. If you scaffold project-local with `specflow init`, you get the
@@ -258,8 +258,8 @@ marketplace:
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
 sub-agents — no binary, no `specflow init` required. The 23 plugin assets (the consolidated
 `specflow` router skill with 11 phase docs, the `specflow-review` auto-invoke alias, the
-`auto-chain` skill, and 9 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist with
-project-local copies without collision.
+`specflow-auto` skill, and 9 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist
+with project-local copies without collision.
 
 When both the plugin and the binary are in use, `specflow upgrade` detects the plugin and
 auto-migrates vanilla on-disk agents and command files (backed up, then deleted — the plugin serves

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specflow-plugin",
-  "description": "Specflow's auto-chain skill, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
+  "description": "Specflow's specflow-auto skill, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
   "version": "1.1.5",
   "author": {
     "name": "MakerLabs"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,15 +1,15 @@
 # specflow-plugin — Claude Code plugin for Specflow
 
 This is the Claude Code plugin distribution of [Specflow](https://specflow.makerlabs.dev). It ships
-the same slash-commands, sub-agents, and the auto-chain skill that the `specflow` binary scaffolds
-into projects — just as a user-scope plugin instead.
+the same slash-commands, sub-agents, and the specflow-auto skill that the `specflow` binary
+scaffolds into projects — just as a user-scope plugin instead.
 
 ## What's in here
 
 | Path                                                                                                                                        | Contents                                                              |
 | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specflow-plugin`, lockstep with the binary version) |
-| `skills/auto-chain/SKILL.md`                                                                                                                | Auto-chain skill — `/specflow-plugin:auto-chain`                      |
+| `skills/specflow-auto/SKILL.md`                                                                                                             | Auto-chain skill — `/specflow-plugin:specflow-auto`                   |
 | `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/specflow-plugin:specify`, etc.     |
 | `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                      |
 | `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specflow-plugin:groom`                                |
@@ -57,7 +57,7 @@ To test changes to the plugin without publishing:
 claude --plugin-dir /path/to/specflow/plugin
 ```
 
-Then invoke any plugin skill: `/specflow-plugin:auto-chain specify "…"`.
+Then invoke any plugin skill: `/specflow-plugin:specflow-auto specify "…"`.
 
 ## Versioning
 

--- a/plugin/skills/specflow-auto/SKILL.md
+++ b/plugin/skills/specflow-auto/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: auto-chain
-description: Auto-chain Specflow workflow — when the user runs /auto-chain specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+name: specflow-auto
+description: Auto-chain Specflow workflow — when the user runs /specflow-auto specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
 ---
 
 # Specflow Auto-Chain
 
 This skill turns the Specflow workflow into a single-command operation. When the
-user invokes `/auto-chain specify "<feature description>"`, you MUST chain every
+user invokes `/specflow-auto specify "<feature description>"`, you MUST chain every
 Specflow phase in the same session without asking the user between phases,
 EXCEPT at the two checkpoints defined below.
 
@@ -66,14 +66,14 @@ the branch)". Wait for explicit confirmation. On "yes", invoke
 
 ## Opt-out
 
-If the user invokes `/auto-chain specify --manual "<description>"`, run
+If the user invokes `/specflow-auto specify --manual "<description>"`, run
 `/specflow specify` only and stop. Do not auto-chain. Each subsequent phase must
 be invoked manually by the user.
 
 ## Single-phase invocations
 
-When the user invokes any phase directly (e.g. `/auto-chain clarify 042`,
-`/auto-chain plan 042`) — i.e. NOT via the entry point `/auto-chain specify` — the
+When the user invokes any phase directly (e.g. `/specflow-auto clarify 042`,
+`/specflow-auto plan 042`) — i.e. NOT via the entry point `/specflow-auto specify` — the
 command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
 re-running phases on an existing feature.
 

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -89,4 +89,4 @@ specify → clarify → plan → tasks → analyze → implement → review → 
   → pre-merge validation + merge
 ```
 
-For an end-to-end run that auto-chains the silent gates, use `/auto-chain specify "<feature>"`.
+For an end-to-end run that auto-chains the silent gates, use `/specflow-auto specify "<feature>"`.

--- a/plugin/skills/specflow/phases/review.md
+++ b/plugin/skills/specflow/phases/review.md
@@ -81,5 +81,5 @@ Remaining findings (MEDIUM/LOW, non-blocking)
 Overall: PASS | FAIL
 ```
 
-If Overall = PASS, invoke `/specflow merge` (or hand back to the auto-chain for
-STOP #2). If FAIL, stop and report to the user.
+If Overall = PASS, invoke `/specflow merge` (or hand back to `/specflow-auto`
+for STOP #2). If FAIL, stop and report to the user.

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -27,7 +27,7 @@ import type { KnownHarness } from "./installed_lock.ts";
  *   - `.claude/skills/specflow/SKILL.md` — the consolidated router skill
  *   - `.claude/skills/specflow/phases/<phase>.md` — the 11 phase docs
  *   - `.claude/skills/specflow-review/SKILL.md` — auto-invoke alias
- *   - `.claude/skills/auto-chain/SKILL.md`
+ *   - `.claude/skills/specflow-auto/SKILL.md`
  *
  * Everything else (project-stateful files in `.specflow/`, harness-
  * static files like `.claude/settings.json`, hooks, `CLAUDE.md`,
@@ -45,7 +45,7 @@ export function isPluginCoveredPath(
   if (dest === ".claude/skills/specflow/SKILL.md") return true;
   if (/^\.claude\/skills\/specflow\/phases\/[a-z]+\.md$/.test(dest)) return true;
   if (dest === ".claude/skills/specflow-review/SKILL.md") return true;
-  if (dest === ".claude/skills/auto-chain/SKILL.md") return true;
+  if (dest === ".claude/skills/specflow-auto/SKILL.md") return true;
 
   return false;
 }
@@ -61,7 +61,7 @@ export function isPluginCoveredPath(
  *
  * Kept in sync with `isPluginCoveredPath` above. Total: 23 paths
  * (9 agents excluding architect + 1 router skill + 11 phase docs +
- * specflow-review alias + auto-chain).
+ * specflow-review alias + specflow-auto).
  */
 export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
   ...[
@@ -90,5 +90,5 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "groom",
   ].map((name) => `.claude/skills/specflow/phases/${name}.md`),
   ".claude/skills/specflow-review/SKILL.md",
-  ".claude/skills/auto-chain/SKILL.md",
+  ".claude/skills/specflow-auto/SKILL.md",
 ];

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -17,7 +17,7 @@ function destinationFor(entry: CoreEntry): string {
     case "skill":
     case "backlog-skill":
       // Claude doesn't add a `specflow-` prefix — skill names are emitted
-      // verbatim as the folder name (`specflow`, `auto-chain`, `backlog`,
+      // verbatim as the folder name (`specflow`, `specflow-auto`, `backlog`,
       // `specflow-review`, …).
       return `.claude/skills/${entry.name}/SKILL.md`;
     case "phase":

--- a/src/infrastructure/harness/skill_folder.ts
+++ b/src/infrastructure/harness/skill_folder.ts
@@ -13,9 +13,9 @@ export function skillFolderName(entry: CoreEntry): string {
     case "backlog-skill":
       // Skill names that already begin with "specflow" are emitted as-is
       // (the router itself is "specflow"; the auto-invoke alias is
-      // "specflow-review"). Other skills (`auto-chain`, `backlog`, …)
-      // get the namespacing prefix to avoid clashes inside a global
-      // skills registry.
+      // "specflow-review"; the auto-chainer is "specflow-auto"). Other
+      // skills (`backlog`, …) get the namespacing prefix to avoid
+      // clashes inside a global skills registry.
       return entry.name === "specflow" || entry.name.startsWith("specflow-")
         ? entry.name
         : `specflow-${entry.name}`;

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -100,7 +100,7 @@ specify → clarify → plan → tasks → analyze → implement → review → 
   → pre-merge validation + merge
 \`\`\`
 
-For an end-to-end run that auto-chains the silent gates, use \`/auto-chain specify "<feature>"\`.
+For an end-to-end run that auto-chains the silent gates, use \`/specflow-auto specify "<feature>"\`.
 `,
     executable: false,
     backend: null,
@@ -1359,8 +1359,8 @@ Remaining findings (MEDIUM/LOW, non-blocking)
 Overall: PASS | FAIL
 \`\`\`
 
-If Overall = PASS, invoke \`/specflow merge\` (or hand back to the auto-chain for
-STOP #2). If FAIL, stop and report to the user.
+If Overall = PASS, invoke \`/specflow merge\` (or hand back to \`/specflow-auto\`
+for STOP #2). If FAIL, stop and report to the user.
 `,
     executable: false,
     backend: null,
@@ -3029,17 +3029,17 @@ should survive across sessions and isn't captured elsewhere:
   },
   {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: `---
-name: auto-chain
-description: Auto-chain Specflow workflow — when the user runs /auto-chain specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+name: specflow-auto
+description: Auto-chain Specflow workflow — when the user runs /specflow-auto specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
 ---
 
 # Specflow Auto-Chain
 
 This skill turns the Specflow workflow into a single-command operation. When the
-user invokes \`/auto-chain specify "<feature description>"\`, you MUST chain every
+user invokes \`/specflow-auto specify "<feature description>"\`, you MUST chain every
 Specflow phase in the same session without asking the user between phases,
 EXCEPT at the two checkpoints defined below.
 
@@ -3099,14 +3099,14 @@ the branch)". Wait for explicit confirmation. On "yes", invoke
 
 ## Opt-out
 
-If the user invokes \`/auto-chain specify --manual "<description>"\`, run
+If the user invokes \`/specflow-auto specify --manual "<description>"\`, run
 \`/specflow specify\` only and stop. Do not auto-chain. Each subsequent phase must
 be invoked manually by the user.
 
 ## Single-phase invocations
 
-When the user invokes any phase directly (e.g. \`/auto-chain clarify 042\`,
-\`/auto-chain plan 042\`) — i.e. NOT via the entry point \`/auto-chain specify\` — the
+When the user invokes any phase directly (e.g. \`/specflow-auto clarify 042\`,
+\`/specflow-auto plan 042\`) — i.e. NOT via the entry point \`/specflow-auto specify\` — the
 command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
 re-running phases on an existing feature.
 
@@ -7906,7 +7906,7 @@ clarifications needed) STOP #2 (pre-merge validation)
 - \`/specflow review\` — architecture + quality gates
 - \`/specflow merge\` — merge the feature branch to main
 - \`/specflow-backlog\` — manage the product backlog (via the PO agent)
-- \`/specflow-auto-chain\` — auto-chain dispatcher invoked by \`/specflow specify\`
+- \`/specflow-auto\` — auto-chain dispatcher invoked by \`/specflow specify\`
 
 ## Agent roles (invocable manually as skills)
 

--- a/templates/core/skills/specflow-auto/SKILL.md
+++ b/templates/core/skills/specflow-auto/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: auto-chain
-description: Auto-chain Specflow workflow — when the user runs /auto-chain specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+name: specflow-auto
+description: Auto-chain Specflow workflow — when the user runs /specflow-auto specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
 ---
 
 # Specflow Auto-Chain
 
 This skill turns the Specflow workflow into a single-command operation. When the
-user invokes `/auto-chain specify "<feature description>"`, you MUST chain every
+user invokes `/specflow-auto specify "<feature description>"`, you MUST chain every
 Specflow phase in the same session without asking the user between phases,
 EXCEPT at the two checkpoints defined below.
 
@@ -66,14 +66,14 @@ the branch)". Wait for explicit confirmation. On "yes", invoke
 
 ## Opt-out
 
-If the user invokes `/auto-chain specify --manual "<description>"`, run
+If the user invokes `/specflow-auto specify --manual "<description>"`, run
 `/specflow specify` only and stop. Do not auto-chain. Each subsequent phase must
 be invoked manually by the user.
 
 ## Single-phase invocations
 
-When the user invokes any phase directly (e.g. `/auto-chain clarify 042`,
-`/auto-chain plan 042`) — i.e. NOT via the entry point `/auto-chain specify` — the
+When the user invokes any phase directly (e.g. `/specflow-auto clarify 042`,
+`/specflow-auto plan 042`) — i.e. NOT via the entry point `/specflow-auto specify` — the
 command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
 re-running phases on an existing feature.
 

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -89,4 +89,4 @@ specify → clarify → plan → tasks → analyze → implement → review → 
   → pre-merge validation + merge
 ```
 
-For an end-to-end run that auto-chains the silent gates, use `/auto-chain specify "<feature>"`.
+For an end-to-end run that auto-chains the silent gates, use `/specflow-auto specify "<feature>"`.

--- a/templates/core/skills/specflow/phases/review.md
+++ b/templates/core/skills/specflow/phases/review.md
@@ -81,5 +81,5 @@ Remaining findings (MEDIUM/LOW, non-blocking)
 Overall: PASS | FAIL
 ```
 
-If Overall = PASS, invoke `/specflow merge` (or hand back to the auto-chain for
-STOP #2). If FAIL, stop and report to the user.
+If Overall = PASS, invoke `/specflow merge` (or hand back to `/specflow-auto`
+for STOP #2). If FAIL, stop and report to the user.

--- a/templates/harness-specific/cursor/specify-rules.mdc
+++ b/templates/harness-specific/cursor/specify-rules.mdc
@@ -29,7 +29,7 @@ clarifications needed) STOP #2 (pre-merge validation)
 - `/specflow review` — architecture + quality gates
 - `/specflow merge` — merge the feature branch to main
 - `/specflow-backlog` — manage the product backlog (via the PO agent)
-- `/specflow-auto-chain` — auto-chain dispatcher invoked by `/specflow specify`
+- `/specflow-auto` — auto-chain dispatcher invoked by `/specflow specify`
 
 ## Agent roles (invocable manually as skills)
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -32,7 +32,7 @@
     { "category": "agent-memory", "name": "devops-sre", "suffix": "MEMORY.md", "source": "core/agents/devops-sre/memory/MEMORY.md" },
     { "category": "agent-memory", "name": "security-auditor", "suffix": "MEMORY.md", "source": "core/agents/security-auditor/memory/MEMORY.md" },
 
-    { "category": "skill", "name": "auto-chain", "source": "core/skills/auto-chain/SKILL.md" },
+    { "category": "skill", "name": "specflow-auto", "source": "core/skills/specflow-auto/SKILL.md" },
 
     { "category": "backlog-skill", "name": "backlog", "source": "core/skills/backlog/SKILL.md" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/local/list.sh", "executable": true, "backend": "local" },

--- a/tests/domain/core_bundle_test.ts
+++ b/tests/domain/core_bundle_test.ts
@@ -16,7 +16,7 @@ Deno.test("CoreCategory is a narrow union", () => {
 Deno.test("CoreEntry enforces the expected shape", () => {
   const entry: CoreEntry = {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "# skill\n",
     executable: false,

--- a/tests/domain/plugin_coverage_test.ts
+++ b/tests/domain/plugin_coverage_test.ts
@@ -66,9 +66,9 @@ Deno.test("isPluginCoveredPath: claude + .claude/skills/specflow/phases/<phase>.
   }
 });
 
-Deno.test("isPluginCoveredPath: claude + auto-chain skill is covered", () => {
+Deno.test("isPluginCoveredPath: claude + specflow-auto skill is covered", () => {
   assertEquals(
-    isPluginCoveredPath("claude", ".claude/skills/auto-chain/SKILL.md"),
+    isPluginCoveredPath("claude", ".claude/skills/specflow-auto/SKILL.md"),
     true,
   );
 });

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -834,11 +834,11 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
         o.name.startsWith(".claude/skills/specflow/") ||
         o.name === ".claude/skills/specflow/SKILL.md" ||
         o.name === ".claude/skills/specflow-review/SKILL.md" ||
-        o.name === ".claude/skills/auto-chain/SKILL.md") &&
+        o.name === ".claude/skills/specflow-auto/SKILL.md") &&
       o.status === "warn"
     );
     // 9 agents + 1 router skill + 11 phase docs + specflow-review alias +
-    // auto-chain = 23 covered paths, all missing.
+    // specflow-auto = 23 covered paths, all missing.
     assertEquals(gapOutcomes.length, 23);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
@@ -897,8 +897,8 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
         await Deno.writeTextFile(join(dir, `.claude/agents/${name}.md`), "stub");
       }
       // Scaffold all skills + commands too (only the agent gap should warn)
-      await Deno.mkdir(join(dir, ".claude/skills/auto-chain"), { recursive: true });
-      await Deno.writeTextFile(join(dir, ".claude/skills/auto-chain/SKILL.md"), "stub");
+      await Deno.mkdir(join(dir, ".claude/skills/specflow-auto"), { recursive: true });
+      await Deno.writeTextFile(join(dir, ".claude/skills/specflow-auto/SKILL.md"), "stub");
       await Deno.mkdir(join(dir, ".claude/skills/specflow-groom"), { recursive: true });
       await Deno.writeTextFile(
         join(dir, ".claude/skills/specflow-groom/SKILL.md"),

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -11,7 +11,7 @@ Deno.test("ClaudeHarness.key and displayName", () => {
 Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
   const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
-  // Router skill + 11 phase docs + auto-chain + specflow-review alias +
+  // Router skill + 11 phase docs + specflow-auto + specflow-review alias +
   // backlog skill + 1 backlog cmd + 9 agents + 5 agent-memory stubs +
   // 16 spec-root entries + AGENTS.md + .gitignore + 5 backlog scripts +
   // .claude/CLAUDE.md + dispatch-agent.sh + loop.md + settings.json + 3 hooks.
@@ -34,7 +34,7 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   assert(".claude/hooks/log-subagent.sh" in mapped);
   assert(".claude/hooks/check-backlog-prereqs.sh" in mapped);
   assert(".claude/agents/product-owner.md" in mapped);
-  assert(".claude/skills/auto-chain/SKILL.md" in mapped);
+  assert(".claude/skills/specflow-auto/SKILL.md" in mapped);
   assert(".claude/skills/backlog/SKILL.md" in mapped);
   assert(".specflow/scripts/backlog/list.sh" in mapped);
   assert(".specflow/memory/constitution.md" in mapped);

--- a/tests/infrastructure/harness/codex_harness_test.ts
+++ b/tests/infrastructure/harness/codex_harness_test.ts
@@ -27,7 +27,7 @@ const SAMPLE: CoreBundle = [
   },
   {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "---\ndescription: Auto-chain dispatcher\n---\n\n# body\n",
     executable: false,
@@ -83,7 +83,7 @@ Deno.test("CodexHarness maps backlog-cmd to .agents/skills/specflow-backlog/SKIL
 Deno.test("CodexHarness maps skill to .agents/skills/specflow-<name>/SKILL.md", () => {
   const h = new CodexHarness();
   const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
-  assert(".agents/skills/specflow-auto-chain/SKILL.md" in mapped);
+  assert(".agents/skills/specflow-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps agent to .codex/agents/<name>.toml with valid TOML", () => {
@@ -123,14 +123,14 @@ Deno.test("CodexHarness emits no Claude/Cursor artefacts", () => {
 Deno.test("CodexHarness injects name+description into SKILL.md when absent", () => {
   const core: CoreBundle = [{
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "# no frontmatter\n",
     executable: false,
   }];
   const h = new CodexHarness();
   const mapped = h.mapBundle(core, { backlogBackend: "local" });
-  const skill = mapped[".agents/skills/specflow-auto-chain/SKILL.md"];
+  const skill = mapped[".agents/skills/specflow-auto/SKILL.md"];
   assert(skill?.content.startsWith("---\n"));
-  assert(skill?.content.includes("name: specflow-auto-chain"));
+  assert(skill?.content.includes("name: specflow-auto"));
 });

--- a/tests/infrastructure/harness/copilot_harness_test.ts
+++ b/tests/infrastructure/harness/copilot_harness_test.ts
@@ -27,7 +27,7 @@ const SAMPLE: CoreBundle = [
   },
   {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "---\ndescription: Auto-chain dispatcher\n---\n\n# body\n",
     executable: false,
@@ -83,7 +83,7 @@ Deno.test("CopilotHarness maps backlog-cmd to .github/instructions/specflow-back
 Deno.test("CopilotHarness maps skill to .github/instructions/specflow-<name>.instructions.md", () => {
   const h = new CopilotHarness();
   const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
-  assert(".github/instructions/specflow-auto-chain.instructions.md" in mapped);
+  assert(".github/instructions/specflow-auto.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps agents to .github/instructions/specflow-agent-<name>.instructions.md", () => {

--- a/tests/infrastructure/harness/cursor_harness_test.ts
+++ b/tests/infrastructure/harness/cursor_harness_test.ts
@@ -33,7 +33,7 @@ const SAMPLE: CoreBundle = [
   },
   {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "---\ndescription: Auto-chain dispatcher\n---\n\n# body\n",
     executable: false,
@@ -87,7 +87,7 @@ Deno.test("CursorHarness maps agents to .cursor/skills/specflow-agent-<name>/SKI
 Deno.test("CursorHarness maps skills to .cursor/skills/specflow-<name>/SKILL.md", () => {
   const h = new CursorHarness();
   const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
-  assert(".cursor/skills/specflow-auto-chain/SKILL.md" in mapped);
+  assert(".cursor/skills/specflow-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps spec-root to .specflow/ and project-root unchanged", () => {

--- a/tests/infrastructure/harness/gemini_harness_test.ts
+++ b/tests/infrastructure/harness/gemini_harness_test.ts
@@ -27,7 +27,7 @@ const SAMPLE: CoreBundle = [
   },
   {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "---\ndescription: Auto-chain dispatcher\n---\n\n# body\n",
     executable: false,
@@ -83,7 +83,7 @@ Deno.test("GeminiHarness maps backlog-cmd to .gemini/commands/specflow-backlog.t
 Deno.test("GeminiHarness maps skill to .gemini/skills/specflow-<name>/SKILL.md", () => {
   const h = new GeminiHarness();
   const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
-  assert(".gemini/skills/specflow-auto-chain/SKILL.md" in mapped);
+  assert(".gemini/skills/specflow-auto/SKILL.md" in mapped);
 });
 
 Deno.test("GeminiHarness maps agent to .gemini/agents/<name>.md with stripped frontmatter", () => {

--- a/tests/infrastructure/harness/opencode_harness_test.ts
+++ b/tests/infrastructure/harness/opencode_harness_test.ts
@@ -139,11 +139,11 @@ Deno.test("agent with no tools field emits no permission block", () => {
 });
 
 Deno.test("skill emits to .opencode/skills/specflow-<name>/SKILL.md with name+description", () => {
-  const bundle = harness.mapBundle([skillEntry("auto-chain")], { backlogBackend: "local" });
-  const dest = ".opencode/skills/specflow-auto-chain/SKILL.md";
+  const bundle = harness.mapBundle([skillEntry("specflow-auto")], { backlogBackend: "local" });
+  const dest = ".opencode/skills/specflow-auto/SKILL.md";
   assertEquals(Object.keys(bundle), [dest]);
-  assertStringIncludes(bundle[dest].content, "name: auto-chain");
-  assertStringIncludes(bundle[dest].content, "description: auto-chain skill");
+  assertStringIncludes(bundle[dest].content, "name: specflow-auto");
+  assertStringIncludes(bundle[dest].content, "description: specflow-auto skill");
 });
 
 Deno.test("router skill named 'specflow' is not double-prefixed", () => {

--- a/tests/infrastructure/harness/skill_folder_test.ts
+++ b/tests/infrastructure/harness/skill_folder_test.ts
@@ -14,7 +14,7 @@ Deno.test("skillFolderName: backlog-cmd → specflow-<name>", () => {
 });
 
 Deno.test("skillFolderName: skill → specflow-<name>", () => {
-  assertEquals(skillFolderName(entry("skill", "auto-chain")), "specflow-auto-chain");
+  assertEquals(skillFolderName(entry("skill", "specflow-auto")), "specflow-auto");
 });
 
 Deno.test("skillFolderName: skill named 'specflow' is not double-prefixed", () => {

--- a/tests/infrastructure/harness/windsurf_harness_test.ts
+++ b/tests/infrastructure/harness/windsurf_harness_test.ts
@@ -28,7 +28,7 @@ const SAMPLE: CoreBundle = [
   },
   {
     category: "skill",
-    name: "auto-chain",
+    name: "specflow-auto",
     suffix: null,
     content: "---\ndescription: Auto-chain dispatcher\n---\n\n# body\n",
     executable: false,
@@ -83,7 +83,7 @@ Deno.test("WindsurfHarness maps backlog-cmd to .windsurf/workflows/specflow-back
 Deno.test("WindsurfHarness maps skill to .windsurf/workflows/specflow-<name>.md", () => {
   const h = new WindsurfHarness();
   const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
-  assert(".windsurf/workflows/specflow-auto-chain.md" in mapped);
+  assert(".windsurf/workflows/specflow-auto.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps agents to .windsurf/workflows/specflow-agent-<name>.md", () => {

--- a/tests/integration/init_antigravity_test.ts
+++ b/tests/integration/init_antigravity_test.ts
@@ -71,7 +71,7 @@ Deno.test("specflow init --ai antigravity scaffolds an Antigravity layout", asyn
     );
     // Auto-chain still ships as its own skill folder.
     assertEquals(
-      await exists(join(root, ".agent/skills/specflow-auto-chain/SKILL.md")),
+      await exists(join(root, ".agent/skills/specflow-auto/SKILL.md")),
       true,
     );
 

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -57,7 +57,7 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
       true,
     );
     assertEquals(await exists(join(root, ".agents/skills/specflow-backlog/SKILL.md")), true);
-    assertEquals(await exists(join(root, ".agents/skills/specflow-auto-chain/SKILL.md")), true);
+    assertEquals(await exists(join(root, ".agents/skills/specflow-auto/SKILL.md")), true);
     // Old per-phase folders are gone post-consolidation.
     assertEquals(
       await exists(join(root, ".agents/skills/specflow-specify/SKILL.md")),
@@ -75,7 +75,7 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     assertEquals(typeof parsed.developer_instructions, "string");
 
     // Top-level skill folders post-consolidation: specflow router +
-    // auto-chain + specflow-review alias + specflow-backlog = 4.
+    // specflow-auto + specflow-review alias + specflow-backlog = 4.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -49,7 +49,7 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
 
     const root = join(parent, "demo");
 
-    // v1.0.0: router instruction + 11 phase instructions + auto-chain +
+    // v1.0.0: router instruction + 11 phase instructions + specflow-auto +
     // specflow-review + backlog + 9 agent instructions.
     assertEquals(
       await exists(join(root, ".github/instructions/specflow.instructions.md")),
@@ -64,7 +64,7 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
       true,
     );
     assertEquals(
-      await exists(join(root, ".github/instructions/specflow-auto-chain.instructions.md")),
+      await exists(join(root, ".github/instructions/specflow-auto.instructions.md")),
       true,
     );
     assertEquals(
@@ -82,7 +82,7 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 11 phases + auto-chain + specflow-review + backlog + 9 agents = 23.
+    // Router + 11 phases + specflow-auto + specflow-review + backlog + 9 agents = 23.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;

--- a/tests/integration/init_cursor_test.ts
+++ b/tests/integration/init_cursor_test.ts
@@ -58,7 +58,7 @@ Deno.test("specflow init --ai cursor scaffolds a Cursor layout", async () => {
       await exists(join(root, ".cursor/skills/specflow-agent-product-owner/SKILL.md")),
       true,
     );
-    assertEquals(await exists(join(root, ".cursor/skills/specflow-auto-chain/SKILL.md")), true);
+    assertEquals(await exists(join(root, ".cursor/skills/specflow-auto/SKILL.md")), true);
     assertEquals(await exists(join(root, ".cursor/rules/specify-rules.mdc")), true);
     // Old per-phase folders are gone post-consolidation.
     assertEquals(

--- a/tests/integration/init_gemini_test.ts
+++ b/tests/integration/init_gemini_test.ts
@@ -72,7 +72,7 @@ Deno.test("specflow init --ai gemini scaffolds a Gemini layout", async () => {
 
     // Markdown skill
     assertEquals(
-      await exists(join(root, ".gemini/skills/specflow-auto-chain/SKILL.md")),
+      await exists(join(root, ".gemini/skills/specflow-auto/SKILL.md")),
       true,
     );
     // Old per-phase commands are gone post-consolidation.

--- a/tests/integration/init_opencode_test.ts
+++ b/tests/integration/init_opencode_test.ts
@@ -80,9 +80,9 @@ Deno.test("specflow init --ai opencode scaffolds a complete OpenCode project lay
 
     // Auto-chain still ships as its own skill folder.
     const autoChainSkill = await Deno.readTextFile(
-      join(root, ".opencode/skills/specflow-auto-chain/SKILL.md"),
+      join(root, ".opencode/skills/specflow-auto/SKILL.md"),
     );
-    assertStringIncludes(autoChainSkill, "name: auto-chain");
+    assertStringIncludes(autoChainSkill, "name: specflow-auto");
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -86,7 +86,7 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
     assertEquals(await exists(join(root, ".claude/commands/specflow.md")), true);
     assertEquals(await exists(join(root, ".claude/agents/product-owner.md")), true);
     assertEquals(await exists(join(root, ".claude/agents/devops-sre.md")), true);
-    assertEquals(await exists(join(root, ".claude/skills/auto-chain/SKILL.md")), true);
+    assertEquals(await exists(join(root, ".claude/skills/specflow-auto/SKILL.md")), true);
 
     // Two commands ship at the moment: backlog + specflow router.
     const commandsCount = (await Array.fromAsync(

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -49,7 +49,7 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
 
     const root = join(parent, "demo");
 
-    // v1.0.0: router workflow + 11 sibling phase workflows + auto-chain +
+    // v1.0.0: router workflow + 11 sibling phase workflows + specflow-auto +
     // specflow-review alias + backlog + 9 agent workflows.
     assertEquals(
       await exists(join(root, ".windsurf/workflows/specflow.md")),
@@ -64,7 +64,7 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
     assertEquals(
-      await exists(join(root, ".windsurf/workflows/specflow-auto-chain.md")),
+      await exists(join(root, ".windsurf/workflows/specflow-auto.md")),
       true,
     );
     assertEquals(
@@ -74,7 +74,7 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 11 phases + auto-chain + specflow-review alias + backlog +
+    // Router + 11 phases + specflow-auto + specflow-review alias + backlog +
     // 9 agent workflows = 23.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -36,8 +36,8 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
   })),
   // Auto-chain stays as a separate skill (own slash-command identity).
   {
-    plugin: "plugin/skills/auto-chain/SKILL.md",
-    source: "templates/core/skills/auto-chain/SKILL.md",
+    plugin: "plugin/skills/specflow-auto/SKILL.md",
+    source: "templates/core/skills/specflow-auto/SKILL.md",
   },
   // Thin alias preserving auto-invocation for the review phase.
   {


### PR DESCRIPTION
## Summary

- Closes #150.
- Pure rename — behavior unchanged. Every Specflow user-facing slash command now starts with `specflow` (`/specflow`, `/specflow-review`, `/specflow-auto`), so autocomplete groups them and the `argument-hint` UX (#143) is easier to discover.

## Renames

| Was | Is |
|---|---|
| `templates/core/skills/auto-chain/` | `templates/core/skills/specflow-auto/` |
| `plugin/skills/auto-chain/` | `plugin/skills/specflow-auto/` |
| `name: auto-chain` (frontmatter) | `name: specflow-auto` |
| `/auto-chain specify` (in SKILL body + cross-refs) | `/specflow-auto specify` |
| Manifest entry name + source path | renamed |

## Threading (35 files touched)

- Source: `src/domain/plugin_coverage.ts`, `src/infrastructure/harness/{claude_harness,skill_folder}.ts` (comment examples). The `skill_folder` mapper already short-circuits on names beginning with `specflow-`, so the new name maps to `specflow-auto` for non-Claude harnesses (was `specflow-auto-chain`).
- Templates: `templates/manifest.json`, cross-refs in `specflow/SKILL.md`, `specflow/phases/review.md`, `harness-specific/cursor/specify-rules.mdc`.
- Plugin mirror: SKILL.md, review.md cross-ref, `README.md`, `.claude-plugin/plugin.json` description.
- Docs: `docs/llms.md` (3 references including the `/specflow-plugin:specflow-auto` example).
- Tests (10 files): mass-rename via sed for `specflow-auto-chain` → `specflow-auto`, `auto-chain/SKILL` → `specflow-auto/SKILL`, `\"auto-chain\"` → `\"specflow-auto\"`, `name: auto-chain` → `name: specflow-auto`. Hand-fix on opencode harness description assertion + project inspector mkdir path + comment prose.

## Test plan

- [x] `deno task bundle` — 66 core entries, 9 harness-specific
- [x] `deno task test` — 489 passed / 0 failed
- [x] **Greenfield smoke**: `init --here --ai claude --backlog local` scaffolds `.claude/skills/specflow-auto/SKILL.md`; no `auto-chain/` directory.
- [x] **Migration smoke**: scaffold with the released v1.1.5 binary (writes `auto-chain/`), then `upgrade` from working tree. Plan correctly emits `+ specflow-auto/SKILL.md` and `✗ auto-chain/SKILL.md`. Final state: `specflow-auto/` populated, `auto-chain/SKILL.md` removed.

## Known minor leftover (pre-existing, not introduced by this PR)

The upgrade removes `.claude/skills/auto-chain/SKILL.md` (the file) but leaves the now-empty `auto-chain/` directory on disk because `deletePaths` doesn't clean empty parents. Harmless — Claude Code only loads SKILL.md files, so the empty dir is invisible to the harness. A user can `rmdir .claude/skills/auto-chain` if the cosmetic noise bothers them. Tracking improvement in `deletePaths` is out of scope for this rename.

## Prose preserved (audit, intentional)

`src/cli/help.ts` tagline ("auto-chain, review, and backlog") and `scripts/build-docs.ts` meta description still say "auto-chain" as a behavior descriptor — verb form referring to the chaining behavior, not the slash command name.