### PR TITLE
docs(hero): rename heading "repo" → "project"

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -57,7 +57,7 @@
         <div class="hero-copy">
           <p class="eyebrow">9 agents · 8 harnesses · 1 curl</p>
           <h1 id="hero-title">
-            A coordinated AI agent team, in your repo.
+            A coordinated AI agent team, in your project.
           </h1>
           <p class="lede">
             Specflow scaffolds the files your AI coding harness consumes — slash-commands,


### PR DESCRIPTION
## Summary

One-word change in the landing-page hero heading. Closes #213.

Before: `A coordinated AI agent team, in your repo.`
After:  `A coordinated AI agent team, in your project.`

Touches `docs/site/index.html` line 60 only. The other "repo" occurrences in the file (lines 24 and 115) are out of scope per the issue's AC.

## Test plan

- [x] Pre-commit hook green (fmt + lint + bundle + check).
- [ ] Visual eyeball after deploy: docs page renders the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)