### PR TITLE
chore(funding): clean FUNDING.yml to active platforms only

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,9 @@
-# These are supported funding model platforms
+# GitHub renders this as the "Sponsor" button on the repo page.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: makerlabsdev
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+
+# To enable GitHub Sponsors for the `mkrlabs` org:
+# 1. Apply at https://github.com/sponsors/accounts/new (KYC + payouts).
+# 2. Once /sponsors/mkrlabs is live, uncomment the line below.
+# github: mkrlabs


### PR DESCRIPTION
## Summary

Drops the 13 commented placeholder entries that shipped with GitHub's default funding template — they were just noise. Keeps:

- \`patreon: makerlabsdev\` (active)
- A small commented block explaining how to enable GitHub Sponsors for the \`mkrlabs\` org once the \`/sponsors/mkrlabs\` profile is approved (KYC + payouts setup at github.com/sponsors/accounts/new)

The \`github:\` line stays commented for now so the repo's Sponsor button doesn't 404 on a profile that doesn't exist yet. Uncomment after the GitHub Sponsors application clears.

## Out of scope

- The actual GitHub Sponsors application — manual UI flow on github.com that requires KYC, banking info, and tax forms. Kevin will do this separately.
- A second sponsorship target (e.g. \`kevinkod\` user account in addition to \`mkrlabs\` org) — keeping it focused on the org for now.