### PR TITLE
docs(claude): document `claude agents` multi-session dispatch

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -258,8 +258,9 @@ frontmatter conventions.
 
 Some harnesses also ship harness-specific helper files alongside the core scaffold:
 
-- **Claude** — `.claude/CLAUDE.md` (harness reference, including `/goal` and `/loop` usage notes) +
-  `.claude/loop.md` (default prompt for `/loop`, Claude's recurring periodic-maintenance feature).
+- **Claude** — `.claude/CLAUDE.md` (harness reference, including `/goal`, `/loop`, and
+  `claude agents` usage notes) + `.claude/loop.md` (default prompt for `/loop`, Claude's recurring
+  periodic-maintenance feature).
 - **Codex** — `.codex/AGENTS.md` (harness reference) + `.codex/goal.md` (default prompt for `/goal`,
   Codex's experimental one-shot long-horizon feature; enable via `goals = true` under `[features]`
   in `config.toml`).

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -8869,6 +8869,20 @@ team's needs.
   \`/loop\` (see \`.claude/loop.md\`) instead. See
   https://code.claude.com/docs/fr/goal.
 
+- **Multi-session dispatch (\`claude agents\`)** — opens a terminal UI
+  that lists every background Claude session, dispatches new ones,
+  and lets you peek / reply / attach without losing context. Specflow's
+  scaffolded subagents in \`.claude/agents/\` appear in the dispatch
+  picker automatically — start one with the agent name as the first
+  word, e.g. \`developer fix the lint errors in src/cli/\`, \`@qa-tester
+  run a sandbox smoke pass\`, or \`@product-owner groom the backlog\`.
+  Skills are dispatchable too: \`/specflow specify "<feature>"\` launches
+  a session running the full spec-plan-tasks chain. File edits are
+  isolated under \`.claude/worktrees/\` (git worktrees), so several
+  Specflow agents can work in parallel without stepping on each
+  other. Requires Claude Code v2.1.139+. See
+  https://code.claude.com/docs/fr/agent-view.
+
 - **Async notifications** — install one of the channel plugins (Telegram,
   Discord, iMessage) so Claude can ping you when a long-running task or
   agent dispatch finishes. See

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -30,6 +30,20 @@ team's needs.
   `/loop` (see `.claude/loop.md`) instead. See
   https://code.claude.com/docs/fr/goal.
 
+- **Multi-session dispatch (`claude agents`)** — opens a terminal UI
+  that lists every background Claude session, dispatches new ones,
+  and lets you peek / reply / attach without losing context. Specflow's
+  scaffolded subagents in `.claude/agents/` appear in the dispatch
+  picker automatically — start one with the agent name as the first
+  word, e.g. `developer fix the lint errors in src/cli/`, `@qa-tester
+  run a sandbox smoke pass`, or `@product-owner groom the backlog`.
+  Skills are dispatchable too: `/specflow specify "<feature>"` launches
+  a session running the full spec-plan-tasks chain. File edits are
+  isolated under `.claude/worktrees/` (git worktrees), so several
+  Specflow agents can work in parallel without stepping on each
+  other. Requires Claude Code v2.1.139+. See
+  https://code.claude.com/docs/fr/agent-view.
+
 - **Async notifications** — install one of the channel plugins (Telegram,
   Discord, iMessage) so Claude can ping you when a long-running task or
   agent dispatch finishes. See

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -505,3 +505,20 @@ Deno.test("scaffolded .claude/CLAUDE.md documents /goal", async () => {
     assertStringIncludes(claudeMd, ".claude/loop.md");
   });
 });
+
+Deno.test("scaffolded .claude/CLAUDE.md documents `claude agents`", async () => {
+  await withTempDir(async (dir) => {
+    const { code, stderr } = await runSpecflow(
+      ["init", "demo", "--no-git", "--ai", "claude", "--backlog", "local"],
+      { cwd: dir },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+    const claudeMd = await Deno.readTextFile(
+      join(dir, "demo/.claude/CLAUDE.md"),
+    );
+    assertStringIncludes(claudeMd, "Multi-session dispatch");
+    assertStringIncludes(claudeMd, "claude agents");
+    assertStringIncludes(claudeMd, "code.claude.com/docs/fr/agent-view");
+    assertStringIncludes(claudeMd, ".claude/worktrees/");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `Multi-session dispatch (claude agents)` bullet to the scaffolded `.claude/CLAUDE.md` under **Optional integrations**, pointing users at Claude Code's terminal UI for managing background sessions (v2.1.139+).
- Highlights how it composes with Specflow scaffolding for free: subagents in `.claude/agents/` are auto-discoverable in the dispatch picker (`developer …`, `@qa-tester …`, `@product-owner …`), and `/specflow specify "<feature>"` works from inside a dispatched session. Notes the `.claude/worktrees/` isolation that lets multiple Specflow agents work in parallel without conflicts.
- Tweaks the `docs/llms.md` harness-helpers paragraph to mention the new coverage.
- Adds one integration test asserting the bullet ships in the scaffolded file.
- No new file, no manifest change, no impact on other harnesses.

## Test plan

- [x] `deno task bundle` regenerates `src/templates_bundle.ts` with the new bullet
- [x] `deno task test` — 566/566 green (was 565)
- [x] `deno task fmt && deno task lint`
- [x] Pre-commit hook (fmt + lint + bundle + check) passed
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)