### PR TITLE
ci(wiki): mirror docs/llms.md to the GitHub Wiki on push to main

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -197,18 +197,37 @@ If a release goes wrong:
 
 ## Prerequisites
 
-The release workflow needs one secret on `mkrlabs/specflow` for the
-homebrew-tap bump step to work:
+Two secrets on `mkrlabs/specflow`:
 
 - **`HOMEBREW_TAP_TOKEN`** — fine-grained GitHub Personal Access Token,
   scoped to `mkrlabs/homebrew-tap` only, with `Contents: Read and write`.
   Created in GitHub → Settings → Developer settings → Personal access
   tokens → Fine-grained tokens. Add it under
   `mkrlabs/specflow` → Settings → Secrets and variables → Actions →
-  New repository secret.
+  New repository secret. Used by `release.yml`'s tap-bump step.
 
-If the secret is missing, the bump step exits 0 with a workflow warning
-(`HOMEBREW_TAP_TOKEN not set — skipping ...`). The release itself still
-ships; only the formula bump is skipped, and `brew upgrade specflow`
-will silently keep serving the previous version until the next release
-that does have the secret.
+  If missing, the bump step exits 0 with a workflow warning
+  (`HOMEBREW_TAP_TOKEN not set — skipping ...`). The release itself still
+  ships; only the formula bump is skipped, and `brew upgrade specflow`
+  will silently keep serving the previous version until the next release
+  that does have the secret.
+
+- **`WIKI_SYNC_TOKEN`** — fine-grained GitHub Personal Access Token,
+  scoped to `mkrlabs/specflow` only, with `Wiki: Read and write` (NOT
+  `Contents` — wiki is a separate permission). Used by `wiki.yml` to
+  push `docs/llms.md` → `<wiki>/Home.md` on every push to `main` that
+  touches `docs/llms.md`. Same provisioning path as
+  `HOMEBREW_TAP_TOKEN`.
+
+  First-time setup: visit `https://github.com/mkrlabs/specflow/wiki`
+  ONCE after enabling the wiki feature so GitHub auto-initializes the
+  default `Home.md` on the wiki's `master` branch (yes, `master` —
+  wiki repos default to `master` regardless of the source repo's
+  default branch). Without that one-time visit, the first sync will
+  fail with `Repository not found` because the wiki repo doesn't
+  physically exist until GitHub auto-inits it.
+
+  If `WIKI_SYNC_TOKEN` is missing, the sync step exits 0 with a
+  workflow warning (`WIKI_SYNC_TOKEN not set — skipping ...`). The
+  source-of-truth `docs/llms.md` and the `specflow.makerlabs.dev`
+  Pages deploy are unaffected; only the wiki mirror is paused.

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,85 @@
+# Mirror docs/llms.md to the GitHub Wiki's Home.md on every push to main.
+# The wiki is a separate git repository at <repo>.wiki.git; the default
+# GITHUB_TOKEN does NOT have access to it, so this workflow needs a
+# fine-grained PAT (`WIKI_SYNC_TOKEN`) scoped to `Wiki: Read and write` on
+# `mkrlabs/specflow` only. See the release SKILL.md "Prerequisites" section
+# for setup instructions.
+#
+# First-time setup: visit https://github.com/mkrlabs/specflow/wiki once
+# after enabling the wiki feature so GitHub auto-initializes the default
+# Home.md on the `master` branch (yes, master — wiki repos default to
+# `master` regardless of the source repo's default branch).
+name: wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/llms.md"
+      - ".github/workflows/wiki.yml"
+  workflow_dispatch:
+
+# Two rapid pushes touching `docs/` would queue overlapping syncs that
+# race on `git push` (non-fast-forward rejection). Serialize them.
+# `cancel-in-progress: false` so an in-flight push completes cleanly
+# rather than leaving the wiki in an intermediate state.
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard — bail if the PAT isn't provisioned yet
+        env:
+          WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+        run: |
+          if [ -z "${WIKI_SYNC_TOKEN:-}" ]; then
+            echo "::warning::WIKI_SYNC_TOKEN not set — skipping wiki sync. Provision the secret per the release SKILL.md prerequisites to enable."
+            exit 0
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Sync docs/llms.md → Wiki Home.md
+        env:
+          WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Re-check the token here too — the previous step's `exit 0`
+          # only ends THAT step, not the job, on GitHub Actions runners.
+          if [ -z "${WIKI_SYNC_TOKEN:-}" ]; then
+            echo "skipping (no token)"
+            exit 0
+          fi
+
+          WIKI_DIR="$(mktemp -d)"
+          REPO="mkrlabs/specflow"
+          git clone --depth 1 \
+            "https://x-access-token:${WIKI_SYNC_TOKEN}@github.com/${REPO}.wiki.git" \
+            "$WIKI_DIR"
+
+          cp docs/llms.md "$WIKI_DIR/Home.md"
+
+          cd "$WIKI_DIR"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git add Home.md
+
+          # Skip the commit when nothing changed (idempotent re-run).
+          # Only the commit is guarded — the push must surface real
+          # errors (e.g. a non-fast-forward rejection during a race the
+          # concurrency group failed to prevent).
+          if git diff --cached --quiet; then
+            echo "::notice::Wiki Home.md is already in sync with docs/llms.md — no commit needed."
+            exit 0
+          fi
+
+          git commit -m "chore: sync from main @ ${GITHUB_SHA::7}"
+          git push
+          echo "::notice::Wiki Home.md synced from docs/llms.md @ ${GITHUB_SHA::7}."


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/wiki.yml\` to keep the freshly-activated GitHub Wiki in sync with \`docs/llms.md\` on every push to main. Composes with the docs-check CI gate from #185 — together they form a two-stage guarantee: the gate ensures \`docs/llms.md\` is updated alongside any user-visible surface change, and this workflow then mirrors that updated content to the wiki within ~30s.

## How it works

| Trigger | \`push\` to \`main\` when \`docs/llms.md\` (or the workflow itself) changes; also \`workflow_dispatch\` for manual reruns |
| --- | --- |
| Action | Clone \`<repo>.wiki.git\` via the \`WIKI_SYNC_TOKEN\` PAT, copy \`docs/llms.md\` over \`Home.md\`, commit on \`master\`, push |
| Idempotent | \`git diff --cached --quiet\` skips the commit when nothing changed; \`git push\` errors surface as red builds (no swallowing) |
| Concurrency | \`group: wiki-sync, cancel-in-progress: false\` — serialize rapid pushes to prevent non-fast-forward race |
| Defensive | If \`WIKI_SYNC_TOKEN\` isn't set yet, the workflow exits 0 with a \`::warning::\` (same pattern as \`HOMEBREW_TAP_TOKEN\` guard in \`release.yml\`) |

## Required setup (manual, by Kevin)

1. Provision **\`WIKI_SYNC_TOKEN\`** as a repo secret on \`mkrlabs/specflow\`:
   - GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
   - Scope: resource owner \`mkrlabs\`, repository \`mkrlabs/specflow\`, permission **\`Wiki: Read and write\`** ONLY (NOT \`Contents\` — they're distinct grants)
   - Add the token under \`mkrlabs/specflow\` → Settings → Secrets and variables → Actions → New repository secret
2. **Visit \`https://github.com/mkrlabs/specflow/wiki\` once** to trigger GitHub's auto-init of \`Home.md\` on the wiki's \`master\` branch (yes, master — wiki repos default to master regardless of source repo's default). Without that one-time visit, the first sync fails with \`Repository not found\`.
3. After (1) and (2), trigger \`wiki.yml\` once via \`workflow_dispatch\` (Actions tab → "wiki" → "Run workflow") to seed the wiki, OR wait for the next \`docs/\` push to fire it.

Both steps documented in \`/.claude/skills/release/SKILL.md\` "Prerequisites" section alongside the existing \`HOMEBREW_TAP_TOKEN\` setup.

## Why CI, not agent-driven

The PO and \`specflow-expert\` agents already gate doc drift via #185 (CI gate + PO close-step audit). Once \`docs/llms.md\` is correct in the repo, replicating it to the wiki is purely mechanical — CI is faster, deterministic, cheaper, and won't hallucinate.

## docs-check gate behavior

This PR touches \`.github/workflows/wiki.yml\` and \`.claude/skills/release/SKILL.md\` only. Neither matches the user-visible surface regex, so the gate exits 0 with "No user-visible surface touched — docs check skipped."