### PR TITLE
test(smoke): assert harness-specific helper files in all-harnesses

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh
@@ -77,6 +77,35 @@ for h in "${HARNESSES[@]}"; do
   pass "$h: scaffold ok ($expected/ + lock declares harness=$h)"
 done
 
+# Harness-specific helper files. Each pair (file path + content anchor)
+# asserts that the harness scaffolds its "ergonomics" extras on top of
+# the generic root + lock. Kept inline (not a loop over harnesses) so
+# additions stay obvious in code review.
+#
+# - Claude: .claude/CLAUDE.md (harness reference) + .claude/loop.md
+#   (default prompt for /loop, recurring maintenance).
+# - Codex: .codex/AGENTS.md (harness reference) + .codex/goal.md
+#   (default prompt for /goal, one-shot long-horizon maintenance,
+#   shipped in v1.2.1).
+check_helper() {
+  local harness="$1" path="$2" anchor="$3"
+  local file="$ROOT/sandbox/$NAME-$harness/$path"
+  if [ ! -f "$file" ]; then
+    fail "$harness helper" "$path missing"
+    return
+  fi
+  if ! grep -q "$anchor" "$file"; then
+    fail "$harness helper" "$path missing anchor '$anchor'"
+    return
+  fi
+  pass "$harness helper: $path ok"
+}
+
+check_helper claude ".claude/CLAUDE.md" "^# Claude Reference"
+check_helper claude ".claude/loop.md"   "^# Project loop prompt"
+check_helper codex  ".codex/AGENTS.md"  "^# Codex Reference"
+check_helper codex  ".codex/goal.md"    "^# Project goal prompt"
+
 echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL 8 HARNESSES PASSED ═══"


### PR DESCRIPTION
## Summary

- Extends `smoke-all-harnesses.sh` to assert each harness scaffolds its ergonomics extras alongside the generic output root + lock.
- Claude: `.claude/CLAUDE.md` + `.claude/loop.md`.
- Codex: `.codex/AGENTS.md` + `.codex/goal.md` (new in v1.2.1 via #205).
- New `check_helper()` helper asserts file existence AND a content anchor (e.g. `^# Codex Reference`) so a hollow scaffold can't silently pass.
- Kept inline rather than table-driven so future additions stay visible in code review.

Triggered by the v1.2.1 release: the new Codex helper files were covered by the Deno integration test (`tests/integration/init_codex_test.ts`) but had no shell-smoke assertion. This closes that gap and back-fills Claude's helper files for symmetry.

## Test plan

- [x] `bash .claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh allharness` — 8 harnesses pass + 4 helper checks pass.
- [x] Pre-commit hook (fmt + lint + bundle + check) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)