### PR TITLE
docs(claude): document /goal in scaffolded .claude/CLAUDE.md

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -258,8 +258,8 @@ frontmatter conventions.
 
 Some harnesses also ship harness-specific helper files alongside the core scaffold:
 
-- **Claude** — `.claude/CLAUDE.md` (harness reference) + `.claude/loop.md` (default prompt for
-  `/loop`, Claude's recurring periodic-maintenance feature).
+- **Claude** — `.claude/CLAUDE.md` (harness reference, including `/goal` and `/loop` usage notes) +
+  `.claude/loop.md` (default prompt for `/loop`, Claude's recurring periodic-maintenance feature).
 - **Codex** — `.codex/AGENTS.md` (harness reference) + `.codex/goal.md` (default prompt for `/goal`,
   Codex's experimental one-shot long-horizon feature; enable via `goals = true` under `[features]`
   in `config.toml`).

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -8859,6 +8859,16 @@ team's needs.
   specs); edit \`loop.md\` freely to add project-specific checks. See
   https://code.claude.com/docs/fr/scheduled-tasks.
 
+- **Goal-directed sessions** — \`/goal <condition>\` keeps Claude taking
+  turns until a fast model judges the condition met. Best conditions
+  state one measurable end state and a turn cap, e.g. \`/goal the Ready
+  column on the Specflow Project is empty and deno task test exits 0,
+  or stop after 20 turns\`. Run headless with \`claude -p "/goal …"\`.
+  Check status with \`/goal\`; cancel with \`/goal clear\` (aliases:
+  \`stop\`/\`off\`/\`reset\`/\`cancel\`). For recurring periodic checks use
+  \`/loop\` (see \`.claude/loop.md\`) instead. See
+  https://code.claude.com/docs/fr/goal.
+
 - **Async notifications** — install one of the channel plugins (Telegram,
   Discord, iMessage) so Claude can ping you when a long-running task or
   agent dispatch finishes. See

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -20,6 +20,16 @@ team's needs.
   specs); edit `loop.md` freely to add project-specific checks. See
   https://code.claude.com/docs/fr/scheduled-tasks.
 
+- **Goal-directed sessions** — `/goal <condition>` keeps Claude taking
+  turns until a fast model judges the condition met. Best conditions
+  state one measurable end state and a turn cap, e.g. `/goal the Ready
+  column on the Specflow Project is empty and deno task test exits 0,
+  or stop after 20 turns`. Run headless with `claude -p "/goal …"`.
+  Check status with `/goal`; cancel with `/goal clear` (aliases:
+  `stop`/`off`/`reset`/`cancel`). For recurring periodic checks use
+  `/loop` (see `.claude/loop.md`) instead. See
+  https://code.claude.com/docs/fr/goal.
+
 - **Async notifications** — install one of the channel plugins (Telegram,
   Discord, iMessage) so Claude can ping you when a long-running task or
   agent dispatch finishes. See

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -487,3 +487,21 @@ Deno.test("specflow init scaffolds the consolidated router skill + 11 phase docs
     );
   });
 });
+
+Deno.test("scaffolded .claude/CLAUDE.md documents /goal", async () => {
+  await withTempDir(async (dir) => {
+    const { code, stderr } = await runSpecflow(
+      ["init", "demo", "--no-git", "--ai", "claude", "--backlog", "local"],
+      { cwd: dir },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+    const claudeMd = await Deno.readTextFile(
+      join(dir, "demo/.claude/CLAUDE.md"),
+    );
+    assertStringIncludes(claudeMd, "## Optional integrations");
+    assertStringIncludes(claudeMd, "Goal-directed sessions");
+    assertStringIncludes(claudeMd, "/goal");
+    assertStringIncludes(claudeMd, "code.claude.com/docs/fr/goal");
+    assertStringIncludes(claudeMd, ".claude/loop.md");
+  });
+});


### PR DESCRIPTION
## Summary

- Claude Code's `/goal` keeps a session running across turns until a fast model judges a user-supplied condition met. Unlike Codex's `/goal` (which reads `.codex/goal.md` as a prompt template), Claude `/goal` consumes no file — the condition itself is the directive.
- Adds a `Goal-directed sessions` bullet to the scaffolded `.claude/CLAUDE.md` (under the existing **Optional integrations** section), with Specflow-flavoured example conditions, headless invocation, lifecycle commands, and a pointer to https://code.claude.com/docs/fr/goal.
- Tweaks the `docs/llms.md` harness-helpers paragraph to mention the new coverage; adds an integration test asserting the bullet ships in the scaffolded file.
- No new file, no manifest change, no impact on other harnesses.

## Test plan

- [x] `deno task bundle` regenerates `src/templates_bundle.ts` with the new bullet under `HARNESS_STATIC.claude["CLAUDE.md"]`
- [x] `deno task test` — full suite green (565 tests)
- [x] `deno task fmt && deno task lint`
- [x] Pre-commit hook (fmt + lint + bundle + check) passed
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)