### PR TITLE
feat(gh-issues): maintainer-only triage skill for inbound user-filed issues

### DIFF
--- a/.claude/skills/gh-issues/SKILL.md
+++ b/.claude/skills/gh-issues/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: gh-issues
+description: >
+  Maintainer-only triage of incoming user-filed GitHub issues
+  (label `from:specflow-expert`). Use when Kevin says "triage inbox",
+  "groom issues", "list inbound", "promote #N", "reject #N", or
+  "dedupe #N". This skill is for the Specflow repo itself — never
+  bundle to user projects.
+argument-hint: <list|dedupe|promote|reject|groom-inbox> [args]
+---
+
+# gh-issues triage skill
+
+Maintainer-side counterpart to the `specflow-expert` agent's bug-report
+protocol (#172). The agent files structured issues against
+`mkrlabs/specflow` with the `from:specflow-expert` label; this skill
+processes the inbox.
+
+**Maintainer-only.** Never lands on user projects. Lives at
+`.claude/skills/gh-issues/` in the Specflow repo. Hard-coded to
+`mkrlabs/specflow` and the `from:specflow-expert` label.
+
+## Sub-commands
+
+Parse `$ARGUMENTS` as `<subcommand> [rest]`. Run the matching script via
+`deno run --allow-run`. Surface its stdout to the user verbatim — it's
+already formatted.
+
+### `list`
+
+```
+deno run --allow-run .claude/skills/gh-issues/scripts/list.ts
+```
+
+Enumerate open issues with label `from:specflow-expert`. Plain table:
+`# | YYYY-MM-DD | author | title`.
+
+### `dedupe <num>`
+
+```
+deno run --allow-run .claude/skills/gh-issues/scripts/dedupe.ts <num>
+```
+
+Top-3 similar issues (open + last 200 closed) by Jaccard token-overlap
+on titles. Buckets: `likely-dupe` (≥0.5), `maybe` (≥0.3), `unrelated`.
+
+### `promote <num> [--priority P0..P3] [--size XS..XL]`
+
+```
+deno run --allow-run .claude/skills/gh-issues/scripts/promote.ts <num>
+```
+
+Defaults: **P3 / M**. Pipeline:
+
+1. Verify `from:specflow-expert` label is present (refuses otherwise).
+2. `move.sh <num> Ready`
+3. `set-field.sh <num> Priority <P>` (exit 11 → fall back to
+   `priority:P3` label, per the existing contract).
+4. `set-field.sh <num> Size <S>` (same fallback).
+5. Public thank-you comment on the issue.
+
+Override defaults: `--priority P1 --size S`. Kevin reviews and lifts
+before final apply via flags — the script doesn't second-guess.
+
+### `reject <num> --reason "..."` — DRY-RUN
+
+```
+deno run --allow-run .claude/skills/gh-issues/scripts/reject.ts <num> --reason "..."
+```
+
+Prints the public comment and `gh issue close` command that would run.
+Does NOT execute. The calling session shows Kevin the output and runs
+the printed commands after explicit confirmation. **Hard contract: no
+auto-close.**
+
+### `groom-inbox`
+
+```
+deno run --allow-run .claude/skills/gh-issues/scripts/groom-inbox.ts
+```
+
+Enumerate the inbox + dedupe each issue against open + last 200 closed.
+Emit a Markdown table with proposed actions. Kevin reads, replies in
+batch (e.g. `175 promote`, `176 reject --reason "dupe of #163"`), and
+the calling session dispatches the per-issue scripts.
+
+## Conventions
+
+- All entry-points are Deno scripts. No Bash wrappers — keeps the
+  argv parsing testable and the type-checking honest.
+- Mutations go through `.claude/skills/backlog/scripts/{move,set-field}.sh`
+  — same contract the PO subagent uses. No PO dispatch needed for
+  triage actions Kevin has already approved via the groom-inbox table.
+- The `from:specflow-expert` label is the inbox gate. The
+  `specflow-expert` agent's bug-report protocol auto-applies it via
+  the URL pre-fill `&labels=from:specflow-expert`. The
+  `.github/ISSUE_TEMPLATE/bug.md` also sets it on manual template-form
+  submissions.
+
+## When NOT to use
+
+- For maintainer-filed issues (e.g. things Kevin opens via `/backlog
+  add`) — those go through the regular PO flow, not triage.
+- For repos other than `mkrlabs/specflow` — hard-coded.
+- For batch closures without per-issue review — `reject.ts` enforces
+  the dry-run pattern; don't bypass it.
+
+## Tests
+
+Pure unit coverage at `tests/scripts/gh_issues_dedupe_test.ts` (Jaccard
+heuristic) and `tests/scripts/gh_issues_argv_test.ts` (promote/reject
+arg parsing). End-to-end smoke against the live API is manual — run
+`list` after a fresh inbound issue to verify the label filter.

--- a/.claude/skills/gh-issues/scripts/_dedupe_heuristic.ts
+++ b/.claude/skills/gh-issues/scripts/_dedupe_heuristic.ts
@@ -1,0 +1,92 @@
+// Pure dedupe heuristic for the gh-issues triage skill. Token-overlap
+// Jaccard similarity on issue titles. Fast, deterministic, no API
+// dependency. False-positives are surfaced for Kevin's review — never
+// auto-closed.
+
+const STOPWORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "is",
+  "with",
+  "for",
+  "to",
+  "on",
+  "of",
+  "and",
+  "or",
+  "in",
+  "it",
+  "at",
+  "by",
+  "from",
+  "this",
+  "that",
+  "was",
+  "be",
+  "are",
+  "as",
+  "but",
+  "not",
+  "no",
+  "if",
+  "when",
+  "where",
+  "why",
+  "how",
+]);
+
+export function tokenize(title: string): Set<string> {
+  return new Set(
+    title
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 1 && !STOPWORDS.has(t)),
+  );
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const t of a) if (b.has(t)) intersection++;
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export type DupeBucket = "likely-dupe" | "maybe" | "unrelated";
+
+export function bucketOf(score: number): DupeBucket {
+  if (score >= 0.5) return "likely-dupe";
+  if (score >= 0.3) return "maybe";
+  return "unrelated";
+}
+
+export type IssueRef = { number: number; title: string };
+export type DupeCandidate = IssueRef & { score: number; bucket: DupeBucket };
+
+/**
+ * Returns the top `topN` candidates from `pool` that resemble
+ * `targetTitle`, sorted by Jaccard score descending. Excludes the
+ * `excludeNumber` issue (typically the target itself). Includes all
+ * candidates with score > 0; the caller filters by bucket if it only
+ * wants `likely-dupe` / `maybe`.
+ */
+export function findCandidates(
+  targetTitle: string,
+  pool: ReadonlyArray<IssueRef>,
+  opts: { topN?: number; excludeNumber?: number } = {},
+): DupeCandidate[] {
+  const topN = opts.topN ?? 3;
+  const exclude = opts.excludeNumber;
+  const targetTokens = tokenize(targetTitle);
+  const scored: DupeCandidate[] = [];
+  for (const issue of pool) {
+    if (issue.number === exclude) continue;
+    const score = jaccard(targetTokens, tokenize(issue.title));
+    if (score > 0) {
+      scored.push({ ...issue, score, bucket: bucketOf(score) });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, topN);
+}

--- a/.claude/skills/gh-issues/scripts/dedupe.ts
+++ b/.claude/skills/gh-issues/scripts/dedupe.ts
@@ -1,0 +1,90 @@
+// gh-issues dedupe <num> — find similar open + recently-closed issues
+// for the given inbound issue. Uses Jaccard token-overlap on titles.
+//
+// Usage: deno run --allow-run dedupe.ts <issue-number>
+
+import { findCandidates, type IssueRef } from "./_dedupe_heuristic.ts";
+
+const REPO = "mkrlabs/specflow";
+
+async function ghJson<T>(args: string[]): Promise<T> {
+  const cmd = new Deno.Command("gh", { args, stdout: "piped", stderr: "piped" });
+  const { code, stdout, stderr } = await cmd.output();
+  if (code !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed: ${new TextDecoder().decode(stderr)}`);
+  }
+  return JSON.parse(new TextDecoder().decode(stdout)) as T;
+}
+
+async function fetchTitle(num: number): Promise<string> {
+  const data = await ghJson<{ title: string }>([
+    "issue",
+    "view",
+    String(num),
+    "--repo",
+    REPO,
+    "--json",
+    "title",
+  ]);
+  return data.title;
+}
+
+async function fetchPool(): Promise<IssueRef[]> {
+  // Open + last 200 closed issues. The 200 cap on closed is a coarse
+  // recency window — anything older is unlikely to be a recurrence
+  // signal anyway.
+  const open = await ghJson<IssueRef[]>([
+    "issue",
+    "list",
+    "--repo",
+    REPO,
+    "--state",
+    "open",
+    "--json",
+    "number,title",
+    "--limit",
+    "200",
+  ]);
+  const closed = await ghJson<IssueRef[]>([
+    "issue",
+    "list",
+    "--repo",
+    REPO,
+    "--state",
+    "closed",
+    "--json",
+    "number,title",
+    "--limit",
+    "200",
+  ]);
+  return [...open, ...closed];
+}
+
+if (import.meta.main) {
+  const numStr = Deno.args[0];
+  if (!numStr) {
+    console.error("usage: dedupe.ts <issue-number>");
+    Deno.exit(1);
+  }
+  const num = Number(numStr);
+  if (!Number.isFinite(num) || num <= 0) {
+    console.error(`invalid issue number: ${numStr}`);
+    Deno.exit(1);
+  }
+
+  const targetTitle = await fetchTitle(num);
+  const pool = await fetchPool();
+  const candidates = findCandidates(targetTitle, pool, { excludeNumber: num });
+
+  console.log(`#${num} — "${targetTitle}"\n`);
+  if (candidates.length === 0) {
+    console.log("  no similar issues found.");
+    Deno.exit(0);
+  }
+
+  for (const c of candidates) {
+    const score = c.score.toFixed(2);
+    const tag = c.bucket === "likely-dupe" ? "❗" : c.bucket === "maybe" ? "?" : "·";
+    console.log(`  ${tag} #${c.number} (${score}, ${c.bucket}) — ${c.title}`);
+  }
+}

--- a/.claude/skills/gh-issues/scripts/groom-inbox.ts
+++ b/.claude/skills/gh-issues/scripts/groom-inbox.ts
@@ -1,0 +1,118 @@
+// gh-issues groom-inbox — orchestrator. List inbound issues + dedupe
+// each against open + recently-closed pool + emit a Markdown table
+// with proposed actions. Kevin reads, replies in batch, the calling
+// session dispatches promote.ts / reject.ts per line.
+//
+// Usage: deno run --allow-run groom-inbox.ts
+
+import { findCandidates, type IssueRef } from "./_dedupe_heuristic.ts";
+
+const REPO = "mkrlabs/specflow";
+const INBOUND_LABEL = "from:specflow-expert";
+
+type GhIssue = IssueRef & { createdAt: string };
+
+async function ghJson<T>(args: string[]): Promise<T> {
+  const cmd = new Deno.Command("gh", { args, stdout: "piped", stderr: "piped" });
+  const { code, stdout, stderr } = await cmd.output();
+  if (code !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed: ${new TextDecoder().decode(stderr)}`);
+  }
+  return JSON.parse(new TextDecoder().decode(stdout)) as T;
+}
+
+async function fetchInbox(): Promise<GhIssue[]> {
+  return await ghJson<GhIssue[]>([
+    "issue",
+    "list",
+    "--repo",
+    REPO,
+    "--label",
+    INBOUND_LABEL,
+    "--state",
+    "open",
+    "--json",
+    "number,title,createdAt",
+    "--limit",
+    "100",
+  ]);
+}
+
+async function fetchPool(): Promise<IssueRef[]> {
+  const open = await ghJson<IssueRef[]>([
+    "issue",
+    "list",
+    "--repo",
+    REPO,
+    "--state",
+    "open",
+    "--json",
+    "number,title",
+    "--limit",
+    "200",
+  ]);
+  const closed = await ghJson<IssueRef[]>([
+    "issue",
+    "list",
+    "--repo",
+    REPO,
+    "--state",
+    "closed",
+    "--json",
+    "number,title",
+    "--limit",
+    "200",
+  ]);
+  return [...open, ...closed];
+}
+
+function trim(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+if (import.meta.main) {
+  const [inbox, pool] = await Promise.all([fetchInbox(), fetchPool()]);
+
+  if (inbox.length === 0) {
+    console.log("✓ inbox empty (no open issues with label `from:specflow-expert`)");
+    Deno.exit(0);
+  }
+
+  console.log(`# Triage groom-inbox — ${inbox.length} issue${inbox.length > 1 ? "s" : ""}\n`);
+  console.log("| # | Title | Opened | Dedupe candidates | Proposed action |");
+  console.log("|---|-------|--------|-------------------|-----------------|");
+
+  for (const issue of inbox) {
+    const candidates = findCandidates(issue.title, pool, {
+      excludeNumber: issue.number,
+      topN: 2,
+    }).filter((c) => c.bucket !== "unrelated");
+
+    const dupeCol = candidates.length === 0
+      ? "—"
+      : candidates
+        .map((c) => `#${c.number} (${c.score.toFixed(2)} ${c.bucket})`)
+        .join("<br>");
+    const likely = candidates.find((c) => c.bucket === "likely-dupe");
+    const action = likely
+      ? `mark-dupe of #${likely.number}?`
+      : "promote (P3/M)";
+    const day = issue.createdAt.slice(0, 10);
+    const title = trim(issue.title.replace(/\|/g, "\\|"), 60);
+    console.log(`| ${issue.number} | ${title} | ${day} | ${dupeCol} | ${action} |`);
+  }
+
+  console.log("");
+  console.log("## Next steps");
+  console.log("Reply with one line per issue, e.g.:");
+  console.log("");
+  console.log("```");
+  console.log("175 promote");
+  console.log("175 promote --priority P1 --size S");
+  console.log('176 reject --reason "duplicate of #163"');
+  console.log("```");
+  console.log("");
+  console.log(
+    "The calling session runs `promote.ts` / `reject.ts` per line. `reject.ts` is dry-run — final close requires Kevin's explicit confirmation.",
+  );
+}

--- a/.claude/skills/gh-issues/scripts/list.ts
+++ b/.claude/skills/gh-issues/scripts/list.ts
@@ -1,0 +1,60 @@
+// gh-issues list — enumerate inbound issues filed by users via the
+// specflow-expert bug-report protocol. Filtered by the
+// `from:specflow-expert` label so it doesn't catch maintainer-filed
+// items.
+//
+// Usage: deno run --allow-run list.ts
+
+const REPO = "mkrlabs/specflow";
+const LABEL = "from:specflow-expert";
+
+type GhIssue = {
+  number: number;
+  title: string;
+  createdAt: string;
+  url: string;
+  author?: { login: string };
+};
+
+async function ghList(): Promise<GhIssue[]> {
+  const cmd = new Deno.Command("gh", {
+    args: [
+      "issue",
+      "list",
+      "--repo",
+      REPO,
+      "--label",
+      LABEL,
+      "--state",
+      "open",
+      "--json",
+      "number,title,createdAt,url,author",
+      "--limit",
+      "100",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await cmd.output();
+  if (code !== 0) {
+    throw new Error(`gh issue list failed: ${new TextDecoder().decode(stderr)}`);
+  }
+  return JSON.parse(new TextDecoder().decode(stdout)) as GhIssue[];
+}
+
+if (import.meta.main) {
+  const issues = await ghList();
+  if (issues.length === 0) {
+    console.log("✓ inbox empty (no open issues with label `from:specflow-expert`)");
+    Deno.exit(0);
+  }
+
+  console.log(`Inbox: ${issues.length} open issue${issues.length > 1 ? "s" : ""}\n`);
+  for (const i of issues) {
+    const day = i.createdAt.slice(0, 10);
+    const author = i.author?.login ?? "unknown";
+    const titleTrim = i.title.length > 70 ? i.title.slice(0, 67) + "…" : i.title;
+    console.log(`  #${String(i.number).padStart(3)} ${day} ${author.padEnd(14)} ${titleTrim}`);
+  }
+  console.log(`\n  ${REPO}/issues?q=is%3Aopen+label%3A${encodeURIComponent(LABEL)}`);
+}

--- a/.claude/skills/gh-issues/scripts/promote.ts
+++ b/.claude/skills/gh-issues/scripts/promote.ts
@@ -1,0 +1,169 @@
+// gh-issues promote <num> [--priority P0|P1|P2|P3] [--size XS|S|M|L|XL]
+// — convert an inbound user-filed issue into a Specflow backlog ticket.
+// Defaults: P3 / M (Kevin reviews and lifts before final apply).
+//
+// Pipeline:
+//   1. Verify the issue carries `from:specflow-expert` (refuses otherwise).
+//   2. move.sh <num> Ready
+//   3. set-field.sh <num> Priority <P>  (exit 11 → fall back to label)
+//   4. set-field.sh <num> Size <S>      (same fallback contract)
+//   5. Public thank-you comment on the issue.
+
+const REPO = "mkrlabs/specflow";
+const BACKLOG_DIR = ".claude/skills/backlog/scripts";
+
+const PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);
+const SIZES = new Set(["XS", "S", "M", "L", "XL"]);
+
+const THANK_YOU = `Thanks for the report! 🙏
+
+I've added this to the Specflow backlog (Status: \`Ready\`). I'll keep this issue updated as the work progresses — no action needed on your end.
+
+If you spot anything else, the bundled \`specflow-expert\` agent in your project (run \`/specflow-expert <question>\` or just ask "report this as a bug" when something breaks) can pre-fill structured reports for future fixes.`;
+
+export type PromoteArgs = {
+  num: number;
+  priority: "P0" | "P1" | "P2" | "P3";
+  size: "XS" | "S" | "M" | "L" | "XL";
+};
+
+export function parsePromoteArgs(argv: ReadonlyArray<string>): PromoteArgs {
+  let num: number | null = null;
+  let priority: PromoteArgs["priority"] = "P3";
+  let size: PromoteArgs["size"] = "M";
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--priority") {
+      const v = argv[++i];
+      if (!v || !PRIORITIES.has(v)) {
+        throw new Error(`--priority must be one of P0..P3 (got: ${v ?? "<missing>"})`);
+      }
+      priority = v as PromoteArgs["priority"];
+    } else if (a === "--size") {
+      const v = argv[++i];
+      if (!v || !SIZES.has(v)) {
+        throw new Error(`--size must be one of XS|S|M|L|XL (got: ${v ?? "<missing>"})`);
+      }
+      size = v as PromoteArgs["size"];
+    } else if (!a.startsWith("-")) {
+      const n = Number(a);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`invalid issue number: ${a}`);
+      }
+      num = n;
+    }
+  }
+  if (num === null) {
+    throw new Error("usage: promote.ts <issue-number> [--priority P0..P3] [--size XS..XL]");
+  }
+  return { num, priority, size };
+}
+
+async function run(cmd: string[]): Promise<{ code: number; out: string; err: string }> {
+  const c = new Deno.Command(cmd[0], { args: cmd.slice(1), stdout: "piped", stderr: "piped" });
+  const { code, stdout, stderr } = await c.output();
+  return {
+    code,
+    out: new TextDecoder().decode(stdout),
+    err: new TextDecoder().decode(stderr),
+  };
+}
+
+async function fetchLabels(num: number): Promise<string[]> {
+  const r = await run([
+    "gh",
+    "issue",
+    "view",
+    String(num),
+    "--repo",
+    REPO,
+    "--json",
+    "labels",
+  ]);
+  if (r.code !== 0) throw new Error(`gh issue view failed: ${r.err}`);
+  const data = JSON.parse(r.out) as { labels: Array<{ name: string }> };
+  return data.labels.map((l) => l.name);
+}
+
+async function setField(
+  num: number,
+  field: "Priority" | "Size",
+  value: string,
+  labelFallback: string,
+): Promise<"field" | "label"> {
+  const r = await run([`${BACKLOG_DIR}/set-field.sh`, String(num), field, value]);
+  if (r.code === 0) return "field";
+  if (r.code === 11) {
+    // Field option missing (e.g. priority:P3 — Project V2 only has P0..P2).
+    // Fall back to the legacy label, per the contract documented in
+    // set-field.sh.
+    const lr = await run([
+      "gh",
+      "issue",
+      "edit",
+      String(num),
+      "--repo",
+      REPO,
+      "--add-label",
+      labelFallback,
+    ]);
+    if (lr.code !== 0) throw new Error(`label fallback failed: ${lr.err}`);
+    return "label";
+  }
+  throw new Error(`set-field ${field}=${value} failed (exit ${r.code}): ${r.err}`);
+}
+
+if (import.meta.main) {
+  let args: PromoteArgs;
+  try {
+    args = parsePromoteArgs(Deno.args);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : e);
+    Deno.exit(1);
+  }
+
+  const labels = await fetchLabels(args.num);
+  if (!labels.includes("from:specflow-expert")) {
+    console.error(
+      `error: #${args.num} is not labelled \`from:specflow-expert\` — ` +
+        `triage promote is for inbound user-filed issues only.`,
+    );
+    Deno.exit(2);
+  }
+
+  const move = await run([`${BACKLOG_DIR}/move.sh`, String(args.num), "Ready"]);
+  if (move.code !== 0) {
+    console.error(`move.sh failed: ${move.err}`);
+    Deno.exit(1);
+  }
+
+  const prioMode = await setField(
+    args.num,
+    "Priority",
+    args.priority,
+    `priority:${args.priority}`,
+  );
+  const sizeMode = await setField(args.num, "Size", args.size, `size:${args.size}`);
+
+  const comment = await run([
+    "gh",
+    "issue",
+    "comment",
+    String(args.num),
+    "--repo",
+    REPO,
+    "--body",
+    THANK_YOU,
+  ]);
+  if (comment.code !== 0) {
+    console.warn(`warn: thank-you comment failed: ${comment.err}`);
+  }
+
+  console.log(
+    `✓ #${args.num} → Ready · Priority=${args.priority} (${prioMode}) · Size=${args.size} (${sizeMode})`,
+  );
+  if (prioMode === "label" || sizeMode === "label") {
+    console.log("  (label fallback used — Project V2 field option missing)");
+  }
+}

--- a/.claude/skills/gh-issues/scripts/reject.ts
+++ b/.claude/skills/gh-issues/scripts/reject.ts
@@ -1,0 +1,68 @@
+// gh-issues reject <num> --reason "..." — DRY-RUN only. Prints the
+// public comment and `gh issue close` command that would run, then
+// exits. The calling session shows this to Kevin and runs it after
+// confirmation.
+//
+// Hard contract: this script never closes anything. Closure goes
+// through Kevin's explicit approval.
+
+const REPO = "mkrlabs/specflow";
+
+export type RejectArgs = { num: number; reason: string };
+
+export function parseRejectArgs(argv: ReadonlyArray<string>): RejectArgs {
+  let num: number | null = null;
+  let reason: string | null = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--reason") {
+      const v = argv[++i];
+      if (!v) throw new Error("--reason requires a value");
+      reason = v;
+    } else if (!a.startsWith("-")) {
+      const n = Number(a);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`invalid issue number: ${a}`);
+      }
+      num = n;
+    }
+  }
+  if (num === null) {
+    throw new Error('usage: reject.ts <issue-number> --reason "<explanation>"');
+  }
+  if (reason === null || reason.trim() === "") {
+    throw new Error("--reason is mandatory and must be non-empty");
+  }
+  return { num, reason };
+}
+
+function shellQuote(s: string): string {
+  // Single-quote wrap for safe shell pasting; embedded single quotes
+  // are escaped via the standard `'\''` trick.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+if (import.meta.main) {
+  let args: RejectArgs;
+  try {
+    args = parseRejectArgs(Deno.args);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : e);
+    Deno.exit(1);
+  }
+
+  const publicBody =
+    `Closing this report — it goes against Specflow's current methodology / vision.\n\n` +
+    `**Reason:** ${args.reason}\n\n` +
+    `Thanks for taking the time to file the issue. If you think this decision is wrong, ` +
+    `feel free to comment with additional context and we'll re-evaluate.`;
+
+  console.log(`# Reject #${args.num} — DRY RUN`);
+  console.log("Show this to Kevin. After explicit approval, run:");
+  console.log("");
+  console.log(`gh issue comment ${args.num} --repo ${REPO} --body ${shellQuote(publicBody)}`);
+  console.log(`gh issue close ${args.num} --repo ${REPO} --reason not_planned`);
+  console.log("");
+  console.log("(reject.ts itself does NOT close — explicit confirmation gate.)");
+}

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report a Specflow problem you hit while running the CLI or using the bundled agents.
 title: ""
-labels: bug
+labels: "bug,from:specflow-expert"
 ---
 
 ## Summary

--- a/plugin/agents/specflow-expert.md
+++ b/plugin/agents/specflow-expert.md
@@ -128,10 +128,10 @@ Email addresses NOT scrubbed (false-positive prone) — tell the user
 to review.
 
 **Surface**: generate
-`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…`
-URL-encoded. If the raw body exceeds **3000 chars**, present a
-fenced code block and ask the user to open
-`https://github.com/mkrlabs/specflow/issues/new` manually and paste.
+`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…&labels=bug,from%3Aspecflow-expert`
+URL-encoded. The label gates the maintainer triage inbox. If the raw
+body exceeds **3000 chars**, present a fenced code block and ask the
+user to paste it into a fresh `issues/new` form.
 
 `gh issue create` is **not** supported in V1 — keep the user in the
 loop on every report. If asked, decline and offer the URL pre-fill.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2996,10 +2996,10 @@ Email addresses NOT scrubbed (false-positive prone) — tell the user
 to review.
 
 **Surface**: generate
-\`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…\`
-URL-encoded. If the raw body exceeds **3000 chars**, present a
-fenced code block and ask the user to open
-\`https://github.com/mkrlabs/specflow/issues/new\` manually and paste.
+\`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…&labels=bug,from%3Aspecflow-expert\`
+URL-encoded. The label gates the maintainer triage inbox. If the raw
+body exceeds **3000 chars**, present a fenced code block and ask the
+user to paste it into a fresh \`issues/new\` form.
 
 \`gh issue create\` is **not** supported in V1 — keep the user in the
 loop on every report. If asked, decline and offer the URL pre-fill.

--- a/templates/core/agents/specflow-expert.md
+++ b/templates/core/agents/specflow-expert.md
@@ -128,10 +128,10 @@ Email addresses NOT scrubbed (false-positive prone) — tell the user
 to review.
 
 **Surface**: generate
-`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…`
-URL-encoded. If the raw body exceeds **3000 chars**, present a
-fenced code block and ask the user to open
-`https://github.com/mkrlabs/specflow/issues/new` manually and paste.
+`https://github.com/mkrlabs/specflow/issues/new?title=…&body=…&labels=bug,from%3Aspecflow-expert`
+URL-encoded. The label gates the maintainer triage inbox. If the raw
+body exceeds **3000 chars**, present a fenced code block and ask the
+user to paste it into a fresh `issues/new` form.
 
 `gh issue create` is **not** supported in V1 — keep the user in the
 loop on every report. If asked, decline and offer the URL pre-fill.

--- a/tests/scripts/gh_issues_argv_test.ts
+++ b/tests/scripts/gh_issues_argv_test.ts
@@ -1,0 +1,60 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { parsePromoteArgs } from "../../.claude/skills/gh-issues/scripts/promote.ts";
+import { parseRejectArgs } from "../../.claude/skills/gh-issues/scripts/reject.ts";
+
+Deno.test("parsePromoteArgs defaults to P3/M", () => {
+  const a = parsePromoteArgs(["42"]);
+  assertEquals(a.num, 42);
+  assertEquals(a.priority, "P3");
+  assertEquals(a.size, "M");
+});
+
+Deno.test("parsePromoteArgs --priority overrides default", () => {
+  const a = parsePromoteArgs(["42", "--priority", "P1"]);
+  assertEquals(a.priority, "P1");
+});
+
+Deno.test("parsePromoteArgs --size overrides default", () => {
+  const a = parsePromoteArgs(["42", "--size", "S"]);
+  assertEquals(a.size, "S");
+});
+
+Deno.test("parsePromoteArgs accepts both flag overrides", () => {
+  const a = parsePromoteArgs(["42", "--priority", "P0", "--size", "XL"]);
+  assertEquals(a.priority, "P0");
+  assertEquals(a.size, "XL");
+});
+
+Deno.test("parsePromoteArgs throws on invalid priority", () => {
+  assertThrows(() => parsePromoteArgs(["42", "--priority", "P9"]));
+});
+
+Deno.test("parsePromoteArgs throws on invalid size", () => {
+  assertThrows(() => parsePromoteArgs(["42", "--size", "XXL"]));
+});
+
+Deno.test("parsePromoteArgs throws on missing positional", () => {
+  assertThrows(() => parsePromoteArgs(["--priority", "P1"]));
+});
+
+Deno.test("parsePromoteArgs throws on non-numeric positional", () => {
+  assertThrows(() => parsePromoteArgs(["abc"]));
+});
+
+Deno.test("parseRejectArgs requires --reason with non-empty value", () => {
+  const a = parseRejectArgs(["42", "--reason", "duplicate of #1"]);
+  assertEquals(a.num, 42);
+  assertEquals(a.reason, "duplicate of #1");
+});
+
+Deno.test("parseRejectArgs throws when --reason missing", () => {
+  assertThrows(() => parseRejectArgs(["42"]));
+});
+
+Deno.test("parseRejectArgs throws when --reason is empty string", () => {
+  assertThrows(() => parseRejectArgs(["42", "--reason", "   "]));
+});
+
+Deno.test("parseRejectArgs throws on missing positional", () => {
+  assertThrows(() => parseRejectArgs(["--reason", "x"]));
+});

--- a/tests/scripts/gh_issues_dedupe_test.ts
+++ b/tests/scripts/gh_issues_dedupe_test.ts
@@ -1,0 +1,101 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  bucketOf,
+  findCandidates,
+  jaccard,
+  tokenize,
+} from "../../.claude/skills/gh-issues/scripts/_dedupe_heuristic.ts";
+
+Deno.test("tokenize lowercases, splits on punctuation, drops stopwords", () => {
+  const toks = tokenize("The init crashes on Windows!");
+  assertEquals(
+    [...toks].sort(),
+    ["crashes", "init", "on", "windows"]
+      // 'on' is in STOPWORDS — should be excluded, plus 'the' is in STOPWORDS
+      .filter((t) => t !== "on")
+      .sort(),
+  );
+});
+
+Deno.test("tokenize returns Set semantics (no duplicates)", () => {
+  const toks = tokenize("init init init");
+  assertEquals(toks.size, 1);
+  assert(toks.has("init"));
+});
+
+Deno.test("tokenize drops 1-char tokens", () => {
+  const toks = tokenize("a b c init");
+  assertEquals([...toks], ["init"]);
+});
+
+Deno.test("jaccard identical sets → 1.0", () => {
+  const a = new Set(["init", "crash", "windows"]);
+  const b = new Set(["init", "crash", "windows"]);
+  assertEquals(jaccard(a, b), 1);
+});
+
+Deno.test("jaccard disjoint sets → 0.0", () => {
+  const a = new Set(["alpha", "beta"]);
+  const b = new Set(["gamma", "delta"]);
+  assertEquals(jaccard(a, b), 0);
+});
+
+Deno.test("jaccard partial overlap → expected ratio", () => {
+  // intersection = 1 ('init'); union = 3 ('init', 'crash', 'fail').
+  const a = new Set(["init", "crash"]);
+  const b = new Set(["init", "fail"]);
+  assertEquals(jaccard(a, b), 1 / 3);
+});
+
+Deno.test("jaccard empty + empty → 0", () => {
+  assertEquals(jaccard(new Set(), new Set()), 0);
+});
+
+Deno.test("bucketOf: >=0.5 → likely-dupe", () => {
+  assertEquals(bucketOf(0.5), "likely-dupe");
+  assertEquals(bucketOf(0.9), "likely-dupe");
+});
+
+Deno.test("bucketOf: 0.3..0.49 → maybe", () => {
+  assertEquals(bucketOf(0.3), "maybe");
+  assertEquals(bucketOf(0.49), "maybe");
+});
+
+Deno.test("bucketOf: <0.3 → unrelated", () => {
+  assertEquals(bucketOf(0.29), "unrelated");
+  assertEquals(bucketOf(0), "unrelated");
+});
+
+Deno.test("findCandidates: top-3 by score, descending", () => {
+  const target = "init crashes on windows";
+  const pool = [
+    { number: 1, title: "init crashes on windows arm64" }, // high overlap
+    { number: 2, title: "upgrade fails on macOS" },
+    { number: 3, title: "init crashes when offline" }, // medium overlap
+    { number: 4, title: "windows installer broken" }, // low overlap
+    { number: 5, title: "completely unrelated thing about parsing" },
+  ];
+  const candidates = findCandidates(target, pool);
+  assertEquals(candidates.length, 3);
+  assertEquals(candidates[0].number, 1);
+  assert(candidates[0].score > candidates[1].score);
+  assert(candidates[1].score >= candidates[2].score);
+});
+
+Deno.test("findCandidates: excludeNumber drops the target itself from the pool", () => {
+  const target = "init crashes on windows";
+  const pool = [
+    { number: 42, title: "init crashes on windows" }, // identical, but is the target
+    { number: 7, title: "init crashes when offline" },
+  ];
+  const candidates = findCandidates(target, pool, { excludeNumber: 42 });
+  assertEquals(candidates.length, 1);
+  assertEquals(candidates[0].number, 7);
+});
+
+Deno.test("findCandidates: zero-overlap entries are filtered out", () => {
+  const candidates = findCandidates("init crashes", [
+    { number: 1, title: "completely different topic xyz" },
+  ]);
+  assertEquals(candidates.length, 0);
+});


### PR DESCRIPTION
## Summary

Maintainer-side counterpart to the bug-report protocol shipped in #172. The agent files structured issues against `mkrlabs/specflow` with the `from:specflow-expert` label; this skill triages them.

Closes #174.

## Skill

`.claude/skills/gh-issues/` — five Deno-scripted sub-commands:

- `list` — enumerate inbound issues (`from:specflow-expert`, open).
- `dedupe <num>` — top-3 similar by Jaccard token-overlap on titles vs open + last 200 closed. Buckets: likely-dupe (≥0.5), maybe (≥0.3), unrelated.
- `promote <num> [--priority] [--size]` — verify inbound label, `move.sh Ready`, `set-field.sh` Priority/Size with P3 label-fallback, thank-you comment. Defaults P3/M.
- `reject <num> --reason "..."` — **DRY-RUN ONLY**. Prints the close command; calling session executes after Kevin's confirmation. Never auto-closes.
- `groom-inbox` — Markdown table of inbox + dedupe candidates + proposed actions. Kevin batch-replies, calling session dispatches.

## Label wiring

`from:specflow-expert` is the inbox gate:
- `.github/ISSUE_TEMPLATE/bug.md` `labels:` line auto-applies on manual template submissions
- `templates/core/agents/specflow-expert.md` (+ plugin) — bug-report URL pre-fill appends `&labels=bug,from%3Aspecflow-expert` for agent-filed issues
- Repo-side label bootstrapped via `gh label create` (one-shot, done in this PR)

## Test plan

- [x] `deno task test` — 541 passed (was 516 + 25 new)
  - 13 dedupe unit tests (tokenize / jaccard / bucketOf / findCandidates)
  - 12 argv unit tests (`parsePromoteArgs` + `parseRejectArgs`: defaults, overrides, validation)
- [x] `smoke-features.sh` green
- [x] CI on this PR

End-to-end smoke against the live API is manual.

## Maintainer-only

Lives entirely under `.claude/skills/gh-issues/`. NOT bundled to user projects via `templates/manifest.json`. Hard-coded to `mkrlabs/specflow`.

## Out of scope

- Auto-close (always Kevin-confirm via dry-run)
- Cross-repo triage
- Sentiment / tone analysis
- AWS secret-key context-gating in the upstream scrubber (V2 follow-up — separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)