### PR TITLE
fix(po): two-step close + board hygiene sweep mode

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -33,9 +33,22 @@ You exclusively control:
   (`Backlog | Ready | "In progress" | "In review" | Done`). The main
   session signals you when status should change (e.g. "PR for #12 is
   open" → you move it to "In review"); you decide and execute.
-- **Closing items** — `gh issue close <num> --repo mkrlabs/specflow
-  --reason {completed|not_planned}`. Always close the issue, don't just
-  move to Done — closing is the audit trail.
+- **Closing items** — close is a **two-step contract**, never one
+  command:
+  1. `.claude/skills/backlog/scripts/move.sh <num> Done` first — sets
+     the Status field on Project #4. `gh issue close` does NOT
+     auto-sync the board, so skipping this step leaves the item stuck
+     in whatever column it was in (typically `In progress`) forever,
+     polluting the kanban view of active work.
+  2. `gh issue close <num> --repo mkrlabs/specflow --reason
+     {completed|not_planned}` second, with a comment referencing the
+     merged PR / commit / decision. The closed issue is the audit
+     trail; the Done column is the up-to-date board state.
+
+  Both steps are mandatory regardless of dispatch shape (close after
+  PR merge, close as `not_planned`, batch close on archive). If
+  `move.sh` fails (permission scope, project layout drift), surface
+  the error in your report — never close-without-moving silently.
 - **Docs upkeep** — verifying that the four user-facing doc surfaces
   stay in sync with what the binary actually does whenever a development
   changes user-visible behavior. See "Docs upkeep mode" below for the
@@ -60,8 +73,17 @@ You are typically dispatched with one of:
   Why` / `## Acceptance criteria`; an item moving to **In review** must
   have an open PR linked), then `move.sh`.
 - **"Close #N"** — verify the work is actually shipped (link to merged
-  PR, version tag, or deployment), then `gh issue close`. If not
-  shipped, refuse and explain.
+  PR, version tag, or deployment), then run the **two-step close
+  contract** (move.sh → Done, then gh issue close). If not shipped,
+  refuse and explain.
+- **"Sweep the board"** / **"audit the In progress column"** /
+  **"clean the kanban"** — board hygiene sweep. Items can drift into
+  the wrong column when an issue is closed via a path that doesn't
+  call `move.sh` first (a merged PR auto-closing the issue, an
+  external `gh issue close`, a webhook, etc.). The fix is to
+  re-align Status with issue state. Run it on demand, or whenever a
+  routine groom catches stale items. The sweep is described in
+  detail under "Board hygiene sweep" below.
 
 For each mutation:
 
@@ -145,6 +167,51 @@ For each mutation:
    to get worse (implementation phase). Don't include it on
    single-mutation dispatches (`add`, `move`, `close`) — there's no
    downstream phase to clean up for.
+
+## Board hygiene sweep
+
+`gh issue close` does not update the Project V2 Status field — it only
+flips the issue's open/closed state. So an issue closed via:
+
+- a merged PR with a `Closes #N` line (GitHub auto-closes, no Status
+  move),
+- an external `gh issue close` call (e.g. Kevin closing from his
+  terminal, the main session before the close-contract was tightened,
+  a Copilot agent, …), or
+- the GitHub web UI
+
+leaves the project board with a stale Status. The kanban view then
+keeps showing closed work as `In progress` / `In review`, polluting
+the view of what's actually active.
+
+When dispatched for a sweep:
+
+1. `gh project item-list 4 --owner mkrlabs --format json` — full board
+   listing, every column, including columns the wrappers don't
+   surface. (`list.sh` filters to `states:OPEN` and would miss closed
+   items still attached to the board.)
+2. For each item with Status ∈ {`In progress`, `In review`}:
+   - `gh issue view <num> --repo mkrlabs/specflow --json state,title,closedAt --jq '{state, title, closedAt}'`
+   - If `state == "CLOSED"` → `move.sh <num> Done`. Reference the
+     close reason / linked PR in your final report.
+   - If `state == "OPEN"` and there is a merged PR linked (look at
+     timeline / `gh pr list --search "linked:#<num>"`) → also move to
+     Done; this is the case where the PR auto-closed the issue but
+     skipped the board update.
+   - Otherwise (open issue, no merged PR) → leave alone. That's
+     genuine in-flight work.
+3. Same logic for `Done` column going the other way: any `Done` item
+   whose underlying issue is REOPENED moves back to the appropriate
+   active column. Rare, but worth catching — typically means a regression
+   reverted the close.
+4. Final report: structured table with each touched item's number,
+   prior Status, new Status, and the reason. Empty columns are
+   reported explicitly (`In review: clean — no items`). No silent
+   no-ops.
+
+This sweep is idempotent — running it twice in a row produces zero
+moves the second time. Safe to invoke after every release, before
+every demo, or as a daily habit.
 
 ## Hard rules
 

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -150,12 +150,22 @@ glance.
 
 ### Closing rules (both backends)
 
-- **Closing a sub-task**: close it directly. Do not cascade to siblings or the
-  parent.
-- **Closing the parent**: every child must be closed first. If the user asks
-  to close a parent with open children, refuse and list the open children.
-- **Cancelling an epic**: close the parent with `not_planned` and close every
-  child the same way in one batch.
+- **Sub-task**: close directly. No cascade to siblings or parent.
+- **Parent / epic**: every child must close first; refuse otherwise.
+- **Cancel epic**: close parent + every child as `not_planned` in one batch.
+- **Two-step close on GitHub / GitLab**: `gh issue close` (and `glab issue
+  close`) do NOT update the Project V2 Status field / GitLab scoped Status
+  label. Always run `move.sh <num> Done` BEFORE `gh issue close <num>
+  --reason {completed|not_planned}`. Skipping the move leaves the item
+  stuck in `In progress` / `In review` indefinitely. Local Markdown is
+  one step (flip `status: done` in frontmatter).
+- **Board hygiene sweep**: when asked to "clean the board" / "sweep stale
+  items", list every column via `gh project item-list <N> --owner <owner>
+  --format json` (the wrappers filter to `states:OPEN` and miss closed
+  items still attached). For items in `In progress` / `In review` whose
+  issue is `CLOSED`, or `OPEN` with a merged PR linked → `move.sh <num>
+  Done`. Mirror for `Done` items whose issue is REOPENED. Idempotent;
+  safe after every release or via `/loop 1d`.
 
 ## Prioritization framework
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2174,12 +2174,22 @@ glance.
 
 ### Closing rules (both backends)
 
-- **Closing a sub-task**: close it directly. Do not cascade to siblings or the
-  parent.
-- **Closing the parent**: every child must be closed first. If the user asks
-  to close a parent with open children, refuse and list the open children.
-- **Cancelling an epic**: close the parent with \`not_planned\` and close every
-  child the same way in one batch.
+- **Sub-task**: close directly. No cascade to siblings or parent.
+- **Parent / epic**: every child must close first; refuse otherwise.
+- **Cancel epic**: close parent + every child as \`not_planned\` in one batch.
+- **Two-step close on GitHub / GitLab**: \`gh issue close\` (and \`glab issue
+  close\`) do NOT update the Project V2 Status field / GitLab scoped Status
+  label. Always run \`move.sh <num> Done\` BEFORE \`gh issue close <num>
+  --reason {completed|not_planned}\`. Skipping the move leaves the item
+  stuck in \`In progress\` / \`In review\` indefinitely. Local Markdown is
+  one step (flip \`status: done\` in frontmatter).
+- **Board hygiene sweep**: when asked to "clean the board" / "sweep stale
+  items", list every column via \`gh project item-list <N> --owner <owner>
+  --format json\` (the wrappers filter to \`states:OPEN\` and miss closed
+  items still attached). For items in \`In progress\` / \`In review\` whose
+  issue is \`CLOSED\`, or \`OPEN\` with a merged PR linked → \`move.sh <num>
+  Done\`. Mirror for \`Done\` items whose issue is REOPENED. Idempotent;
+  safe after every release or via \`/loop 1d\`.
 
 ## Prioritization framework
 

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -150,12 +150,22 @@ glance.
 
 ### Closing rules (both backends)
 
-- **Closing a sub-task**: close it directly. Do not cascade to siblings or the
-  parent.
-- **Closing the parent**: every child must be closed first. If the user asks
-  to close a parent with open children, refuse and list the open children.
-- **Cancelling an epic**: close the parent with `not_planned` and close every
-  child the same way in one batch.
+- **Sub-task**: close directly. No cascade to siblings or parent.
+- **Parent / epic**: every child must close first; refuse otherwise.
+- **Cancel epic**: close parent + every child as `not_planned` in one batch.
+- **Two-step close on GitHub / GitLab**: `gh issue close` (and `glab issue
+  close`) do NOT update the Project V2 Status field / GitLab scoped Status
+  label. Always run `move.sh <num> Done` BEFORE `gh issue close <num>
+  --reason {completed|not_planned}`. Skipping the move leaves the item
+  stuck in `In progress` / `In review` indefinitely. Local Markdown is
+  one step (flip `status: done` in frontmatter).
+- **Board hygiene sweep**: when asked to "clean the board" / "sweep stale
+  items", list every column via `gh project item-list <N> --owner <owner>
+  --format json` (the wrappers filter to `states:OPEN` and miss closed
+  items still attached). For items in `In progress` / `In review` whose
+  issue is `CLOSED`, or `OPEN` with a merged PR linked → `move.sh <num>
+  Done`. Mirror for `Done` items whose issue is REOPENED. Idempotent;
+  safe after every release or via `/loop 1d`.
 
 ## Prioritization framework
 


### PR DESCRIPTION
## Summary

- Cleans up two stale items on Project #4 (#1, #141 — both closed weeks ago but stuck in `In progress`).
- Tightens the PO agent so this gap can't recur: closing is now a **two-step contract** and a **board hygiene sweep** mode is documented.

## Root cause

`gh issue close` does NOT update the Project V2 Status field. So an issue closed via `gh issue close`, a merged PR's `Closes #N` auto-close, or an external tool all leave the kanban with a stale Status. Over time `In progress` / `In review` accumulate shipped work, and the board no longer reflects active work.

## Changes

**`.claude/agents/product-owner.md`** (Specflow's in-repo PO):
- "Close items" scope rewritten as a 2-step contract: `move.sh <num> Done` first, `gh issue close <num> --reason ...` second.
- Same contract restated in "Workflow on every dispatch" for `Close #N` calls.
- New `"Sweep the board"` / `"audit In progress"` dispatch shape.
- New `"Board hygiene sweep"` section detailing how to enumerate stale items via `gh project item-list` (`list.sh` filters to `states:OPEN` and misses them), reconcile, and report.

**`templates/core/agents/product-owner.md`** (ships to user projects):
- "Closing rules" extended with the two-step close bullet and a sweep bullet. Compact phrasing — must fit under Windsurf's 12000-char Cascade cap.

**`plugin/agents/product-owner.md`**: synced verbatim.

## Sweep run before commit

| # | Title | Prior | New | Reason |
|---|-------|-------|-----|--------|
| #1 | Add html doc with github pages | In progress | Done | Closed 2026-05-01 via PR #8 + #92 |
| #141 | Catch ClaudeSettingsParseError at the CLI boundary | In progress | Done | Closed 2026-05-09 via PR #142 |

`In review` was already empty.

## Test plan

- [x] `deno task bundle` — 66 core entries, 9 harness-specific
- [x] `deno task test` — 489 passed / 0 failed (Windsurf 12000-char cap test that was tripping at 14064 now passes at 12003-source)
- [x] Manual sweep on Project #4 — board clean post-merge, idempotent re-run produces zero moves