### PR TITLE
fix(docs): pin code blocks to a fixed dark theme

### DIFF
--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -14,6 +14,11 @@
   --color-btn-primary-fg: #ffffff;
   --color-btn-primary-border: #246a73;
 
+  /* Code blocks — pinned to fixed dark values so they stay dark regardless
+     of the OS color scheme. Not overridden in the dark-mode media query. */
+  --codeblock-bg: #16182e;
+  --codeblock-fg: #ffffff;
+
   /* Neutrals */
   --color-neutral-0: #ffffff;
   --color-neutral-50: #f7f8fc;
@@ -459,8 +464,8 @@ main > section {
  * --------------------------------------------------------------- */
 
 .codeblock {
-  background: var(--color-neutral-900);
-  color: var(--color-neutral-0);
+  background: var(--codeblock-bg);
+  color: var(--codeblock-fg);
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
@@ -815,8 +820,8 @@ main > section {
 }
 
 .markdown-body pre {
-  background: var(--color-neutral-900);
-  color: var(--color-neutral-0);
+  background: var(--codeblock-bg);
+  color: var(--codeblock-fg);
   border-radius: var(--radius-md);
   padding: var(--space-4) var(--space-5);
   overflow-x: auto;


### PR DESCRIPTION
## Summary

Introduces `--codeblock-bg` / `--codeblock-fg` tokens defined only in `:root` — they are intentionally NOT overridden in the `@media (prefers-color-scheme: dark)` block. As a result, `.codeblock` and `.markdown-body pre` now stay dark in both light- and dark-mode OS contexts.

Previously both rules used `--color-neutral-900` / `--color-neutral-0`, which the dark-mode media query flips to near-white / near-black — causing the install snippet and rendered-docs code blocks to invert to a light background that looked broken next to the surrounding dark page.

Closes #207.

## Test plan

- [x] Pre-commit hook green (fmt + lint + bundle + check).
- [x] Both selectors verified to reference the new pinned tokens.
- [x] New tokens absent from the dark-mode override block — verified.
- [ ] **Visual sanity check after deploy** — please eyeball the install snippet on https://specflow.makerlabs.dev once `Deploy docs to Pages` runs on `main`, with the OS toggled between light and dark mode. Expectation: dark background in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)