### PR TITLE
fix(release): bump templates/manifest.json in lockstep

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -32,15 +32,16 @@ Specflow repo.
    deno run --allow-read --allow-write scripts/bump-version.ts <kind>
    ```
 
-   This updates `deno.json`, `src/domain/version.ts`, AND
-   `plugin/.claude-plugin/plugin.json` in lockstep. The
-   release.yml pre-flight step fails fast on plugin/binary version
-   drift, so all three must move together.
+   This updates `deno.json`, `src/domain/version.ts`,
+   `plugin/.claude-plugin/plugin.json`, AND `templates/manifest.json`
+   in lockstep. The release.yml pre-flight step fails fast on
+   plugin/manifest/binary version drift, so all four must move
+   together.
 
 2. **Review the diff** and confirm with Kevin:
 
    ```bash
-   git diff deno.json src/domain/version.ts plugin/.claude-plugin/plugin.json
+   git diff deno.json src/domain/version.ts plugin/.claude-plugin/plugin.json templates/manifest.json
    ```
 
 3. **Regenerate the bundle** in case templates changed since the last release:
@@ -77,7 +78,7 @@ Specflow repo.
 
    ```bash
    git add deno.json src/domain/version.ts src/templates_bundle.ts \
-           plugin/.claude-plugin/plugin.json
+           plugin/.claude-plugin/plugin.json templates/manifest.json
    git commit -m "chore: release v<NEXT>"
    ```
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,16 @@ jobs:
             echo "::error::plugin/.claude-plugin/plugin.json version ($PLUGIN_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
             exit 1
           fi
-          echo "✓ plugin manifest valid, scaffold present, version $PLUGIN_VERSION matches binary"
+          # 4. Hard fail if templates/manifest.json version drifts.
+          # `TEMPLATES_VERSION` in src/templates_bundle.ts is generated
+          # from this file; surfacing a stale value would mislabel the
+          # binary's `--version` output.
+          MANIFEST_VERSION=$(jq -r .version templates/manifest.json)
+          if [ "$BIN_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "::error::templates/manifest.json version ($MANIFEST_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
+            exit 1
+          fi
+          echo "✓ plugin manifest valid, scaffold present, versions $PLUGIN_VERSION/$MANIFEST_VERSION match binary"
       - name: Cross-compile all targets
         run: deno run --allow-read --allow-write --allow-run --allow-env scripts/build.ts
       - name: Compute checksums

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -42,21 +42,34 @@ function bump(
   return `${major}.${minor}.${patch}`;
 }
 
-async function readCurrentVersion(): Promise<string> {
-  const raw = await Deno.readTextFile("deno.json");
+// File targets that all four version fields live in. Exported so tests can
+// assert the same set the bump script writes to, and so `writeVersions`
+// stays single-source-of-truth.
+export const VERSIONED_FILES = [
+  "deno.json",
+  "src/domain/version.ts",
+  "plugin/.claude-plugin/plugin.json",
+  "templates/manifest.json",
+] as const;
+
+async function readCurrentVersion(baseDir: string): Promise<string> {
+  const raw = await Deno.readTextFile(`${baseDir}/deno.json`);
   const parsed = JSON.parse(raw) as { version: string };
   return parsed.version;
 }
 
-async function writeVersions(next: string): Promise<void> {
-  const denoRaw = await Deno.readTextFile("deno.json");
+export async function writeVersions(
+  next: string,
+  baseDir: string = ".",
+): Promise<void> {
+  const denoRaw = await Deno.readTextFile(`${baseDir}/deno.json`);
   const updatedDeno = denoRaw.replace(
     /"version":\s*"[^"]+"/,
     `"version": "${next}"`,
   );
-  await Deno.writeTextFile("deno.json", updatedDeno);
+  await Deno.writeTextFile(`${baseDir}/deno.json`, updatedDeno);
 
-  const verPath = "src/domain/version.ts";
+  const verPath = `${baseDir}/src/domain/version.ts`;
   const verRaw = await Deno.readTextFile(verPath);
   const updatedVer = verRaw.replace(
     /export const VERSION\s*=\s*"[^"]+"/,
@@ -67,13 +80,26 @@ async function writeVersions(next: string): Promise<void> {
   // Lockstep the specflow-plugin plugin manifest (#73 slice 8). The
   // release workflow's pre-flight step compares deno.json `version`
   // against this file's `version` and fails fast on drift.
-  const pluginManifestPath = "plugin/.claude-plugin/plugin.json";
+  const pluginManifestPath = `${baseDir}/plugin/.claude-plugin/plugin.json`;
   const pluginRaw = await Deno.readTextFile(pluginManifestPath);
   const updatedPlugin = pluginRaw.replace(
     /"version":\s*"[^"]+"/,
     `"version": "${next}"`,
   );
   await Deno.writeTextFile(pluginManifestPath, updatedPlugin);
+
+  // Lockstep the templates manifest. `TEMPLATES_VERSION` in
+  // `src/templates_bundle.ts` is regenerated from this file by
+  // `deno task bundle`, and it's what the binary surfaces under
+  // `specflow --version` (the "templates X.Y.Z" suffix). Skipping
+  // this bump leaves a cosmetic drift visible to every user.
+  const templatesManifestPath = `${baseDir}/templates/manifest.json`;
+  const templatesRaw = await Deno.readTextFile(templatesManifestPath);
+  const updatedTemplates = templatesRaw.replace(
+    /"version":\s*"[^"]+"/,
+    `"version": "${next}"`,
+  );
+  await Deno.writeTextFile(templatesManifestPath, updatedTemplates);
 }
 
 async function main() {
@@ -84,13 +110,11 @@ async function main() {
     );
     Deno.exit(2);
   }
-  const version = await readCurrentVersion();
+  const version = await readCurrentVersion(".");
   const next = computeNextVersion(version, kind as BumpKind);
   await writeVersions(next);
   console.log(`Bumped ${version} → ${next}`);
-  console.log(
-    `Updated: deno.json, src/domain/version.ts, plugin/.claude-plugin/plugin.json`,
-  );
+  console.log(`Updated: ${VERSIONED_FILES.join(", ")}`);
 }
 
 if (import.meta.main) await main();

--- a/tests/scripts/bump_version_test.ts
+++ b/tests/scripts/bump_version_test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "@std/assert";
-import { computeNextVersion } from "../../scripts/bump-version.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { computeNextVersion, VERSIONED_FILES, writeVersions } from "../../scripts/bump-version.ts";
 
 Deno.test("computeNextVersion patch bump", () => {
   assertEquals(computeNextVersion("0.1.0", "patch"), "0.1.1");
@@ -23,4 +24,62 @@ Deno.test("computeNextVersion prerelease bump appends/increments suffix", () => 
     computeNextVersion("0.1.1-alpha.1", "prerelease:alpha"),
     "0.1.1-alpha.2",
   );
+});
+
+Deno.test("VERSIONED_FILES covers every file the release workflow gates on", () => {
+  // If you add a file here, also add a guard for it to release.yml's
+  // pre-flight step. Keep this list and the workflow in lockstep.
+  assertEquals(
+    VERSIONED_FILES,
+    [
+      "deno.json",
+      "src/domain/version.ts",
+      "plugin/.claude-plugin/plugin.json",
+      "templates/manifest.json",
+    ] as const,
+  );
+});
+
+Deno.test("writeVersions bumps every versioned file in lockstep", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "bump-version-test-" });
+  try {
+    // Lay out fixtures matching the real repo paths, all at version 1.2.3.
+    await Deno.writeTextFile(
+      join(tmp, "deno.json"),
+      `{\n  "name": "@mkrlabs/specflow",\n  "version": "1.2.3"\n}\n`,
+    );
+    await Deno.mkdir(join(tmp, "src/domain"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmp, "src/domain/version.ts"),
+      `export const VERSION = "1.2.3";\n`,
+    );
+    await Deno.mkdir(join(tmp, "plugin/.claude-plugin"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmp, "plugin/.claude-plugin/plugin.json"),
+      `{\n  "name": "specflow-plugin",\n  "version": "1.2.3"\n}\n`,
+    );
+    await Deno.mkdir(join(tmp, "templates"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmp, "templates/manifest.json"),
+      `{\n  "version": "1.2.3",\n  "core": []\n}\n`,
+    );
+
+    await writeVersions("1.2.4", tmp);
+
+    for (const f of VERSIONED_FILES) {
+      const contents = await Deno.readTextFile(join(tmp, f));
+      assertStringIncludes(
+        contents,
+        "1.2.4",
+        `${f} should contain the bumped version`,
+      );
+      assertEquals(
+        contents.includes("1.2.3"),
+        false,
+        `${f} should not still contain the old version`,
+      );
+    }
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
 });


### PR DESCRIPTION
## Summary

- `scripts/bump-version.ts` now bumps `templates/manifest.json#version`
  alongside the other three versioned files (with an `(optional baseDir)`
  param refactor for testability).
- `.github/workflows/release.yml` pre-flight gains a fourth lockstep guard
  on `templates/manifest.json#version` ↔ `deno.json#version`.
- New integration test in `tests/scripts/bump_version_test.ts` runs
  `writeVersions` against a fixture tree and asserts every entry of the
  exported `VERSIONED_FILES` got bumped.
- Release skill prose updated so future runs include `templates/manifest.json`
  in the diff/add commands.

## Why

v1.1.9 shipped with `specflow --version` reporting `1.1.9 (templates
1.1.8)`. The bundled `TEMPLATES_VERSION` is read from `templates/manifest.json`
at `deno task bundle` time; the bump script never touched the manifest.
Prior releases had been bumping the manifest manually. With this fix
the bump is automatic AND the workflow hard-fails if a future caller
forgets the lockstep.

## Test plan

- [x] `deno task test` — 491 passed (was 489 + 2 new)
- [x] `deno fmt --check` clean
- [x] CI on this PR before merging

## Out of scope

- Re-tagging v1.1.9 — tags are immutable per devops-sre rule. Roll
  forward to v1.1.10 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)