### PR TITLE
fix(auto-chain): lift disable-model-invocation on /specflow router

### DIFF
--- a/.claude/agents/architect/memory/MEMORY.md
+++ b/.claude/agents/architect/memory/MEMORY.md
@@ -15,3 +15,4 @@ obsolete once they are encoded in `AGENTS.md`).
 - [Claude plugin boundary](claude-plugin-boundary.md) — which templates go to the plugin vs stay binary-owned; the project-state rule
 - [Claude plugin backwards compat](claude-plugin-compat.md) — state table + detection method for v0.x inline agents when plugin is installed
 - [Router skill consolidation](router-skill-consolidation.md) — decisions for collapsing 11 specflow-* phase skills into a single /specflow router + phases/ subdirectory
+- [Auto-chain disable-model-invocation fix](auto-chain-disable-model-invocation.md) — lift the flag from the router to unblock Skill-tool chaining by specflow-auto

--- a/.claude/agents/architect/memory/auto-chain-disable-model-invocation.md
+++ b/.claude/agents/architect/memory/auto-chain-disable-model-invocation.md
@@ -1,0 +1,16 @@
+---
+name: auto-chain-disable-model-invocation
+description: Why disable-model-invocation must be lifted from /specflow router to allow /specflow-auto Skill-tool chaining, and what the safe path is
+type: decision
+---
+
+**Rule: lift `disable-model-invocation: true` from `templates/core/skills/specflow/SKILL.md`. The flag blocks the `Skill` tool call that `specflow-auto` depends on.**
+
+Why: The original rationale (design spec Q1) was "prevent spurious auto-spawn on casual mention." That goal is still met by keeping the flag on `specflow-review` alias and leaving `specflow-auto` as the explicit entry point. The risk of auto-spawn from lifting the flag is low because the `when_to_use` trigger phrases are specific ("spec out a feature", "write a spec", etc.) — they don't fire on casual mention of "specflow."
+
+**How to apply:**
+- Remove `disable-model-invocation: true` from line 3 of `templates/core/skills/specflow/SKILL.md`
+- Flip the smoke assertion at `.claude/skills/test-sandbox/scripts/smoke-features.sh:63-64` from "grep for `disable-model-invocation: true`" to "assert `disable-model-invocation` is absent (or false) on the router"
+- The `specflow-review` alias (auto-invoke surface for the review phase) is unaffected — it already has no `disable-model-invocation` flag
+- `disable-model-invocation` is a Claude Code-only runtime concept; the other 6 harnesses (cursor, codex, copilot, gemini, windsurf, opencode) copy the file verbatim and ignore the flag — the bug only manifests on Claude Code
+- Do NOT do option 2 (bypass router from specflow-auto) — it would duplicate routing logic and break the clean phase-doc pattern

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -60,8 +60,8 @@ for phase in specify constitution clarify plan tasks analyze implement merge rev
 done
 check "name: specflow on the router SKILL.md" \
   'head -3 .claude/skills/specflow/SKILL.md | grep -q "name: specflow"'
-check "disable-model-invocation set on the router" \
-  'grep -q "disable-model-invocation: true" .claude/skills/specflow/SKILL.md'
+check "disable-model-invocation NOT set on the router (Skill-tool chaining must work)" \
+  '! grep -q "disable-model-invocation: true" .claude/skills/specflow/SKILL.md'
 check "specflow-review auto-invoke alias present" \
   '[ -f .claude/skills/specflow-review/SKILL.md ]'
 

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: specflow
-disable-model-invocation: true
 description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). `/specflow` with no args prints the workflow overview.
 argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 when_to_use: |

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11,7 +11,6 @@ export const CORE_BUNDLE: CoreBundle = [
     suffix: null,
     content: `---
 name: specflow
-disable-model-invocation: true
 description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). \`/specflow\` with no args prints the workflow overview.
 argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 when_to_use: |

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: specflow
-disable-model-invocation: true
 description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). `/specflow` with no args prints the workflow overview.
 argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
 when_to_use: |

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -478,6 +478,12 @@ Deno.test("specflow init scaffolds the consolidated router skill + 11 phase docs
       join(root, ".claude/skills/specflow/SKILL.md"),
     );
     assertStringIncludes(routerContent, "name: specflow");
-    assertStringIncludes(routerContent, "disable-model-invocation: true");
+    // The router must NOT carry `disable-model-invocation: true` —
+    // /specflow-auto chains phases via `Skill(specflow, "<phase>")`,
+    // and that flag would block the chain on Claude Code (#166).
+    assertEquals(
+      routerContent.includes("disable-model-invocation: true"),
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Lift `disable-model-invocation: true` from the `/specflow` router
  (`templates/core/skills/specflow/SKILL.md` + plugin mirror).
- Flip the regression-guard smoke assertion + integration test to lock
  the absence of the flag.

Closes #166.

## Why

The flag was set in v1.0.0 (PR #127) to prevent Claude from
auto-spawning the heavy workflow on casual mentions of "specflow".
But Claude Code conflates two checks under the same flag:
(a) auto-spawn on description match, AND
(b) programmatic invocation via the `Skill` tool by another skill.

`/specflow-auto`'s entire job is to chain phases via `Skill(specflow,
"<phase> ...")`. The flag broke that:

```
⏺ Skill(specflow)
  ⎿  Initializing…
  ⎿  Error: Skill specflow cannot be used with Skill tool
     due to disable-model-invocation
```

The auto-chain — one of Specflow's four marketed differentiators —
was effectively non-functional on Claude Code. Kevin hit it
repeatedly on a downstream project.

The original "no auto-spawn on casual mention" goal is still served
by the tight `when_to_use:` trigger phrases on `/specflow` ("spec out
a feature", "write a spec", etc.) which don't fire on bare mentions
of "specflow", and by the fact that `specflow-auto` is the
human-facing entry point for the chain.

The flag is Claude-Code-specific; the other 7 harnesses copy the file
verbatim and ignore the field — this bug was Claude-only.

## Test plan

- [x] `deno task test` — 492 passed
- [x] `smoke-features.sh feat` — assertion flipped, green
- [x] CI on this PR

## Out of scope

- Auto-routing tweaks to the description / when_to_use trigger phrases
  — they already work today; lifting the flag just unblocks the
  programmatic path that `specflow-auto` depends on.
- The other 7 harnesses — they were never affected by this flag; no
  per-harness logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)