### PR TITLE
docs(llms): document /specflow-auto chain semantics + mid-chain re-entry

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -266,6 +266,45 @@ The generated `specify` skill chains `clarify → plan → tasks → analyze →
 in a single session. Upstream stops at every step and asks the human to invoke the next one.
 Specflow only stops twice: when clarification is genuinely required, and once before merging.
 
+The chain is invoked through the bundled `/specflow-auto` skill:
+
+```
+/specflow-auto specify "<feature description>"
+```
+
+Two checkpoints inside the chain:
+
+- **STOP #1 — clarify** runs after `clarify`. If `spec.md` still has `[NEEDS CLARIFICATION]`
+  markers, the model surfaces the top 3 questions and waits. Once you answer, the chain resumes
+  automatically. If there are no markers, the chain continues silently.
+- **STOP #2 — pre-merge** runs after `review`. The model summarises the work (files changed, tests,
+  open risks, business outcome) and asks `Ready to merge?` before invoking `merge`. Reply `yes` to
+  finish.
+
+To opt out of the chain entirely (run only `specify` and stop):
+
+```
+/specflow-auto specify --manual "<feature description>"
+```
+
+#### Mid-chain re-entry
+
+Any phase other than `specify` can also enter the chain when invoked through `/specflow-auto` —
+useful for two real workflows:
+
+- **Manual review between early phases** — read `spec.md` after `specify` lands, then
+  `/specflow-auto clarify N` resumes the chain through `plan → tasks → … → STOP #2`.
+- **Context-budget recovery** — open a fresh session after compaction and run
+  `/specflow-auto implement N` to pick up the tail (`→ review → STOP #2`).
+
+The default is **context-aware**: if downstream artefacts under `.specflow/specs/<feature>/` are
+missing, the chain fires; if they exist, the invocation is treated as a single-phase re-run (so
+regenerating `plan.md` doesn't accidentally cascade through the rest). Two explicit overrides when
+the default guesses wrong:
+
+- `/specflow-auto <phase> N --continue` — force the chain regardless of artefact state.
+- `/specflow-auto <phase> N --once` — force one-shot regardless.
+
 ### 2. `review` phase post-implement
 
 After `implement`, the generated workflow runs a dedicated `review` phase that checks structure


### PR DESCRIPTION
## Summary

Follow-up to #182. The implementation shipped in #183 / v1.1.21 but the public docs (`specflow.makerlabs.dev/llms.txt`) only mentioned `/specflow-auto` in passing — no coverage of the chain phases, STOP checkpoints, \`--manual\` opt-out, or the new mid-chain re-entry flow. Users had to read the bundled SKILL.md inside a scaffolded project to discover any of it.

## Changes

Expands the **Auto-chained pipeline** section (under "What makes Specflow different from upstream Spec Kit") with:

- Entry-point syntax — \`/specflow-auto specify "..."\`
- The two STOP checkpoints (clarify if markers remain, pre-merge summary)
- \`--manual\` opt-out for spec-only runs
- A new **Mid-chain re-entry** subsection covering:
  - the **context-aware default** (chain when downstream artefacts are missing, one-shot when they exist)
  - the explicit \`--continue\` and \`--once\` overrides
  - the two real workflows from #182 (manual review between early phases, context-budget recovery)

## Verification

- \`deno run scripts/build-docs.ts\` produces \`docs-dist/llms.txt\` containing all three new strings ("Mid-chain re-entry", \`--continue\`, \`--once\`).
- 555/555 unit tests still green (no logic touched).
- Docs site auto-redeploys on tag push via \`pages.yml\` — next release will surface this on \`specflow.makerlabs.dev\` automatically.

## Out of scope

- Backlog epic / sub-task documentation (the \`add.sh --parent\` flag, \`cascade-check.sh\`, the per-backend link mechanism table) — also missing from \`llms.md\` as of v1.1.20 / v1.1.21. Worth a follow-up but not folded in here to keep this PR scoped to #182.