### PR TITLE
fix(upgrade): silence false-positive customized-locally reports + add --reset-baseline

### DIFF
--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -14,6 +14,15 @@ export type UpgradeProjectInput = {
   projectDir: string;
   dryRun: boolean;
   force: boolean;
+  /**
+   * `--reset-baseline` flag. Heals stale lock SHAs left by older binaries
+   * (and any other source of disk/lock divergence) by trusting the
+   * on-disk content as the new baseline. Existing files where
+   * `diskSha != lockSha` get their lock SHA force-reset; the plan then
+   * compares disk vs bundle directly. Use after the user confirms they
+   * never edited the affected files.
+   */
+  resetBaseline?: boolean;
 };
 
 export type UpgradeProjectResult =
@@ -116,8 +125,12 @@ export class UpgradeProjectUseCase {
       diskShas,
       lock,
       newShas,
-      pluginInstalled,
-      (dest) => isPluginCoveredPath(lock.harness, dest),
+      {
+        pluginInstalled,
+        isPluginCovered: (dest) => isPluginCoveredPath(lock.harness, dest),
+        isSkipIfExists: (dest) => bundle[dest]?.skipIfExists === true,
+        resetBaseline: input.resetBaseline ?? false,
+      },
     );
 
     const hasActualWork = plan.some((a) =>
@@ -255,5 +268,10 @@ export class UpgradeProjectUseCase {
 
 async function shaOfBundle(file: TemplateFile | undefined): Promise<string> {
   if (!file) return "";
-  return await sha256Hex(file.content);
+  // Mirror init_project's hash logic: mergeBlock files are hashed on the
+  // *block body* only, not the full file. Keeping these two paths in
+  // lockstep is critical — a divergence here is what caused #163's
+  // false-positive "customized" reports on `.gitignore` upgrades.
+  const shaInput = file.mergeBlock !== undefined ? canonicalBlockBody(file.content) : file.content;
+  return await sha256Hex(shaInput);
 }

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -17,6 +17,7 @@ export type UpgradeIntent = {
   dryRun: boolean;
   force: boolean;
   backlog: BacklogBackend | null;
+  resetBaseline: boolean;
 };
 
 /**
@@ -228,6 +229,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
       projectDir,
       dryRun: intent.dryRun,
       force: intent.force,
+      resetBaseline: intent.resetBaseline,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -247,7 +249,10 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     console.log(
       dim(
         "\nFor customized files, review the diff below and merge manually if desired.\n" +
-          "Re-run with --force to overwrite them (edits will be backed up to .specflow.bak).\n",
+          "Re-run with --force to overwrite them (edits will be backed up to .specflow.bak).\n" +
+          "If you never edited these files, the lock baseline is stale — re-run with\n" +
+          "`specflow upgrade --reset-baseline` to trust the on-disk content as the new\n" +
+          "baseline and apply the upstream updates cleanly.\n",
       ),
     );
     // Resolve the harness from the lock to render diffs in the correct file tree.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -9,7 +9,7 @@ ${bold("Usage:")}
   specflow init --here                Bootstrap in the current directory
   specflow self-update [--check]      Update the specflow binary
   specflow check [--project]          Diagnose the environment (and optionally the project)
-  specflow upgrade [--dry-run] [--force] [--backlog <name>]
+  specflow upgrade [--dry-run] [--force] [--backlog <name>] [--reset-baseline]
                                       Update project templates to the binary's version
   specflow --version, -v              Print version
   specflow --help, -h                 Show this help
@@ -28,6 +28,9 @@ ${bold("Flags (for upgrade):")}
   --force             Overwrite locally-customized files (existing content backed up to *.specflow.bak)
   --backlog <name>    Switch the backlog backend (local | github | gitlab). Re-renders the backlog skill;
                       existing data in the previous backend is NOT migrated.
+  --reset-baseline    Trust the on-disk content as the new SHA baseline. Use when files are flagged
+                      "customized locally" but you never edited them (heals stale lock SHAs). Combine
+                      with --dry-run to preview what would change.
 
 ${bold("Docs:")}    ${cyan("https://specflow.makerlabs.dev")}
 ${bold("Source:")}  ${cyan("https://github.com/mkrlabs/specflow")}`;

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -70,6 +70,11 @@ export type Intent =
      * current backend.
      */
     backlog: "local" | "github" | "gitlab" | null;
+    /**
+     * `--reset-baseline`. Heals stale lock SHAs by trusting the on-disk
+     * content as the new baseline. See `UpgradeProjectInput.resetBaseline`.
+     */
+    resetBaseline: boolean;
   }
   | { kind: "unknown"; received: string };
 
@@ -86,6 +91,7 @@ export function parseArgs(argv: string[]): Intent {
       "check",
       "dry-run",
       "project",
+      "reset-baseline",
     ],
     string: ["ai", "backlog", "backlog-url", "backlog-repo"],
     alias: { v: "version", h: "help" },
@@ -156,6 +162,7 @@ export function parseArgs(argv: string[]): Intent {
       dryRun: Boolean(parsed["dry-run"]),
       force: Boolean(parsed.force),
       backlog: backlogResult.value,
+      resetBaseline: Boolean(parsed["reset-baseline"]),
     };
   }
 

--- a/src/domain/upgrade_plan.ts
+++ b/src/domain/upgrade_plan.ts
@@ -66,22 +66,70 @@ export type UpgradePlan = ReadonlyArray<UpgradeAction>;
  * produce no action — the caller drops them from the new lock
  * implicitly by iterating only `newShas`.
  */
+/**
+ * Optional inputs that didn't exist in the v1.0 plan signature. Carried as
+ * a single object so future additions don't keep growing the positional
+ * parameter list.
+ */
+export type UpgradePlanOptions = {
+  pluginInstalled?: boolean;
+  isPluginCovered?: (dest: string) => boolean;
+  /**
+   * Predicate identifying `skipIfExists` bundle entries. Such files
+   * (e.g. `AGENTS.md`, `.specflow/memory/constitution.md`) may exist on
+   * disk before init touches them — in which case init deliberately
+   * skips writing AND skips recording them in the lock. Without this
+   * predicate, upgrade saw `diskSha defined + lockSha undefined` and
+   * misclassified the user-owned file as "customized locally". With
+   * the predicate, those files are silently omitted from the plan —
+   * they were never specflow-managed.
+   */
+  isSkipIfExists?: (dest: string) => boolean;
+  /**
+   * `--reset-baseline` mode. When true, files where `diskSha != lockSha`
+   * have their lock SHA force-reset to the disk SHA before the plan is
+   * computed. Net effect: stale locks (e.g. from a pre-v1.0 binary that
+   * recorded the wrong SHA) get re-aligned with reality and the plan
+   * compares disk against bundle directly. Risk: a user who genuinely
+   * customised a file loses their edit signal. Document accordingly.
+   */
+  resetBaseline?: boolean;
+};
+
 export function computeUpgradePlan(
   diskShas: Map<string, string>,
   lock: InstalledLock,
   newShas: Map<string, string>,
-  pluginInstalled: boolean = false,
+  pluginInstalledOrOpts: boolean | UpgradePlanOptions = false,
   isPluginCovered: (dest: string) => boolean = () => false,
 ): UpgradePlan {
+  // Accept both legacy positional form (boolean + predicate) and the new
+  // options-bag form. Existing callers and tests use the legacy shape.
+  const opts: UpgradePlanOptions = typeof pluginInstalledOrOpts === "object"
+    ? pluginInstalledOrOpts
+    : { pluginInstalled: pluginInstalledOrOpts, isPluginCovered };
+  const pluginInstalled = opts.pluginInstalled ?? false;
+  const isPluginCoveredFn = opts.isPluginCovered ?? (() => false);
+  const isSkipIfExists = opts.isSkipIfExists ?? (() => false);
+  const resetBaseline = opts.resetBaseline ?? false;
   const actions: UpgradeAction[] = [];
   const sortedDests = [...newShas.keys()].sort();
 
   for (const dest of sortedDests) {
     const newSha = newShas.get(dest)!;
     const diskSha = diskShas.get(dest);
-    const lockSha = lock.entries.get(dest)?.sha256;
+    let lockSha = lock.entries.get(dest)?.sha256;
 
-    const covered = pluginInstalled && isPluginCovered(dest);
+    // Reset-baseline: if the on-disk content disagrees with the lock SHA,
+    // trust the disk. This heals stale locks left by pre-v1.0 binaries
+    // and is the migration path for the false-positive "customized"
+    // bug (#163). Skipped when the lock genuinely has no entry — that
+    // case still falls through to the skipIfExists / customized branch.
+    if (resetBaseline && diskSha !== undefined && lockSha !== undefined && diskSha !== lockSha) {
+      lockSha = diskSha;
+    }
+
+    const covered = pluginInstalled && isPluginCoveredFn(dest);
 
     if (diskSha === undefined) {
       // File missing on disk. Plugin-covered + plugin installed:
@@ -107,6 +155,14 @@ export function computeUpgradePlan(
       continue;
     }
     if (lockSha === undefined) {
+      // skipIfExists files (AGENTS.md, .specflow/memory/constitution.md, …)
+      // that the user already had at init time were deliberately not
+      // tracked by the lock. They were never specflow-managed; do not
+      // emit any action — silent skip prevents the false-positive
+      // "customized locally" report (#163).
+      if (isSkipIfExists(dest)) {
+        continue;
+      }
       actions.push({
         kind: "preserve",
         dest,

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -105,6 +105,7 @@ Deno.test("parseArgs returns upgrade intent", () => {
     dryRun: false,
     force: false,
     backlog: null,
+    resetBaseline: false,
   });
 });
 
@@ -114,6 +115,17 @@ Deno.test("parseArgs returns upgrade intent with --dry-run --force", () => {
     dryRun: true,
     force: true,
     backlog: null,
+    resetBaseline: false,
+  });
+});
+
+Deno.test("parseArgs returns upgrade intent with --reset-baseline", () => {
+  assertEquals(parseArgs(["upgrade", "--reset-baseline"]), {
+    kind: "upgrade",
+    dryRun: false,
+    force: false,
+    backlog: null,
+    resetBaseline: true,
   });
 });
 

--- a/tests/domain/upgrade_plan_test.ts
+++ b/tests/domain/upgrade_plan_test.ts
@@ -287,3 +287,58 @@ Deno.test("plugin migration: uncovered path + plugin installed → existing beha
   const plan = computeUpgradePlan(diskShas, lock, newShas, true, isCovered);
   assertEquals(plan.find((p) => p.dest === UNCOVERED)?.kind, "auto-update");
 });
+
+// #163: skipIfExists files (AGENTS.md etc.) that pre-existed at init are
+// silently skipped — their absence from the lock must not flag them as
+// "customized locally".
+Deno.test("computeUpgradePlan: skipIfExists file not in lock → silently omitted", async () => {
+  const path = "AGENTS.md";
+  const newSha = await sha256Hex("# new bundled content\n");
+  const diskSha = await sha256Hex("# user's pre-existing AGENTS.md\n");
+  // No entry for AGENTS.md in the lock — typical of a brownfield init
+  // where the file already existed and was therefore not written by
+  // specflow (and not recorded).
+  const plan = computeUpgradePlan(
+    new Map([[path, diskSha]]),
+    emptyLock,
+    new Map([[path, newSha]]),
+    { isSkipIfExists: (d) => d === path },
+  );
+  // No action emitted for the skipIfExists file.
+  assertEquals(plan.length, 0);
+});
+
+// #163: --reset-baseline (resetBaseline=true) heals stale lock SHAs by
+// trusting the on-disk content as the new baseline. The plan then
+// auto-updates against the bundle.
+Deno.test("computeUpgradePlan: resetBaseline aligns stale lock with disk → auto-update", async () => {
+  const path = ".claude/skills/specflow/SKILL.md";
+  const diskSha = await sha256Hex("router skill — current on disk\n");
+  const newSha = await sha256Hex("router skill — new bundle content\n");
+  const lock = lockWith(path, "stale-sha-from-an-old-binary");
+  const plan = computeUpgradePlan(
+    new Map([[path, diskSha]]),
+    lock,
+    new Map([[path, newSha]]),
+    { resetBaseline: true },
+  );
+  // resetBaseline forced lockSha to diskSha → diskSha matches lockSha →
+  // auto-update against the new bundle.
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].kind, "auto-update");
+});
+
+// Same scenario WITHOUT --reset-baseline → preserved as "customized".
+Deno.test("computeUpgradePlan: stale lock without resetBaseline → preserve customized", async () => {
+  const path = ".claude/skills/specflow/SKILL.md";
+  const diskSha = await sha256Hex("router skill — current on disk\n");
+  const newSha = await sha256Hex("router skill — new bundle content\n");
+  const lock = lockWith(path, "stale-sha-from-an-old-binary");
+  const plan = computeUpgradePlan(
+    new Map([[path, diskSha]]),
+    lock,
+    new Map([[path, newSha]]),
+  );
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].kind, "preserve");
+});

--- a/tests/integration/upgrade_test.ts
+++ b/tests/integration/upgrade_test.ts
@@ -51,6 +51,45 @@ Deno.test("upgrade on freshly-init'd project is up-to-date", async () => {
   });
 });
 
+// Regression guard for #163: a fresh init followed by `upgrade --dry-run`
+// MUST report "already up to date". Before the fix, AGENTS.md and
+// .specflow/memory/constitution.md (skipIfExists files) were classified
+// as "customized locally" because they had no lock entry. The guard
+// catches any future regression that re-introduces a similar
+// false-positive on a never-edited project.
+Deno.test("upgrade --dry-run on freshly-init'd project reports zero customized files", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0);
+
+    const projectDir = join(parent, "demo");
+    const dry = await runSpecflow(["upgrade", "--dry-run"], { cwd: projectDir });
+    assertEquals(dry.code, 0, dry.stderr);
+    assertStringIncludes(dry.stdout, "already up to date");
+    assertEquals(
+      dry.stdout.includes("customized locally"),
+      false,
+      "fresh init must not produce any customized-locally warning",
+    );
+  });
+});
+
+// `--reset-baseline` is a no-op on a clean install (nothing to heal) but
+// must not error out. Smoke-tests that the flag plumbing works end-to-end.
+Deno.test("upgrade --reset-baseline on freshly-init'd project is also up-to-date", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0);
+
+    const projectDir = join(parent, "demo");
+    const upgrade = await runSpecflow(["upgrade", "--reset-baseline", "--dry-run"], {
+      cwd: projectDir,
+    });
+    assertEquals(upgrade.code, 0, upgrade.stderr);
+    assertStringIncludes(upgrade.stdout, "already up to date");
+  });
+});
+
 Deno.test("upgrade fails with clear message when lock missing", async () => {
   await withTempDir(async (dir) => {
     const upgrade = await runSpecflow(["upgrade"], { cwd: dir });


### PR DESCRIPTION
## Summary

Three independent defects in the upgrade SHA pipeline, fixed together. Closes #163.

A project that ran only `specflow init` and `specflow upgrade` — with zero manual edits — saw `upgrade --dry-run` flag 23 files as 'customized locally'. Every doc fix shipped in subsequent releases was silently skipped unless the user re-ran with `--force`.

## Three defects

**Bug A** — `shaOfBundle()` ignored mergeBlock canonicalization. Init hashes `canonicalBlockBody(content)` for `.gitignore`-style mergeBlock files; upgrade was hashing `file.content` verbatim. Fix: mirror init.

**Bug B** — `skipIfExists` files (`AGENTS.md`, `.specflow/memory/constitution.md`) polluted the upgrade plan. At init they're left alone AND not added to the lock; at upgrade they appeared as 'customized' because `diskSha defined + lockSha undefined`. Fix: `computeUpgradePlan` accepts `isSkipIfExists`; emit no action for those.

**Bug C** — stale lock SHAs from older binaries had no recovery path. Fix: new `--reset-baseline` flag. Force-reset `lockSha = diskSha` where they diverge → disk-as-baseline → upstream fixes apply cleanly.

## UX

Sharpened 'customized locally' hint with a `--reset-baseline` callout.

## Test plan

- [x] `deno task test` — 506 passed (was 500 + 6 new)
- [x] `smoke-features.sh` green
- [x] CI on this PR

## Migration

```
specflow upgrade --reset-baseline --dry-run   # preview
specflow upgrade --reset-baseline             # apply
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)