### PR TITLE
ci(docs): add docs-check gate + bake docs-upkeep into PO close-step

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -49,6 +49,19 @@ You exclusively control:
   PR merge, close as `not_planned`, batch close on archive). If
   `move.sh` fails (permission scope, project layout drift), surface
   the error in your report — never close-without-moving silently.
+
+  **Docs-upkeep audit on every close-after-merge.** When the dispatch
+  is "close issue #N because PR #M merged", ALWAYS inspect the merged
+  diff via `gh pr diff <M>` and run the docs-upkeep heuristic against
+  it (see "Docs upkeep mode" below for the surface definitions). End
+  the close report with one of two lines:
+  - `docs audit: no user-visible surface touched — no docs change needed`
+  - `docs audit: user-visible surface touched — recommended docs PR: <one-line summary of the drift>`
+
+  Do NOT auto-open a follow-up docs ticket — surface the recommendation
+  in the report and let the main session decide. The mechanical
+  `docs-check.yml` CI gate is the safety net for cases this audit
+  misses, but the audit catches the cleaner cases proactively.
 - **Docs upkeep** — verifying that the four user-facing doc surfaces
   stay in sync with what the binary actually does whenever a development
   changes user-visible behavior. See "Docs upkeep mode" below for the

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,75 @@
+# Fail any PR that touches Specflow's user-visible surface without also
+# updating docs/llms.md (or carrying the `docs:not-needed` bypass label).
+#
+# See `.claude/agents/product-owner.md` (Docs upkeep section) for the
+# canonical list of doc surfaces the PO is meant to keep in sync; this
+# workflow is the mechanical safety net that catches drift at PR time.
+name: docs-check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # No fetch-depth bump needed — we use the base/head SHAs from the
+        # pull_request event payload, both of which GitHub Actions
+        # pre-fetches into the runner workspace.
+
+      - name: Detect drift
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          set -euo pipefail
+
+          # Bypass: contributor has already asserted no docs change is needed.
+          if echo "$PR_LABELS" | grep -q '"docs:not-needed"'; then
+            echo "::notice::PR carries the 'docs:not-needed' label — skipping docs-drift check."
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+          echo "Changed files in this PR:"
+          echo "$changed" | sed 's/^/  /'
+
+          # User-visible surface — anything that affects the public CLI,
+          # bundled scaffold, plugin assets, or the docs index itself.
+          # Keep this in sync with the PO's "Docs upkeep" section in
+          # .claude/agents/product-owner.md.
+          surface_re='^(templates/core/skills/|templates/core/agents/|templates/core/commands/|src/cli/|templates/manifest\.json$|templates/core/specflow/LABELS\.md$|templates/core/specflow/backlog\.md$)'
+
+          touched_surface=$(echo "$changed" | grep -E "$surface_re" || true)
+          touched_docs=$(echo "$changed" | grep -E '^docs/llms\.md$' || true)
+
+          if [ -z "$touched_surface" ]; then
+            echo "::notice::No user-visible surface touched — docs check skipped."
+            exit 0
+          fi
+
+          if [ -n "$touched_docs" ]; then
+            echo "::notice::User-visible surface touched and docs/llms.md updated alongside — OK."
+            exit 0
+          fi
+
+          # User-visible surface changed; docs unchanged; no bypass label.
+          echo "::error::This PR touches user-visible surface but does not update docs/llms.md."
+          echo ""
+          echo "Affected files (matching the user-visible surface heuristic):"
+          echo "$touched_surface" | sed 's/^/  /'
+          echo ""
+          echo "Either update docs/llms.md in the same PR, or add the"
+          echo "'docs:not-needed' label if this change genuinely doesn't"
+          echo "affect the public surface (internal refactor, test-only,"
+          echo "etc.). The PO docs-upkeep contract in"
+          echo ".claude/agents/product-owner.md describes which surfaces"
+          echo "are expected to track docs/llms.md."
+          exit 1

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,9 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        # No fetch-depth bump needed — we use the base/head SHAs from the
-        # pull_request event payload, both of which GitHub Actions
-        # pre-fetches into the runner workspace.
+        with:
+          # actions/checkout's default shallow clone (depth 1) doesn't
+          # include the PR base commit, so `git diff <base>...<head>`
+          # fails with "Invalid symmetric difference expression". Full
+          # fetch is the simplest reliable fix; the runner cost is
+          # ~5-10s extra on this otherwise sub-second job.
+          fetch-depth: 0
 
       - name: Detect drift
         env:


### PR DESCRIPTION
## Summary

Auto-enforce that user-visible behavior changes ship with corresponding docs. Two complementary layers, both motivated by the v1.1.20-21 pattern (epic feature + auto-chain re-entry shipped without doc updates; gap caught only after the fact).

### Layer 1 — `.github/workflows/docs-check.yml` (mechanical gate)

Fails any PR that touches the user-visible surface AND does not update \`docs/llms.md\` AND does not carry the \`docs:not-needed\` bypass label. Surface = \`templates/core/skills/**\`, \`templates/core/agents/**\`, \`templates/core/commands/**\`, \`src/cli/**\`, \`templates/manifest.json\`, \`templates/core/specflow/{LABELS,backlog}.md\`.

Design notes (per devops-sre advisory):

- Uses \`pull_request.base.sha\`/\`head.sha\` payload for the diff — no deep-fetch needed.
- Permissions stay \`contents: read\` + \`pull-requests: read\`. No write surface, no secrets.
- Failure rendered via \`::error::\` annotation — surfaces directly in the PR check summary, no extra click.
- Bypass label \`docs:not-needed\` already created on the repo (color #ededed).

### Layer 2 — PO close-step contract (soft proactive layer)

\`.claude/agents/product-owner.md\`'s close-step now ALWAYS runs a docs-upkeep audit on \`gh pr diff <num>\` for every close-after-merge dispatch. The PO's close report ends with either \`docs audit: no user-visible surface touched — no docs change needed\` or \`docs audit: recommended docs PR: <one-line summary>\`. Does NOT auto-open a follow-up ticket (working contract: don't manufacture tickets unprompted) — surfaces the recommendation, lets the main session decide.

The two layers are complementary: PO catches drift before the gate has to fire; CI gate is the safety net for everything the PO misses.

## Test plan

- [x] \`deno task test\` — 555/555 green (no logic changes affecting tests)
- [x] Verified the new gate does NOT trip on its own PR: this PR's diff touches \`.claude/agents/\` and \`.github/workflows/\` only, neither match the user-visible surface regex.
- [ ] Once merged, the next feature PR that touches \`templates/core/skills/**\` or similar will be the live integration test of the gate.

## Out of scope

- Bundled scaffolded PO doc (\`templates/core/agents/product-owner.md\`) — not updated. The audit/contract is maintainer-side workflow only; user projects don't have a \`docs/llms.md\` of Specflow's shape so the same logic doesn't apply to them. If user projects later want a similar drift gate they can opt in via their own CI.
- PR-comment posting on failure — keeping permissions read-only for now. Can be added later if the \`::error::\` annotation proves insufficient in practice.

## Bypass usage

For internal-only changes that match a surface path but don't need docs (test-only, refactor with no API change, etc.):

\`\`\`bash
gh pr edit <num> --add-label docs:not-needed
\`\`\`

The label is documented in the workflow's failure message so contributors learn about the escape hatch the first time they hit the gate.