### PR TITLE
feat(codex): scaffold /goal prompt template and reference doc on init

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -256,6 +256,14 @@ All harnesses share the same source-of-truth content in `templates/core/`. The p
 in `src/infrastructure/harness/` map that core bundle to each harness's directory layout and
 frontmatter conventions.
 
+Some harnesses also ship harness-specific helper files alongside the core scaffold:
+
+- **Claude** — `.claude/CLAUDE.md` (harness reference) + `.claude/loop.md` (default prompt for
+  `/loop`, Claude's recurring periodic-maintenance feature).
+- **Codex** — `.codex/AGENTS.md` (harness reference) + `.codex/goal.md` (default prompt for `/goal`,
+  Codex's experimental one-shot long-horizon feature; enable via `goals = true` under `[features]`
+  in `config.toml`).
+
 ## What makes Specflow different from upstream Spec Kit
 
 Specflow is a fork of the official `specify` CLI with four additions:

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -2,6 +2,7 @@ import { stringify as stringifyToml } from "@std/toml";
 import type { BundleOptions, Harness } from "../../application/ports.ts";
 import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
+import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
@@ -91,6 +92,10 @@ export class CodexHarness implements Harness {
           };
           break;
       }
+    }
+    const staticFiles = HARNESS_STATIC[this.key] ?? {};
+    for (const [dest, file] of Object.entries(staticFiles)) {
+      out[dest] = file;
     }
     return out;
   }

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -9257,6 +9257,80 @@ exit 0
       executable: true,
     },
   },
+  "codex": {
+    ".codex/AGENTS.md": {
+      content: `# Codex Reference
+
+- **Project documentation and rules**: the primary reference is \`AGENTS.md\`
+  at the project root. Read it first.
+- **Skills**: installed skills live in \`.agents/skills/\`.
+- **Subagents**: Codex subagent definitions live in \`.codex/agents/\`
+  (TOML format).
+- **Backlog**: managed via the \`/specflow groom\` workflow — when the
+  project uses the local Markdown backend, see \`.specflow/backlog.md\`.
+
+## Optional integrations
+
+These are Codex CLI features Specflow does NOT configure by default, but
+that pair well with the scaffolded workflow.
+
+- **Periodic maintenance** — \`/goal\` runs the prompt in \`.codex/goal.md\`
+  as a one-shot long-horizon objective (groom backlog, surface stale PRs,
+  list orphan specs); edit \`goal.md\` freely. The feature is experimental
+  — opt in by adding \`goals = true\` under \`[features]\` in your Codex
+  \`config.toml\`, or toggle it with \`/experimental\`. Lifecycle controls:
+  \`/goal pause\`, \`/goal resume\`, \`/goal clear\`. See
+  https://developers.openai.com/codex/use-cases/follow-goals.
+
+- **CLI reference** — full Codex CLI surface (slash commands, config
+  schema, headless mode): https://developers.openai.com/codex/cli/reference.
+
+- **More Codex use cases** — https://developers.openai.com/codex/use-cases.
+`,
+      executable: false,
+    },
+    ".codex/goal.md": {
+      content: `# Project goal prompt
+
+This file customizes what \`/goal\` runs when invoked without an explicit
+objective. Specflow ships a sensible default below — edit freely to match
+this project's hygiene needs.
+
+## Default goal prompt
+
+Run a hygiene pass on this Specflow project:
+
+1. Invoke the \`/specflow groom\` skill — it grooms the backlog, surfaces
+   stale PRs, and flags orphan specs.
+2. If anything actionable came out of the pass, summarize it concisely
+   so the human reading the result can decide what to do.
+3. If everything is healthy, say so in one sentence and stop. Do not
+   manufacture work.
+
+## Recommended invocation
+
+\`/goal\` is one-shot long-horizon, not a recurring timer. Good moments to
+run it:
+
+- **Start of a session**: open Codex, run \`/goal\`, let it groom while
+  you context-switch.
+- **End of a sprint**: run \`/goal\` to leave the backlog tidy before a
+  release branch is cut.
+- **Lifecycle controls**: \`/goal pause\`, \`/goal resume\`, \`/goal clear\`.
+
+## Customizing further
+
+Append project-specific checks to the prompt above. Examples:
+
+- "Check that the staging deploy from the last \`main\` commit succeeded."
+- "Verify the daily backup ran in the last 24 hours."
+- "Ping if any feature flag is still enabled after its sunset date."
+
+Each \`/goal\` run loads the full prompt, so keep it focused.
+`,
+      executable: false,
+    },
+  },
   "cursor": {
     ".cursor/rules/specify-rules.mdc": {
       content: `---

--- a/templates/harness-specific/codex/AGENTS.md
+++ b/templates/harness-specific/codex/AGENTS.md
@@ -1,0 +1,27 @@
+# Codex Reference
+
+- **Project documentation and rules**: the primary reference is `AGENTS.md`
+  at the project root. Read it first.
+- **Skills**: installed skills live in `.agents/skills/`.
+- **Subagents**: Codex subagent definitions live in `.codex/agents/`
+  (TOML format).
+- **Backlog**: managed via the `/specflow groom` workflow — when the
+  project uses the local Markdown backend, see `.specflow/backlog.md`.
+
+## Optional integrations
+
+These are Codex CLI features Specflow does NOT configure by default, but
+that pair well with the scaffolded workflow.
+
+- **Periodic maintenance** — `/goal` runs the prompt in `.codex/goal.md`
+  as a one-shot long-horizon objective (groom backlog, surface stale PRs,
+  list orphan specs); edit `goal.md` freely. The feature is experimental
+  — opt in by adding `goals = true` under `[features]` in your Codex
+  `config.toml`, or toggle it with `/experimental`. Lifecycle controls:
+  `/goal pause`, `/goal resume`, `/goal clear`. See
+  https://developers.openai.com/codex/use-cases/follow-goals.
+
+- **CLI reference** — full Codex CLI surface (slash commands, config
+  schema, headless mode): https://developers.openai.com/codex/cli/reference.
+
+- **More Codex use cases** — https://developers.openai.com/codex/use-cases.

--- a/templates/harness-specific/codex/goal.md
+++ b/templates/harness-specific/codex/goal.md
@@ -1,0 +1,37 @@
+# Project goal prompt
+
+This file customizes what `/goal` runs when invoked without an explicit
+objective. Specflow ships a sensible default below — edit freely to match
+this project's hygiene needs.
+
+## Default goal prompt
+
+Run a hygiene pass on this Specflow project:
+
+1. Invoke the `/specflow groom` skill — it grooms the backlog, surfaces
+   stale PRs, and flags orphan specs.
+2. If anything actionable came out of the pass, summarize it concisely
+   so the human reading the result can decide what to do.
+3. If everything is healthy, say so in one sentence and stop. Do not
+   manufacture work.
+
+## Recommended invocation
+
+`/goal` is one-shot long-horizon, not a recurring timer. Good moments to
+run it:
+
+- **Start of a session**: open Codex, run `/goal`, let it groom while
+  you context-switch.
+- **End of a sprint**: run `/goal` to leave the backlog tidy before a
+  release branch is cut.
+- **Lifecycle controls**: `/goal pause`, `/goal resume`, `/goal clear`.
+
+## Customizing further
+
+Append project-specific checks to the prompt above. Examples:
+
+- "Check that the staging deploy from the last `main` commit succeeded."
+- "Verify the daily backup ran in the last 24 hours."
+- "Ping if any feature flag is still enabled after its sunset date."
+
+Each `/goal` run loads the full prompt, so keep it focused.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -92,6 +92,8 @@
     { "harness": "claude", "destination": ".claude/hooks/protect-generated.sh", "source": "harness-specific/claude/hooks/protect-generated.sh", "executable": true },
     { "harness": "claude", "destination": ".claude/hooks/log-subagent.sh", "source": "harness-specific/claude/hooks/log-subagent.sh", "executable": true },
     { "harness": "claude", "destination": ".claude/hooks/check-backlog-prereqs.sh", "source": "harness-specific/claude/hooks/check-backlog-prereqs.sh", "executable": true },
+    { "harness": "codex", "destination": ".codex/AGENTS.md", "source": "harness-specific/codex/AGENTS.md" },
+    { "harness": "codex", "destination": ".codex/goal.md", "source": "harness-specific/codex/goal.md" },
     { "harness": "cursor", "destination": ".cursor/rules/specify-rules.mdc", "source": "harness-specific/cursor/specify-rules.mdc" }
   ]
 }

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -74,6 +74,18 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     assertEquals(typeof parsed.description, "string");
     assertEquals(typeof parsed.developer_instructions, "string");
 
+    // Codex harness reference doc + /goal prompt template
+    assertEquals(await exists(join(root, ".codex/AGENTS.md")), true);
+    assertEquals(await exists(join(root, ".codex/goal.md")), true);
+    const codexAgentsMd = await Deno.readTextFile(join(root, ".codex/AGENTS.md"));
+    assertEquals(codexAgentsMd.includes("# Codex Reference"), true);
+    assertEquals(codexAgentsMd.includes("## Optional integrations"), true);
+    assertEquals(codexAgentsMd.includes(".codex/goal.md"), true);
+    const codexGoalMd = await Deno.readTextFile(join(root, ".codex/goal.md"));
+    assertEquals(codexGoalMd.includes("# Project goal prompt"), true);
+    assertEquals(codexGoalMd.includes("## Default goal prompt"), true);
+    assertEquals(codexGoalMd.includes("/specflow groom"), true);
+
     // Top-level skill folders post-consolidation: specflow router +
     // specflow-auto + specflow-review alias + specflow-backlog = 4.
     const agentsSkillsCount = (await Array.fromAsync(


### PR DESCRIPTION
## Summary

- Adds `templates/harness-specific/codex/goal.md` — a Specflow-aware default prompt for Codex's experimental **Follow a goal** (`/goal`) feature, structurally mirroring the Claude harness's `loop.md` but reworded for `/goal`'s one-shot long-horizon semantics (no recurring schedule).
- Adds `templates/harness-specific/codex/AGENTS.md` — Codex harness reference doc, analogous to `claude/CLAUDE.md`, with an **Optional integrations → Periodic maintenance** section linking the bundled `goal.md`, the `[features].goals = true` opt-in, and the official docs.
- Wires `HARNESS_STATIC[codex]` into `CodexHarness.mapBundle` (Codex didn't consume static files before — only Claude and Cursor did).
- Regenerates `src/templates_bundle.ts` via `deno task bundle` and extends `tests/integration/init_codex_test.ts` to assert both new files scaffold correctly.

Closes #204.

## Test plan

- [x] `deno task test` — 564 passed / 0 failed (incl. extended `init_codex_test.ts`).
- [x] `deno task fmt` clean.
- [x] `deno task lint` clean.
- [x] `deno task check` clean.
- [ ] Smoke: `specflow init demo --ai codex --no-git` in a temp dir produces `.codex/AGENTS.md` and `.codex/goal.md` with the expected content (validated by the integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)