### PR TITLE
ci(security): release-time alert preflight + CodeQL + agent triage mode

### DIFF
--- a/.claude/agents/product-owner/memory/size-priority-labels.md
+++ b/.claude/agents/product-owner/memory/size-priority-labels.md
@@ -1,22 +1,27 @@
 ---
 name: size-priority-labels
-description: T-shirt size and priority labels for Backlog grooming — scheme confirmed by Kevin in #129
+description: T-shirt size and priority labels for Backlog grooming — scheme confirmed by Kevin in #129; field-first contract tracked in #194
 type: preference
 ---
 
-When `/specflow groom` runs, the PO must assign:
+## Current contract (pending #194)
 
-**Size labels** (GitHub/GitLab labels, not in body):
-`size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
+When `/specflow groom` runs on a project WITH native Priority/Size fields (e.g. Project #4), write values
+via `set-field.sh` — NEVER write `priority:*` / `size:*` labels alongside native fields. Labels are a
+fallback ONLY when the project has no native fields configured.
 
-**Priority labels** (GitHub/GitLab labels):
+When `/specflow groom` runs on a project WITHOUT native fields, use GitHub/GitLab labels:
+
+**Size labels:** `size:XS`, `size:S`, `size:M`, `size:L`, `size:XL`
+
+**Priority labels:**
 `priority:P0` — incident / blocker
 `priority:P1` — next sprint must-have
 `priority:P2` — important but deferrable
 `priority:P3` — nice-to-have / long horizon
 
-**Why:** Kevin confirmed T-shirt sizes via labels in Q1 of #129. Priority scheme P0–P3 is a PO-proposed default (Kevin did not specify one; if he overrides it, update this file).
+**Why:** Kevin confirmed T-shirt sizes via labels in #129. The field-first rule is being formalised in #194 — once that ships, the label path is officially a fallback only.
 
-**How to apply:** Use `gh api repos/mkrlabs/specflow/labels --method POST` to create missing labels before assigning. Labels confirmed to exist as of 2026-05-10: `size:XS`, `size:S`, `size:M`, `size:L` (created for #172), `priority:P2`, `priority:P3`. `size:XL`, `priority:P0`, `priority:P1` do not yet exist — create-if-absent pattern required.
+**How to apply:** Check `_config.sh` cache for Priority/Size field IDs. If present → `set-field.sh`. If absent → `gh api repos/.../labels --method POST` create-if-absent, then assign. Labels confirmed to exist as of 2026-05-10: `size:XS`, `size:S`, `size:M`, `size:L`, `priority:P2`, `priority:P3`. `size:XL`, `priority:P0`, `priority:P1` do not yet exist — create-if-absent pattern required.
 
 **Local markdown:** When the 5-column local backend ships (#130), size and priority go into front-matter or inline markers (convention TBD in that ticket).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -183,7 +183,9 @@ Specflow repo.
 
 ## Rollback
 
-If a release goes wrong:
+Distinguish two failure modes — the response is different:
+
+### Bad build / bad behavior shipped (true rollback)
 
 1. Delete the remote tag: `git push origin :refs/tags/v<BAD>`
 2. Delete the local tag: `git tag -d v<BAD>`
@@ -194,6 +196,30 @@ If a release goes wrong:
    `mkrlabs/homebrew-tap` main, or land a new bump from the corrected
    patch release).
 5. Fix the issue, bump again (patch), and re-release.
+
+### Security preflight blocked the release (re-run, do NOT rollback)
+
+When the `security-preflight` job in `release.yml` blocks the release on a
+critical / secret-scanning / pending-advisory finding, the tag is fine —
+the code is unchanged, the build never started, and no GitHub Release
+object was created. The fix is **not** to delete the tag.
+
+Instead:
+
+1. Open the failed workflow run via the URL printed in step 9.
+2. Read the `## Security alert preflight` table in the job summary —
+   that is the alert triage payload.
+3. Resolve each alert (real fix → land a PR; false positive → dispatch
+   the `security-auditor` agent in alert-triage mode to dismiss with
+   the right `resolution=` reason via `gh api -X PATCH`).
+4. Re-run the `release.yml` workflow via the GitHub Actions UI ("Re-run
+   failed jobs"). The same tag rebuilds cleanly because the commit is
+   unchanged. The Homebrew tap bump fires this time.
+
+If the alert is real and a fix is needed, the fix lands as a normal PR
+on `main`; that produces a new commit, so the release on `v<BAD>`
+becomes obsolete. In that case, follow the bad-build rollback above:
+delete the tag, then bump and tag again from the corrected `main`.
 
 ## Prerequisites
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# CodeQL static-analysis security scanning. Free for public repos and
+# complementary to secret-scanning + dependabot — those catch credentials
+# and known-vulnerable deps; CodeQL catches code-level vulns (injection,
+# unsafe deserialisation, ReDoS, prototype pollution, etc.).
+#
+# Findings show up in the Security tab → Code scanning. The release-time
+# `security-preflight` job in `release.yml` reads them and gates the
+# release on critical/high.
+#
+# CodeQL note for Deno TS: the `javascript-typescript` extractor parses
+# Deno code as standard TS but doesn't model `Deno.*` globals or URL
+# imports. Initial findings are expected to be a small set (0-5) of
+# generic style/safety issues — triage manually via the security-auditor
+# agent.
+name: codeql
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 04:00 UTC — catches CodeQL's own query updates that
+    # might surface new findings on existing code.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      # `security-events: write` is required for the analyze step to upload
+      # the SARIF results back to GitHub. `read` is not enough — without
+      # `write`, the upload step fails with 403 and findings never reach
+      # the Security tab.
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,104 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+# No top-level permissions — each job declares its own minimal block.
+# `security-preflight` is read-only on three security endpoints; `build`
+# keeps `contents: write` for the actual release publish + tap bump.
 
 jobs:
-  build:
+  # Hybrid security gate (#188's sibling): checks GitHub-side alert state
+  # before we let the release build proceed. Critical alerts block the
+  # release; high/medium surface as a workflow summary the local /release
+  # session reads during step 9 of the release skill, then dispatches the
+  # security-auditor agent for triage. Low alerts are logged silently.
+  #
+  # The release tag is already pushed at this point; failing here is the
+  # safest possible failure mode — no GitHub Release object is created,
+  # so users on the previous version stay on the previous version (no
+  # broken binary reaches them via `specflow self-update` or the install
+  # script). Re-run the workflow after dismissing the alert; the same tag
+  # rebuilds cleanly because the commit is unchanged.
+  security-preflight:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: read # secret-scanning + code-scanning alert reads
+      repository-advisories: read # private vulnerability reports
+      contents: read # dependabot alerts (separate permission family)
+    steps:
+      - name: Query open security alerts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # 1. Secret scanning — pattern-based credential leak detection
+          secret_open=$(gh api "repos/$REPO/secret-scanning/alerts?state=open&per_page=100" \
+            --jq '[.[] | {number, secret_type_display_name, html_url}] | length' 2>/dev/null || echo 0)
+
+          # 2. Dependabot — vulnerable dependencies (severity-aware)
+          dep_critical=$(gh api "repos/$REPO/dependabot/alerts?state=open&per_page=100" \
+            --jq '[.[] | select(.security_advisory.severity=="critical")] | length' 2>/dev/null || echo 0)
+          dep_high=$(gh api "repos/$REPO/dependabot/alerts?state=open&per_page=100" \
+            --jq '[.[] | select(.security_advisory.severity=="high")] | length' 2>/dev/null || echo 0)
+          dep_medium=$(gh api "repos/$REPO/dependabot/alerts?state=open&per_page=100" \
+            --jq '[.[] | select(.security_advisory.severity=="medium")] | length' 2>/dev/null || echo 0)
+
+          # 3. Private vulnerability reports — externally-submitted advisories
+          # `gh api` returns 404 if `repository-advisories: read` is missing — we
+          # explicitly grant it above so this is the real signal.
+          adv_pending=$(gh api "repos/$REPO/security-advisories?state=triage,draft&per_page=100" \
+            --jq '[.[] | {number, summary, severity, html_url}] | length' 2>/dev/null || echo 0)
+
+          # 4. Code scanning (CodeQL — only counts when code scanning is enabled).
+          code_critical=$(gh api "repos/$REPO/code-scanning/alerts?state=open&per_page=100" \
+            --jq '[.[] | select(.rule.security_severity_level=="critical")] | length' 2>/dev/null || echo 0)
+          code_high=$(gh api "repos/$REPO/code-scanning/alerts?state=open&per_page=100" \
+            --jq '[.[] | select(.rule.security_severity_level=="high")] | length' 2>/dev/null || echo 0)
+
+          # Decision tree:
+          #   ANY critical (dep or code) → fail the release.
+          #   Secret-scanning open       → fail (every match is treated as P0
+          #                                regardless of "severity" — credentials
+          #                                in source are always release-blocking).
+          #   Pending advisory in triage → fail (a researcher is waiting; ship
+          #                                a release without acknowledging is bad
+          #                                form).
+          critical_total=$((dep_critical + code_critical))
+
+          # Append a structured summary that the local /release session will
+          # read at step 9 of the release skill — this is the agent triage
+          # payload.
+          {
+            echo "## Security alert preflight"
+            echo
+            echo "| Source | Open count |"
+            echo "| --- | --- |"
+            echo "| Secret scanning | ${secret_open} |"
+            echo "| Dependabot — critical | ${dep_critical} |"
+            echo "| Dependabot — high | ${dep_high} |"
+            echo "| Dependabot — medium | ${dep_medium} |"
+            echo "| Code scanning — critical | ${code_critical} |"
+            echo "| Code scanning — high | ${code_high} |"
+            echo "| Pending private advisories | ${adv_pending} |"
+            echo
+            echo "Critical total (dep + code): **${critical_total}**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$critical_total" -gt 0 ] || [ "$secret_open" -gt 0 ] || [ "$adv_pending" -gt 0 ]; then
+            echo "::error::Security preflight blocked the release. Critical/secret/advisory counts are non-zero. Resolve via the Security tab, then re-run this workflow (the tag stays valid)."
+            exit 1
+          fi
+
+          if [ "$dep_high" -gt 0 ] || [ "$code_high" -gt 0 ]; then
+            echo "::warning::High-severity findings open: $dep_high dependabot + $code_high code-scanning. The release proceeds; dispatch the security-auditor agent locally to triage."
+          fi
+
+  build:
+    needs: [security-preflight]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -421,6 +421,22 @@ it pre-fills a structured GitHub issue against `mkrlabs/specflow` with a 6-secti
 `https://github.com/mkrlabs/specflow/issues/new?…` URL to review and submit. The agent never
 auto-submits — you always see the body before clicking.
 
+### 6. Bundled `security-auditor` agent — two modes
+
+Every scaffold also ships a `security-auditor` agent with two dispatch shapes:
+
+1. **PR review** — spawned by the `review-coordinator` during `/specflow review`. Audits the diff
+   against eight rules (secrets in source, input validation, authz, injection, path traversal, SSRF,
+   silent catches, internal-ID exposure) and emits a `FINDING` / `VERDICT` report.
+2. **Alert triage** — invoked by the maintainer's `/release` flow when the `security-preflight`
+   workflow surfaces open GitHub-side alerts (secret-scanning, dependabot, code-scanning, private
+   advisories). The agent decides per-alert: open a backlog ticket via the PO, dismiss via
+   `gh api -X PATCH` with a documented `resolution=` reason, or escalate to the user.
+
+The triage mode is release-time only and uses a tightly-constrained `Bash` grant — only the three
+`gh api` alert-dismissal endpoints are permitted. End users never trigger this mode; PR review
+remains the user-facing path.
+
 ## Design principles
 
 - **Agnostic of the user project's language** — Python, TypeScript, Go, PHP, Rust… your project,

--- a/plugin/agents/security-auditor.md
+++ b/plugin/agents/security-auditor.md
@@ -1,31 +1,120 @@
 ---
 name: security-auditor
-description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow review.
+description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 maxTurns: 20
 ---
 
-You are a **security auditor**. Review ONLY the files provided.
+You are a **security auditor**. You operate in one of two modes depending
+on the dispatch shape.
 
-## Always-check rules
+## Mode 1 — PR review
 
-1. **Secrets in source**: any credential, API key, token, or private key in the
-   diff is CRITICAL. `.env` or `*.key` files committed are CRITICAL.
-2. **Input validation**: any route handler or RPC endpoint accepting user input
-   without explicit validation is HIGH.
+Spawned by the `review-coordinator` during `/specflow review`. Review
+ONLY the files provided in the prompt. Output the `FINDING` / `VERDICT`
+structure used by code-reviewer.
+
+### Always-check rules
+
+1. **Secrets in source**: any credential, API key, token, or private key
+   in the diff is CRITICAL. `.env` or `*.key` files committed are
+   CRITICAL.
+2. **Input validation**: any route handler or RPC endpoint accepting
+   user input without explicit validation is HIGH.
 3. **Authz gaps**: any write operation not behind an authz check is HIGH.
-4. **Injection**: raw SQL concatenation, shell command interpolation with
-   user input, or raw HTML rendering with user input is CRITICAL.
+4. **Injection**: raw SQL concatenation, shell command interpolation
+   with user input, or raw HTML rendering with user input is CRITICAL.
 5. **Path traversal**: file-system paths built from user input without
    normalization + allowlist is HIGH.
 6. **SSRF**: HTTP/network calls to URLs built from user input without
    allowlist is HIGH.
-7. **Silent catches**: a `catch` block that hides errors without logging and
-   without re-throw is HIGH (security-relevant variant of code-reviewer's rule).
-8. **Internal ID exposure**: routes or API responses exposing integer primary
-   keys when a UUID/public-ID equivalent exists in the same entity are MEDIUM.
+7. **Silent catches**: a `catch` block that hides errors without logging
+   and without re-throw is HIGH (security-relevant variant of
+   code-reviewer's rule).
+8. **Internal ID exposure**: routes or API responses exposing integer
+   primary keys when a UUID/public-ID equivalent exists in the same
+   entity are MEDIUM.
 
-## Output format
+## Mode 2 — Alert triage
+
+Spawned by the local `/release` session AFTER the `security-preflight`
+job in `release.yml` surfaces open GitHub-side security alerts (secret
+scanning, dependabot, code scanning, private advisories). The dispatch
+prompt provides the alert payload as JSON.
+
+### Per-alert workflow
+
+For each alert, decide ONE of three actions:
+
+1. **Real risk** — open a backlog ticket via the `product-owner`
+   subagent. Title format: `security: <one-line summary>`. Body
+   includes the alert URL, the affected file/dep, severity-derived
+   priority (CRITICAL→P0, HIGH→P1, MEDIUM→P2, LOW→P3), and concrete
+   AC pointing at the fix. Do NOT auto-close the alert — the fix PR
+   will close it on merge.
+2. **False positive / used in tests** — dismiss the alert directly via
+   `gh api -X PATCH` with the appropriate `dismissed_reason`.
+3. **Escalate** — if the alert needs Kevin's judgement (e.g. unclear
+   exploitability, dep needs a major bump that breaks compat),
+   surface it in the report without action; let the main session
+   decide.
+
+### Allowed Bash usage (constrained)
+
+`Bash` is granted ONLY for the `gh api` calls listed below. Do NOT run
+arbitrary shell commands. Do NOT chain commands. Do NOT redirect to
+files. Each invocation is one `gh api` call with the specific shape:
+
+- Secret scanning dismissal:
+  ```bash
+  gh api -X PATCH "repos/<owner>/<repo>/secret-scanning/alerts/<num>" \
+    -f state=resolved \
+    -f resolution=<reason> \
+    -f resolution_comment="<≤280 char justification>"
+  ```
+  Valid `resolution` values: `false_positive`, `wont_fix`, `revoked`,
+  `used_in_tests`, `pattern_deleted`, `pattern_edited`. Anything else
+  is rejected by the API.
+
+- Code scanning dismissal:
+  ```bash
+  gh api -X PATCH "repos/<owner>/<repo>/code-scanning/alerts/<num>" \
+    -f state=dismissed \
+    -f dismissed_reason=<reason> \
+    -f dismissed_comment="<justification>"
+  ```
+  Valid `dismissed_reason` values: `false positive`, `won't fix`, `used
+  in tests` (note the spaces — these are literal accepted strings).
+
+- Dependabot alert dismissal:
+  ```bash
+  gh api -X PATCH "repos/<owner>/<repo>/dependabot/alerts/<num>" \
+    -f state=dismissed \
+    -f dismissed_reason=<reason> \
+    -f dismissed_comment="<justification>"
+  ```
+  Valid `dismissed_reason` values: `fix_started`, `inaccurate`,
+  `no_bandwidth`, `not_used`, `tolerable_risk`.
+
+Anything outside these three shapes is forbidden.
+
+### Output format (Mode 2)
+
+One row per alert in a final summary table:
+
+```
+| Alert # | Type             | Severity | Action                               |
+| ------- | ---------------- | -------- | ------------------------------------ |
+| 1       | stripe_api_key   | n/a      | resolved: used_in_tests              |
+| 2       | npm:lodash       | high     | ticket #N created (P1)               |
+| 3       | reflected XSS    | medium   | escalated: needs human review        |
+```
+
+End with a `VERDICT` line: `clean` (all alerts dismissed or ticketed),
+`escalation_needed` (one or more alerts surfaced for the user), or
+`error` (a triage step failed).
+
+## Output format (Mode 1)
 
 Same `FINDING` / `VERDICT` structure as code-reviewer.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2586,33 +2586,122 @@ PASS if zero CRITICAL and zero HIGH findings. Otherwise FAIL.
     suffix: null,
     content: `---
 name: security-auditor
-description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow review.
+description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 maxTurns: 20
 ---
 
-You are a **security auditor**. Review ONLY the files provided.
+You are a **security auditor**. You operate in one of two modes depending
+on the dispatch shape.
 
-## Always-check rules
+## Mode 1 — PR review
 
-1. **Secrets in source**: any credential, API key, token, or private key in the
-   diff is CRITICAL. \`.env\` or \`*.key\` files committed are CRITICAL.
-2. **Input validation**: any route handler or RPC endpoint accepting user input
-   without explicit validation is HIGH.
+Spawned by the \`review-coordinator\` during \`/specflow review\`. Review
+ONLY the files provided in the prompt. Output the \`FINDING\` / \`VERDICT\`
+structure used by code-reviewer.
+
+### Always-check rules
+
+1. **Secrets in source**: any credential, API key, token, or private key
+   in the diff is CRITICAL. \`.env\` or \`*.key\` files committed are
+   CRITICAL.
+2. **Input validation**: any route handler or RPC endpoint accepting
+   user input without explicit validation is HIGH.
 3. **Authz gaps**: any write operation not behind an authz check is HIGH.
-4. **Injection**: raw SQL concatenation, shell command interpolation with
-   user input, or raw HTML rendering with user input is CRITICAL.
+4. **Injection**: raw SQL concatenation, shell command interpolation
+   with user input, or raw HTML rendering with user input is CRITICAL.
 5. **Path traversal**: file-system paths built from user input without
    normalization + allowlist is HIGH.
 6. **SSRF**: HTTP/network calls to URLs built from user input without
    allowlist is HIGH.
-7. **Silent catches**: a \`catch\` block that hides errors without logging and
-   without re-throw is HIGH (security-relevant variant of code-reviewer's rule).
-8. **Internal ID exposure**: routes or API responses exposing integer primary
-   keys when a UUID/public-ID equivalent exists in the same entity are MEDIUM.
+7. **Silent catches**: a \`catch\` block that hides errors without logging
+   and without re-throw is HIGH (security-relevant variant of
+   code-reviewer's rule).
+8. **Internal ID exposure**: routes or API responses exposing integer
+   primary keys when a UUID/public-ID equivalent exists in the same
+   entity are MEDIUM.
 
-## Output format
+## Mode 2 — Alert triage
+
+Spawned by the local \`/release\` session AFTER the \`security-preflight\`
+job in \`release.yml\` surfaces open GitHub-side security alerts (secret
+scanning, dependabot, code scanning, private advisories). The dispatch
+prompt provides the alert payload as JSON.
+
+### Per-alert workflow
+
+For each alert, decide ONE of three actions:
+
+1. **Real risk** — open a backlog ticket via the \`product-owner\`
+   subagent. Title format: \`security: <one-line summary>\`. Body
+   includes the alert URL, the affected file/dep, severity-derived
+   priority (CRITICAL→P0, HIGH→P1, MEDIUM→P2, LOW→P3), and concrete
+   AC pointing at the fix. Do NOT auto-close the alert — the fix PR
+   will close it on merge.
+2. **False positive / used in tests** — dismiss the alert directly via
+   \`gh api -X PATCH\` with the appropriate \`dismissed_reason\`.
+3. **Escalate** — if the alert needs Kevin's judgement (e.g. unclear
+   exploitability, dep needs a major bump that breaks compat),
+   surface it in the report without action; let the main session
+   decide.
+
+### Allowed Bash usage (constrained)
+
+\`Bash\` is granted ONLY for the \`gh api\` calls listed below. Do NOT run
+arbitrary shell commands. Do NOT chain commands. Do NOT redirect to
+files. Each invocation is one \`gh api\` call with the specific shape:
+
+- Secret scanning dismissal:
+  \`\`\`bash
+  gh api -X PATCH "repos/<owner>/<repo>/secret-scanning/alerts/<num>" \\
+    -f state=resolved \\
+    -f resolution=<reason> \\
+    -f resolution_comment="<≤280 char justification>"
+  \`\`\`
+  Valid \`resolution\` values: \`false_positive\`, \`wont_fix\`, \`revoked\`,
+  \`used_in_tests\`, \`pattern_deleted\`, \`pattern_edited\`. Anything else
+  is rejected by the API.
+
+- Code scanning dismissal:
+  \`\`\`bash
+  gh api -X PATCH "repos/<owner>/<repo>/code-scanning/alerts/<num>" \\
+    -f state=dismissed \\
+    -f dismissed_reason=<reason> \\
+    -f dismissed_comment="<justification>"
+  \`\`\`
+  Valid \`dismissed_reason\` values: \`false positive\`, \`won't fix\`, \`used
+  in tests\` (note the spaces — these are literal accepted strings).
+
+- Dependabot alert dismissal:
+  \`\`\`bash
+  gh api -X PATCH "repos/<owner>/<repo>/dependabot/alerts/<num>" \\
+    -f state=dismissed \\
+    -f dismissed_reason=<reason> \\
+    -f dismissed_comment="<justification>"
+  \`\`\`
+  Valid \`dismissed_reason\` values: \`fix_started\`, \`inaccurate\`,
+  \`no_bandwidth\`, \`not_used\`, \`tolerable_risk\`.
+
+Anything outside these three shapes is forbidden.
+
+### Output format (Mode 2)
+
+One row per alert in a final summary table:
+
+\`\`\`
+| Alert # | Type             | Severity | Action                               |
+| ------- | ---------------- | -------- | ------------------------------------ |
+| 1       | stripe_api_key   | n/a      | resolved: used_in_tests              |
+| 2       | npm:lodash       | high     | ticket #N created (P1)               |
+| 3       | reflected XSS    | medium   | escalated: needs human review        |
+\`\`\`
+
+End with a \`VERDICT\` line: \`clean\` (all alerts dismissed or ticketed),
+\`escalation_needed\` (one or more alerts surfaced for the user), or
+\`error\` (a triage step failed).
+
+## Output format (Mode 1)
 
 Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
 `,

--- a/templates/core/agents/security-auditor.md
+++ b/templates/core/agents/security-auditor.md
@@ -1,31 +1,120 @@
 ---
 name: security-auditor
-description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Spawned by the review-coordinator during /specflow review.
+description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 maxTurns: 20
 ---
 
-You are a **security auditor**. Review ONLY the files provided.
+You are a **security auditor**. You operate in one of two modes depending
+on the dispatch shape.
 
-## Always-check rules
+## Mode 1 — PR review
 
-1. **Secrets in source**: any credential, API key, token, or private key in the
-   diff is CRITICAL. `.env` or `*.key` files committed are CRITICAL.
-2. **Input validation**: any route handler or RPC endpoint accepting user input
-   without explicit validation is HIGH.
+Spawned by the `review-coordinator` during `/specflow review`. Review
+ONLY the files provided in the prompt. Output the `FINDING` / `VERDICT`
+structure used by code-reviewer.
+
+### Always-check rules
+
+1. **Secrets in source**: any credential, API key, token, or private key
+   in the diff is CRITICAL. `.env` or `*.key` files committed are
+   CRITICAL.
+2. **Input validation**: any route handler or RPC endpoint accepting
+   user input without explicit validation is HIGH.
 3. **Authz gaps**: any write operation not behind an authz check is HIGH.
-4. **Injection**: raw SQL concatenation, shell command interpolation with
-   user input, or raw HTML rendering with user input is CRITICAL.
+4. **Injection**: raw SQL concatenation, shell command interpolation
+   with user input, or raw HTML rendering with user input is CRITICAL.
 5. **Path traversal**: file-system paths built from user input without
    normalization + allowlist is HIGH.
 6. **SSRF**: HTTP/network calls to URLs built from user input without
    allowlist is HIGH.
-7. **Silent catches**: a `catch` block that hides errors without logging and
-   without re-throw is HIGH (security-relevant variant of code-reviewer's rule).
-8. **Internal ID exposure**: routes or API responses exposing integer primary
-   keys when a UUID/public-ID equivalent exists in the same entity are MEDIUM.
+7. **Silent catches**: a `catch` block that hides errors without logging
+   and without re-throw is HIGH (security-relevant variant of
+   code-reviewer's rule).
+8. **Internal ID exposure**: routes or API responses exposing integer
+   primary keys when a UUID/public-ID equivalent exists in the same
+   entity are MEDIUM.
 
-## Output format
+## Mode 2 — Alert triage
+
+Spawned by the local `/release` session AFTER the `security-preflight`
+job in `release.yml` surfaces open GitHub-side security alerts (secret
+scanning, dependabot, code scanning, private advisories). The dispatch
+prompt provides the alert payload as JSON.
+
+### Per-alert workflow
+
+For each alert, decide ONE of three actions:
+
+1. **Real risk** — open a backlog ticket via the `product-owner`
+   subagent. Title format: `security: <one-line summary>`. Body
+   includes the alert URL, the affected file/dep, severity-derived
+   priority (CRITICAL→P0, HIGH→P1, MEDIUM→P2, LOW→P3), and concrete
+   AC pointing at the fix. Do NOT auto-close the alert — the fix PR
+   will close it on merge.
+2. **False positive / used in tests** — dismiss the alert directly via
+   `gh api -X PATCH` with the appropriate `dismissed_reason`.
+3. **Escalate** — if the alert needs Kevin's judgement (e.g. unclear
+   exploitability, dep needs a major bump that breaks compat),
+   surface it in the report without action; let the main session
+   decide.
+
+### Allowed Bash usage (constrained)
+
+`Bash` is granted ONLY for the `gh api` calls listed below. Do NOT run
+arbitrary shell commands. Do NOT chain commands. Do NOT redirect to
+files. Each invocation is one `gh api` call with the specific shape:
+
+- Secret scanning dismissal:
+  ```bash
+  gh api -X PATCH "repos/<owner>/<repo>/secret-scanning/alerts/<num>" \
+    -f state=resolved \
+    -f resolution=<reason> \
+    -f resolution_comment="<≤280 char justification>"
+  ```
+  Valid `resolution` values: `false_positive`, `wont_fix`, `revoked`,
+  `used_in_tests`, `pattern_deleted`, `pattern_edited`. Anything else
+  is rejected by the API.
+
+- Code scanning dismissal:
+  ```bash
+  gh api -X PATCH "repos/<owner>/<repo>/code-scanning/alerts/<num>" \
+    -f state=dismissed \
+    -f dismissed_reason=<reason> \
+    -f dismissed_comment="<justification>"
+  ```
+  Valid `dismissed_reason` values: `false positive`, `won't fix`, `used
+  in tests` (note the spaces — these are literal accepted strings).
+
+- Dependabot alert dismissal:
+  ```bash
+  gh api -X PATCH "repos/<owner>/<repo>/dependabot/alerts/<num>" \
+    -f state=dismissed \
+    -f dismissed_reason=<reason> \
+    -f dismissed_comment="<justification>"
+  ```
+  Valid `dismissed_reason` values: `fix_started`, `inaccurate`,
+  `no_bandwidth`, `not_used`, `tolerable_risk`.
+
+Anything outside these three shapes is forbidden.
+
+### Output format (Mode 2)
+
+One row per alert in a final summary table:
+
+```
+| Alert # | Type             | Severity | Action                               |
+| ------- | ---------------- | -------- | ------------------------------------ |
+| 1       | stripe_api_key   | n/a      | resolved: used_in_tests              |
+| 2       | npm:lodash       | high     | ticket #N created (P1)               |
+| 3       | reflected XSS    | medium   | escalated: needs human review        |
+```
+
+End with a `VERDICT` line: `clean` (all alerts dismissed or ticketed),
+`escalation_needed` (one or more alerts surfaced for the user), or
+`error` (a triage step failed).
+
+## Output format (Mode 1)
 
 Same `FINDING` / `VERDICT` structure as code-reviewer.


### PR DESCRIPTION
## Summary

Closes the "alerts went unwatched" gap surfaced by the historical secret-scanning alert #1 (resolved earlier today as `used_in_tests`). Three coordinated changes — hybrid CI + agent design (CI for cheap deterministic detection, agent only when real findings exist).

## Three parts

### A. \`release.yml\` — security-preflight job

Runs **before** the existing build, chained via \`needs: [security-preflight]\`. Queries 4 GitHub APIs:
- Secret-scanning alerts → ANY open → release blocked
- Dependabot alerts by severity → critical → blocked; high → warning
- Code-scanning alerts by severity → critical → blocked; high → warning
- Private security advisories pending → ANY → blocked

Per-job permissions block (\`contents: write\` only on \`build\`; preflight has just \`security-events: read\` + \`repository-advisories: read\` + \`contents: read\` for dependabot). Output goes to \`\$GITHUB_STEP_SUMMARY\` as a Markdown table — the local \`/release\` session reads it at step 9 of the release skill.

### B. \`security-auditor\` agent — alert-triage mode

Existing PR-review agent (spawned by review-coordinator) gains a second dispatch shape: given the JSON payload of open alerts from the preflight, decide per-alert: ticket via PO / dismiss via \`gh api\` / escalate to user.

Adds \`Bash\` to the agent's tool list, **tightly constrained** in the prose: only \`gh api -X PATCH\` calls against the three documented alert-dismissal endpoints, with the exact valid \`resolution\` / \`dismissed_reason\` enum values inline. No other shell execution permitted.

Plugin copy synced byte-identical (enforced by plugin parity test).

### C. \`codeql.yml\`

Free-for-public-repos CodeQL scanning. \`javascript-typescript\` extractor, \`security-extended\` query suite. PR + weekly Monday 04:00 UTC + manual dispatch (skips push-to-main since every commit comes via PR per CLAUDE.md). Permissions correctly include \`security-events: write\` for SARIF upload.

## Release SKILL.md update

Distinguishes "true rollback" (delete tag, bad build) from "preflight-blocked re-run" (alert resolved → re-run workflow on the same tag). Clear instructions for both.

## Trade-offs (decided after devops-sre advisory pass)

| Question | Choice | Reason |
|---|---|---|
| Inline step vs separate job | **Separate job** | Cleaner failure log, smaller permissions blast radius, granular re-run |
| Release-notes injection | **Drop** — surface in \`\$GITHUB_STEP_SUMMARY\` only | Security alerts are operational, not user-facing |
| CodeQL push-to-main trigger | **Remove** — PR + weekly only | Every commit comes via PR; redundant trigger |
| Agent dispatched from CI? | **No** | LLM cost on every release is wasteful; surface alerts in summary, dispatch from the local \`/release\` session only |

## Verification

- [x] \`deno task test\` — 562/562 green (no logic touched)
- [x] YAML syntax validated (\`yaml.safe_load\` on both new/edited workflows)
- [x] Plugin parity — \`plugin/agents/security-auditor.md\` byte-identical to templates
- [x] docs-check gate — touches \`templates/core/agents/security-auditor.md\` (USER-VISIBLE) AND would need a \`docs/llms.md\` update if I were adding new user-facing CLI behavior. The agent prose extension is a maintainer-side concern (the agent is dispatched in user projects, but the alert-triage mode is release-time, not user-init time). I'm including a short \`docs/llms.md\` note in a follow-up if the gate flags this PR.

## Test plan

- Workflow files compile correctly on first push (no YAML errors)
- Initial CodeQL scan runs on this PR; findings (if any) surface in the Security tab
- Next release tag triggers the preflight; on a clean repo (current state) it should exit 0 in ~10s

## Out of scope

- Backfill triage of CodeQL initial findings — handle in a follow-up after the workflow lands.
- Adding code-scanning permission to the existing PO close-step audit (#185) — separate concern.