### PR TITLE
fix: native Priority/Size fields are the source of truth (#194)

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -192,32 +192,37 @@ For each mutation:
    single-mutation dispatches (`add`, `move`, `close`) — there's no
    downstream phase to clean up for.
 
-## Sizing and priority — field-first, label fallback
+## Sizing and priority — fields are the source of truth
 
-Project #4 has native single-select fields `Priority` (P0..P2) and
-`Size` (XS..XL). When you size or prioritise an item, **write to the
-field — do not also apply a label** (drift). Use the helper at
-`.claude/skills/backlog/scripts/set-field.sh`:
+Project #4 has native single-select fields `Priority` (P0..P3) and
+`Size` (XS..XL). When you size or prioritise an item, write the value
+to the field via the helper below — **NEVER also apply a `priority:*`
+/ `size:*` label on an item that already has the native field**. The
+two are not peer signals; the label exists only as a fallback when the
+field cannot accept the value. Anything else is the dual-signal drift
+that prompted #194.
 
 ```
 set-field.sh <issue> Priority P1     # writes the field
 set-field.sh <issue> Size M
 ```
 
-Exit codes:
-- `0` → field updated, no label needed.
+Helper at `.claude/skills/backlog/scripts/set-field.sh`. Exit codes:
+- `0` → field updated, no label needed (the only happy path).
 - `10` → no such field on Project #4 (shouldn't happen — but if it
   does, fall back to `priority:*` / `size:*` labels and surface the
-  drift).
-- `11` → option missing (only `priority:P3` today, since the field
-  ships with P0..P2). Apply the matching `priority:P3` label as
-  fallback.
+  drift in the report).
+- `11` → field present but option missing on Project #4. Add the
+  option to the field (Project settings → field → "+" Add option, or
+  the `updateProjectV2Field` GraphQL mutation) and re-run rather than
+  silently falling back to a label.
 - `12` → issue not on Project #4. Resolve the attachment first.
 
 The legacy `priority:*` / `size:*` labels were swept off the open
 issues by `.claude/skills/backlog/scripts/migrate-labels-to-fields.sh`
-when this contract landed. The script is idempotent — re-run anytime
-the board feels out of sync.
+(landed via #157, completed by #194 once the field gained the missing
+P3 option). The sweep script is idempotent — re-run anytime the board
+feels out of sync.
 
 ## Epic / sub-task detection
 

--- a/.claude/skills/backlog/scripts/set-field.sh
+++ b/.claude/skills/backlog/scripts/set-field.sh
@@ -28,15 +28,12 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
     FIELD_ID="PVTSSF_lADOBv46cs4BV4GzzhRQrbw"
     CANONICAL="Priority"
     case "$VALUE" in
-      P0) OPT="79628723" ;;
-      P1) OPT="0a877460" ;;
-      P2) OPT="da944a9c" ;;
-      P3)
-        echo "field 'Priority' has no option 'P3' — fall back to label" >&2
-        exit 11
-        ;;
+      P0) OPT="093323d6" ;;
+      P1) OPT="7b8ac56e" ;;
+      P2) OPT="eae399b4" ;;
+      P3) OPT="59c235b3" ;;
       *)
-        echo "unknown Priority value '$VALUE' (P0|P1|P2)" >&2
+        echo "unknown Priority value '$VALUE' (P0|P1|P2|P3)" >&2
         exit 11
         ;;
     esac

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
@@ -70,14 +70,20 @@ echo
 echo "═══ #158  semantic labels bootstrap (ensure-labels.sh) ═══"
 check "ensure-labels.sh present + executable" \
   '[ -x .specflow/scripts/backlog/ensure-labels.sh ]'
-check "ensure-labels.sh mentions canonical 7-label palette" \
-  'grep -q "security" .specflow/scripts/backlog/ensure-labels.sh && grep -q "refactor" .specflow/scripts/backlog/ensure-labels.sh && grep -q "tech-debt" .specflow/scripts/backlog/ensure-labels.sh'
+check "ensure-labels.sh seeds the canonical 7-label palette in full" \
+  'for lbl in security refactor docs tech-debt dx performance dependency; do
+     grep -q "ensure_label \"$lbl\"" .specflow/scripts/backlog/ensure-labels.sh || exit 1;
+   done'
+check "ensure-labels.sh seeds zero priority:*/size:* labels (#194)" \
+  '! grep -E "ensure_label \"(priority|size):" .specflow/scripts/backlog/ensure-labels.sh'
 check "ensure-labels.sh idempotent (skips already-present labels)" \
   'grep -q "already present" .specflow/scripts/backlog/ensure-labels.sh'
-check "ensure-labels.sh verifies the GitHub default 'bug' label" \
+check "ensure-labels.sh verifies the GitHub default '"'"'bug'"'"' label" \
   'grep -qF "bug" .specflow/scripts/backlog/ensure-labels.sh'
 check "SKILL.md mentions ensure-labels.sh (#158)" \
   'grep -q "ensure-labels.sh" .claude/skills/backlog/SKILL.md'
+check "SKILL.md states fields are the source of truth (#194)" \
+  'grep -q "fields are the source of truth" .claude/skills/backlog/SKILL.md'
 
 echo
 echo "═══ #157  Priority/Size native fields documented in SKILL.md ═══"

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -356,6 +356,16 @@ repo. Idempotent; never edits or deletes existing labels. The GitHub default `bu
 but never re-created. The full reference lives in `.specflow/LABELS.md` next to the install —
 including a guidance note for local backend users on tagging via task-file frontmatter.
 
+**Priority and Size — native fields are the source of truth.** When a GitHub project ships native
+`Priority` and/or `Size` single-select fields on Project V2, the bundled
+`.specflow/scripts/backlog/set-field.sh` writes the value to the field — and the PO **never** also
+applies a `priority:*` / `size:*` label on the same item. Labels are reserved as a strict fallback
+for projects whose board has no such field; they are not a peer signal. `set-field.sh` exit codes
+tell the caller which path applies: `0` = field updated, `10` = field absent (fall back to label),
+`11` = field present but option missing (add the option, then re-run; only fall back to a label if
+you can't add it), `12` = issue not on the project. `detect-fields.sh` (run once per groom) emits
+the field/option IDs into env vars for case-insensitive matching.
+
 **Epics & sub-tasks.** Big work that needs decomposition lives as a parent **epic** with one or more
 **sub-tasks**. The link mechanism differs per backend, but the contract is the same: parents cannot
 close while any child is still open.

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -31,19 +31,20 @@ missing or empty, flag it to the user — the project is under-documented.
 Every backlog item you touch MUST exit with both a size
 (`XS`..`XL`) and a priority (`P0`..`P3`) persisted. **Gate**, not polish.
 
-**GitHub — field-first, label fallback.** Specflow projects ship with
-native single-select fields `Priority` and `Size`. When present, write
-to the field; do NOT also apply a label (drift). When absent, fall
-back to `priority:*` / `size:*` labels. Bundled scripts at
+**GitHub — fields are the source of truth; labels are a STRICT
+fallback.** When the project has native single-select fields `Priority`
+and/or `Size`, write the value to the field and **NEVER** also apply
+a `priority:*` / `size:*` label on the same item — that's the dual-
+signal drift `set-field.sh` exists to prevent. Labels are reserved for
+projects whose board has no such field. Bundled scripts at
 `.specflow/scripts/backlog/`:
 
 - `detect-fields.sh` — env lines with field/option IDs (case-insensitive
   match). Run once per groom run.
 - `set-field.sh <issue> <Priority|Size> <value>` — exit codes:
-  - `0` → wrote field, no label.
-  - `10` → no such field → apply matching label.
-  - `11` → field exists but option missing (today: `priority:P3` —
-    canonical fields ship with P0..P2) → apply matching label.
+  - `0` → wrote field, no label (preferred path).
+  - `10` → field absent on this project → apply matching label.
+  - `11` → field present but option missing → apply matching label.
   - `12` → not on project → surface under `⚠ size / priority missing`.
 
 If the fallback label is missing, `gh label create` / `glab label

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2134,19 +2134,20 @@ missing or empty, flag it to the user — the project is under-documented.
 Every backlog item you touch MUST exit with both a size
 (\`XS\`..\`XL\`) and a priority (\`P0\`..\`P3\`) persisted. **Gate**, not polish.
 
-**GitHub — field-first, label fallback.** Specflow projects ship with
-native single-select fields \`Priority\` and \`Size\`. When present, write
-to the field; do NOT also apply a label (drift). When absent, fall
-back to \`priority:*\` / \`size:*\` labels. Bundled scripts at
+**GitHub — fields are the source of truth; labels are a STRICT
+fallback.** When the project has native single-select fields \`Priority\`
+and/or \`Size\`, write the value to the field and **NEVER** also apply
+a \`priority:*\` / \`size:*\` label on the same item — that's the dual-
+signal drift \`set-field.sh\` exists to prevent. Labels are reserved for
+projects whose board has no such field. Bundled scripts at
 \`.specflow/scripts/backlog/\`:
 
 - \`detect-fields.sh\` — env lines with field/option IDs (case-insensitive
   match). Run once per groom run.
 - \`set-field.sh <issue> <Priority|Size> <value>\` — exit codes:
-  - \`0\` → wrote field, no label.
-  - \`10\` → no such field → apply matching label.
-  - \`11\` → field exists but option missing (today: \`priority:P3\` —
-    canonical fields ship with P0..P2) → apply matching label.
+  - \`0\` → wrote field, no label (preferred path).
+  - \`10\` → field absent on this project → apply matching label.
+  - \`11\` → field present but option missing → apply matching label.
   - \`12\` → not on project → surface under \`⚠ size / priority missing\`.
 
 If the fallback label is missing, \`gh label create\` / \`glab label
@@ -3789,12 +3790,18 @@ Specflow change — the skill is path-aware.
 - **Closing** — close the issue (don't just move to Done). The repo's
   issue history is the audit trail.
 - **Drafts** are not used. Every task is a real issue.
-- **Priority / Size** — when the project has native single-select
-  \`Priority\` and/or \`Size\` fields, prefer \`set-field.sh\` over text
-  labels. Non-zero exit codes tell the caller when to fall back to
-  labels: \`10\` = no such field on the project, \`11\` = field exists but
-  the value option is missing (e.g. \`priority:P3\` on a 3-level field),
-  \`12\` = issue not on the project.
+- **Priority / Size — fields are the source of truth.** When the
+  project has native single-select \`Priority\` and/or \`Size\` fields,
+  always write through \`set-field.sh\` and **NEVER also apply a
+  matching \`priority:*\` / \`size:*\` label on the same item** — that
+  dual-signal drift is exactly what the helper exists to prevent.
+  Labels are reserved as a strict fallback for projects whose board
+  has no such field. Non-zero exit codes tell the caller which
+  fallback applies: \`10\` = field absent on the project (use the
+  label), \`11\` = field present but the value option is missing
+  (add the option to the field, then re-run; only fall back to a
+  label if you can't add the option), \`12\` = issue not on the
+  project.
 
 ### Prerequisites
 

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -31,19 +31,20 @@ missing or empty, flag it to the user — the project is under-documented.
 Every backlog item you touch MUST exit with both a size
 (`XS`..`XL`) and a priority (`P0`..`P3`) persisted. **Gate**, not polish.
 
-**GitHub — field-first, label fallback.** Specflow projects ship with
-native single-select fields `Priority` and `Size`. When present, write
-to the field; do NOT also apply a label (drift). When absent, fall
-back to `priority:*` / `size:*` labels. Bundled scripts at
+**GitHub — fields are the source of truth; labels are a STRICT
+fallback.** When the project has native single-select fields `Priority`
+and/or `Size`, write the value to the field and **NEVER** also apply
+a `priority:*` / `size:*` label on the same item — that's the dual-
+signal drift `set-field.sh` exists to prevent. Labels are reserved for
+projects whose board has no such field. Bundled scripts at
 `.specflow/scripts/backlog/`:
 
 - `detect-fields.sh` — env lines with field/option IDs (case-insensitive
   match). Run once per groom run.
 - `set-field.sh <issue> <Priority|Size> <value>` — exit codes:
-  - `0` → wrote field, no label.
-  - `10` → no such field → apply matching label.
-  - `11` → field exists but option missing (today: `priority:P3` —
-    canonical fields ship with P0..P2) → apply matching label.
+  - `0` → wrote field, no label (preferred path).
+  - `10` → field absent on this project → apply matching label.
+  - `11` → field present but option missing → apply matching label.
   - `12` → not on project → surface under `⚠ size / priority missing`.
 
 If the fallback label is missing, `gh label create` / `glab label

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -156,12 +156,18 @@ Specflow change — the skill is path-aware.
 - **Closing** — close the issue (don't just move to Done). The repo's
   issue history is the audit trail.
 - **Drafts** are not used. Every task is a real issue.
-- **Priority / Size** — when the project has native single-select
-  `Priority` and/or `Size` fields, prefer `set-field.sh` over text
-  labels. Non-zero exit codes tell the caller when to fall back to
-  labels: `10` = no such field on the project, `11` = field exists but
-  the value option is missing (e.g. `priority:P3` on a 3-level field),
-  `12` = issue not on the project.
+- **Priority / Size — fields are the source of truth.** When the
+  project has native single-select `Priority` and/or `Size` fields,
+  always write through `set-field.sh` and **NEVER also apply a
+  matching `priority:*` / `size:*` label on the same item** — that
+  dual-signal drift is exactly what the helper exists to prevent.
+  Labels are reserved as a strict fallback for projects whose board
+  has no such field. Non-zero exit codes tell the caller which
+  fallback applies: `10` = field absent on the project (use the
+  label), `11` = field present but the value option is missing
+  (add the option to the field, then re-run; only fall back to a
+  label if you can't add the option), `12` = issue not on the
+  project.
 
 ### Prerequisites
 


### PR DESCRIPTION
## Summary

Closes #194 — closes the loop on the native Project V2 fields migration started in #157.

- **P3 added to native Priority field on Project #4** via `updateProjectV2Field` (P0/P1/P2/P3, RED→ORANGE→YELLOW→GREEN). Recipe captured in the issue close comment.
- **Sweep complete** — `migrate-labels-to-fields.sh` ran against all open issues; #176 was the only one carrying a legacy `priority:*` label and is now `Priority=P3` natively, label stripped. Zero open issues retain `priority:*` / `size:*` labels.
- **Hardcoded option IDs refreshed** in the maintainer `set-field.sh` (the `updateProjectV2Field` mutation rotates option IDs even when names match) and `P3` mapped to its new id.
- **PO docs tightened** in `templates/core/agents/product-owner.md` (bundled), `.claude/agents/product-owner.md` (in-repo Project #4), and `plugin/agents/product-owner.md` (parity): when a project has the native field, **NEVER** also apply the matching label. Labels are a strict fallback for projects without the field — not a peer signal.
- **Backlog `SKILL.md` tightened** with the same field-first contract.
- **Smoke assertions** in `smoke-backlog-github.sh`: ensure-labels.sh seeds exactly the 7 semantic labels (security/refactor/docs/tech-debt/dx/performance/dependency) and zero `priority:*` / `size:*` labels; SKILL.md states "fields are the source of truth".

## AC checklist

- [x] Add P3 option to native Priority single-select field on Project #4.
- [x] Sweep open issues — zero `priority:*` / `size:*` labels remain on any open issue (verified post-merge by `gh issue list`).
- [x] Tighten the bundled PO doc (`templates/core/agents/product-owner.md`) — labels are a strict fallback only.
- [x] Mirror the change into `.claude/agents/product-owner.md` (in-repo PO).
- [x] Tighten `templates/core/skills/backlog/SKILL.md` with the field-first contract.
- [x] Verify `ensure-labels.sh` seeds only the 7 semantic labels (zero priority/size).
- [x] Smoke test asserts the 7 semantic labels + zero legacy labels are seeded.

## Test plan

- [x] `deno task test` — 562 passed
- [x] `deno fmt` / `deno lint` — clean
- [x] `bash .claude/skills/test-sandbox/scripts/smoke-backlog-github.sh ghback194` — all checks pass with the new assertions
- [x] Live verify on Project #4: `gh issue list --state open ... | grep -E '^(priority|size):'` returns empty
- [x] Live verify on #176: native `Priority=P3`, label stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)