### PR TITLE
feat(docs+agent): version.json endpoint + proactive upgrade nudge

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "build": "deno task bundle && deno run --allow-read --allow-write --allow-run scripts/build.ts",
-    "docs:build": "deno run --allow-read --allow-write --allow-env scripts/build-docs.ts",
+    "docs:build": "deno run --allow-read --allow-write --allow-env --allow-net scripts/build-docs.ts",
     "setup": "deno run --allow-read --allow-write --allow-run scripts/install-hooks.ts"
   },
   "imports": {

--- a/plugin/agents/specflow-expert.md
+++ b/plugin/agents/specflow-expert.md
@@ -55,8 +55,45 @@ For "what's new" / version-delta questions only:
    time of your installed Specflow version. For the latest, run
    `specflow self-update` and ask me again."
 
-Do **not** fetch proactively. Fetch only when the user explicitly
-asks about what changed, latest features, or the newest release.
+Do **not** fetch proactively from this protocol. Fetch the full
+release notes only when the user explicitly asks about what changed,
+latest features, or the newest release.
+
+## Version check protocol (proactive nudge)
+
+This is a separate, lightweight check — distinct from the live fetch
+protocol above. Run it ONLY when the user's question matches the
+auto-route triggers in your `description` ("how does specflow X",
+"what is /specflow Y", "explain", "quoi de neuf", etc.). Do NOT run
+it on a manual `/specflow-expert` invocation whose question does not
+match those triggers — silence beats noise.
+
+1. Read `.specflow/installed.lock` and extract the `templates_version`
+   field. If the file is absent or unreadable, skip silently.
+2. `WebFetch` `https://specflow.makerlabs.dev/version.json`. Expect
+   `{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}`. On any
+   failure (non-200, network error, malformed JSON), skip silently
+   — never surface the error to the user.
+3. Compare versions. If `templates_version` < `version` (lexicographic
+   semver compare on `X.Y.Z` strings is sufficient), prepend ONE line
+   to your response BEFORE the actual answer:
+
+   > 📦 Specflow v{version} is available (you have v{templates_version})
+   > — run `specflow upgrade` to pull in the new templates.
+
+4. If already up to date, or any step failed, emit nothing extra and
+   answer the user's question directly.
+5. Do **not** suggest `specflow upgrade --force` automatically. You
+   may mention `--force` exists if the user later asks why a
+   customised file was skipped by `upgrade`.
+
+This protocol is gated AT MOST once per session — if you've already
+emitted the nudge in this session, do not re-emit it.
+
+If the user explicitly asks "what's new" / "quoi de neuf", route to
+the **live fetch protocol** above instead — do not run this check
+(it would emit just the version line; the live protocol gives them
+the full release notes they're asking for).
 
 ## Vendored knowledge snapshot
 

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -25,6 +25,66 @@ async function readVersion(denoJsonPath = "deno.json"): Promise<string> {
 }
 
 /**
+ * Fetch the last `count` GitHub releases and render a "Recent releases"
+ * Markdown section. On any failure (network, non-2xx, malformed payload),
+ * emit a warning to stderr and return an empty string — the docs deploy
+ * MUST NOT fail because of a cosmetic section.
+ *
+ * Public-repo unauthenticated calls have a 60 req/hr ceiling on GitHub
+ * runners — sufficient for the build cadence.
+ */
+export async function fetchRecentReleases(count = 5): Promise<string> {
+  const url = `https://api.github.com/repos/mkrlabs/specflow/releases?per_page=${count}`;
+  let releases: Array<{ tag_name: string; body: string }>;
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) {
+      console.warn(
+        `::warning::fetchRecentReleases: HTTP ${res.status} from ${url} — skipping section`,
+      );
+      return "";
+    }
+    releases = await res.json();
+  } catch (err) {
+    console.warn(
+      `::warning::fetchRecentReleases: ${
+        err instanceof Error ? err.message : err
+      } — skipping section`,
+    );
+    return "";
+  }
+  if (!Array.isArray(releases) || releases.length === 0) return "";
+
+  const lines: string[] = ["## Recent releases", ""];
+  for (const r of releases.slice(0, count)) {
+    const oneLiner = extractOneLiner(r.body ?? "");
+    const tagUrl = `${REPO_URL}/releases/tag/${r.tag_name}`;
+    lines.push(`- [${r.tag_name}](${tagUrl}) — ${oneLiner}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Extracts a one-liner summary from a `gen-changelog.ts`-style release body.
+ * Skips heading lines (`##`, `###`) and the trailing `**Full changelog:**`.
+ * Returns the first bullet text, or the first non-empty non-heading line if
+ * no bullet is present.
+ */
+export function extractOneLiner(body: string): string {
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("#")) continue;
+    if (line.startsWith("**Full changelog")) continue;
+    if (line.startsWith("- ")) return line.slice(2).trim();
+    return line;
+  }
+  return "";
+}
+
+/**
  * GitHub Pages custom domain. Emitted as `docs-dist/CNAME` so each deploy
  * republishes it; without this, GitHub Pages drops the custom domain on
  * subsequent workflow deploys (build_type=workflow ignores the repo
@@ -93,24 +153,44 @@ export async function buildDocs(opts: {
   source?: string;
   outDir?: string;
   version?: string;
-} = {}): Promise<{ html: string; markdown: string; version: string }> {
+  fetchReleases?: () => Promise<string>;
+} = {}): Promise<
+  { html: string; markdown: string; version: string; versionJson: string }
+> {
   const source = opts.source ?? SOURCE;
   const outDir = opts.outDir ?? OUT_DIR;
   const version = opts.version ?? await readVersion();
+  const fetchReleases = opts.fetchReleases ?? (() => fetchRecentReleases());
   const outHtml = `${outDir}/index.html`;
   const outMd = `${outDir}/llms.txt`;
+  const outVersionJson = `${outDir}/version.json`;
 
   const sourceMarkdown = await Deno.readTextFile(source);
-  const rendered = render(sourceMarkdown, { allowIframes: false });
+  const releaseSection = await fetchReleases();
+  const enrichedMarkdown = releaseSection
+    ? `${sourceMarkdown}\n\n${releaseSection}\n`
+    : sourceMarkdown;
+  const rendered = render(enrichedMarkdown, { allowIframes: false });
   const html = HTML_TEMPLATE(rendered, version);
-  const markdown = `<!-- Specflow v${version} — ${REPO_URL} -->\n\n${sourceMarkdown}`;
+  const markdown = `<!-- Specflow v${version} — ${REPO_URL} -->\n\n${enrichedMarkdown}`;
+
+  // Lightweight machine-readable endpoint consumed by the `specflow-expert`
+  // agent to compare the user's installed version against the latest
+  // released one. `released_at` is the build timestamp — accurate within
+  // the day since static.yml redeploys on every release commit.
+  const versionJson = JSON.stringify(
+    { version, released_at: new Date().toISOString().split("T")[0] },
+    null,
+    2,
+  ) + "\n";
 
   await Deno.mkdir(outDir, { recursive: true });
   await Deno.writeTextFile(outHtml, html);
   await Deno.writeTextFile(outMd, markdown);
   await Deno.writeTextFile(`${outDir}/CNAME`, `${CUSTOM_DOMAIN}\n`);
+  await Deno.writeTextFile(outVersionJson, versionJson);
 
-  return { html, markdown, version };
+  return { html, markdown, version, versionJson };
 }
 
 if (import.meta.main) {
@@ -118,4 +198,5 @@ if (import.meta.main) {
   console.log(`✓ wrote ${OUT_HTML} (${html.length} bytes, v${version})`);
   console.log(`✓ wrote ${OUT_MD}`);
   console.log(`✓ wrote ${OUT_CNAME} (${CUSTOM_DOMAIN})`);
+  console.log(`✓ wrote ${OUT_DIR}/version.json (v${version})`);
 }

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2923,8 +2923,45 @@ For "what's new" / version-delta questions only:
    time of your installed Specflow version. For the latest, run
    \`specflow self-update\` and ask me again."
 
-Do **not** fetch proactively. Fetch only when the user explicitly
-asks about what changed, latest features, or the newest release.
+Do **not** fetch proactively from this protocol. Fetch the full
+release notes only when the user explicitly asks about what changed,
+latest features, or the newest release.
+
+## Version check protocol (proactive nudge)
+
+This is a separate, lightweight check — distinct from the live fetch
+protocol above. Run it ONLY when the user's question matches the
+auto-route triggers in your \`description\` ("how does specflow X",
+"what is /specflow Y", "explain", "quoi de neuf", etc.). Do NOT run
+it on a manual \`/specflow-expert\` invocation whose question does not
+match those triggers — silence beats noise.
+
+1. Read \`.specflow/installed.lock\` and extract the \`templates_version\`
+   field. If the file is absent or unreadable, skip silently.
+2. \`WebFetch\` \`https://specflow.makerlabs.dev/version.json\`. Expect
+   \`{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}\`. On any
+   failure (non-200, network error, malformed JSON), skip silently
+   — never surface the error to the user.
+3. Compare versions. If \`templates_version\` < \`version\` (lexicographic
+   semver compare on \`X.Y.Z\` strings is sufficient), prepend ONE line
+   to your response BEFORE the actual answer:
+
+   > 📦 Specflow v{version} is available (you have v{templates_version})
+   > — run \`specflow upgrade\` to pull in the new templates.
+
+4. If already up to date, or any step failed, emit nothing extra and
+   answer the user's question directly.
+5. Do **not** suggest \`specflow upgrade --force\` automatically. You
+   may mention \`--force\` exists if the user later asks why a
+   customised file was skipped by \`upgrade\`.
+
+This protocol is gated AT MOST once per session — if you've already
+emitted the nudge in this session, do not re-emit it.
+
+If the user explicitly asks "what's new" / "quoi de neuf", route to
+the **live fetch protocol** above instead — do not run this check
+(it would emit just the version line; the live protocol gives them
+the full release notes they're asking for).
 
 ## Vendored knowledge snapshot
 

--- a/templates/core/agents/specflow-expert.md
+++ b/templates/core/agents/specflow-expert.md
@@ -55,8 +55,45 @@ For "what's new" / version-delta questions only:
    time of your installed Specflow version. For the latest, run
    `specflow self-update` and ask me again."
 
-Do **not** fetch proactively. Fetch only when the user explicitly
-asks about what changed, latest features, or the newest release.
+Do **not** fetch proactively from this protocol. Fetch the full
+release notes only when the user explicitly asks about what changed,
+latest features, or the newest release.
+
+## Version check protocol (proactive nudge)
+
+This is a separate, lightweight check — distinct from the live fetch
+protocol above. Run it ONLY when the user's question matches the
+auto-route triggers in your `description` ("how does specflow X",
+"what is /specflow Y", "explain", "quoi de neuf", etc.). Do NOT run
+it on a manual `/specflow-expert` invocation whose question does not
+match those triggers — silence beats noise.
+
+1. Read `.specflow/installed.lock` and extract the `templates_version`
+   field. If the file is absent or unreadable, skip silently.
+2. `WebFetch` `https://specflow.makerlabs.dev/version.json`. Expect
+   `{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}`. On any
+   failure (non-200, network error, malformed JSON), skip silently
+   — never surface the error to the user.
+3. Compare versions. If `templates_version` < `version` (lexicographic
+   semver compare on `X.Y.Z` strings is sufficient), prepend ONE line
+   to your response BEFORE the actual answer:
+
+   > 📦 Specflow v{version} is available (you have v{templates_version})
+   > — run `specflow upgrade` to pull in the new templates.
+
+4. If already up to date, or any step failed, emit nothing extra and
+   answer the user's question directly.
+5. Do **not** suggest `specflow upgrade --force` automatically. You
+   may mention `--force` exists if the user later asks why a
+   customised file was skipped by `upgrade`.
+
+This protocol is gated AT MOST once per session — if you've already
+emitted the nudge in this session, do not re-emit it.
+
+If the user explicitly asks "what's new" / "quoi de neuf", route to
+the **live fetch protocol** above instead — do not run this check
+(it would emit just the version line; the live protocol gives them
+the full release notes they're asking for).
 
 ## Vendored knowledge snapshot
 

--- a/tests/scripts/build_docs_test.ts
+++ b/tests/scripts/build_docs_test.ts
@@ -1,7 +1,12 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs/exists";
 import { join } from "@std/path";
-import { buildDocs } from "../../scripts/build-docs.ts";
+import { buildDocs, extractOneLiner } from "../../scripts/build-docs.ts";
+
+// All tests pass a `fetchReleases` stub by default so the build is
+// hermetic — the real `fetchRecentReleases()` would hit the GitHub
+// Releases API.
+const noReleases = () => Promise.resolve("");
 
 async function withTempSource(
   markdown: string,
@@ -21,11 +26,24 @@ async function withTempSource(
 Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", async () => {
   const md = "# Hello Specflow\n\nThis is a **test** doc.\n";
   await withTempSource(md, async (source, outDir) => {
-    await buildDocs({ source, outDir, version: "9.9.9" });
+    await buildDocs({
+      source,
+      outDir,
+      version: "9.9.9",
+      fetchReleases: noReleases,
+    });
 
     assertEquals(await exists(join(outDir, "index.html")), true);
     assertEquals(await exists(join(outDir, "llms.txt")), true);
     assertEquals(await exists(join(outDir, "CNAME")), true);
+    assertEquals(await exists(join(outDir, "version.json")), true);
+
+    const versionJson = JSON.parse(
+      await Deno.readTextFile(join(outDir, "version.json")),
+    );
+    assertEquals(versionJson.version, "9.9.9");
+    assertEquals(typeof versionJson.released_at, "string");
+    assertEquals(/^\d{4}-\d{2}-\d{2}$/.test(versionJson.released_at), true);
 
     const html = await Deno.readTextFile(join(outDir, "index.html"));
     assertStringIncludes(html, "<h1");
@@ -53,7 +71,7 @@ Deno.test("buildDocs writes index.html and llms.txt with rendered markdown", asy
 Deno.test("buildDocs reads version from deno.json by default", async () => {
   const md = "# Hello\n";
   await withTempSource(md, async (source, outDir) => {
-    const result = await buildDocs({ source, outDir });
+    const result = await buildDocs({ source, outDir, fetchReleases: noReleases });
     const denoJson = JSON.parse(await Deno.readTextFile("deno.json"));
     assertEquals(result.version, denoJson.version);
     assertStringIncludes(result.html, `v${denoJson.version}`);
@@ -68,6 +86,7 @@ Deno.test("buildDocs renders the actual Specflow docs without error", async () =
       source: "docs/llms.md",
       outDir: root,
       version: "9.9.9",
+      fetchReleases: noReleases,
     });
     // Sanity: the real docs mention install + harnesses, which are headline
     // sections that should never disappear silently.
@@ -78,4 +97,68 @@ Deno.test("buildDocs renders the actual Specflow docs without error", async () =
   } finally {
     await Deno.remove(root, { recursive: true });
   }
+});
+
+Deno.test("buildDocs appends Recent releases section when fetchReleases returns content", async () => {
+  const md = "# Doc\n";
+  const stub = () =>
+    Promise.resolve([
+      "## Recent releases",
+      "",
+      "- [v1.1.13](https://github.com/mkrlabs/specflow/releases/tag/v1.1.13) — Lift disable-model-invocation on /specflow router (#167)",
+      "- [v1.1.12](https://github.com/mkrlabs/specflow/releases/tag/v1.1.12) — Bundle a specflow-expert agent across all 8 harnesses",
+    ].join("\n"));
+  await withTempSource(md, async (source, outDir) => {
+    const result = await buildDocs({
+      source,
+      outDir,
+      version: "9.9.9",
+      fetchReleases: stub,
+    });
+    assertStringIncludes(result.markdown, "## Recent releases");
+    assertStringIncludes(result.markdown, "[v1.1.13](https://github.com");
+    assertStringIncludes(result.html, "Recent releases");
+    const txt = await Deno.readTextFile(join(outDir, "llms.txt"));
+    assertStringIncludes(txt, "Recent releases");
+  });
+});
+
+Deno.test("buildDocs omits Recent releases section when fetchReleases returns empty string", async () => {
+  const md = "# Only doc\n";
+  await withTempSource(md, async (source, outDir) => {
+    const result = await buildDocs({
+      source,
+      outDir,
+      version: "9.9.9",
+      fetchReleases: noReleases,
+    });
+    assertEquals(result.markdown.includes("Recent releases"), false);
+  });
+});
+
+Deno.test("extractOneLiner picks first bullet, skipping headings and footer", () => {
+  const body = `## What's changed in v1.1.13
+
+### Bug fixes
+
+- Lift disable-model-invocation on /specflow router (#167)
+
+**Full changelog:** https://github.com/mkrlabs/specflow/compare/v1.1.12...v1.1.13`;
+  assertEquals(
+    extractOneLiner(body),
+    "Lift disable-model-invocation on /specflow router (#167)",
+  );
+});
+
+Deno.test("extractOneLiner returns first non-heading line when no bullet", () => {
+  const body = `## v0.1.0
+
+Initial release.
+
+- bullet that comes after`;
+  assertEquals(extractOneLiner(body), "Initial release.");
+});
+
+Deno.test("extractOneLiner returns empty string for empty body", () => {
+  assertEquals(extractOneLiner(""), "");
 });


### PR DESCRIPTION
## Summary

Three coordinated additions so a Specflow-scaffolded project knows when it's behind and the user gets nudged at the right moment.

1. **`/version.json` endpoint** at `specflow.makerlabs.dev/version.json` — `{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}`. Emitted by `scripts/build-docs.ts` on every docs deploy.

2. **"Recent releases" section** auto-appended to `docs/llms.md` at build time. `buildDocs()` fetches the GitHub Releases API, extracts a one-liner per version, and embeds a bullet list with tag links. Silent-fail (`::warning::` + skip) if the API is unreachable. `fetchReleases` is injectable so tests stay hermetic.

3. **Proactive upgrade nudge** in the `specflow-expert` agent. New "Version check protocol" section runs ONLY on auto-route triggers (Specflow-related questions), reads `.specflow/installed.lock`, fetches `/version.json`, prepends a one-liner `📦 Specflow vX is available — run \`specflow upgrade\`` if the user is behind. Capped at one nudge per session. Never auto-suggests `--force`.

Closes #168.

## Why

Kevin's terrain ask: "Idéalement, l'agent SpecFlow expert proposerait lui-même l'upgrade dès qu'il détecte une nouvelle release." Today the on-demand "what's new" path (#164) requires the user to ask. This PR makes the version-check proactive (when the user is already asking about Specflow) without being noisy (silent on manual `/specflow-expert` invocations on unrelated questions).

## Test plan

- [x] `deno task test` — 497 passed (was 492, +5 new cases)
- [x] `smoke-features.sh` green
- [x] Agent body 11005 string chars — under the Windsurf 12000 cap
- [x] Plugin parity (byte-identical agent file enforced by `plugin_sync_test`)
- [x] CI on this PR

## Decisions

Per Kevin's `AskUserQuestion` answers:
- JSON endpoint format (extensible, vs plain text)
- Fetch on auto-route triggers only (vs every dispatch / vs explicit only)
- Always suggest plain `specflow upgrade`; never auto-suggest `--force`

Per architect's design pass + devops-sre advisory:
- `released_at` = build timestamp (vs git tag date — would have required `fetch-depth: 0` in static.yml)
- `fetchReleases` is an injectable parameter of `buildDocs()` (hermetic tests)
- Bullet extractor: skip headings + `**Full changelog:**`, return first `- ` bullet
- Silent-fail with `::warning::` on stderr (vs hard-fail; vs silent-drop)

## Out of scope

- Push notifications / Slack hooks — pull-based version check only
- Auto-running `specflow upgrade` — agent suggests, never executes
- Per-channel versioning (stable/beta/canary) — single channel for now
- Replacing `scripts/gen-changelog.ts` — it stays as-is; this PR adds a docs-side rendering, not a release-side change

🤖 Generated with [Claude Code](https://claude.com/claude-code)