### PR TITLE
docs: document --backlog-url and --backlog-repo in llms.md

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -164,14 +164,59 @@ Three backends are supported: `local` (default), `github`, `gitlab`. See
 [Backlog as product source of truth](#3-backlog-as-product-source-of-truth) for what each one stores
 and how the PO agent talks to it.
 
-### Run `init` non-interactively (CI / scripts)
+#### Pre-fill the backlog config with `--backlog-url`
 
-When you pass both `--ai` and `--backlog`, no interactive prompt is shown — `specflow init` runs
-fully unattended, which is what you want in CI or scripted setup:
+When the chosen backend is `github` or `gitlab`, `specflow init` can take the project's Kanban URL
+up front and write a fully-populated `.specflow/backlog-config.yml` — no manual edit needed before
+running `/backlog`. Pass the project URL via `--backlog-url`:
 
 ```bash
-specflow init my-project --ai claude --backlog github
-specflow init --here --no-git --ai cursor --backlog gitlab
+# GitHub org-owned project
+specflow init --here --ai claude --backlog github \
+  --backlog-url https://github.com/orgs/myorg/projects/1
+
+# GitHub user-owned project
+specflow init --here --ai claude --backlog github \
+  --backlog-url https://github.com/users/alice/projects/12
+
+# GitLab (gitlab.com or self-hosted)
+specflow init --here --ai claude --backlog gitlab \
+  --backlog-url https://gitlab.com/mygroup/myproject
+```
+
+Three URL formats are supported:
+
+- GitHub org-owned: `https://github.com/orgs/<org>/projects/<N>`
+- GitHub user-owned: `https://github.com/users/<user>/projects/<N>`
+- GitLab project: `https://<host>/<group>/<project>`
+
+For GitHub, the `repo:` field of the populated config is derived from `git remote get-url origin`
+(both HTTPS and SSH remote shapes are recognised). Pass `--backlog-repo <owner>/<name>` to override
+that derivation when the project lives across multiple repos or the local remote isn't `origin`.
+
+Without `--backlog-url` on a TTY, `specflow init` interactively prompts for the URL after the
+backend picker. **In non-TTY mode (CI / scripted setup) `--backlog-url` is required when `--backlog`
+is `github` or `gitlab`** — omitting it exits with code `2` and a clear error message. The
+non-clobber invariant still holds: re-running `init` against a project with an existing
+`backlog-config.yml` does NOT overwrite it.
+
+### Run `init` non-interactively (CI / scripts)
+
+When you pass both `--ai` and `--backlog` (and `--backlog-url` when the backend is remote), no
+interactive prompt is shown — `specflow init` runs fully unattended, which is what you want in CI or
+scripted setup:
+
+```bash
+# Local backend — zero-config, just the two flags
+specflow init my-project --ai claude --backlog local
+
+# GitHub backend — --backlog-url is required in non-TTY mode
+specflow init my-project --ai claude --backlog github \
+  --backlog-url https://github.com/orgs/myorg/projects/1
+
+# GitLab backend — same shape
+specflow init --here --no-git --ai cursor --backlog gitlab \
+  --backlog-url https://gitlab.com/mygroup/myproject
 ```
 
 Without those flags, `specflow init` shows an arrow-key picker (↑/↓ to move, space/enter to select)


### PR DESCRIPTION
## Summary

- Closes #154.
- Adds the two flags shipped in v1.1.7 (#148: `--backlog-url`, `--backlog-repo`) to the canonical user doc at `docs/llms.md`. They were correctly documented in `specflow --help` but missing from `https://specflow.makerlabs.dev/llms.txt`.
- Surfaced as F1 in the v1.1.7 QA pass (`sandbox/qa-report-20260509-104836.md`).

## Changes

**`docs/llms.md`** — two surgical additions:

1. New subsection `Pre-fill the backlog config with --backlog-url` under "Pick a backlog backend":
   - 3 supported URL formats (GitHub org-owned, GitHub user-owned, GitLab — including self-hosted)
   - GitHub `repo:` derivation priority: `--backlog-repo` flag → `git remote get-url origin` → empty stub fallback
   - Non-clobber invariant call-out
   - Explicit "**required in non-TTY mode** when `--backlog` is `github` or `gitlab`" warning

2. The existing "Run `init` non-interactively (CI / scripts)" section's CI examples updated to the corrected forms — local backend (zero-config), GitHub backend (with `--backlog-url`), GitLab backend (with `--backlog-url`).

## Test plan

- [x] `deno run scripts/build-docs.ts` regenerates `docs-dist/llms.txt` — 12 mentions of `backlog-url` / `backlog-repo` now present (was 0)
- [x] `deno task test` — 489 passed / 0 failed
- [ ] Post-merge: docs deploy on next tag push lands the new content at `https://specflow.makerlabs.dev/llms.txt`
- [ ] Next QA pass does NOT re-flag F1