### PR TITLE
feat(ci): post comment on linked issues when fix PR is opened (#179)

### DIFF
--- a/.github/workflows/pr-link-comment.yml
+++ b/.github/workflows/pr-link-comment.yml
@@ -1,0 +1,57 @@
+# When a PR is OPENED with a body referencing one or more issues via
+# `Closes #N` / `Fixes #N` / `Resolves #N`, post a comment on each
+# referenced issue so the reporter has an immediate, visible signal that
+# work has started — instead of silently waiting until the PR merges and
+# the auto-close trailer fires.
+#
+# Tracked at #179. Fires only on `opened` (per spec) so PR edits, branch
+# pushes, and reopens never re-comment. The `opened`-only trigger gives
+# us "exactly once per issue-per-PR pairing" for free.
+name: pr-link-comment
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment-on-linked-issues:
+    # Skip fork PRs entirely. On a `pull_request` event from a fork,
+    # `GITHUB_TOKEN` is read-only and `gh api -X POST .../comments` would
+    # return 403, turning a green PR into a misleading red one. Specflow
+    # is single-maintainer; this guard fails-open on the rare community
+    # fork rather than silently suppressing the error.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # only credential in play; everything else comes from the event payload
+    steps:
+      - name: Post linked-issue comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # PR body is user-controlled, so it is passed via the env: block
+          # (not interpolated into the YAML) and dereferenced through
+          # double-quoted "$PR_BODY". This treats the body as a literal
+          # string for grep — word splitting and glob expansion are
+          # suppressed. Do NOT "simplify" the quoting away; that turns
+          # this into a shell-injection sink.
+          issues=$(printf '%s' "$PR_BODY" \
+            | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' \
+            | grep -oE '#[0-9]+' \
+            | sed 's/#//' \
+            | sort -u || true)
+          if [ -z "$issues" ]; then
+            echo "no Closes/Fixes/Resolves references — nothing to comment"
+            exit 0
+          fi
+          for n in $issues; do
+            gh api -X POST "repos/$REPO/issues/$n/comments" \
+              -f body="Work has started on this in PR #$PR_NUMBER ($PR_URL). The issue will close automatically when the PR merges." \
+              >/dev/null
+            echo "✓ commented on #$n"
+          done


### PR DESCRIPTION
## Summary

Closes #179 — adds a `pr-link-comment` GitHub Actions workflow that comments on every linked issue when a fix PR is opened, so reporters get immediate visibility instead of waiting silently for the auto-close trailer.

When this PR opens (or any future PR with `Closes #N` / `Fixes #N` / `Resolves #N`), the workflow:

1. Extracts every linked issue from the PR body (case-insensitive).
2. Posts a structured comment on each: "Work has started on this in PR #<N> (<URL>). The issue will close automatically when the PR merges."
3. Skips silently when the PR body has no Closes/Fixes/Resolves references.

## Design (per devops-sre advisory)

- **Trigger:** `pull_request.types: [opened]` only — never on edits, pushes, reopens, or merge. Naturally idempotent (exactly once per issue-per-PR pairing) without needing a marker-based dedup.
- **Fork-PR safety:** job-level `if: github.event.pull_request.head.repo.full_name == github.repository` skips fork PRs entirely. On a fork's `pull_request` event, `GITHUB_TOKEN` is read-only and `gh api -X POST` would 403 — fail-open is cleaner than a misleading red status on a community contribution.
- **Permissions:** only `issues: write` (least privilege). Everything else comes from the event payload.
- **Shell-injection guard:** PR body passed via `env: PR_BODY` and dereferenced as `"$PR_BODY"` (double-quoted) to suppress word splitting / glob expansion. Inline comment in the workflow protects the quoting from being "cleaned up" in a future edit.
- **No `concurrency:` block needed** — independent runs on different issue sets, no shared state.

## AC checklist (#179)

- [x] Comment fires when PR body contains `Closes #N` / `Fixes #N` / `Resolves #N`
- [x] Multiple linked issues → one comment each (regex extracts + `sort -u` deduplicates)
- [x] Comment identifies the PR number and URL
- [x] Fires for every linked issue regardless of source label
- [x] Exactly once per issue-per-PR pairing (`opened`-only trigger)
- [x] Does not fire on branch creation
- [x] Does not fire after PR merges (`Closes #N` already auto-closes)

## Test plan

- [x] YAML parse: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-link-comment.yml'))"` clean
- [x] Regex sanity: multi-line PR body with mixed-case `Closes/Fixes/resolves #N` extracts all 3 distinct issues, dedups duplicates
- [x] Devops-sre advisory pass — all 4 findings addressed
- [ ] **Live test** — first real test fires on the NEXT PR after this one merges (GitHub runs workflows from the base branch on `pull_request` events, so a workflow added in a head branch doesn't fire on its own opening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)