### PR TITLE
feat(specflow-auto): allow mid-chain re-entry from any phase (#182)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -170,6 +170,15 @@ check "SKILL.md describes the cascade-check close gate" \
   'grep -q "cascade-check.sh" .claude/skills/backlog/SKILL.md'
 
 echo
+echo "═══ #182  specflow-auto — mid-chain re-entry ═══"
+check "specflow-auto SKILL.md documents mid-chain re-entry" \
+  'grep -q "Mid-chain re-entry" .claude/skills/specflow-auto/SKILL.md'
+check "specflow-auto SKILL.md describes the --continue flag" \
+  'grep -q -- "--continue" .claude/skills/specflow-auto/SKILL.md'
+check "specflow-auto SKILL.md describes the --once flag" \
+  'grep -q -- "--once" .claude/skills/specflow-auto/SKILL.md'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL CHECKS PASSED ═══"
   exit 0

--- a/plugin/skills/specflow-auto/SKILL.md
+++ b/plugin/skills/specflow-auto/SKILL.md
@@ -70,12 +70,48 @@ If the user invokes `/specflow-auto specify --manual "<description>"`, run
 `/specflow specify` only and stop. Do not auto-chain. Each subsequent phase must
 be invoked manually by the user.
 
-## Single-phase invocations
+## Mid-chain re-entry
 
-When the user invokes any phase directly (e.g. `/specflow-auto clarify 042`,
-`/specflow-auto plan 042`) — i.e. NOT via the entry point `/specflow-auto specify` — the
-command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
-re-running phases on an existing feature.
+When the user invokes any phase other than `specify` directly (e.g.
+`/specflow-auto plan 042`, `/specflow-auto implement 042`), apply this
+context-aware default:
+
+- **Downstream artefacts missing** → chain. The user is resuming an
+  interrupted flow (long session, fresh shell after compaction, manual
+  review between early phases). Continue through the remaining phases →
+  STOP #2 with the same checkpoints as the entry-point flow.
+- **Downstream artefacts present** → one-shot. The user is re-running a
+  single phase (regenerate `plan.md` after a tweak, re-analyse after a
+  spec edit). Do NOT cascade.
+
+"Downstream artefacts" means files under `.specflow/specs/<feature>/`
+produced by phases AFTER the one being invoked:
+
+| Invoked phase | Downstream artefacts to check |
+|---|---|
+| `clarify`   | `plan.md`, `tasks.md` |
+| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
+| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
+| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
+| `implement` | a merged PR, a `review.md`, or task completion past 50% |
+| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
+
+If any listed artefact is present, infer one-shot intent. If all are
+absent, chain.
+
+### Explicit overrides
+
+- `/specflow-auto <phase> N --continue` — force the chain regardless of
+  artefact state. Useful when you want to regenerate a phase AND cascade
+  downstream work afterwards (e.g. tweak `plan.md`, then re-run
+  `tasks → analyze → implement → review` from scratch).
+- `/specflow-auto <phase> N --once` — force one-shot regardless. Useful
+  when downstream artefacts haven't been generated yet but you only
+  want to run this single phase right now (e.g. inspect the spec
+  before authorising the rest of the chain).
+
+The flags are mutually exclusive; the explicit form always wins over
+the artefact-detection default.
 
 ## Failure handling
 
@@ -89,5 +125,7 @@ re-running phases on an existing feature.
 ## Context budget
 
 Long features (≥13 story points or ≥30 tasks) may exhaust context during
-`/specflow implement`. If compaction occurs mid-chain, inform the user and let
-them resume manually from the last completed phase.
+`/specflow implement`. If compaction occurs mid-chain, inform the user and
+let them resume from a fresh session — the artefact-detection default in
+"Mid-chain re-entry" above will pick up where the previous run stopped, or
+they can pass `--continue` explicitly.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3438,12 +3438,48 @@ If the user invokes \`/specflow-auto specify --manual "<description>"\`, run
 \`/specflow specify\` only and stop. Do not auto-chain. Each subsequent phase must
 be invoked manually by the user.
 
-## Single-phase invocations
+## Mid-chain re-entry
 
-When the user invokes any phase directly (e.g. \`/specflow-auto clarify 042\`,
-\`/specflow-auto plan 042\`) — i.e. NOT via the entry point \`/specflow-auto specify\` — the
-command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
-re-running phases on an existing feature.
+When the user invokes any phase other than \`specify\` directly (e.g.
+\`/specflow-auto plan 042\`, \`/specflow-auto implement 042\`), apply this
+context-aware default:
+
+- **Downstream artefacts missing** → chain. The user is resuming an
+  interrupted flow (long session, fresh shell after compaction, manual
+  review between early phases). Continue through the remaining phases →
+  STOP #2 with the same checkpoints as the entry-point flow.
+- **Downstream artefacts present** → one-shot. The user is re-running a
+  single phase (regenerate \`plan.md\` after a tweak, re-analyse after a
+  spec edit). Do NOT cascade.
+
+"Downstream artefacts" means files under \`.specflow/specs/<feature>/\`
+produced by phases AFTER the one being invoked:
+
+| Invoked phase | Downstream artefacts to check |
+|---|---|
+| \`clarify\`   | \`plan.md\`, \`tasks.md\` |
+| \`plan\`      | \`tasks.md\`, \`data-model.md\`, \`contracts/\`, \`quickstart.md\` |
+| \`tasks\`     | \`tasks.md\` markings beyond the initial generation, or any task marked done |
+| \`analyze\`   | nothing (analyze is a read-only gate; treat as one-shot unless \`--continue\`) |
+| \`implement\` | a merged PR, a \`review.md\`, or task completion past 50% |
+| \`review\`    | nothing past review (chain-tail is just \`merge\`); treat as one-shot unless \`--continue\` |
+
+If any listed artefact is present, infer one-shot intent. If all are
+absent, chain.
+
+### Explicit overrides
+
+- \`/specflow-auto <phase> N --continue\` — force the chain regardless of
+  artefact state. Useful when you want to regenerate a phase AND cascade
+  downstream work afterwards (e.g. tweak \`plan.md\`, then re-run
+  \`tasks → analyze → implement → review\` from scratch).
+- \`/specflow-auto <phase> N --once\` — force one-shot regardless. Useful
+  when downstream artefacts haven't been generated yet but you only
+  want to run this single phase right now (e.g. inspect the spec
+  before authorising the rest of the chain).
+
+The flags are mutually exclusive; the explicit form always wins over
+the artefact-detection default.
 
 ## Failure handling
 
@@ -3457,8 +3493,10 @@ re-running phases on an existing feature.
 ## Context budget
 
 Long features (≥13 story points or ≥30 tasks) may exhaust context during
-\`/specflow implement\`. If compaction occurs mid-chain, inform the user and let
-them resume manually from the last completed phase.
+\`/specflow implement\`. If compaction occurs mid-chain, inform the user and
+let them resume from a fresh session — the artefact-detection default in
+"Mid-chain re-entry" above will pick up where the previous run stopped, or
+they can pass \`--continue\` explicitly.
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/specflow-auto/SKILL.md
+++ b/templates/core/skills/specflow-auto/SKILL.md
@@ -70,12 +70,48 @@ If the user invokes `/specflow-auto specify --manual "<description>"`, run
 `/specflow specify` only and stop. Do not auto-chain. Each subsequent phase must
 be invoked manually by the user.
 
-## Single-phase invocations
+## Mid-chain re-entry
 
-When the user invokes any phase directly (e.g. `/specflow-auto clarify 042`,
-`/specflow-auto plan 042`) — i.e. NOT via the entry point `/specflow-auto specify` — the
-command is one-shot. Do NOT auto-chain. Single-phase invocations exist for
-re-running phases on an existing feature.
+When the user invokes any phase other than `specify` directly (e.g.
+`/specflow-auto plan 042`, `/specflow-auto implement 042`), apply this
+context-aware default:
+
+- **Downstream artefacts missing** → chain. The user is resuming an
+  interrupted flow (long session, fresh shell after compaction, manual
+  review between early phases). Continue through the remaining phases →
+  STOP #2 with the same checkpoints as the entry-point flow.
+- **Downstream artefacts present** → one-shot. The user is re-running a
+  single phase (regenerate `plan.md` after a tweak, re-analyse after a
+  spec edit). Do NOT cascade.
+
+"Downstream artefacts" means files under `.specflow/specs/<feature>/`
+produced by phases AFTER the one being invoked:
+
+| Invoked phase | Downstream artefacts to check |
+|---|---|
+| `clarify`   | `plan.md`, `tasks.md` |
+| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
+| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
+| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
+| `implement` | a merged PR, a `review.md`, or task completion past 50% |
+| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
+
+If any listed artefact is present, infer one-shot intent. If all are
+absent, chain.
+
+### Explicit overrides
+
+- `/specflow-auto <phase> N --continue` — force the chain regardless of
+  artefact state. Useful when you want to regenerate a phase AND cascade
+  downstream work afterwards (e.g. tweak `plan.md`, then re-run
+  `tasks → analyze → implement → review` from scratch).
+- `/specflow-auto <phase> N --once` — force one-shot regardless. Useful
+  when downstream artefacts haven't been generated yet but you only
+  want to run this single phase right now (e.g. inspect the spec
+  before authorising the rest of the chain).
+
+The flags are mutually exclusive; the explicit form always wins over
+the artefact-detection default.
 
 ## Failure handling
 
@@ -89,5 +125,7 @@ re-running phases on an existing feature.
 ## Context budget
 
 Long features (≥13 story points or ≥30 tasks) may exhaust context during
-`/specflow implement`. If compaction occurs mid-chain, inform the user and let
-them resume manually from the last completed phase.
+`/specflow implement`. If compaction occurs mid-chain, inform the user and
+let them resume from a fresh session — the artefact-detection default in
+"Mid-chain re-entry" above will pick up where the previous run stopped, or
+they can pass `--continue` explicitly.


### PR DESCRIPTION
## Summary

Closes #182.

`/specflow-auto` no longer rejects mid-chain re-entry as one-shot. Two real workflows that today require typing 6 commands by hand are now first-class:

- **Manual-review workflow** — `/specflow-auto specify "..."` (writes spec.md, model stops), user reads + edits, then `/specflow-auto clarify N` and the chain resumes through `→ plan → tasks → analyze → implement → review → STOP #2` automatically.
- **Context-budget recovery** — fresh session after compaction, `/specflow-auto implement N` picks up the tail (`→ review → STOP #2`).

## Behavior

| Invocation | Behavior |
|---|---|
| `/specflow-auto specify "..."` | full chain (unchanged) |
| `/specflow-auto specify --manual "..."` | manual mode (unchanged) |
| `/specflow-auto <phase> N` | **context-aware**: chain if downstream artefacts missing, one-shot if any present |
| `/specflow-auto <phase> N --continue` | force chain regardless |
| `/specflow-auto <phase> N --once` | force one-shot regardless |

The SKILL.md includes a per-phase table mapping each invocation to the artefacts that would flag re-run intent, so the heuristic stays unambiguous.

## Test plan

- [x] `deno task test` — 555/555 green
- [x] `smoke-features.sh` — PASSES with new \`Mid-chain re-entry\` + \`--continue\` + \`--once\` assertions
- [x] Plugin parity test — `plugin/skills/specflow-auto/SKILL.md` byte-identical to templates copy
- [ ] Manual UX validation: in a sandbox project, run `/specflow-auto specify "test feature"`, let it stop after `spec.md` is written, then run `/specflow-auto clarify N` and confirm the chain resumes (no re-entry of `specify`).
- [ ] Manual UX validation: in the same project, run `/specflow-auto plan N` after artefacts exist; confirm one-shot behavior. Then re-run with `--continue` and confirm the chain cascades.

## Out of scope (per #182)

- Silent-gate semantics inside the chain (already working).
- Auto-chain after `merge` (intentionally terminal).
- Cross-feature chaining.

## Notes

Pure skill-prose change — no Deno or shell code, no schema migration. The skill is interpreted by the LLM session at runtime.