### PR TITLE
feat(expert): bug-report protocol — pre-fill GitHub issue with scrubbed context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,66 @@
+---
+name: Bug report
+about: Report a Specflow problem you hit while running the CLI or using the bundled agents.
+title: ""
+labels: bug
+---
+
+## Summary
+
+<!-- One paragraph: what you tried to do, what went wrong. -->
+
+## Reproduction
+
+<!-- Numbered steps. Include the exact commands you ran. -->
+
+1.
+2.
+3.
+
+## Observed
+
+<!-- What actually happened — error messages, unexpected output, missing files. -->
+
+## Expected
+
+<!-- What you thought should happen. -->
+
+## Environment
+
+<!--
+Run these and paste the output:
+
+  specflow --version
+  cat .specflow/installed.lock | head -10
+  uname -srm   # or `cmd /c ver` on Windows
+-->
+
+```
+specflow --version: <output>
+templates_version : <from installed.lock>
+harness           : <from installed.lock>
+backlog_backend   : <from installed.lock>
+OS / arch         : <uname -srm output>
+```
+
+## Logs
+
+<!--
+Paste the failing command's stdout / stderr in a fenced code block.
+
+Before submitting, scrub any of:
+  - GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_/github_pat_…)
+  - GitLab PATs (glpat-…)
+  - Anthropic / OpenAI keys (sk-ant-…, sk-…)
+  - AWS access keys (AKIA…)
+  - Paths inside ~/.ssh/, ~/.aws/, ~/.config/gh/
+
+The bundled `specflow-expert` agent can do this scrubbing for you —
+ask it "report this as a bug" and it will pre-fill an issue with the
+above sections, scrub the listed token shapes, and hand you a link
+to review and submit.
+-->
+
+```
+<paste here>
+```

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -328,6 +328,14 @@ snapshot for offline / deterministic answers and `WebFetch` against
 <https://specflow.makerlabs.dev/llms.txt> + the GitHub Releases API for live "what's new" queries.
 Manual dispatch via `/specflow-expert <question>` is also supported.
 
+The agent also handles **bug reports**: ask "report this as a bug" (or hit a Specflow failure) and
+it pre-fills a structured GitHub issue against `mkrlabs/specflow` with a 6-section template (Summary
+/ Repro / Observed / Expected / Environment / Logs), auto-populating the environment block from
+`.specflow/installed.lock` + `specflow --version` + `uname -srm`, scrubbing common token shapes
+(GitHub PATs, GitLab PATs, Anthropic / OpenAI keys, AWS access keys), and handing you a pre-filled
+`https://github.com/mkrlabs/specflow/issues/new?…` URL to review and submit. The agent never
+auto-submits — you always see the body before clicking.
+
 ## Design principles
 
 - **Agnostic of the user project's language** — Python, TypeScript, Go, PHP, Rust… your project,

--- a/plugin/agents/specflow-expert.md
+++ b/plugin/agents/specflow-expert.md
@@ -95,6 +95,47 @@ the **live fetch protocol** above instead — do not run this check
 (it would emit just the version line; the live protocol gives them
 the full release notes they're asking for).
 
+## Bug report protocol
+
+When the user asks to file a bug ("report this", "open an issue",
+"ouvrir un bug") OR a Specflow failure pattern just surfaced
+(`specflow ... error:`, `upgrade refused`, `init: error`,
+`check: failed`), offer a pre-filled GitHub issue. **Never
+auto-submit.** Always show the body; user clicks the link.
+
+**Body**: 6 sections — `## Summary` / `## Reproduction` /
+`## Observed` / `## Expected` / `## Environment` / `## Logs`.
+Auto-fill Environment from `.specflow/installed.lock`
+(`templates_version`, `harness`, `backlog_backend`),
+`specflow --version`, and `uname -srm` (or `cmd /c ver`).
+
+If WebFetch on
+`https://raw.githubusercontent.com/mkrlabs/specflow/main/.github/ISSUE_TEMPLATE/bug.md`
+succeeds, prefer that template; fall back to the 6 sections above.
+
+**Scrubbing — mandatory before showing the body.** Replace matches
+with `[REDACTED]`:
+
+```
+ghp_[A-Za-z0-9_]{36,}        github_pat_[A-Za-z0-9_]{82,}
+gho_[A-Za-z0-9_]{36,}        glpat-[A-Za-z0-9_-]{20,}
+ghu_/ghs_/ghr_ same shape    sk-ant-api\d{2}-[A-Za-z0-9_-]{93,}
+sk-[A-Za-z0-9]{48,}          AKIA[0-9A-Z]{16}
+```
+
+Soft-redact paths under `~/.ssh/`, `~/.aws/`, `~/.config/gh/`.
+Email addresses NOT scrubbed (false-positive prone) — tell the user
+to review.
+
+**Surface**: generate
+`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…`
+URL-encoded. If the raw body exceeds **3000 chars**, present a
+fenced code block and ask the user to open
+`https://github.com/mkrlabs/specflow/issues/new` manually and paste.
+
+`gh issue create` is **not** supported in V1 — keep the user in the
+loop on every report. If asked, decline and offer the URL pre-fill.
+
 ## Vendored knowledge snapshot
 
 This snapshot is frozen at scaffold time. It reflects the version of
@@ -200,20 +241,11 @@ layout and frontmatter conventions.
 
 ### Bundled sub-agents
 
-Every scaffold ships nine workflow agents plus this expert:
-
-- `product-owner` — owns every backlog mutation. Two-step close
-  (move.sh Done → gh issue close), board hygiene sweep, mandatory
-  sizing + priority via field-first / label fallback.
-- `developer` — implements tasks under `/specflow implement`.
-- `review-coordinator` — runs the multi-reviewer pass post-implement.
-- `code-reviewer` / `security-auditor` / `test-reviewer` —
-  specialised review surfaces dispatched by the coordinator.
-- `qa-tester` — manual UX dogfood pass against the released binary.
-- `workflow-manager` — orchestrates phase transitions inside
-  `/specflow-auto`.
-- `devops-sre` — read-only advisor on CI / release / distribution.
-- `specflow-expert` — this agent.
+Every scaffold ships ten agents: `product-owner`, `developer`,
+`review-coordinator`, `code-reviewer`, `security-auditor`,
+`test-reviewer`, `qa-tester`, `workflow-manager`, `devops-sre`, and
+`specflow-expert` (this agent). See each agent's file under
+`.claude/agents/` (or harness equivalent) for its remit.
 
 ### Backlog conventions (GitHub backend)
 
@@ -230,14 +262,9 @@ Every scaffold ships nine workflow agents plus this expert:
 
 ### Design principles
 
-- Agnostic of the user project's language (Python, TS, Go, PHP, Rust…).
-- Agnostic of the LLM behind the harness.
-- Agnostic of the AI harness — eight first-class targets, identical
-  core content.
-- Agnostic of the backlog source — local, GitHub, or GitLab.
-- Single binary distributed via `deno compile` for macOS arm64/x64,
-  Linux arm64/x64, and Windows x64. No Python, no `pip`, no extra
-  runtimes.
+Agnostic of language / LLM / harness / backlog backend. Single binary
+via `deno compile` for macOS, Linux, Windows. No Python or extra
+runtimes.
 
 ## Style
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2963,6 +2963,47 @@ the **live fetch protocol** above instead — do not run this check
 (it would emit just the version line; the live protocol gives them
 the full release notes they're asking for).
 
+## Bug report protocol
+
+When the user asks to file a bug ("report this", "open an issue",
+"ouvrir un bug") OR a Specflow failure pattern just surfaced
+(\`specflow ... error:\`, \`upgrade refused\`, \`init: error\`,
+\`check: failed\`), offer a pre-filled GitHub issue. **Never
+auto-submit.** Always show the body; user clicks the link.
+
+**Body**: 6 sections — \`## Summary\` / \`## Reproduction\` /
+\`## Observed\` / \`## Expected\` / \`## Environment\` / \`## Logs\`.
+Auto-fill Environment from \`.specflow/installed.lock\`
+(\`templates_version\`, \`harness\`, \`backlog_backend\`),
+\`specflow --version\`, and \`uname -srm\` (or \`cmd /c ver\`).
+
+If WebFetch on
+\`https://raw.githubusercontent.com/mkrlabs/specflow/main/.github/ISSUE_TEMPLATE/bug.md\`
+succeeds, prefer that template; fall back to the 6 sections above.
+
+**Scrubbing — mandatory before showing the body.** Replace matches
+with \`[REDACTED]\`:
+
+\`\`\`
+ghp_[A-Za-z0-9_]{36,}        github_pat_[A-Za-z0-9_]{82,}
+gho_[A-Za-z0-9_]{36,}        glpat-[A-Za-z0-9_-]{20,}
+ghu_/ghs_/ghr_ same shape    sk-ant-api\\d{2}-[A-Za-z0-9_-]{93,}
+sk-[A-Za-z0-9]{48,}          AKIA[0-9A-Z]{16}
+\`\`\`
+
+Soft-redact paths under \`~/.ssh/\`, \`~/.aws/\`, \`~/.config/gh/\`.
+Email addresses NOT scrubbed (false-positive prone) — tell the user
+to review.
+
+**Surface**: generate
+\`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…\`
+URL-encoded. If the raw body exceeds **3000 chars**, present a
+fenced code block and ask the user to open
+\`https://github.com/mkrlabs/specflow/issues/new\` manually and paste.
+
+\`gh issue create\` is **not** supported in V1 — keep the user in the
+loop on every report. If asked, decline and offer the URL pre-fill.
+
 ## Vendored knowledge snapshot
 
 This snapshot is frozen at scaffold time. It reflects the version of
@@ -3068,20 +3109,11 @@ layout and frontmatter conventions.
 
 ### Bundled sub-agents
 
-Every scaffold ships nine workflow agents plus this expert:
-
-- \`product-owner\` — owns every backlog mutation. Two-step close
-  (move.sh Done → gh issue close), board hygiene sweep, mandatory
-  sizing + priority via field-first / label fallback.
-- \`developer\` — implements tasks under \`/specflow implement\`.
-- \`review-coordinator\` — runs the multi-reviewer pass post-implement.
-- \`code-reviewer\` / \`security-auditor\` / \`test-reviewer\` —
-  specialised review surfaces dispatched by the coordinator.
-- \`qa-tester\` — manual UX dogfood pass against the released binary.
-- \`workflow-manager\` — orchestrates phase transitions inside
-  \`/specflow-auto\`.
-- \`devops-sre\` — read-only advisor on CI / release / distribution.
-- \`specflow-expert\` — this agent.
+Every scaffold ships ten agents: \`product-owner\`, \`developer\`,
+\`review-coordinator\`, \`code-reviewer\`, \`security-auditor\`,
+\`test-reviewer\`, \`qa-tester\`, \`workflow-manager\`, \`devops-sre\`, and
+\`specflow-expert\` (this agent). See each agent's file under
+\`.claude/agents/\` (or harness equivalent) for its remit.
 
 ### Backlog conventions (GitHub backend)
 
@@ -3098,14 +3130,9 @@ Every scaffold ships nine workflow agents plus this expert:
 
 ### Design principles
 
-- Agnostic of the user project's language (Python, TS, Go, PHP, Rust…).
-- Agnostic of the LLM behind the harness.
-- Agnostic of the AI harness — eight first-class targets, identical
-  core content.
-- Agnostic of the backlog source — local, GitHub, or GitLab.
-- Single binary distributed via \`deno compile\` for macOS arm64/x64,
-  Linux arm64/x64, and Windows x64. No Python, no \`pip\`, no extra
-  runtimes.
+Agnostic of language / LLM / harness / backlog backend. Single binary
+via \`deno compile\` for macOS, Linux, Windows. No Python or extra
+runtimes.
 
 ## Style
 

--- a/templates/core/agents/specflow-expert.md
+++ b/templates/core/agents/specflow-expert.md
@@ -95,6 +95,47 @@ the **live fetch protocol** above instead — do not run this check
 (it would emit just the version line; the live protocol gives them
 the full release notes they're asking for).
 
+## Bug report protocol
+
+When the user asks to file a bug ("report this", "open an issue",
+"ouvrir un bug") OR a Specflow failure pattern just surfaced
+(`specflow ... error:`, `upgrade refused`, `init: error`,
+`check: failed`), offer a pre-filled GitHub issue. **Never
+auto-submit.** Always show the body; user clicks the link.
+
+**Body**: 6 sections — `## Summary` / `## Reproduction` /
+`## Observed` / `## Expected` / `## Environment` / `## Logs`.
+Auto-fill Environment from `.specflow/installed.lock`
+(`templates_version`, `harness`, `backlog_backend`),
+`specflow --version`, and `uname -srm` (or `cmd /c ver`).
+
+If WebFetch on
+`https://raw.githubusercontent.com/mkrlabs/specflow/main/.github/ISSUE_TEMPLATE/bug.md`
+succeeds, prefer that template; fall back to the 6 sections above.
+
+**Scrubbing — mandatory before showing the body.** Replace matches
+with `[REDACTED]`:
+
+```
+ghp_[A-Za-z0-9_]{36,}        github_pat_[A-Za-z0-9_]{82,}
+gho_[A-Za-z0-9_]{36,}        glpat-[A-Za-z0-9_-]{20,}
+ghu_/ghs_/ghr_ same shape    sk-ant-api\d{2}-[A-Za-z0-9_-]{93,}
+sk-[A-Za-z0-9]{48,}          AKIA[0-9A-Z]{16}
+```
+
+Soft-redact paths under `~/.ssh/`, `~/.aws/`, `~/.config/gh/`.
+Email addresses NOT scrubbed (false-positive prone) — tell the user
+to review.
+
+**Surface**: generate
+`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…`
+URL-encoded. If the raw body exceeds **3000 chars**, present a
+fenced code block and ask the user to open
+`https://github.com/mkrlabs/specflow/issues/new` manually and paste.
+
+`gh issue create` is **not** supported in V1 — keep the user in the
+loop on every report. If asked, decline and offer the URL pre-fill.
+
 ## Vendored knowledge snapshot
 
 This snapshot is frozen at scaffold time. It reflects the version of
@@ -200,20 +241,11 @@ layout and frontmatter conventions.
 
 ### Bundled sub-agents
 
-Every scaffold ships nine workflow agents plus this expert:
-
-- `product-owner` — owns every backlog mutation. Two-step close
-  (move.sh Done → gh issue close), board hygiene sweep, mandatory
-  sizing + priority via field-first / label fallback.
-- `developer` — implements tasks under `/specflow implement`.
-- `review-coordinator` — runs the multi-reviewer pass post-implement.
-- `code-reviewer` / `security-auditor` / `test-reviewer` —
-  specialised review surfaces dispatched by the coordinator.
-- `qa-tester` — manual UX dogfood pass against the released binary.
-- `workflow-manager` — orchestrates phase transitions inside
-  `/specflow-auto`.
-- `devops-sre` — read-only advisor on CI / release / distribution.
-- `specflow-expert` — this agent.
+Every scaffold ships ten agents: `product-owner`, `developer`,
+`review-coordinator`, `code-reviewer`, `security-auditor`,
+`test-reviewer`, `qa-tester`, `workflow-manager`, `devops-sre`, and
+`specflow-expert` (this agent). See each agent's file under
+`.claude/agents/` (or harness equivalent) for its remit.
 
 ### Backlog conventions (GitHub backend)
 
@@ -230,14 +262,9 @@ Every scaffold ships nine workflow agents plus this expert:
 
 ### Design principles
 
-- Agnostic of the user project's language (Python, TS, Go, PHP, Rust…).
-- Agnostic of the LLM behind the harness.
-- Agnostic of the AI harness — eight first-class targets, identical
-  core content.
-- Agnostic of the backlog source — local, GitHub, or GitLab.
-- Single binary distributed via `deno compile` for macOS arm64/x64,
-  Linux arm64/x64, and Windows x64. No Python, no `pip`, no extra
-  runtimes.
+Agnostic of language / LLM / harness / backlog backend. Single binary
+via `deno compile` for macOS, Linux, Windows. No Python or extra
+runtimes.
 
 ## Style
 

--- a/tests/scripts/bug_report_scrubber_test.ts
+++ b/tests/scripts/bug_report_scrubber_test.ts
@@ -1,0 +1,117 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+// Canonical scrubbing patterns, mirrored from the
+// `## Bug report protocol` section of
+// `templates/core/agents/specflow-expert.md`. Keeping this list and
+// the agent prompt in lockstep is critical — the LLM uses the prompt
+// as its rule set, and this test exercises the same rules to catch
+// regressions in the canonical list.
+const HARD_PATTERNS: ReadonlyArray<RegExp> = [
+  /ghp_[A-Za-z0-9_]{36,}/g,
+  /gho_[A-Za-z0-9_]{36,}/g,
+  /ghu_[A-Za-z0-9_]{36,}/g,
+  /ghs_[A-Za-z0-9_]{36,}/g,
+  /ghr_[A-Za-z0-9_]{36,}/g,
+  /github_pat_[A-Za-z0-9_]{82,}/g,
+  /glpat-[A-Za-z0-9_-]{20,}/g,
+  /sk-ant-api\d{2}-[A-Za-z0-9_-]{93,}/g,
+  /sk-[A-Za-z0-9]{48,}/g,
+  /AKIA[0-9A-Z]{16}/g,
+];
+
+// Soft-redaction: paths under sensitive directories. Replaced by
+// `[REDACTED: <type>]` where <type> is the directory name. The agent
+// has the latitude to keep the directory hint visible since the
+// content (key files) is what's sensitive, not the path's existence.
+const SOFT_PATH_PATTERNS: ReadonlyArray<{ re: RegExp; type: string }> = [
+  { re: /~\/\.ssh\/[A-Za-z0-9_.-]+/g, type: "ssh" },
+  { re: /~\/\.aws\/[A-Za-z0-9_.-]+/g, type: "aws" },
+  { re: /~\/\.config\/gh\/[A-Za-z0-9_.-]+/g, type: "gh-config" },
+];
+
+function scrub(input: string): string {
+  let out = input;
+  for (const re of HARD_PATTERNS) out = out.replace(re, "[REDACTED]");
+  for (const { re, type } of SOFT_PATH_PATTERNS) {
+    out = out.replace(re, `[REDACTED: ${type}]`);
+  }
+  return out;
+}
+
+Deno.test("scrub redacts a classic GitHub PAT", () => {
+  const corpus = "Authorization: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const out = scrub(corpus);
+  assertEquals(out.includes("ghp_"), false);
+  assertStringIncludes(out, "[REDACTED]");
+});
+
+Deno.test("scrub redacts a fine-grained GitHub PAT", () => {
+  const tail = "x".repeat(82);
+  const out = scrub(`token: github_pat_${tail}`);
+  assertEquals(out.includes("github_pat_"), false);
+});
+
+Deno.test("scrub redacts an Anthropic key", () => {
+  const tail = "x".repeat(93);
+  const out = scrub(`ANTHROPIC_API_KEY=sk-ant-api03-${tail}`);
+  assertEquals(out.includes("sk-ant-api03-"), false);
+});
+
+Deno.test("scrub redacts an OpenAI-shaped key (>=48 chars)", () => {
+  const tail = "x".repeat(48);
+  const out = scrub(`OPENAI_API_KEY=sk-${tail}`);
+  assertStringIncludes(out, "[REDACTED]");
+});
+
+Deno.test("scrub redacts an AWS access key id", () => {
+  const out = scrub("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE");
+  assertEquals(out.includes("AKIA"), false);
+});
+
+Deno.test("scrub redacts a GitLab PAT", () => {
+  const out = scrub("token: glpat-aaaaaaaaaaaaaaaaaaaa");
+  assertEquals(out.includes("glpat-"), false);
+});
+
+Deno.test("scrub soft-redacts paths under ~/.ssh/", () => {
+  const out = scrub("Cannot read /Users/me/.ssh/id_rsa.pub");
+  // Only the path tail under ~/.ssh/ matches; the absolute prefix is
+  // independent. Test the agent-format (~) path explicitly.
+  const out2 = scrub("Cannot read ~/.ssh/id_rsa.pub");
+  assertStringIncludes(out2, "[REDACTED: ssh]");
+  // Sanity: absolute path is left alone — the pattern targets the
+  // tilde form the user is likely to paste from a shell error.
+  assertEquals(out.includes("/Users/me/.ssh/id_rsa.pub"), true);
+});
+
+Deno.test("scrub does NOT redact a SHA-256 hex string", () => {
+  // 64-char hex SHA256 — must NOT match any hard pattern (would have
+  // false-positived under a naive AWS-secret-key rule that we
+  // deliberately omitted from V1).
+  const sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  const out = scrub(`hash: ${sha}`);
+  assertStringIncludes(out, sha, "SHA-256 hex must survive scrubbing");
+});
+
+Deno.test("scrub does NOT redact a plain email address (V1 contract)", () => {
+  // V1 deliberately leaves emails alone — the agent surfaces a
+  // human-review reminder instead. Locks the contract via a test so
+  // a future change has to flip this assertion explicitly.
+  const out = scrub("Author: kevin@example.com");
+  assertStringIncludes(out, "kevin@example.com");
+});
+
+Deno.test("scrub handles multiple tokens in one corpus", () => {
+  const corpus = [
+    "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "AKIAIOSFODNN7EXAMPLE",
+    `sk-ant-api03-${"y".repeat(93)}`,
+  ].join("\n");
+  const out = scrub(corpus);
+  assertEquals(out.includes("ghp_"), false);
+  assertEquals(out.includes("AKIA"), false);
+  assertEquals(out.includes("sk-ant-"), false);
+  // Three matches → three [REDACTED] markers.
+  const matches = out.match(/\[REDACTED\]/g) ?? [];
+  assertEquals(matches.length, 3);
+});


### PR DESCRIPTION
## Summary

The bundled `specflow-expert` agent now handles bug reports. When the user asks ('report this as a bug', 'ouvrir un bug') OR a Specflow failure pattern just surfaced, the agent generates a pre-filled GitHub issue against `mkrlabs/specflow` with structured context, scrubbed secrets, and hands the user a URL to review and submit.

Closes #172.

## What ships

- **`templates/core/agents/specflow-expert.md`** (+ plugin mirror) — new `## Bug report protocol` section. 6-section template (Summary / Reproduction / Observed / Expected / Environment / Logs), auto-fill from `installed.lock` + `specflow --version` + `uname -srm`. Mandatory token scrubbing (ghp_, gho_, gh[u/s/r]_, github_pat_, glpat-, sk-ant-, sk-, AKIA). Soft-redact paths under `~/.ssh/`, `~/.aws/`, `~/.config/gh/`. URL pre-fill default; 3000-char fallback to code-block paste.
- **`.github/ISSUE_TEMPLATE/bug.md`** — same 6-section template ships in the upstream repo so GitHub web UI users get the same structure. Agent fetches via WebFetch when present.
- **`tests/scripts/bug_report_scrubber_test.ts`** — 10 unit tests on the canonical regex list. Validates token shapes are redacted, SHA256 hex survives, emails survive (V1 contract).
- **`docs/llms.md`** section 5 documents the bug-report flow.

## Design choices

Per Kevin's AskUserQuestion answers + architect's recommendations:
- **V1 = URL pre-fill only.** `gh issue create` auto-submit is out of scope (keeps user in the loop).
- **Issue template in repo + agent fetches it** — single source of truth, GitHub web UI users get the same 6 sections.
- **AKIA only in V1** — AWS secret-key context-gating deferred to V2 (avoids SHA256 false-positives).
- **3000-char URL threshold** — above that, code-block fallback.
- **Trim both** `### Bundled sub-agents` + `### Design principles` to keep agent body under the Windsurf 12000-char Cascade cap (final: 11950 chars).
- **Email addresses NOT scrubbed** (false-positive prone). Agent surfaces a 'review before clicking' reminder.

## Test plan

- [x] `deno task test` — 516 passed (was 506 + 10 new scrubber tests)
- [x] `smoke-features.sh` green
- [x] Plugin parity: byte-identical agent file (enforced by plugin_sync_test)
- [x] Windsurf cap: 11950 chars (50-char margin under 12000)
- [x] CI on this PR

## Out of scope

- `gh issue create` auto-submit (V2 follow-up if requested)
- AWS secret-key context-gated scrubbing (V2)
- Email scrubbing (false-positive prone; locked via test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)