### PR TITLE
fix(backlog/github): remove unused $project GraphQL variable in list.sh

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -4109,7 +4109,7 @@ set -euo pipefail
 FILTER="\${1:-}"
 
 JSON=\$(gh api graphql -f query='
-  query(\$owner:String!, \$name:String!, \$project:Int!) {
+  query(\$owner:String!, \$name:String!) {
     repository(owner:\$owner, name:\$name) {
       issues(first:100, states:OPEN) {
         nodes {
@@ -4132,8 +4132,7 @@ JSON=\$(gh api graphql -f query='
     }
   }' \\
   -f owner="\$REPO_OWNER" \\
-  -f name="\$REPO_NAME" \\
-  -F project="\$PROJECT_NUMBER")
+  -f name="\$REPO_NAME")
 
 echo "\$JSON" | jq -r --argjson project "\$PROJECT_NUMBER" --arg filter "\$FILTER" '
   .data.repository.issues.nodes[]

--- a/templates/core/skills/backlog/scripts/github/list.sh
+++ b/templates/core/skills/backlog/scripts/github/list.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 FILTER="${1:-}"
 
 JSON=$(gh api graphql -f query='
-  query($owner:String!, $name:String!, $project:Int!) {
+  query($owner:String!, $name:String!) {
     repository(owner:$owner, name:$name) {
       issues(first:100, states:OPEN) {
         nodes {
@@ -32,8 +32,7 @@ JSON=$(gh api graphql -f query='
     }
   }' \
   -f owner="$REPO_OWNER" \
-  -f name="$REPO_NAME" \
-  -F project="$PROJECT_NUMBER")
+  -f name="$REPO_NAME")
 
 echo "$JSON" | jq -r --argjson project "$PROJECT_NUMBER" --arg filter "$FILTER" '
   .data.repository.issues.nodes[]


### PR DESCRIPTION
## Summary

Closes #177.

`templates/core/skills/backlog/scripts/github/list.sh` declared `$project:Int!` in its GraphQL signature but never referenced it inside the query body — `gh api graphql` rejects unused variables in strict mode, so the script emitted stderr noise + an empty stdout (the project filter was already happening entirely in `jq` via `--argjson project`).

Minimal patch:

- Drop `$project:Int!` from the query signature.
- Drop the matching `-F project=…` argument.
- Leave the `jq` post-filter unchanged — it still receives `$PROJECT_NUMBER` via `--argjson project`.

## Verification

- 541/541 unit tests green (`deno task test`).
- `smoke-backlog-github.sh` green (the github backend scaffold still ships every script the PO contracts depend on).
- Live-tested the corrected query against `mkrlabs/specflow` — no GraphQL warnings, Backlog rows (including #176 and #177 itself) come back as expected.

## Impact

`/specflow groom` now sees real Backlog items on github-backend projects, instead of silently treating the column as empty. Bug surfaced during a live `/specflow groom` run on `mkrlabs/dinodrinks` after a fresh `specflow init`.