### PR TITLE
docs(backlog): document detect-fields.sh / set-field.sh in SKILL.md

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3317,6 +3317,8 @@ project\` calls and read configuration from \`backlog-config.yml\`.
 .specflow/scripts/backlog/add.sh "<title>" [body] [labels-csv]
 .specflow/scripts/backlog/move.sh <number> <Status>   # sets Project Status field
 .specflow/scripts/backlog/clarify-comment.sh <num> "<question>"
+.specflow/scripts/backlog/detect-fields.sh                                 # discover native Priority/Size single-select fields → env lines
+.specflow/scripts/backlog/set-field.sh <num> <Priority|Size> <value>       # set the native Project V2 field; exit codes 10/11/12 signal label fallback
 \`\`\`
 
 For closing or editing, use \`gh\` directly:
@@ -3343,6 +3345,12 @@ Specflow change — the skill is path-aware.
 - **Closing** — close the issue (don't just move to Done). The repo's
   issue history is the audit trail.
 - **Drafts** are not used. Every task is a real issue.
+- **Priority / Size** — when the project has native single-select
+  \`Priority\` and/or \`Size\` fields, prefer \`set-field.sh\` over text
+  labels. Non-zero exit codes tell the caller when to fall back to
+  labels: \`10\` = no such field on the project, \`11\` = field exists but
+  the value option is missing (e.g. \`priority:P3\` on a 3-level field),
+  \`12\` = issue not on the project.
 
 ### Prerequisites
 

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -127,6 +127,8 @@ project` calls and read configuration from `backlog-config.yml`.
 .specflow/scripts/backlog/add.sh "<title>" [body] [labels-csv]
 .specflow/scripts/backlog/move.sh <number> <Status>   # sets Project Status field
 .specflow/scripts/backlog/clarify-comment.sh <num> "<question>"
+.specflow/scripts/backlog/detect-fields.sh                                 # discover native Priority/Size single-select fields → env lines
+.specflow/scripts/backlog/set-field.sh <num> <Priority|Size> <value>       # set the native Project V2 field; exit codes 10/11/12 signal label fallback
 ```
 
 For closing or editing, use `gh` directly:
@@ -153,6 +155,12 @@ Specflow change — the skill is path-aware.
 - **Closing** — close the issue (don't just move to Done). The repo's
   issue history is the audit trail.
 - **Drafts** are not used. Every task is a real issue.
+- **Priority / Size** — when the project has native single-select
+  `Priority` and/or `Size` fields, prefer `set-field.sh` over text
+  labels. Non-zero exit codes tell the caller when to fall back to
+  labels: `10` = no such field on the project, `11` = field exists but
+  the value option is missing (e.g. `priority:P3` on a 3-level field),
+  `12` = issue not on the project.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Summary

- Append `detect-fields.sh` + `set-field.sh` to the GitHub-backend
  "Shell scripts — always available" block in
  `templates/core/skills/backlog/SKILL.md`.
- New "Priority / Size" convention bullet documenting the field-first
  preference and the exit-code-driven label fallback.

Closes #161.

## Why

The two scripts shipped in v1.1.10 but the SKILL.md (which is the
canonical reference for the scaffolded PO agent) wasn't updated. As a
result, scaffolded projects upgraded to 1.1.10 still see the old
5-script list and the PO keeps applying labels even on projects with
native Priority/Size fields configured.

## Test plan

- [x] `deno task test` — 491 passed
- [x] CI on this PR

## Out of scope

- The agent contract files (`templates/core/agents/product-owner.md`
  and `templates/core/skills/specflow/phases/groom.md`) already
  document the field-first routing; #161 was specifically about
  `templates/core/skills/backlog/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)