### PR TITLE
feat(backlog): epic / sub-task support end-to-end (#180)

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -206,6 +206,43 @@ issues by `.claude/skills/backlog/scripts/migrate-labels-to-fields.sh`
 when this contract landed. The script is idempotent — re-run anytime
 the board feels out of sync.
 
+## Epic / sub-task detection
+
+You **proactively** propose epic decomposition on every `/backlog add`
+and during grooming sweeps over the Backlog column — Kevin shouldn't
+have to ask. The bundled scaffolded PO (shipped to user projects) has
+the same heuristic; this section ensures the in-repo agent that owns
+Project #4 has parity.
+
+**Trigger phrases:** "break down", "into tasks", "phased", "as an
+epic", "rewrite", "end-to-end", "across the stack", "multi-step".
+
+**Structural triggers:**
+
+- More than 5 distinct `## Acceptance criteria` bullets, OR
+- Scope crosses ≥2 subsystems (e.g. backlog + agents + tests; or
+  multiple bundled backends), OR
+- Estimated `Size: L` / `Size: XL` on the native Project V2 field.
+
+**Behavior:**
+
+- **Obvious decomposition** (clear functional split): auto-create the
+  epic on `mkrlabs/specflow` + children via the GitHub native
+  sub-issues API (`gh api -X POST .../issues/<parent>/sub_issues`).
+  Report the structure back ("Created epic #N with children #N+1, …").
+- **Ambiguous decomposition** (large but split unclear): ask Kevin
+  once with a concrete proposal — "Looks like 4 sub-tasks: A / B / C
+  / D — create as children of new epic #N, or refine first?"
+- **Single-task ambiguity** (large but cohesive): keep as one task.
+
+**Closing parents:** before `gh issue close <parent>`, run the
+bundled `cascade-check.sh <parent>` from the project's
+`.specflow/scripts/backlog/` to verify every linked sub-issue is
+already closed. Exit 11 means children remain open; refuse the close
+and surface the open list to Kevin. Project V2's `Sub-issues
+progress` field renders the parent/child hierarchy on the board
+automatically once children are linked — no extra wiring.
+
 ## Board hygiene sweep
 
 `gh issue close` does not update the Project V2 Status field — it only

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
@@ -85,6 +85,22 @@ check "SKILL.md describes Priority/Size field-first contract" \
   'grep -q "Priority" .claude/skills/backlog/SKILL.md && grep -q "Size" .claude/skills/backlog/SKILL.md'
 
 echo
+echo "═══ #180  add.sh --parent flag (sub-issues API wiring) ═══"
+check "add.sh parses --parent flag" \
+  'grep -q -- "--parent" .specflow/scripts/backlog/add.sh'
+check "add.sh references the sub_issues REST endpoint" \
+  'grep -q "sub_issues" .specflow/scripts/backlog/add.sh'
+
+echo
+echo "═══ #180  cascade-check.sh present + executable ═══"
+check "cascade-check.sh present + executable" \
+  '[ -x .specflow/scripts/backlog/cascade-check.sh ]'
+check "cascade-check.sh queries sub_issues for open children" \
+  'grep -q "sub_issues" .specflow/scripts/backlog/cascade-check.sh'
+check "cascade-check.sh exits 11 when children block close" \
+  'grep -q "exit 11" .specflow/scripts/backlog/cascade-check.sh'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL GITHUB BACKLOG CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-gitlab.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-gitlab.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Verify the GitLab-backend backlog scaffolding ships every script the
+# PO + grooming + epic contracts depend on. Tests file presence,
+# executable bits, --parent flag wiring, and SKILL.md references — no
+# live `glab` calls (the script behavior against a real project is
+# covered by integration tests and manual QA).
+#
+# Usage: smoke-backlog-gitlab.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-backlog-gitlab.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$ROOT/sandbox/$NAME"
+
+# Trap-based cleanup: wipe the scenario directory on every exit path
+# (success OR failure) so the sandbox/ tree never accumulates orphans.
+trap 'bash "$SCRIPT_DIR/clean.sh" "$NAME" >/dev/null 2>&1 || true' EXIT
+
+bash "$SCRIPT_DIR/bootstrap-empty.sh" "$NAME" >/dev/null
+(cd "$DIR" && deno run --allow-all "$ROOT/src/main.ts" \
+  init --here --no-git --ai claude --backlog gitlab \
+  --backlog-url "https://gitlab.com/example/proj" >/dev/null 2>&1)
+
+cd "$DIR"
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1 — $2"; fails=$((fails + 1)); }
+
+check() {
+  local desc="$1" cmd="$2"
+  if eval "$cmd" >/dev/null 2>&1; then pass "$desc"; else fail "$desc" "command: $cmd"; fi
+}
+
+echo "═══ backlog backend lock + config ═══"
+check "lock records gitlab backend" \
+  'grep -q "backlog_backend: gitlab" .specflow/installed.lock'
+check "backlog-config.yml stub present" \
+  '[ -f .specflow/backlog-config.yml ]'
+
+echo
+echo "═══ canonical backlog scripts ═══"
+for s in list view add move clarify-comment ensure-labels; do
+  check "$s.sh present + executable" "[ -x .specflow/scripts/backlog/$s.sh ]"
+done
+
+echo
+echo "═══ #180  add.sh --parent flag (scoped-label parent::#NNN) ═══"
+check "add.sh parses --parent flag" \
+  'grep -q -- "--parent" .specflow/scripts/backlog/add.sh'
+check "add.sh emits parent::#NNN scoped label" \
+  'grep -q "parent::#" .specflow/scripts/backlog/add.sh'
+
+echo
+echo "═══ #180  cascade-check.sh present + executable ═══"
+check "cascade-check.sh present + executable" \
+  '[ -x .specflow/scripts/backlog/cascade-check.sh ]'
+check "cascade-check.sh queries the parent::#NNN scoped label" \
+  'grep -q "parent::#" .specflow/scripts/backlog/cascade-check.sh'
+check "cascade-check.sh exits 11 when children block close" \
+  'grep -q "exit 11" .specflow/scripts/backlog/cascade-check.sh'
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL GITLAB BACKLOG CHECKS PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails CHECK(S) FAILED ═══"
+  exit 1
+fi

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
@@ -97,6 +97,34 @@ bash .specflow/scripts/backlog/add.sh "Second" "" >/dev/null
   || fail "expected 002-second.md" "$(ls .specflow/backlog/)"
 
 echo
+echo "═══ #180  add --parent (sub-task of #001) ═══"
+out=$(bash .specflow/scripts/backlog/add.sh "Subtask of 1" "" --parent 1)
+echo "$out"
+echo "$out" | grep -q "✓ created #003" \
+  && pass "add --parent prints '✓ created #003'" \
+  || fail "add --parent output" "$out"
+[ -f .specflow/backlog/003-subtask-of-1.md ] \
+  && pass "003-subtask-of-1.md created" \
+  || fail "expected 003-subtask-of-1.md" "$(ls .specflow/backlog/)"
+grep -q '^parent: "#001"$' .specflow/backlog/003-subtask-of-1.md \
+  && pass "child frontmatter declares parent: \"#001\"" \
+  || fail "parent key missing in child" "$(head -10 .specflow/backlog/003-subtask-of-1.md)"
+grep -q "^## Sub-tasks$" .specflow/backlog/001-first-item.md \
+  && pass "parent body grew a Sub-tasks section" \
+  || fail "no Sub-tasks section in parent" "$(tail -10 .specflow/backlog/001-first-item.md)"
+grep -q "#003" .specflow/backlog/001-first-item.md \
+  && pass "parent body cross-links to #003" \
+  || fail "parent body missing #003 link" "$(tail -10 .specflow/backlog/001-first-item.md)"
+
+echo
+echo "═══ #180  add --parent refuses unknown parent ═══"
+if bash .specflow/scripts/backlog/add.sh "Orphan" "" --parent 999 2>/dev/null; then
+  fail "should have refused parent #999" "(unexpected exit 0)"
+else
+  pass "refused to create child of non-existent parent #999"
+fi
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL BACKLOG CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -152,6 +152,15 @@ check ".specflow/logs/ in bundled .gitignore" \
   'grep -q "\.specflow/logs/" .gitignore'
 
 echo
+echo "═══ #180  PO doc — epic detection heuristic + cascade-check refs ═══"
+check "PO doc documents the epic detection heuristic" \
+  'grep -q "Epic detection heuristic" .claude/agents/product-owner.md'
+check "PO doc references cascade-check.sh as the close gate" \
+  'grep -q "cascade-check.sh" .claude/agents/product-owner.md'
+check "PO doc covers GitLab backend epic story (parent::# scoped label)" \
+  'grep -q "On the GitLab backend" .claude/agents/product-owner.md'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -161,6 +161,15 @@ check "PO doc covers GitLab backend epic story (parent::# scoped label)" \
   'grep -q "On the GitLab backend" .claude/agents/product-owner.md'
 
 echo
+echo "═══ #180  SKILL.md — Epics & sub-tasks section ═══"
+check "SKILL.md gains an Epics & sub-tasks section" \
+  'grep -q "Epics & sub-tasks" .claude/skills/backlog/SKILL.md'
+check "SKILL.md describes the --parent flag" \
+  'grep -q -- "--parent" .claude/skills/backlog/SKILL.md'
+check "SKILL.md describes the cascade-check close gate" \
+  'grep -q "cascade-check.sh" .claude/skills/backlog/SKILL.md'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -158,7 +158,7 @@ check "PO doc documents the epic detection heuristic" \
 check "PO doc references cascade-check.sh as the close gate" \
   'grep -q "cascade-check.sh" .claude/agents/product-owner.md'
 check "PO doc covers GitLab backend epic story (parent::# scoped label)" \
-  'grep -q "On the GitLab backend" .claude/agents/product-owner.md'
+  'grep -q "parent::#" .claude/agents/product-owner.md'
 
 echo
 echo "═══ #180  SKILL.md — Epics & sub-tasks section ═══"

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -111,48 +111,28 @@ An **epic** is a backlog item that owns one or more **sub-tasks**. The PO must
 be able to create them, reference them as a unit, and close the parent only
 when every child is closed.
 
-### On the GitHub backend
+### Creating sub-tasks (all backends)
 
-Use the GitHub native sub-issues API (currently in beta). Reference docs:
-<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues>.
+Use `add.sh --parent <num>` — it does the right thing per backend:
 
-Create a sub-issue from an existing parent (the parent must already exist):
+- **github**: creates the child + POSTs to `/issues/<parent>/sub_issues`
+  (native beta API). Project V2 renders children under the parent's
+  `Sub-issues progress` field automatically.
+- **gitlab**: tags the child with a `parent::#NNN` scoped label.
+  Native Epics are Premium-only; the scoped label works on every tier.
+- **local**: writes `parent: "#NNN"` into the child's frontmatter and
+  cross-links under a `## Sub-tasks` section in the parent file.
 
-```bash
-# Step 1 — create the child issue normally
-CHILD=$(gh issue create --title "<child title>" --body "<child body>" --json number --jq '.number')
+Fails fast (exit 3) if the parent doesn't exist.
 
-# Step 2 — fetch the child's node id (REST id, not issue number)
-CHILD_ID=$(gh api repos/:owner/:repo/issues/$CHILD --jq '.id')
-
-# Step 3 — link it under the parent
-gh api -X POST repos/:owner/:repo/issues/<PARENT_NUMBER>/sub_issues \
-  -f sub_issue_id=$CHILD_ID
-```
-
-List, reorder, or unlink sub-issues:
-
-```bash
-gh api repos/:owner/:repo/issues/<PARENT>/sub_issues
-gh api -X DELETE repos/:owner/:repo/issues/<PARENT>/sub_issue \
-  -f sub_issue_id=<CHILD_REST_ID>
-```
-
-### On the local Markdown backend
-
-A sub-task is an ordinary task file with `parent: "#NNN"` in its frontmatter,
-where `NNN` is the parent's local id. The parent itself is a normal task — no
-flag needed; it becomes an "epic" by virtue of having children.
-
-To create a sub-task: scaffold the new file as usual, then set its `parent`
-key. Update both the parent's task file (cross-link in the body) and the
-backlog index (`.specflow/backlog.md`) so the relationship is visible at a
-glance.
-
-### Closing rules (both backends)
+### Closing rules (all three backends)
 
 - **Sub-task**: close directly. No cascade to siblings or parent.
-- **Parent / epic**: every child must close first; refuse otherwise.
+- **Parent / epic**: every child must close first. Run
+  `cascade-check.sh <num>` (github + gitlab) before `gh issue close` /
+  `glab issue close` — exit 11 means open children block close, 0 means
+  safe. On local, `grep -l 'parent: "#NNN"' .specflow/backlog/*.md` is
+  the equivalent check.
 - **Cancel epic**: close parent + every child as `not_planned` in one batch.
 - **Two-step close on GitHub / GitLab**: `gh issue close` (and `glab issue
   close`) do NOT update the Project V2 Status field / GitLab scoped Status
@@ -167,6 +147,22 @@ glance.
   issue is `CLOSED`, or `OPEN` with a merged PR linked → `move.sh <num>
   Done`. Mirror for `Done` items whose issue is REOPENED. Idempotent;
   safe after every release or via `/loop 1d`.
+
+### Epic detection heuristic
+
+Propose epic decomposition on every `/backlog add` and during grooming.
+
+**Triggers:** phrases like "break down", "phased", "rewrite",
+"end-to-end"; >5 AC bullets; scope crosses ≥2 subsystems; size L/XL.
+
+**Behavior:**
+
+- **Obvious split**: auto-create epic + children, report structure.
+- **Ambiguous split**: ask once — "Looks like N sub-tasks: A/B/C/D —
+  create as children of epic #N?"
+- **Cohesive but large**: keep as single task.
+
+Never silently swallow scope.
 
 ## Prioritization framework
 
@@ -244,9 +240,8 @@ Sync the index on the local backend; use `gh issue edit` on GitHub.
 
 ### `/backlog estimate <id>`
 
-Detailed complexity estimate with a sub-task breakdown. If the breakdown
-exceeds one task's worth of work, propose splitting into an epic with
-explicit sub-tasks (offer to create them).
+Detailed complexity estimate. If the work exceeds one task, apply the
+"Epic detection heuristic" above.
 
 ### `/backlog status`
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2180,29 +2180,41 @@ when every child is closed.
 
 ### On the GitHub backend
 
-Use the GitHub native sub-issues API (currently in beta). Reference docs:
+Use \`add.sh --parent <num>\` from the bundled backlog scripts. It wraps the
+native sub-issues API (beta) into a single command — creates the child,
+fetches its REST id, and POSTs to
+\`repos/:owner/:repo/issues/<parent>/sub_issues\`. Project V2 boards render
+the children automatically under the parent's \`Sub-issues progress\` field;
+no extra wiring needed. Reference docs:
 <https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues>.
 
-Create a sub-issue from an existing parent (the parent must already exist):
-
 \`\`\`bash
-# Step 1 — create the child issue normally
-CHILD=\$(gh issue create --title "<child title>" --body "<child body>" --json number --jq '.number')
-
-# Step 2 — fetch the child's node id (REST id, not issue number)
-CHILD_ID=\$(gh api repos/:owner/:repo/issues/\$CHILD --jq '.id')
-
-# Step 3 — link it under the parent
-gh api -X POST repos/:owner/:repo/issues/<PARENT_NUMBER>/sub_issues \\
-  -f sub_issue_id=\$CHILD_ID
+# Create child as a sub-issue of parent #042
+.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
 \`\`\`
 
-List, reorder, or unlink sub-issues:
+For low-level inspection or unlinking:
 
 \`\`\`bash
 gh api repos/:owner/:repo/issues/<PARENT>/sub_issues
 gh api -X DELETE repos/:owner/:repo/issues/<PARENT>/sub_issue \\
   -f sub_issue_id=<CHILD_REST_ID>
+\`\`\`
+
+### On the GitLab backend
+
+GitLab native Epics are Premium-tier only. The bundled scripts use a
+**scoped-label fallback** that works on every tier (Free + Premium +
+Ultimate) and stays consistent with the existing \`Status::*\` pattern:
+
+- Children carry a \`parent::#NNN\` scoped label pointing at the parent.
+- \`add.sh --parent <num>\` adds it automatically alongside \`Status::Backlog\`.
+- \`cascade-check.sh <num>\` lists open children via \`glab issue list --label
+  "parent::#NNN" --opened\` and refuses (exit 11) if any remain.
+
+\`\`\`bash
+# Create child as a sub-issue of parent #042
+.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
 \`\`\`
 
 ### On the local Markdown backend
@@ -2211,15 +2223,20 @@ A sub-task is an ordinary task file with \`parent: "#NNN"\` in its frontmatter,
 where \`NNN\` is the parent's local id. The parent itself is a normal task — no
 flag needed; it becomes an "epic" by virtue of having children.
 
-To create a sub-task: scaffold the new file as usual, then set its \`parent\`
-key. Update both the parent's task file (cross-link in the body) and the
-backlog index (\`.specflow/backlog.md\`) so the relationship is visible at a
-glance.
+Use \`add.sh --parent <num>\` to scaffold a child: it writes the \`parent\` key
+into the new file's frontmatter and appends a cross-link under a \`## Sub-tasks\`
+section in the parent file. The index (\`.specflow/backlog.md\`) is regenerated
+automatically.
 
-### Closing rules (both backends)
+### Closing rules (all three backends)
 
 - **Sub-task**: close directly. No cascade to siblings or parent.
-- **Parent / epic**: every child must close first; refuse otherwise.
+- **Parent / epic**: every child must close first; refuse otherwise. The
+  bundled \`cascade-check.sh <num>\` is the close gate on github + gitlab —
+  exits 11 with the open children listed when close is unsafe, exits 0
+  when safe. The PO MUST run it before \`gh issue close\` / \`glab issue close\`.
+  On the local backend, \`grep -l 'parent: "#NNN"' .specflow/backlog/*.md\`
+  followed by a status check is the equivalent.
 - **Cancel epic**: close parent + every child as \`not_planned\` in one batch.
 - **Two-step close on GitHub / GitLab**: \`gh issue close\` (and \`glab issue
   close\`) do NOT update the Project V2 Status field / GitLab scoped Status
@@ -2234,6 +2251,44 @@ glance.
   issue is \`CLOSED\`, or \`OPEN\` with a merged PR linked → \`move.sh <num>
   Done\`. Mirror for \`Done\` items whose issue is REOPENED. Idempotent;
   safe after every release or via \`/loop 1d\`.
+
+### Epic detection heuristic
+
+The PO must **proactively detect** when a request is too big for one task
+and propose breaking it into an epic + sub-tasks — Kevin shouldn't have to
+ask. Apply the heuristic on every \`/backlog add\` and on every grooming
+pass over Backlog-column items:
+
+**Trigger phrases in the title or body** — "break down", "into tasks",
+"phased", "as an epic", "rewrite", "end-to-end", "across the stack",
+"multi-step", "first land X, then Y, then Z".
+
+**Structural triggers:**
+
+- More than 5 distinct \`## Acceptance criteria\` bullets, OR
+- Scope crosses ≥2 subsystems (e.g. CLI + docs + tests; or three
+  different backends), OR
+- Estimated complexity > 5 story points (or \`Size: L\` / \`Size: XL\` on
+  the github backend's native field).
+
+**Behavior:**
+
+- **Obvious decomposition** (clear functional split visible in the body —
+  e.g. "wire X across github + gitlab + local" naturally splits into 3
+  per-backend children): auto-create the epic + children, report the
+  structure back ("Created epic #N with children #N+1, #N+2, #N+3").
+- **Ambiguous decomposition** (request is large but the split isn't
+  obvious): ask Kevin once with a concrete proposal — "Looks like 4
+  sub-tasks: A / B / C / D — create as children of new epic #N, or
+  refine first?" Never bloat one issue with N hidden ACs because
+  decomposition is hard.
+- **Single-task ambiguity** (request is large but cohesive — one
+  feature, one surface, one PR): keep it as a single task, even if it
+  has many ACs.
+
+**Never silently swallow scope.** When in doubt, propose the epic
+shape; let Kevin approve or reshape it. A rejected proposal costs
+seconds; a hidden 8-AC issue costs days.
 
 ## Prioritization framework
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -4240,31 +4240,74 @@ gh issue view "\$1" --repo "\$REPO" --comments
     name: "add",
     suffix: "add.sh",
     content: `#!/usr/bin/env bash
-# Create a GitHub Issue and attach it to the configured Project.
-# Usage: add.sh "<title>" [body] [labels-csv]
+# Create a GitHub Issue and attach it to the configured Project. Optional
+# \`--parent <num>\` flag links the new issue as a sub-issue of an existing
+# parent via GitHub's native \`/sub_issues\` REST endpoint (beta).
+#
+# Usage:
+#   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
 # shellcheck source=./_config.sh
 . "\$(dirname "\$0")/_config.sh"
 
-if [ "\$#" -lt 1 ]; then
-  echo 'usage: add.sh "<title>" [body] [labels-csv]' >&2
+PARENT=""
+ARGS=()
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --parent)
+      if [ \$# -lt 2 ]; then
+        echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+        exit 2
+      fi
+      PARENT="\$2"
+      shift 2
+      ;;
+    *)
+      ARGS+=("\$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "\${#ARGS[@]}" -lt 1 ]; then
+  echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
   exit 2
 fi
-TITLE="\$1"
-BODY="\${2:-}"
-LABELS="\${3:-}"
+TITLE="\${ARGS[0]}"
+BODY="\${ARGS[1]:-}"
+LABELS="\${ARGS[2]:-}"
 
-ARGS=("--repo" "\$REPO" "--title" "\$TITLE")
-if [ -n "\$BODY" ]; then ARGS+=("--body" "\$BODY"); else ARGS+=("--body" ""); fi
-if [ -n "\$LABELS" ]; then ARGS+=("--label" "\$LABELS"); fi
+# When --parent is set, fail fast if the parent issue doesn't exist —
+# GitHub's sub_issues POST returns a confusing 404 otherwise.
+if [ -n "\$PARENT" ]; then
+  if ! gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$PARENT" --jq '.number' >/dev/null 2>&1; then
+    echo "✗ parent issue #\$PARENT not found in \$REPO_OWNER/\$REPO_NAME" >&2
+    exit 3
+  fi
+fi
 
-URL=\$(gh issue create "\${ARGS[@]}")
+CREATE_ARGS=("--repo" "\$REPO" "--title" "\$TITLE")
+if [ -n "\$BODY" ]; then CREATE_ARGS+=("--body" "\$BODY"); else CREATE_ARGS+=("--body" ""); fi
+if [ -n "\$LABELS" ]; then CREATE_ARGS+=("--label" "\$LABELS"); fi
+
+URL=\$(gh issue create "\${CREATE_ARGS[@]}")
 echo "✓ created: \$URL"
 
 # Attach to the project
 gh project item-add "\$PROJECT_NUMBER" --owner "\$REPO_OWNER" --url "\$URL" >/dev/null
 echo "✓ attached to Project #\$PROJECT_NUMBER"
+
+# Link as a sub-issue if --parent was given. Two-step: extract the new
+# issue's REST id (NOT its number — sub_issues is keyed by id), then POST
+# to the parent's /sub_issues endpoint.
+if [ -n "\$PARENT" ]; then
+  CHILD_NUM="\${URL##*/}"
+  CHILD_ID=\$(gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$CHILD_NUM" --jq '.id')
+  gh api -X POST "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$PARENT/sub_issues" \\
+    -F sub_issue_id="\$CHILD_ID" >/dev/null
+  echo "✓ linked as sub-issue of #\$PARENT"
+fi
 `,
     executable: true,
     backend: "github",
@@ -4536,6 +4579,54 @@ else
   echo "  warn: 'bug' label missing — usually a GitHub default. Check repo settings if you want it." >&2
 fi
 echo "done."
+`,
+    executable: true,
+    backend: "github",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
+    name: "cascade-check",
+    suffix: "cascade-check.sh",
+    content: `#!/usr/bin/env bash
+# Verify that a parent issue is safe to close — every linked sub-issue
+# must already be closed. Refuses (exit 11) otherwise so the PO can
+# surface the open children and finish them first.
+#
+# Usage:   cascade-check.sh <issue-number>
+# Exit:    0  parent has no open children — safe to close
+#          11 at least one child is still open — close blocked
+#          2  usage error
+#          3  parent issue does not exist
+set -euo pipefail
+
+# shellcheck source=./_config.sh
+. "\$(dirname "\$0")/_config.sh"
+
+if [ "\$#" -lt 1 ]; then
+  echo 'usage: cascade-check.sh <issue-number>' >&2
+  exit 2
+fi
+NUM="\$1"
+
+if ! gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$NUM" --jq '.number' >/dev/null 2>&1; then
+  echo "✗ issue #\$NUM not found in \$REPO_OWNER/\$REPO_NAME" >&2
+  exit 3
+fi
+
+# Native sub-issues endpoint (beta). Returns [] when no children exist.
+OPEN=\$(gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$NUM/sub_issues" \\
+  --jq '[.[] | select(.state=="open")] | length' 2>/dev/null || echo 0)
+
+if [ "\$OPEN" -gt 0 ]; then
+  echo "✗ #\$NUM has \$OPEN open child issue(s) — close them first"
+  gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$NUM/sub_issues" \\
+    --jq '.[] | select(.state=="open") | "  - #\\(.number) — \\(.title)"'
+  exit 11
+fi
+
+echo "✓ #\$NUM safe to close (no open children)"
+exit 0
 `,
     executable: true,
     backend: "github",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2178,65 +2178,28 @@ An **epic** is a backlog item that owns one or more **sub-tasks**. The PO must
 be able to create them, reference them as a unit, and close the parent only
 when every child is closed.
 
-### On the GitHub backend
+### Creating sub-tasks (all backends)
 
-Use \`add.sh --parent <num>\` from the bundled backlog scripts. It wraps the
-native sub-issues API (beta) into a single command — creates the child,
-fetches its REST id, and POSTs to
-\`repos/:owner/:repo/issues/<parent>/sub_issues\`. Project V2 boards render
-the children automatically under the parent's \`Sub-issues progress\` field;
-no extra wiring needed. Reference docs:
-<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues>.
+Use \`add.sh --parent <num>\` — it does the right thing per backend:
 
-\`\`\`bash
-# Create child as a sub-issue of parent #042
-.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
-\`\`\`
+- **github**: creates the child + POSTs to \`/issues/<parent>/sub_issues\`
+  (native beta API). Project V2 renders children under the parent's
+  \`Sub-issues progress\` field automatically.
+- **gitlab**: tags the child with a \`parent::#NNN\` scoped label.
+  Native Epics are Premium-only; the scoped label works on every tier.
+- **local**: writes \`parent: "#NNN"\` into the child's frontmatter and
+  cross-links under a \`## Sub-tasks\` section in the parent file.
 
-For low-level inspection or unlinking:
-
-\`\`\`bash
-gh api repos/:owner/:repo/issues/<PARENT>/sub_issues
-gh api -X DELETE repos/:owner/:repo/issues/<PARENT>/sub_issue \\
-  -f sub_issue_id=<CHILD_REST_ID>
-\`\`\`
-
-### On the GitLab backend
-
-GitLab native Epics are Premium-tier only. The bundled scripts use a
-**scoped-label fallback** that works on every tier (Free + Premium +
-Ultimate) and stays consistent with the existing \`Status::*\` pattern:
-
-- Children carry a \`parent::#NNN\` scoped label pointing at the parent.
-- \`add.sh --parent <num>\` adds it automatically alongside \`Status::Backlog\`.
-- \`cascade-check.sh <num>\` lists open children via \`glab issue list --label
-  "parent::#NNN" --opened\` and refuses (exit 11) if any remain.
-
-\`\`\`bash
-# Create child as a sub-issue of parent #042
-.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
-\`\`\`
-
-### On the local Markdown backend
-
-A sub-task is an ordinary task file with \`parent: "#NNN"\` in its frontmatter,
-where \`NNN\` is the parent's local id. The parent itself is a normal task — no
-flag needed; it becomes an "epic" by virtue of having children.
-
-Use \`add.sh --parent <num>\` to scaffold a child: it writes the \`parent\` key
-into the new file's frontmatter and appends a cross-link under a \`## Sub-tasks\`
-section in the parent file. The index (\`.specflow/backlog.md\`) is regenerated
-automatically.
+Fails fast (exit 3) if the parent doesn't exist.
 
 ### Closing rules (all three backends)
 
 - **Sub-task**: close directly. No cascade to siblings or parent.
-- **Parent / epic**: every child must close first; refuse otherwise. The
-  bundled \`cascade-check.sh <num>\` is the close gate on github + gitlab —
-  exits 11 with the open children listed when close is unsafe, exits 0
-  when safe. The PO MUST run it before \`gh issue close\` / \`glab issue close\`.
-  On the local backend, \`grep -l 'parent: "#NNN"' .specflow/backlog/*.md\`
-  followed by a status check is the equivalent.
+- **Parent / epic**: every child must close first. Run
+  \`cascade-check.sh <num>\` (github + gitlab) before \`gh issue close\` /
+  \`glab issue close\` — exit 11 means open children block close, 0 means
+  safe. On local, \`grep -l 'parent: "#NNN"' .specflow/backlog/*.md\` is
+  the equivalent check.
 - **Cancel epic**: close parent + every child as \`not_planned\` in one batch.
 - **Two-step close on GitHub / GitLab**: \`gh issue close\` (and \`glab issue
   close\`) do NOT update the Project V2 Status field / GitLab scoped Status
@@ -2254,41 +2217,19 @@ automatically.
 
 ### Epic detection heuristic
 
-The PO must **proactively detect** when a request is too big for one task
-and propose breaking it into an epic + sub-tasks — Kevin shouldn't have to
-ask. Apply the heuristic on every \`/backlog add\` and on every grooming
-pass over Backlog-column items:
+Propose epic decomposition on every \`/backlog add\` and during grooming.
 
-**Trigger phrases in the title or body** — "break down", "into tasks",
-"phased", "as an epic", "rewrite", "end-to-end", "across the stack",
-"multi-step", "first land X, then Y, then Z".
-
-**Structural triggers:**
-
-- More than 5 distinct \`## Acceptance criteria\` bullets, OR
-- Scope crosses ≥2 subsystems (e.g. CLI + docs + tests; or three
-  different backends), OR
-- Estimated complexity > 5 story points (or \`Size: L\` / \`Size: XL\` on
-  the github backend's native field).
+**Triggers:** phrases like "break down", "phased", "rewrite",
+"end-to-end"; >5 AC bullets; scope crosses ≥2 subsystems; size L/XL.
 
 **Behavior:**
 
-- **Obvious decomposition** (clear functional split visible in the body —
-  e.g. "wire X across github + gitlab + local" naturally splits into 3
-  per-backend children): auto-create the epic + children, report the
-  structure back ("Created epic #N with children #N+1, #N+2, #N+3").
-- **Ambiguous decomposition** (request is large but the split isn't
-  obvious): ask Kevin once with a concrete proposal — "Looks like 4
-  sub-tasks: A / B / C / D — create as children of new epic #N, or
-  refine first?" Never bloat one issue with N hidden ACs because
-  decomposition is hard.
-- **Single-task ambiguity** (request is large but cohesive — one
-  feature, one surface, one PR): keep it as a single task, even if it
-  has many ACs.
+- **Obvious split**: auto-create epic + children, report structure.
+- **Ambiguous split**: ask once — "Looks like N sub-tasks: A/B/C/D —
+  create as children of epic #N?"
+- **Cohesive but large**: keep as single task.
 
-**Never silently swallow scope.** When in doubt, propose the epic
-shape; let Kevin approve or reshape it. A rejected proposal costs
-seconds; a hidden 8-AC issue costs days.
+Never silently swallow scope.
 
 ## Prioritization framework
 
@@ -2366,9 +2307,8 @@ Sync the index on the local backend; use \`gh issue edit\` on GitHub.
 
 ### \`/backlog estimate <id>\`
 
-Detailed complexity estimate with a sub-task breakdown. If the breakdown
-exceeds one task's worth of work, propose splitting into an epic with
-explicit sub-tasks (offer to create them).
+Detailed complexity estimate. If the work exceeds one task, apply the
+"Epic detection heuristic" above.
 
 ### \`/backlog status\`
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3785,21 +3785,61 @@ cat "\${matches[0]}"
     suffix: "add.sh",
     content: `#!/usr/bin/env bash
 # Add a new backlog item. Auto-numbers + slugifies. Status starts at "Backlog".
-# Usage: add.sh "<title>" [body]
+# Optional \`--parent <num>\` flag turns the new item into a sub-task of an
+# existing parent (writes \`parent: "#NNN"\` into frontmatter and cross-links
+# the parent file under a \`## Sub-tasks\` section).
+#
+# Usage:
+#   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
-if [ "\$#" -lt 1 ]; then
-  echo 'usage: add.sh "<title>" [body]' >&2
+PARENT=""
+ARGS=()
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --parent)
+      if [ \$# -lt 2 ]; then
+        echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
+        exit 2
+      fi
+      PARENT="\$2"
+      shift 2
+      ;;
+    *)
+      ARGS+=("\$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "\${#ARGS[@]}" -lt 1 ]; then
+  echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
   exit 2
 fi
-TITLE="\$1"
-BODY="\${2:-}"
+TITLE="\${ARGS[0]}"
+BODY="\${ARGS[1]:-}"
 
 ROOT="\$(cd "\$(dirname "\$0")/../../.." && pwd)"
 BACKLOG_DIR="\$ROOT/.specflow/backlog"
 INDEX="\$ROOT/.specflow/backlog.md"
 RENDER="\$(dirname "\$0")/render-index.sh"
 mkdir -p "\$BACKLOG_DIR"
+
+# When --parent is set, refuse to create a child of a non-existent parent.
+PARENT_FILE=""
+PARENT_PADDED=""
+if [ -n "\$PARENT" ]; then
+  PARENT_PADDED=\$(printf "%03d" "\$PARENT")
+  shopt -s nullglob
+  for candidate in "\$BACKLOG_DIR/\$PARENT_PADDED"-*.md; do
+    PARENT_FILE="\$candidate"
+    break
+  done
+  if [ -z "\$PARENT_FILE" ]; then
+    echo "✗ parent #\$PARENT_PADDED not found in \$BACKLOG_DIR" >&2
+    exit 3
+  fi
+fi
 
 # Next free number
 shopt -s nullglob
@@ -3818,7 +3858,27 @@ SLUG=\$(echo "\$TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; 
 FILE="\$BACKLOG_DIR/\$NEXT-\$SLUG.md"
 NOW=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-cat > "\$FILE" <<EOF
+if [ -n "\$PARENT" ]; then
+  cat > "\$FILE" <<EOF
+---
+number: \$NEXT
+title: \$TITLE
+status: Backlog
+size:
+priority:
+parent: "#\$PARENT_PADDED"
+created: \$NOW
+---
+
+\$BODY
+EOF
+  # Append a cross-link to the parent file under a \`## Sub-tasks\` section.
+  if ! grep -q "^## Sub-tasks\$" "\$PARENT_FILE"; then
+    printf '\\n## Sub-tasks\\n\\n' >> "\$PARENT_FILE"
+  fi
+  printf -- '- #%s — %s\\n' "\$NEXT" "\$TITLE" >> "\$PARENT_FILE"
+else
+  cat > "\$FILE" <<EOF
 ---
 number: \$NEXT
 title: \$TITLE
@@ -3830,12 +3890,16 @@ created: \$NOW
 
 \$BODY
 EOF
+fi
 
 # Regenerate the column-organised index from the file tree.
 bash "\$RENDER" "\$ROOT"
 
 echo "✓ created #\$NEXT — \$TITLE"
 echo "  \$FILE"
+if [ -n "\$PARENT" ]; then
+  echo "  ↳ child of #\$PARENT_PADDED — \$PARENT_FILE"
+fi
 `,
     executable: true,
     backend: "local",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -4739,35 +4739,66 @@ glab issue view "\$1" --repo "\$PROJECT_ID" --comments
     name: "add",
     suffix: "add.sh",
     content: `#!/usr/bin/env bash
-# Create a GitLab Issue with the Status::Backlog scoped label.
-# Usage: add.sh "<title>" [body] [labels-csv]
+# Create a GitLab Issue with the Status::Backlog scoped label. Optional
+# \`--parent <num>\` flag adds a \`parent::#NNN\` scoped label so the new
+# issue can be discovered as a child of an existing parent. (GitLab's
+# native Epics API is Premium-only; the scoped-label fallback works on
+# every tier and stays consistent with the existing Status::* pattern.)
+#
+# Usage:
+#   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
 # shellcheck source=./_config.sh
 . "\$(dirname "\$0")/_config.sh"
 
-if [ "\$#" -lt 1 ]; then
-  echo 'usage: add.sh "<title>" [body] [labels-csv]' >&2
+PARENT=""
+ARGS=()
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    --parent)
+      if [ \$# -lt 2 ]; then
+        echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+        exit 2
+      fi
+      PARENT="\$2"
+      shift 2
+      ;;
+    *)
+      ARGS+=("\$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "\${#ARGS[@]}" -lt 1 ]; then
+  echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
   exit 2
 fi
-TITLE="\$1"
-BODY="\${2:-}"
-EXTRA_LABELS="\${3:-}"
+TITLE="\${ARGS[0]}"
+BODY="\${ARGS[1]:-}"
+EXTRA_LABELS="\${ARGS[2]:-}"
 
 LABELS="Status::Backlog"
 if [ -n "\$EXTRA_LABELS" ]; then
   LABELS="\$LABELS,\$EXTRA_LABELS"
 fi
+if [ -n "\$PARENT" ]; then
+  LABELS="\$LABELS,parent::#\$PARENT"
+fi
 
-ARGS=(
+CREATE_ARGS=(
   "--repo" "\$PROJECT_ID"
   "--title" "\$TITLE"
   "--label" "\$LABELS"
   "--description" "\$BODY"
 )
 
-URL=\$(glab issue create "\${ARGS[@]}" 2>&1 | grep -oE 'https://[^ ]+' | head -1)
+URL=\$(glab issue create "\${CREATE_ARGS[@]}" 2>&1 | grep -oE 'https://[^ ]+' | head -1)
 echo "✓ created: \$URL"
+if [ -n "\$PARENT" ]; then
+  echo "✓ tagged parent::#\$PARENT (scoped label)"
+fi
 `,
     executable: true,
     backend: "gitlab",
@@ -4894,6 +4925,50 @@ ensure_label "dx"          "5319e7" "Developer experience (tooling, onboarding, 
 ensure_label "performance" "e99695" "Latency, throughput, or memory improvements"
 ensure_label "dependency"  "cccccc" "Dependency bump or vendoring"
 echo "done."
+`,
+    executable: true,
+    backend: "gitlab",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
+    name: "cascade-check",
+    suffix: "cascade-check.sh",
+    content: `#!/usr/bin/env bash
+# Verify that a parent issue is safe to close — every child tagged with
+# the \`parent::#NNN\` scoped label must already be closed. Refuses (exit
+# 11) otherwise so the PO can surface the open children and finish them
+# first.
+#
+# Usage:   cascade-check.sh <issue-number>
+# Exit:    0  parent has no open children — safe to close
+#          11 at least one child is still open — close blocked
+#          2  usage error
+set -euo pipefail
+
+# shellcheck source=./_config.sh
+. "\$(dirname "\$0")/_config.sh"
+
+if [ "\$#" -lt 1 ]; then
+  echo 'usage: cascade-check.sh <issue-number>' >&2
+  exit 2
+fi
+NUM="\$1"
+
+# Children carry a scoped label \`parent::#NNN\`. Ask glab for open issues
+# with that label; output is one issue per line on the standard format.
+OPEN=\$(glab issue list --repo "\$PROJECT_ID" \\
+  --label "parent::#\$NUM" --opened 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "\$OPEN" -gt 0 ]; then
+  echo "✗ #\$NUM has \$OPEN open child issue(s) — close them first"
+  glab issue list --repo "\$PROJECT_ID" --label "parent::#\$NUM" --opened 2>/dev/null \\
+    | sed 's/^/  /'
+  exit 11
+fi
+
+echo "✓ #\$NUM safe to close (no open children with parent::#\$NUM)"
+exit 0
 `,
     executable: true,
     backend: "gitlab",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3764,6 +3764,35 @@ The first time the PO runs against this project, it will create the 5
 \`In progress\`, \`In review\`, \`Done\`).
 <!-- END: backend=gitlab -->
 
+## Epics & sub-tasks
+
+Big work that needs decomposition lives as a parent **epic** with one or
+more **sub-tasks**. The link mechanism differs per backend, but the PO
+contract is the same: parents cannot close while any child is open.
+
+| Backend | Parent → child link | Discoverability |
+|---|---|---|
+| local | \`parent: "#NNN"\` in the child's frontmatter, plus a \`## Sub-tasks\` cross-link added to the parent file's body | \`grep -l 'parent: "#042"' .specflow/backlog/*.md\` lists every child of #042 |
+| github | Native sub-issues API (\`gh api -X POST .../issues/<parent>/sub_issues\`) | Project V2 boards render the children automatically under the parent's \`Sub-issues progress\` field |
+| gitlab | Scoped label \`parent::#NNN\` on the child (Free-tier compatible; native Epics are Premium-only) | \`glab issue list --label "parent::#042" --opened\` lists every child of #042 |
+
+**Creating a child:** \`add.sh --parent <num>\` does the right thing on
+every backend — writes the link, attaches to the project/board, and
+fails fast if the named parent doesn't exist (exit 3).
+
+**Closing a parent:** \`cascade-check.sh <num>\` (github + gitlab) is the
+close gate — exits 11 with the open children listed when close is
+unsafe, exits 0 when all children are closed. The PO must run it before
+\`gh issue close\` / \`glab issue close\`. The local backend uses an
+inline grep equivalent.
+
+**Auto-detection:** the bundled \`product-owner\` agent proactively
+detects epic-worthy requests (>5 AC bullets, scope crosses ≥2
+subsystems, trigger phrases like "break down" / "phased" / "as an
+epic") and either auto-decomposes or proposes a concrete sub-task list
+— see the "Epic detection heuristic" section in
+\`.claude/agents/product-owner.md\`.
+
 ## When NOT to use this skill
 
 - The user is implementing a backlog item — that's normal coding work;

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -111,65 +111,28 @@ An **epic** is a backlog item that owns one or more **sub-tasks**. The PO must
 be able to create them, reference them as a unit, and close the parent only
 when every child is closed.
 
-### On the GitHub backend
+### Creating sub-tasks (all backends)
 
-Use `add.sh --parent <num>` from the bundled backlog scripts. It wraps the
-native sub-issues API (beta) into a single command — creates the child,
-fetches its REST id, and POSTs to
-`repos/:owner/:repo/issues/<parent>/sub_issues`. Project V2 boards render
-the children automatically under the parent's `Sub-issues progress` field;
-no extra wiring needed. Reference docs:
-<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues>.
+Use `add.sh --parent <num>` — it does the right thing per backend:
 
-```bash
-# Create child as a sub-issue of parent #042
-.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
-```
+- **github**: creates the child + POSTs to `/issues/<parent>/sub_issues`
+  (native beta API). Project V2 renders children under the parent's
+  `Sub-issues progress` field automatically.
+- **gitlab**: tags the child with a `parent::#NNN` scoped label.
+  Native Epics are Premium-only; the scoped label works on every tier.
+- **local**: writes `parent: "#NNN"` into the child's frontmatter and
+  cross-links under a `## Sub-tasks` section in the parent file.
 
-For low-level inspection or unlinking:
-
-```bash
-gh api repos/:owner/:repo/issues/<PARENT>/sub_issues
-gh api -X DELETE repos/:owner/:repo/issues/<PARENT>/sub_issue \
-  -f sub_issue_id=<CHILD_REST_ID>
-```
-
-### On the GitLab backend
-
-GitLab native Epics are Premium-tier only. The bundled scripts use a
-**scoped-label fallback** that works on every tier (Free + Premium +
-Ultimate) and stays consistent with the existing `Status::*` pattern:
-
-- Children carry a `parent::#NNN` scoped label pointing at the parent.
-- `add.sh --parent <num>` adds it automatically alongside `Status::Backlog`.
-- `cascade-check.sh <num>` lists open children via `glab issue list --label
-  "parent::#NNN" --opened` and refuses (exit 11) if any remain.
-
-```bash
-# Create child as a sub-issue of parent #042
-.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
-```
-
-### On the local Markdown backend
-
-A sub-task is an ordinary task file with `parent: "#NNN"` in its frontmatter,
-where `NNN` is the parent's local id. The parent itself is a normal task — no
-flag needed; it becomes an "epic" by virtue of having children.
-
-Use `add.sh --parent <num>` to scaffold a child: it writes the `parent` key
-into the new file's frontmatter and appends a cross-link under a `## Sub-tasks`
-section in the parent file. The index (`.specflow/backlog.md`) is regenerated
-automatically.
+Fails fast (exit 3) if the parent doesn't exist.
 
 ### Closing rules (all three backends)
 
 - **Sub-task**: close directly. No cascade to siblings or parent.
-- **Parent / epic**: every child must close first; refuse otherwise. The
-  bundled `cascade-check.sh <num>` is the close gate on github + gitlab —
-  exits 11 with the open children listed when close is unsafe, exits 0
-  when safe. The PO MUST run it before `gh issue close` / `glab issue close`.
-  On the local backend, `grep -l 'parent: "#NNN"' .specflow/backlog/*.md`
-  followed by a status check is the equivalent.
+- **Parent / epic**: every child must close first. Run
+  `cascade-check.sh <num>` (github + gitlab) before `gh issue close` /
+  `glab issue close` — exit 11 means open children block close, 0 means
+  safe. On local, `grep -l 'parent: "#NNN"' .specflow/backlog/*.md` is
+  the equivalent check.
 - **Cancel epic**: close parent + every child as `not_planned` in one batch.
 - **Two-step close on GitHub / GitLab**: `gh issue close` (and `glab issue
   close`) do NOT update the Project V2 Status field / GitLab scoped Status
@@ -187,41 +150,19 @@ automatically.
 
 ### Epic detection heuristic
 
-The PO must **proactively detect** when a request is too big for one task
-and propose breaking it into an epic + sub-tasks — Kevin shouldn't have to
-ask. Apply the heuristic on every `/backlog add` and on every grooming
-pass over Backlog-column items:
+Propose epic decomposition on every `/backlog add` and during grooming.
 
-**Trigger phrases in the title or body** — "break down", "into tasks",
-"phased", "as an epic", "rewrite", "end-to-end", "across the stack",
-"multi-step", "first land X, then Y, then Z".
-
-**Structural triggers:**
-
-- More than 5 distinct `## Acceptance criteria` bullets, OR
-- Scope crosses ≥2 subsystems (e.g. CLI + docs + tests; or three
-  different backends), OR
-- Estimated complexity > 5 story points (or `Size: L` / `Size: XL` on
-  the github backend's native field).
+**Triggers:** phrases like "break down", "phased", "rewrite",
+"end-to-end"; >5 AC bullets; scope crosses ≥2 subsystems; size L/XL.
 
 **Behavior:**
 
-- **Obvious decomposition** (clear functional split visible in the body —
-  e.g. "wire X across github + gitlab + local" naturally splits into 3
-  per-backend children): auto-create the epic + children, report the
-  structure back ("Created epic #N with children #N+1, #N+2, #N+3").
-- **Ambiguous decomposition** (request is large but the split isn't
-  obvious): ask Kevin once with a concrete proposal — "Looks like 4
-  sub-tasks: A / B / C / D — create as children of new epic #N, or
-  refine first?" Never bloat one issue with N hidden ACs because
-  decomposition is hard.
-- **Single-task ambiguity** (request is large but cohesive — one
-  feature, one surface, one PR): keep it as a single task, even if it
-  has many ACs.
+- **Obvious split**: auto-create epic + children, report structure.
+- **Ambiguous split**: ask once — "Looks like N sub-tasks: A/B/C/D —
+  create as children of epic #N?"
+- **Cohesive but large**: keep as single task.
 
-**Never silently swallow scope.** When in doubt, propose the epic
-shape; let Kevin approve or reshape it. A rejected proposal costs
-seconds; a hidden 8-AC issue costs days.
+Never silently swallow scope.
 
 ## Prioritization framework
 
@@ -299,9 +240,8 @@ Sync the index on the local backend; use `gh issue edit` on GitHub.
 
 ### `/backlog estimate <id>`
 
-Detailed complexity estimate with a sub-task breakdown. If the breakdown
-exceeds one task's worth of work, propose splitting into an epic with
-explicit sub-tasks (offer to create them).
+Detailed complexity estimate. If the work exceeds one task, apply the
+"Epic detection heuristic" above.
 
 ### `/backlog status`
 

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -113,29 +113,41 @@ when every child is closed.
 
 ### On the GitHub backend
 
-Use the GitHub native sub-issues API (currently in beta). Reference docs:
+Use `add.sh --parent <num>` from the bundled backlog scripts. It wraps the
+native sub-issues API (beta) into a single command — creates the child,
+fetches its REST id, and POSTs to
+`repos/:owner/:repo/issues/<parent>/sub_issues`. Project V2 boards render
+the children automatically under the parent's `Sub-issues progress` field;
+no extra wiring needed. Reference docs:
 <https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues>.
 
-Create a sub-issue from an existing parent (the parent must already exist):
-
 ```bash
-# Step 1 — create the child issue normally
-CHILD=$(gh issue create --title "<child title>" --body "<child body>" --json number --jq '.number')
-
-# Step 2 — fetch the child's node id (REST id, not issue number)
-CHILD_ID=$(gh api repos/:owner/:repo/issues/$CHILD --jq '.id')
-
-# Step 3 — link it under the parent
-gh api -X POST repos/:owner/:repo/issues/<PARENT_NUMBER>/sub_issues \
-  -f sub_issue_id=$CHILD_ID
+# Create child as a sub-issue of parent #042
+.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
 ```
 
-List, reorder, or unlink sub-issues:
+For low-level inspection or unlinking:
 
 ```bash
 gh api repos/:owner/:repo/issues/<PARENT>/sub_issues
 gh api -X DELETE repos/:owner/:repo/issues/<PARENT>/sub_issue \
   -f sub_issue_id=<CHILD_REST_ID>
+```
+
+### On the GitLab backend
+
+GitLab native Epics are Premium-tier only. The bundled scripts use a
+**scoped-label fallback** that works on every tier (Free + Premium +
+Ultimate) and stays consistent with the existing `Status::*` pattern:
+
+- Children carry a `parent::#NNN` scoped label pointing at the parent.
+- `add.sh --parent <num>` adds it automatically alongside `Status::Backlog`.
+- `cascade-check.sh <num>` lists open children via `glab issue list --label
+  "parent::#NNN" --opened` and refuses (exit 11) if any remain.
+
+```bash
+# Create child as a sub-issue of parent #042
+.specflow/scripts/backlog/add.sh "Child title" "Child body" "" --parent 42
 ```
 
 ### On the local Markdown backend
@@ -144,15 +156,20 @@ A sub-task is an ordinary task file with `parent: "#NNN"` in its frontmatter,
 where `NNN` is the parent's local id. The parent itself is a normal task — no
 flag needed; it becomes an "epic" by virtue of having children.
 
-To create a sub-task: scaffold the new file as usual, then set its `parent`
-key. Update both the parent's task file (cross-link in the body) and the
-backlog index (`.specflow/backlog.md`) so the relationship is visible at a
-glance.
+Use `add.sh --parent <num>` to scaffold a child: it writes the `parent` key
+into the new file's frontmatter and appends a cross-link under a `## Sub-tasks`
+section in the parent file. The index (`.specflow/backlog.md`) is regenerated
+automatically.
 
-### Closing rules (both backends)
+### Closing rules (all three backends)
 
 - **Sub-task**: close directly. No cascade to siblings or parent.
-- **Parent / epic**: every child must close first; refuse otherwise.
+- **Parent / epic**: every child must close first; refuse otherwise. The
+  bundled `cascade-check.sh <num>` is the close gate on github + gitlab —
+  exits 11 with the open children listed when close is unsafe, exits 0
+  when safe. The PO MUST run it before `gh issue close` / `glab issue close`.
+  On the local backend, `grep -l 'parent: "#NNN"' .specflow/backlog/*.md`
+  followed by a status check is the equivalent.
 - **Cancel epic**: close parent + every child as `not_planned` in one batch.
 - **Two-step close on GitHub / GitLab**: `gh issue close` (and `glab issue
   close`) do NOT update the Project V2 Status field / GitLab scoped Status
@@ -167,6 +184,44 @@ glance.
   issue is `CLOSED`, or `OPEN` with a merged PR linked → `move.sh <num>
   Done`. Mirror for `Done` items whose issue is REOPENED. Idempotent;
   safe after every release or via `/loop 1d`.
+
+### Epic detection heuristic
+
+The PO must **proactively detect** when a request is too big for one task
+and propose breaking it into an epic + sub-tasks — Kevin shouldn't have to
+ask. Apply the heuristic on every `/backlog add` and on every grooming
+pass over Backlog-column items:
+
+**Trigger phrases in the title or body** — "break down", "into tasks",
+"phased", "as an epic", "rewrite", "end-to-end", "across the stack",
+"multi-step", "first land X, then Y, then Z".
+
+**Structural triggers:**
+
+- More than 5 distinct `## Acceptance criteria` bullets, OR
+- Scope crosses ≥2 subsystems (e.g. CLI + docs + tests; or three
+  different backends), OR
+- Estimated complexity > 5 story points (or `Size: L` / `Size: XL` on
+  the github backend's native field).
+
+**Behavior:**
+
+- **Obvious decomposition** (clear functional split visible in the body —
+  e.g. "wire X across github + gitlab + local" naturally splits into 3
+  per-backend children): auto-create the epic + children, report the
+  structure back ("Created epic #N with children #N+1, #N+2, #N+3").
+- **Ambiguous decomposition** (request is large but the split isn't
+  obvious): ask Kevin once with a concrete proposal — "Looks like 4
+  sub-tasks: A / B / C / D — create as children of new epic #N, or
+  refine first?" Never bloat one issue with N hidden ACs because
+  decomposition is hard.
+- **Single-task ambiguity** (request is large but cohesive — one
+  feature, one surface, one PR): keep it as a single task, even if it
+  has many ACs.
+
+**Never silently swallow scope.** When in doubt, propose the epic
+shape; let Kevin approve or reshape it. A rejected proposal costs
+seconds; a hidden 8-AC issue costs days.
 
 ## Prioritization framework
 

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -234,6 +234,35 @@ The first time the PO runs against this project, it will create the 5
 `In progress`, `In review`, `Done`).
 <!-- END: backend=gitlab -->
 
+## Epics & sub-tasks
+
+Big work that needs decomposition lives as a parent **epic** with one or
+more **sub-tasks**. The link mechanism differs per backend, but the PO
+contract is the same: parents cannot close while any child is open.
+
+| Backend | Parent → child link | Discoverability |
+|---|---|---|
+| local | `parent: "#NNN"` in the child's frontmatter, plus a `## Sub-tasks` cross-link added to the parent file's body | `grep -l 'parent: "#042"' .specflow/backlog/*.md` lists every child of #042 |
+| github | Native sub-issues API (`gh api -X POST .../issues/<parent>/sub_issues`) | Project V2 boards render the children automatically under the parent's `Sub-issues progress` field |
+| gitlab | Scoped label `parent::#NNN` on the child (Free-tier compatible; native Epics are Premium-only) | `glab issue list --label "parent::#042" --opened` lists every child of #042 |
+
+**Creating a child:** `add.sh --parent <num>` does the right thing on
+every backend — writes the link, attaches to the project/board, and
+fails fast if the named parent doesn't exist (exit 3).
+
+**Closing a parent:** `cascade-check.sh <num>` (github + gitlab) is the
+close gate — exits 11 with the open children listed when close is
+unsafe, exits 0 when all children are closed. The PO must run it before
+`gh issue close` / `glab issue close`. The local backend uses an
+inline grep equivalent.
+
+**Auto-detection:** the bundled `product-owner` agent proactively
+detects epic-worthy requests (>5 AC bullets, scope crosses ≥2
+subsystems, trigger phrases like "break down" / "phased" / "as an
+epic") and either auto-decomposes or proposes a concrete sub-task list
+— see the "Epic detection heuristic" section in
+`.claude/agents/product-owner.md`.
+
 ## When NOT to use this skill
 
 - The user is implementing a backlog item — that's normal coding work;

--- a/templates/core/skills/backlog/scripts/github/add.sh
+++ b/templates/core/skills/backlog/scripts/github/add.sh
@@ -1,26 +1,69 @@
 #!/usr/bin/env bash
-# Create a GitHub Issue and attach it to the configured Project.
-# Usage: add.sh "<title>" [body] [labels-csv]
+# Create a GitHub Issue and attach it to the configured Project. Optional
+# `--parent <num>` flag links the new issue as a sub-issue of an existing
+# parent via GitHub's native `/sub_issues` REST endpoint (beta).
+#
+# Usage:
+#   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
 # shellcheck source=./_config.sh
 . "$(dirname "$0")/_config.sh"
 
-if [ "$#" -lt 1 ]; then
-  echo 'usage: add.sh "<title>" [body] [labels-csv]' >&2
+PARENT=""
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --parent)
+      if [ $# -lt 2 ]; then
+        echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+        exit 2
+      fi
+      PARENT="$2"
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#ARGS[@]}" -lt 1 ]; then
+  echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
   exit 2
 fi
-TITLE="$1"
-BODY="${2:-}"
-LABELS="${3:-}"
+TITLE="${ARGS[0]}"
+BODY="${ARGS[1]:-}"
+LABELS="${ARGS[2]:-}"
 
-ARGS=("--repo" "$REPO" "--title" "$TITLE")
-if [ -n "$BODY" ]; then ARGS+=("--body" "$BODY"); else ARGS+=("--body" ""); fi
-if [ -n "$LABELS" ]; then ARGS+=("--label" "$LABELS"); fi
+# When --parent is set, fail fast if the parent issue doesn't exist —
+# GitHub's sub_issues POST returns a confusing 404 otherwise.
+if [ -n "$PARENT" ]; then
+  if ! gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PARENT" --jq '.number' >/dev/null 2>&1; then
+    echo "✗ parent issue #$PARENT not found in $REPO_OWNER/$REPO_NAME" >&2
+    exit 3
+  fi
+fi
 
-URL=$(gh issue create "${ARGS[@]}")
+CREATE_ARGS=("--repo" "$REPO" "--title" "$TITLE")
+if [ -n "$BODY" ]; then CREATE_ARGS+=("--body" "$BODY"); else CREATE_ARGS+=("--body" ""); fi
+if [ -n "$LABELS" ]; then CREATE_ARGS+=("--label" "$LABELS"); fi
+
+URL=$(gh issue create "${CREATE_ARGS[@]}")
 echo "✓ created: $URL"
 
 # Attach to the project
 gh project item-add "$PROJECT_NUMBER" --owner "$REPO_OWNER" --url "$URL" >/dev/null
 echo "✓ attached to Project #$PROJECT_NUMBER"
+
+# Link as a sub-issue if --parent was given. Two-step: extract the new
+# issue's REST id (NOT its number — sub_issues is keyed by id), then POST
+# to the parent's /sub_issues endpoint.
+if [ -n "$PARENT" ]; then
+  CHILD_NUM="${URL##*/}"
+  CHILD_ID=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$CHILD_NUM" --jq '.id')
+  gh api -X POST "repos/$REPO_OWNER/$REPO_NAME/issues/$PARENT/sub_issues" \
+    -F sub_issue_id="$CHILD_ID" >/dev/null
+  echo "✓ linked as sub-issue of #$PARENT"
+fi

--- a/templates/core/skills/backlog/scripts/github/cascade-check.sh
+++ b/templates/core/skills/backlog/scripts/github/cascade-check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verify that a parent issue is safe to close — every linked sub-issue
+# must already be closed. Refuses (exit 11) otherwise so the PO can
+# surface the open children and finish them first.
+#
+# Usage:   cascade-check.sh <issue-number>
+# Exit:    0  parent has no open children — safe to close
+#          11 at least one child is still open — close blocked
+#          2  usage error
+#          3  parent issue does not exist
+set -euo pipefail
+
+# shellcheck source=./_config.sh
+. "$(dirname "$0")/_config.sh"
+
+if [ "$#" -lt 1 ]; then
+  echo 'usage: cascade-check.sh <issue-number>' >&2
+  exit 2
+fi
+NUM="$1"
+
+if ! gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$NUM" --jq '.number' >/dev/null 2>&1; then
+  echo "✗ issue #$NUM not found in $REPO_OWNER/$REPO_NAME" >&2
+  exit 3
+fi
+
+# Native sub-issues endpoint (beta). Returns [] when no children exist.
+OPEN=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$NUM/sub_issues" \
+  --jq '[.[] | select(.state=="open")] | length' 2>/dev/null || echo 0)
+
+if [ "$OPEN" -gt 0 ]; then
+  echo "✗ #$NUM has $OPEN open child issue(s) — close them first"
+  gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$NUM/sub_issues" \
+    --jq '.[] | select(.state=="open") | "  - #\(.number) — \(.title)"'
+  exit 11
+fi
+
+echo "✓ #$NUM safe to close (no open children)"
+exit 0

--- a/templates/core/skills/backlog/scripts/gitlab/add.sh
+++ b/templates/core/skills/backlog/scripts/gitlab/add.sh
@@ -1,30 +1,61 @@
 #!/usr/bin/env bash
-# Create a GitLab Issue with the Status::Backlog scoped label.
-# Usage: add.sh "<title>" [body] [labels-csv]
+# Create a GitLab Issue with the Status::Backlog scoped label. Optional
+# `--parent <num>` flag adds a `parent::#NNN` scoped label so the new
+# issue can be discovered as a child of an existing parent. (GitLab's
+# native Epics API is Premium-only; the scoped-label fallback works on
+# every tier and stays consistent with the existing Status::* pattern.)
+#
+# Usage:
+#   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
 # shellcheck source=./_config.sh
 . "$(dirname "$0")/_config.sh"
 
-if [ "$#" -lt 1 ]; then
-  echo 'usage: add.sh "<title>" [body] [labels-csv]' >&2
+PARENT=""
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --parent)
+      if [ $# -lt 2 ]; then
+        echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+        exit 2
+      fi
+      PARENT="$2"
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#ARGS[@]}" -lt 1 ]; then
+  echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
   exit 2
 fi
-TITLE="$1"
-BODY="${2:-}"
-EXTRA_LABELS="${3:-}"
+TITLE="${ARGS[0]}"
+BODY="${ARGS[1]:-}"
+EXTRA_LABELS="${ARGS[2]:-}"
 
 LABELS="Status::Backlog"
 if [ -n "$EXTRA_LABELS" ]; then
   LABELS="$LABELS,$EXTRA_LABELS"
 fi
+if [ -n "$PARENT" ]; then
+  LABELS="$LABELS,parent::#$PARENT"
+fi
 
-ARGS=(
+CREATE_ARGS=(
   "--repo" "$PROJECT_ID"
   "--title" "$TITLE"
   "--label" "$LABELS"
   "--description" "$BODY"
 )
 
-URL=$(glab issue create "${ARGS[@]}" 2>&1 | grep -oE 'https://[^ ]+' | head -1)
+URL=$(glab issue create "${CREATE_ARGS[@]}" 2>&1 | grep -oE 'https://[^ ]+' | head -1)
 echo "✓ created: $URL"
+if [ -n "$PARENT" ]; then
+  echo "✓ tagged parent::#$PARENT (scoped label)"
+fi

--- a/templates/core/skills/backlog/scripts/gitlab/cascade-check.sh
+++ b/templates/core/skills/backlog/scripts/gitlab/cascade-check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Verify that a parent issue is safe to close — every child tagged with
+# the `parent::#NNN` scoped label must already be closed. Refuses (exit
+# 11) otherwise so the PO can surface the open children and finish them
+# first.
+#
+# Usage:   cascade-check.sh <issue-number>
+# Exit:    0  parent has no open children — safe to close
+#          11 at least one child is still open — close blocked
+#          2  usage error
+set -euo pipefail
+
+# shellcheck source=./_config.sh
+. "$(dirname "$0")/_config.sh"
+
+if [ "$#" -lt 1 ]; then
+  echo 'usage: cascade-check.sh <issue-number>' >&2
+  exit 2
+fi
+NUM="$1"
+
+# Children carry a scoped label `parent::#NNN`. Ask glab for open issues
+# with that label; output is one issue per line on the standard format.
+OPEN=$(glab issue list --repo "$PROJECT_ID" \
+  --label "parent::#$NUM" --opened 2>/dev/null | wc -l | tr -d ' ')
+
+if [ "$OPEN" -gt 0 ]; then
+  echo "✗ #$NUM has $OPEN open child issue(s) — close them first"
+  glab issue list --repo "$PROJECT_ID" --label "parent::#$NUM" --opened 2>/dev/null \
+    | sed 's/^/  /'
+  exit 11
+fi
+
+echo "✓ #$NUM safe to close (no open children with parent::#$NUM)"
+exit 0

--- a/templates/core/skills/backlog/scripts/local/add.sh
+++ b/templates/core/skills/backlog/scripts/local/add.sh
@@ -1,20 +1,60 @@
 #!/usr/bin/env bash
 # Add a new backlog item. Auto-numbers + slugifies. Status starts at "Backlog".
-# Usage: add.sh "<title>" [body]
+# Optional `--parent <num>` flag turns the new item into a sub-task of an
+# existing parent (writes `parent: "#NNN"` into frontmatter and cross-links
+# the parent file under a `## Sub-tasks` section).
+#
+# Usage:
+#   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
-if [ "$#" -lt 1 ]; then
-  echo 'usage: add.sh "<title>" [body]' >&2
+PARENT=""
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --parent)
+      if [ $# -lt 2 ]; then
+        echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
+        exit 2
+      fi
+      PARENT="$2"
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#ARGS[@]}" -lt 1 ]; then
+  echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
   exit 2
 fi
-TITLE="$1"
-BODY="${2:-}"
+TITLE="${ARGS[0]}"
+BODY="${ARGS[1]:-}"
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 BACKLOG_DIR="$ROOT/.specflow/backlog"
 INDEX="$ROOT/.specflow/backlog.md"
 RENDER="$(dirname "$0")/render-index.sh"
 mkdir -p "$BACKLOG_DIR"
+
+# When --parent is set, refuse to create a child of a non-existent parent.
+PARENT_FILE=""
+PARENT_PADDED=""
+if [ -n "$PARENT" ]; then
+  PARENT_PADDED=$(printf "%03d" "$PARENT")
+  shopt -s nullglob
+  for candidate in "$BACKLOG_DIR/$PARENT_PADDED"-*.md; do
+    PARENT_FILE="$candidate"
+    break
+  done
+  if [ -z "$PARENT_FILE" ]; then
+    echo "✗ parent #$PARENT_PADDED not found in $BACKLOG_DIR" >&2
+    exit 3
+  fi
+fi
 
 # Next free number
 shopt -s nullglob
@@ -33,7 +73,27 @@ SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/
 FILE="$BACKLOG_DIR/$NEXT-$SLUG.md"
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-cat > "$FILE" <<EOF
+if [ -n "$PARENT" ]; then
+  cat > "$FILE" <<EOF
+---
+number: $NEXT
+title: $TITLE
+status: Backlog
+size:
+priority:
+parent: "#$PARENT_PADDED"
+created: $NOW
+---
+
+$BODY
+EOF
+  # Append a cross-link to the parent file under a `## Sub-tasks` section.
+  if ! grep -q "^## Sub-tasks$" "$PARENT_FILE"; then
+    printf '\n## Sub-tasks\n\n' >> "$PARENT_FILE"
+  fi
+  printf -- '- #%s — %s\n' "$NEXT" "$TITLE" >> "$PARENT_FILE"
+else
+  cat > "$FILE" <<EOF
 ---
 number: $NEXT
 title: $TITLE
@@ -45,9 +105,13 @@ created: $NOW
 
 $BODY
 EOF
+fi
 
 # Regenerate the column-organised index from the file tree.
 bash "$RENDER" "$ROOT"
 
 echo "✓ created #$NEXT — $TITLE"
 echo "  $FILE"
+if [ -n "$PARENT" ]; then
+  echo "  ↳ child of #$PARENT_PADDED — $PARENT_FILE"
+fi

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -51,6 +51,7 @@
     { "category": "backlog-script", "name": "detect-fields", "suffix": "detect-fields.sh", "source": "core/skills/backlog/scripts/github/detect-fields.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "set-field", "suffix": "set-field.sh", "source": "core/skills/backlog/scripts/github/set-field.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "ensure-labels", "suffix": "ensure-labels.sh", "source": "core/skills/backlog/scripts/github/ensure-labels.sh", "executable": true, "backend": "github" },
+    { "category": "backlog-script", "name": "cascade-check", "suffix": "cascade-check.sh", "source": "core/skills/backlog/scripts/github/cascade-check.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "_config", "suffix": "_config.sh", "source": "core/skills/backlog/scripts/gitlab/_config.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/gitlab/list.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "view", "suffix": "view.sh", "source": "core/skills/backlog/scripts/gitlab/view.sh", "executable": true, "backend": "gitlab" },

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -59,6 +59,7 @@
     { "category": "backlog-script", "name": "move", "suffix": "move.sh", "source": "core/skills/backlog/scripts/gitlab/move.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "clarify-comment", "suffix": "clarify-comment.sh", "source": "core/skills/backlog/scripts/gitlab/clarify-comment.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "ensure-labels", "suffix": "ensure-labels.sh", "source": "core/skills/backlog/scripts/gitlab/ensure-labels.sh", "executable": true, "backend": "gitlab" },
+    { "category": "backlog-script", "name": "cascade-check", "suffix": "cascade-check.sh", "source": "core/skills/backlog/scripts/gitlab/cascade-check.sh", "executable": true, "backend": "gitlab" },
 
     { "category": "spec-root", "name": "specify", "suffix": "memory/constitution.md", "source": "core/specflow/memory/constitution.md", "skipIfExists": true },
     { "category": "spec-root", "name": "specify", "suffix": "backlog.md", "source": "core/specflow/backlog.md" },

--- a/tests/helpers/parent_link.ts
+++ b/tests/helpers/parent_link.ts
@@ -1,0 +1,78 @@
+// Pure helpers for inspecting and emitting the parent/child link
+// convention used by the local Markdown backlog backend.
+//
+// The local scripts (`add.sh --parent <num>`, `cascade-check`-style
+// queries, future tooling) write `parent: "#NNN"` into the frontmatter
+// of a child task. These helpers mirror that convention so unit tests
+// can verify shell-script output without re-implementing parsing.
+//
+// Convention:
+//   parent: "#NNN"   — child of issue NNN
+//   parent: null     — top-level (or omit the key entirely)
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/;
+const PARENT_RE = /^parent:\s*(?:"#(\d+)"|#?(\d+))\s*$/m;
+
+/**
+ * Extract the parent issue number from a task file's content.
+ *
+ * Returns the parent number as a string (preserving zero-padding when
+ * the source value used it) or `null` when the task has no parent —
+ * either the key is absent, the value is the literal `null`, the
+ * frontmatter is malformed, or the file is empty.
+ *
+ * Only the first `parent:` line inside the frontmatter wins; lines
+ * outside the frontmatter fences are ignored.
+ */
+export function extractParent(content: string): string | null {
+  if (!content) return null;
+  const fmMatch = FRONTMATTER_RE.exec(content);
+  if (!fmMatch) return null;
+  const fm = fmMatch[1];
+  const m = PARENT_RE.exec(fm);
+  if (!m) return null;
+  return m[1] ?? m[2] ?? null;
+}
+
+/**
+ * Emit the canonical `parent: "#NNN"` frontmatter line for a given
+ * parent issue number. Numbers below 1000 are zero-padded to 3 digits
+ * to match the auto-numbering convention used by `add.sh`.
+ *
+ * Throws on non-positive integers — `parent: "#000"` and `parent: "#-1"`
+ * are nonsense in this convention.
+ */
+export function formatParentFrontmatter(num: number): string {
+  if (!Number.isInteger(num) || num < 1) {
+    throw new Error(`parent number must be a positive integer, got ${num}`);
+  }
+  const padded = num < 1000 ? String(num).padStart(3, "0") : String(num);
+  return `parent: "#${padded}"`;
+}
+
+/**
+ * Walk a backlog directory and return the absolute paths of every
+ * `.md` task file whose frontmatter declares the given parent number.
+ *
+ * Result is sorted by directory listing order (typically file-name
+ * alphabetical, which mirrors task-number order). Non-`.md` files are
+ * ignored, as are files without a recognisable `parent:` line.
+ */
+export async function findChildren(
+  dir: string,
+  parentNum: string,
+): Promise<string[]> {
+  const target = parentNum.replace(/^#/, "");
+  const out: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (!entry.isFile || !entry.name.endsWith(".md")) continue;
+    const path = `${dir}/${entry.name}`;
+    const content = await Deno.readTextFile(path);
+    const found = extractParent(content);
+    if (found === null) continue;
+    if (found === target || found.replace(/^0+/, "") === target.replace(/^0+/, "")) {
+      out.push(path);
+    }
+  }
+  return out.sort();
+}

--- a/tests/scripts/parent_link_test.ts
+++ b/tests/scripts/parent_link_test.ts
@@ -1,0 +1,143 @@
+import { assert, assertEquals } from "@std/assert";
+import { extractParent, findChildren, formatParentFrontmatter } from "../helpers/parent_link.ts";
+
+Deno.test("extractParent returns the zero-padded number from #NNN", () => {
+  const fm = `---
+number: 003
+title: Subtask of 1
+status: Backlog
+parent: "#001"
+---
+
+body`;
+  assertEquals(extractParent(fm), "001");
+});
+
+Deno.test("extractParent handles unquoted #NNN", () => {
+  const fm = `---
+parent: #042
+---`;
+  assertEquals(extractParent(fm), "042");
+});
+
+Deno.test("extractParent returns null when key is missing", () => {
+  const fm = `---
+number: 001
+title: Top-level
+---`;
+  assertEquals(extractParent(fm), null);
+});
+
+Deno.test("extractParent returns null when value is null literal", () => {
+  const fm = `---
+parent: null
+---`;
+  assertEquals(extractParent(fm), null);
+});
+
+Deno.test("extractParent returns null on empty string", () => {
+  assertEquals(extractParent(""), null);
+});
+
+Deno.test("extractParent returns null when frontmatter is malformed (no fences)", () => {
+  assertEquals(extractParent('parent: "#001"\nno fences'), null);
+});
+
+Deno.test("extractParent picks the first match when key appears twice", () => {
+  const fm = `---
+parent: "#001"
+parent: "#999"
+---`;
+  assertEquals(extractParent(fm), "001");
+});
+
+Deno.test("extractParent ignores parent: lines outside frontmatter", () => {
+  const fm = `---
+number: 003
+---
+
+This task is the parent: "#999" of nobody.`;
+  assertEquals(extractParent(fm), null);
+});
+
+Deno.test("formatParentFrontmatter zero-pads to 3 digits", () => {
+  assertEquals(formatParentFrontmatter(1), 'parent: "#001"');
+  assertEquals(formatParentFrontmatter(42), 'parent: "#042"');
+  assertEquals(formatParentFrontmatter(999), 'parent: "#999"');
+});
+
+Deno.test("formatParentFrontmatter preserves widths >=3 digits", () => {
+  assertEquals(formatParentFrontmatter(1000), 'parent: "#1000"');
+});
+
+Deno.test("formatParentFrontmatter throws on non-positive integers", () => {
+  let threw = false;
+  try {
+    formatParentFrontmatter(0);
+  } catch {
+    threw = true;
+  }
+  assert(threw, "expected throw on 0");
+});
+
+Deno.test("findChildren returns files whose frontmatter has parent: #NNN", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "parent-link-test-" });
+  try {
+    await Deno.writeTextFile(
+      `${dir}/001-parent.md`,
+      `---\nnumber: 001\ntitle: Parent\nstatus: Backlog\n---\n`,
+    );
+    await Deno.writeTextFile(
+      `${dir}/002-child-a.md`,
+      `---\nnumber: 002\ntitle: Child A\nstatus: Backlog\nparent: "#001"\n---\n`,
+    );
+    await Deno.writeTextFile(
+      `${dir}/003-child-b.md`,
+      `---\nnumber: 003\ntitle: Child B\nstatus: Ready\nparent: "#001"\n---\n`,
+    );
+    await Deno.writeTextFile(
+      `${dir}/004-unrelated.md`,
+      `---\nnumber: 004\ntitle: Unrelated\nstatus: Backlog\n---\n`,
+    );
+
+    const children = await findChildren(dir, "001");
+    assertEquals(children.sort(), [
+      `${dir}/002-child-a.md`,
+      `${dir}/003-child-b.md`,
+    ]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findChildren returns empty array when no children exist", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "parent-link-test-" });
+  try {
+    await Deno.writeTextFile(
+      `${dir}/001-parent.md`,
+      `---\nnumber: 001\ntitle: Parent\n---\n`,
+    );
+    const children = await findChildren(dir, "001");
+    assertEquals(children, []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findChildren ignores non-.md files", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "parent-link-test-" });
+  try {
+    await Deno.writeTextFile(
+      `${dir}/002-child.md`,
+      `---\nparent: "#001"\n---\n`,
+    );
+    await Deno.writeTextFile(
+      `${dir}/notes.txt`,
+      `---\nparent: "#001"\n---\n`,
+    );
+    const children = await findChildren(dir, "001");
+    assertEquals(children, [`${dir}/002-child.md`]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #180.

Wires epic / sub-task support across all three backlog backends, gives the Product Owner agent a heuristic to detect epic-worthy requests proactively, and protects the closing-cascade rule with tests. The audit that drove this ticket flagged 6 gaps; every one is covered below.

## Acceptance criteria

- [x] **PO-driven epic detection** — `templates/core/agents/product-owner.md` and `.claude/agents/product-owner.md` both gain an "Epic detection heuristic" section: triggers (phrases + structural rules), behavior (auto-decompose obvious / propose-with-list ambiguous / single-task cohesive), and the "never silently swallow scope" rule.
- [x] **GitHub backend scripts** — `add.sh --parent <num>` does the two-step create-then-link via `gh api -X POST .../sub_issues`. `cascade-check.sh <num>` queries `/sub_issues` and exits 11 when any child remains open.
- [x] **Local Markdown backend scripts** — `add.sh --parent <num>` writes `parent: "#NNN"` into the child's frontmatter, cross-links under a `## Sub-tasks` section in the parent file, and refuses (exit 3) when the parent doesn't exist.
- [x] **GitLab backend scripts** — `add.sh --parent <num>` adds a `parent::#NNN` scoped label (Free-tier compatible). `cascade-check.sh <num>` lists open children via `glab issue list --label "parent::#NNN" --opened`. PO doc covers the GitLab fallback rationale.
- [x] **Maintainer PO doc** (`.claude/agents/product-owner.md`) gained a parity "Epic / sub-task detection" section so the agent that owns Project #4 has the same capability the user-facing one does.
- [x] **SKILL.md** gained an "Epics & sub-tasks" section with a per-backend link mechanism table and pointers to `add.sh --parent` + `cascade-check.sh`.
- [x] **Smoke + unit tests** — 14 new pure-helper unit tests in `tests/scripts/parent_link_test.ts` (555 total, all green); new round-trip block in `smoke-backlog-local.sh`; new presence/wiring assertions in `smoke-backlog-github.sh`; new `smoke-backlog-gitlab.sh`; new PO/SKILL assertions in `smoke-features.sh`.

## Implementation notes

- **GitLab fallback chosen:** scoped label `parent::#NNN` rather than native Epics API. Native Epics are Premium-tier only; the scoped label works on every tier and stays consistent with the existing `Status::*` pattern.
- **Test surface:** extracted pure Deno helpers (`extractParent`, `formatParentFrontmatter`, `findChildren`) into `tests/helpers/parent_link.ts` — same pattern as `gh_issues_dedupe_test.ts`. Pure unit tests cover frontmatter parsing edge cases; smoke tests cover end-to-end shell behavior.
- **`cascade-check.sh` placement:** ships as a script (auditable, version-controlled, smoke-tested) rather than inline PO logic.
- **Windsurf 12000-char cap:** the PO doc grew significantly with the new heuristic + GitLab content. Trimmed back to 11877 chars to keep the bundled `.windsurf/workflows/specflow-agent-product-owner.md` under the cap. `plugin/agents/product-owner.md` re-synced byte-identical (enforced by the `plugin parity` test).

## Test plan

- [x] `deno task test` — 555/555 green (541 baseline + 14 new parent-link tests)
- [x] `smoke-features.sh` — PASSES with new heuristic + SKILL.md assertions
- [x] `smoke-backlog-local.sh` — PASSES with new `add --parent` round-trip
- [x] `smoke-backlog-github.sh` — PASSES with `cascade-check.sh` + `--parent` flag presence
- [x] `smoke-backlog-gitlab.sh` (NEW) — PASSES with `parent::#NNN` scoped label + cascade-check.sh
- [x] `smoke-hooks.sh` — PASSES (unchanged)
- [x] `smoke-picker.sh` — PASSES (unchanged)
- [x] `smoke-all-harnesses.sh` — PASSES across all 8 harnesses
- [ ] Manual QA against a live github project after release: parent → child round-trip via `add.sh --parent`, verify Project V2 board shows children under the parent's "Sub-issues progress" field, run `cascade-check.sh` against an open child + closed child to confirm exit codes.

## Out of scope (deferred)

- Sequential / parallel orchestration of sub-task execution (orchestration concern, not backlog).
- Story-point automation or AI-driven complexity estimation.
- Migrating existing flat backlog items into epics retroactively.