### PR TITLE
ci(wiki): switch from fine-grained PAT to SSH Deploy Key

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -212,22 +212,43 @@ Two secrets on `mkrlabs/specflow`:
   will silently keep serving the previous version until the next release
   that does have the secret.
 
-- **`WIKI_SYNC_TOKEN`** — fine-grained GitHub Personal Access Token,
-  scoped to `mkrlabs/specflow` only, with `Wiki: Read and write` (NOT
-  `Contents` — wiki is a separate permission). Used by `wiki.yml` to
-  push `docs/llms.md` → `<wiki>/Home.md` on every push to `main` that
-  touches `docs/llms.md`. Same provisioning path as
-  `HOMEBREW_TAP_TOKEN`.
+- **`WIKI_SSH_KEY`** — SSH **Deploy Key** (not a PAT). Fine-grained PATs
+  on GitHub do not expose a "Wiki" permission — it's a real GitHub
+  limitation. A deploy key with write access to `mkrlabs/specflow` can
+  push to the wiki repo too (GitHub treats the wiki as part of the
+  same repo for deploy-key purposes). Used by `wiki.yml` to mirror
+  `docs/llms.md` → `<wiki>/Home.md` on every push to `main`.
 
-  First-time setup: visit `https://github.com/mkrlabs/specflow/wiki`
+  Setup (one-time):
+  ```bash
+  # 1. Generate an ed25519 keypair (no passphrase — it's a CI key).
+  ssh-keygen -t ed25519 -f /tmp/wiki-deploy -N "" \
+    -C "specflow-wiki-sync"
+
+  # 2. Public key → repo Deploy Keys (with write access).
+  gh repo deploy-key add /tmp/wiki-deploy.pub \
+    --repo mkrlabs/specflow \
+    --title "wiki-sync (CI)" \
+    --allow-write
+
+  # 3. Private key → repo secret WIKI_SSH_KEY.
+  gh secret set WIKI_SSH_KEY \
+    --repo mkrlabs/specflow \
+    < /tmp/wiki-deploy
+
+  # 4. Wipe the local keypair files — they're now in GitHub.
+  shred -u /tmp/wiki-deploy /tmp/wiki-deploy.pub
+  ```
+
+  First-time wiki init: visit `https://github.com/mkrlabs/specflow/wiki`
   ONCE after enabling the wiki feature so GitHub auto-initializes the
   default `Home.md` on the wiki's `master` branch (yes, `master` —
   wiki repos default to `master` regardless of the source repo's
-  default branch). Without that one-time visit, the first sync will
-  fail with `Repository not found` because the wiki repo doesn't
-  physically exist until GitHub auto-inits it.
+  default branch). Without that one-time visit, the first sync fails
+  with `Repository not found` because the wiki repo doesn't physically
+  exist until GitHub auto-inits it.
 
-  If `WIKI_SYNC_TOKEN` is missing, the sync step exits 0 with a
-  workflow warning (`WIKI_SYNC_TOKEN not set — skipping ...`). The
+  If `WIKI_SSH_KEY` is missing, the sync step exits 0 with a workflow
+  warning (`WIKI_SSH_KEY not set — skipping ...`). The
   source-of-truth `docs/llms.md` and the `specflow.makerlabs.dev`
   Pages deploy are unaffected; only the wiki mirror is paused.

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,14 +1,19 @@
 # Mirror docs/llms.md to the GitHub Wiki's Home.md on every push to main.
 # The wiki is a separate git repository at <repo>.wiki.git; the default
-# GITHUB_TOKEN does NOT have access to it, so this workflow needs a
-# fine-grained PAT (`WIKI_SYNC_TOKEN`) scoped to `Wiki: Read and write` on
-# `mkrlabs/specflow` only. See the release SKILL.md "Prerequisites" section
-# for setup instructions.
+# GITHUB_TOKEN does NOT have access to it, AND fine-grained PATs do NOT
+# expose a "Wiki" permission (a real GitHub limitation as of 2026). The
+# clean answer is a Deploy Key: per-repo SSH key, no expiration, scoped
+# to this repo only — and GitHub treats the wiki as part of the repo
+# for deploy-key purposes, so a write-enabled deploy key on
+# `mkrlabs/specflow` can push to `mkrlabs/specflow.wiki.git` too.
 #
-# First-time setup: visit https://github.com/mkrlabs/specflow/wiki once
-# after enabling the wiki feature so GitHub auto-initializes the default
-# Home.md on the `master` branch (yes, master — wiki repos default to
-# `master` regardless of the source repo's default branch).
+# Setup (one-time, by the maintainer): see the release SKILL.md
+# "Prerequisites" section for the keygen + upload + secret-store recipe.
+#
+# First-time wiki init: visit https://github.com/mkrlabs/specflow/wiki
+# once after enabling the wiki feature so GitHub auto-initializes the
+# default Home.md on the `master` branch (yes, master — wiki repos
+# default to `master` regardless of the source repo's default branch).
 name: wiki
 
 on:
@@ -34,34 +39,61 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Guard — bail if the PAT isn't provisioned yet
+      - name: Guard — bail if the deploy key isn't provisioned yet
         env:
-          WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+          WIKI_SSH_KEY: ${{ secrets.WIKI_SSH_KEY }}
         run: |
-          if [ -z "${WIKI_SYNC_TOKEN:-}" ]; then
-            echo "::warning::WIKI_SYNC_TOKEN not set — skipping wiki sync. Provision the secret per the release SKILL.md prerequisites to enable."
+          if [ -z "${WIKI_SSH_KEY:-}" ]; then
+            echo "::warning::WIKI_SSH_KEY not set — skipping wiki sync. Provision the deploy key per the release SKILL.md prerequisites to enable."
             exit 0
           fi
 
       - uses: actions/checkout@v4
 
-      - name: Sync docs/llms.md → Wiki Home.md
+      - name: Set up SSH agent with the wiki deploy key
         env:
-          WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+          WIKI_SSH_KEY: ${{ secrets.WIKI_SSH_KEY }}
         run: |
           set -euo pipefail
+          if [ -z "${WIKI_SSH_KEY:-}" ]; then
+            echo "skipping (no key)"
+            exit 0
+          fi
 
-          # Re-check the token here too — the previous step's `exit 0`
-          # only ends THAT step, not the job, on GitHub Actions runners.
-          if [ -z "${WIKI_SYNC_TOKEN:-}" ]; then
-            echo "skipping (no token)"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          # Pre-populate known_hosts so the clone doesn't prompt for
+          # host key verification on a fresh runner.
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          chmod 600 ~/.ssh/known_hosts
+
+          # Write the deploy private key.
+          printf '%s\n' "$WIKI_SSH_KEY" > ~/.ssh/wiki_deploy_key
+          chmod 600 ~/.ssh/wiki_deploy_key
+
+          # Force git to use this key for all github.com SSH operations
+          # in this job.
+          cat > ~/.ssh/config <<EOF
+          Host github.com
+            IdentityFile ~/.ssh/wiki_deploy_key
+            IdentitiesOnly yes
+            User git
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Sync docs/llms.md → Wiki Home.md
+        env:
+          WIKI_SSH_KEY: ${{ secrets.WIKI_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WIKI_SSH_KEY:-}" ]; then
+            echo "skipping (no key)"
             exit 0
           fi
 
           WIKI_DIR="$(mktemp -d)"
-          REPO="mkrlabs/specflow"
           git clone --depth 1 \
-            "https://x-access-token:${WIKI_SYNC_TOKEN}@github.com/${REPO}.wiki.git" \
+            "git@github.com:mkrlabs/specflow.wiki.git" \
             "$WIKI_DIR"
 
           cp docs/llms.md "$WIKI_DIR/Home.md"


### PR DESCRIPTION
## Summary

Fine-grained PATs on GitHub do NOT expose a "Wiki" permission — it's a real platform limitation, not a UI quirk. Searching the permissions list for "wiki" returns "No items available" because the permission simply doesn't exist for fine-grained tokens.

Switching the wiki sync workflow to a **Deploy Key** instead:

| | Fine-grained PAT (rejected) | Deploy Key (chosen) |
|---|---|---|
| Wiki write support | **No** (permission missing) | **Yes** (wiki is part of repo for deploy keys) |
| Scope | n/a | This repo only |
| Expiration | 90d / rotate | None (revoke when needed) |
| Setup complexity | Single PAT generate | ssh-keygen + 2 gh CLI commands |

## Workflow changes

- Drop the HTTPS+token clone path.
- Add an "Set up SSH agent" step that writes the private key from \`WIKI_SSH_KEY\` to \`~/.ssh/wiki_deploy_key\`, pre-populates \`known_hosts\` via \`ssh-keyscan\`, and forces git to use that key for \`github.com\` via \`~/.ssh/config\`.
- Switch clone URL to \`git@github.com:mkrlabs/specflow.wiki.git\`.
- Rename the secret guard from \`WIKI_SYNC_TOKEN\` → \`WIKI_SSH_KEY\` (the token branch never had a real value in production, so no migration needed).

## Release SKILL.md

Updated the \`WIKI_SYNC_TOKEN\` block in "Prerequisites" with the full deploy-key recipe — \`ssh-keygen\`, \`gh repo deploy-key add\`, \`gh secret set\`, plus the \`shred\` cleanup step. Future maintainers can reproduce the setup verbatim.

## Manual setup steps for Kevin (post-merge)

```bash
# 1. Generate keypair (no passphrase — it's a CI key)
ssh-keygen -t ed25519 -f /tmp/wiki-deploy -N "" -C "specflow-wiki-sync"

# 2. Public key → repo Deploy Keys (write-enabled)
gh repo deploy-key add /tmp/wiki-deploy.pub \\
  --repo mkrlabs/specflow \\
  --title "wiki-sync (CI)" \\
  --allow-write

# 3. Private key → repo secret WIKI_SSH_KEY
gh secret set WIKI_SSH_KEY --repo mkrlabs/specflow < /tmp/wiki-deploy

# 4. Wipe local files
shred -u /tmp/wiki-deploy /tmp/wiki-deploy.pub
```

Plus the one-time visit to \`https://github.com/mkrlabs/specflow/wiki\` to trigger GitHub's wiki auto-init (otherwise first sync fails with \`Repository not found\`).

## docs-check gate

Touches \`.github/workflows/\` and \`.claude/skills/\` only — neither matches the user-visible surface regex. Gate exits 0.