### PR TITLE
fix(backlog): cascade-check.sh exits 12 on already-closed parent

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
@@ -107,6 +107,13 @@ check "cascade-check.sh exits 11 when children block close" \
   'grep -q "exit 11" .specflow/scripts/backlog/cascade-check.sh'
 
 echo
+echo "═══ #202  cascade-check.sh short-circuits on already-closed parent ═══"
+check "cascade-check.sh exits 12 when parent already closed" \
+  'grep -q "exit 12" .specflow/scripts/backlog/cascade-check.sh'
+check "cascade-check.sh inspects parent state before children" \
+  'grep -q "PARENT_STATE" .specflow/scripts/backlog/cascade-check.sh'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL GITHUB BACKLOG CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-gitlab.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-gitlab.sh
@@ -61,6 +61,15 @@ check "cascade-check.sh exits 11 when children block close" \
   'grep -q "exit 11" .specflow/scripts/backlog/cascade-check.sh'
 
 echo
+echo "═══ #202  cascade-check.sh short-circuits on already-closed parent ═══"
+check "cascade-check.sh exits 3 when parent does not exist" \
+  'grep -q "exit 3" .specflow/scripts/backlog/cascade-check.sh'
+check "cascade-check.sh exits 12 when parent already closed" \
+  'grep -q "exit 12" .specflow/scripts/backlog/cascade-check.sh'
+check "cascade-check.sh inspects parent state before children" \
+  'grep -q "PARENT_STATE" .specflow/scripts/backlog/cascade-check.sh'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL GITLAB BACKLOG CHECKS PASSED ═══"
   exit 0

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -384,8 +384,10 @@ link, attaches to the project/board, and refuses (exit 3) when the named parent 
 ```
 
 The bundled `cascade-check.sh <num>` (github + gitlab) is the close gate — exits 11 with the open
-children listed when close is unsafe, exits 0 when all children are closed. The PO runs it before
-`gh issue close` / `glab issue close`. The local backend uses an inline `grep` equivalent.
+children listed when close is unsafe, exits 12 (informational) when the parent is already closed so
+callers don't issue a redundant `close` and 422, exits 3 when the parent doesn't exist, exits 0 when
+all children are closed. The PO runs it before `gh issue close` / `glab issue close`. The local
+backend uses an inline `grep` equivalent.
 
 The Product Owner agent **proactively** proposes epic decomposition during `/backlog add` and during
 grooming whenever a request crosses ≥2 subsystems, has more than 5 acceptance-criteria bullets, or

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5009,8 +5009,9 @@ echo "done."
 # Usage:   cascade-check.sh <issue-number>
 # Exit:    0  parent has no open children — safe to close
 #          11 at least one child is still open — close blocked
-#          2  usage error
+#          12 parent is already closed — nothing to gate (short-circuit)
 #          3  parent issue does not exist
+#          2  usage error
 set -euo pipefail
 
 # shellcheck source=./_config.sh
@@ -5022,9 +5023,21 @@ if [ "\$#" -lt 1 ]; then
 fi
 NUM="\$1"
 
-if ! gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$NUM" --jq '.number' >/dev/null 2>&1; then
+# One API call covers existence + state. Empty stdout = the issue is not
+# reachable (404 or transient) — same exit-3 contract as the previous
+# two-call shape, one fewer round trip.
+PARENT_STATE=\$(gh api "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$NUM" --jq '.state' 2>/dev/null || true)
+if [ -z "\$PARENT_STATE" ]; then
   echo "✗ issue #\$NUM not found in \$REPO_OWNER/\$REPO_NAME" >&2
   exit 3
+fi
+
+# Already-closed short-circuit: callers that trust exit 0 would issue a
+# redundant \`gh issue close\` and get a 422. Surface this explicitly so
+# wrappers (PO agent, CI) treat non-zero as "stop, don't close again".
+if [ "\$PARENT_STATE" = "closed" ]; then
+  echo "ℹ #\$NUM is already closed — nothing to gate"
+  exit 12
 fi
 
 # Native sub-issues endpoint (beta). Returns [] when no children exist.
@@ -5356,6 +5369,8 @@ echo "done."
 # Usage:   cascade-check.sh <issue-number>
 # Exit:    0  parent has no open children — safe to close
 #          11 at least one child is still open — close blocked
+#          12 parent is already closed — nothing to gate (short-circuit)
+#          3  parent issue does not exist
 #          2  usage error
 set -euo pipefail
 
@@ -5367,6 +5382,21 @@ if [ "\$#" -lt 1 ]; then
   exit 2
 fi
 NUM="\$1"
+
+# Existence + state in one glab call. Mirrors the GitHub backend so both
+# variants share the exit-code contract (3 = missing, 12 = already closed,
+# 11 = open children, 0 = safe). GitLab issue states are \`opened\`/\`closed\`.
+PARENT_STATE=\$(glab issue view "\$NUM" --repo "\$PROJECT_ID" --output json 2>/dev/null \\
+  | jq -r '.state // empty' 2>/dev/null || true)
+if [ -z "\$PARENT_STATE" ]; then
+  echo "✗ issue #\$NUM not found in \$PROJECT_ID" >&2
+  exit 3
+fi
+
+if [ "\$PARENT_STATE" = "closed" ]; then
+  echo "ℹ #\$NUM is already closed — nothing to gate"
+  exit 12
+fi
 
 # Children carry a scoped label \`parent::#NNN\`. Ask glab for open issues
 # with that label; output is one issue per line on the standard format.

--- a/templates/core/skills/backlog/scripts/github/cascade-check.sh
+++ b/templates/core/skills/backlog/scripts/github/cascade-check.sh
@@ -6,8 +6,9 @@
 # Usage:   cascade-check.sh <issue-number>
 # Exit:    0  parent has no open children — safe to close
 #          11 at least one child is still open — close blocked
-#          2  usage error
+#          12 parent is already closed — nothing to gate (short-circuit)
 #          3  parent issue does not exist
+#          2  usage error
 set -euo pipefail
 
 # shellcheck source=./_config.sh
@@ -19,9 +20,21 @@ if [ "$#" -lt 1 ]; then
 fi
 NUM="$1"
 
-if ! gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$NUM" --jq '.number' >/dev/null 2>&1; then
+# One API call covers existence + state. Empty stdout = the issue is not
+# reachable (404 or transient) — same exit-3 contract as the previous
+# two-call shape, one fewer round trip.
+PARENT_STATE=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$NUM" --jq '.state' 2>/dev/null || true)
+if [ -z "$PARENT_STATE" ]; then
   echo "✗ issue #$NUM not found in $REPO_OWNER/$REPO_NAME" >&2
   exit 3
+fi
+
+# Already-closed short-circuit: callers that trust exit 0 would issue a
+# redundant `gh issue close` and get a 422. Surface this explicitly so
+# wrappers (PO agent, CI) treat non-zero as "stop, don't close again".
+if [ "$PARENT_STATE" = "closed" ]; then
+  echo "ℹ #$NUM is already closed — nothing to gate"
+  exit 12
 fi
 
 # Native sub-issues endpoint (beta). Returns [] when no children exist.

--- a/templates/core/skills/backlog/scripts/gitlab/cascade-check.sh
+++ b/templates/core/skills/backlog/scripts/gitlab/cascade-check.sh
@@ -7,6 +7,8 @@
 # Usage:   cascade-check.sh <issue-number>
 # Exit:    0  parent has no open children — safe to close
 #          11 at least one child is still open — close blocked
+#          12 parent is already closed — nothing to gate (short-circuit)
+#          3  parent issue does not exist
 #          2  usage error
 set -euo pipefail
 
@@ -18,6 +20,21 @@ if [ "$#" -lt 1 ]; then
   exit 2
 fi
 NUM="$1"
+
+# Existence + state in one glab call. Mirrors the GitHub backend so both
+# variants share the exit-code contract (3 = missing, 12 = already closed,
+# 11 = open children, 0 = safe). GitLab issue states are `opened`/`closed`.
+PARENT_STATE=$(glab issue view "$NUM" --repo "$PROJECT_ID" --output json 2>/dev/null \
+  | jq -r '.state // empty' 2>/dev/null || true)
+if [ -z "$PARENT_STATE" ]; then
+  echo "✗ issue #$NUM not found in $PROJECT_ID" >&2
+  exit 3
+fi
+
+if [ "$PARENT_STATE" = "closed" ]; then
+  echo "ℹ #$NUM is already closed — nothing to gate"
+  exit 12
+fi
 
 # Children carry a scoped label `parent::#NNN`. Ask glab for open issues
 # with that label; output is one issue per line on the standard format.


### PR DESCRIPTION
## Summary

Fixes the contract bug in `cascade-check.sh` flagged by issue #202: both backends silently return `exit 0` ("safe to close") when the parent is already closed, because only the open-children count is inspected. Wrappers trusting that exit code then call `gh/glab issue close` redundantly and receive a 422.

Closes #202.

## What changed

- **GitHub backend** — collapse existence + new state check into one `gh api ... --jq '.state'` call. Empty stdout → `exit 3` (not found); `state == "closed"` → `exit 12` with `ℹ #N is already closed — nothing to gate`. One fewer round trip than the previous two-call shape.
- **GitLab backend** — gains *both* checks (the script previously had neither). One `glab issue view --output json | jq '.state'` covers existence + state. Same exit-code surface as GitHub now (`3 / 11 / 12 / 0 / 2`) — no divergent contract between backends.
- **Header comments** updated on both scripts to document `exit 12` and the symmetrical `exit 3` on GitLab.
- **Smoke coverage** extended in `smoke-backlog-github.sh` and `smoke-backlog-gitlab.sh`: assertions on `PARENT_STATE` inspection, `exit 12`, and (GitLab) `exit 3`.

## Backwards compat

Existing callers branching on `0` vs non-zero remain correct. `exit 12` is non-zero, so they halt before the redundant close — the safer default.

## Repro from the issue

`mkrlabs/videolab#8` (closed parent) + `#10` (closed child). After the close sequence completed, `cascade-check.sh 8` still exited 0 with `✓ #8 safe to close (no open children)`. With this change, `exit 12` + `ℹ #8 is already closed — nothing to gate`.

## Test plan

- [x] `bash -n` syntax check on both modified scripts.
- [x] `deno task test` — all 564 tests pass.
- [x] `deno fmt` / `lint` / `bundle` / `check` — clean (pre-commit hook enforces).
- [x] Test-sandbox `audit.sh` — no coverage gaps after the smoke updates.
- [ ] Optional manual run on a real GitHub project (smoke-backlog-github.sh exit 12 path) before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)