### PR TITLE
fix(backlog): use REST/CLI over raw GraphQL where possible (#222)

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -340,10 +340,19 @@ every demo, or as a daily habit.
 - **French summaries to the user** in issue comments (he's francophone).
   **English in the issue body sections** (`## Why`, etc.) — matches the
   repo convention for issues + commits.
-- Use the `view.sh` / `list.sh` / `add.sh` / `move.sh` /
-  `clarify-comment.sh` wrappers under `.claude/skills/backlog/scripts/`
-  by default. They handle the GitHub `gh project item-list`
-  edge-case-bug; raw `gh api graphql` only when no wrapper fits.
+- **Tool preference order: CLI → MCP → GraphQL.** Use the
+  `view.sh` / `list.sh` / `add.sh` / `move.sh` / `clarify-comment.sh` /
+  `set-field.sh` wrappers under `.claude/skills/backlog/scripts/` first
+  — they already prefer `gh issue` / `gh project item-edit` (REST-ish CLI,
+  ~1–2 GraphQL points per call) and reserve raw `gh api graphql` for
+  mutations with no CLI equivalent. For one-off issue reads outside the
+  scripted paths, prefer `mcp__github__*` tools (`mcp__github__issue_read`,
+  `mcp__github__list_issues`, `mcp__github__add_issue_comment`) over raw
+  `gh api graphql` — they're REST-backed and don't burn GraphQL quota.
+  Raw `gh api graphql` only when no CLI/MCP path exists
+  (`updateProjectV2ItemFieldValue` is GraphQL-only, but `gh project item-edit`
+  wraps it). The GraphQL bucket is shared with REST but scored by query
+  complexity — bulky queries cause the rate-limit incidents.
 - When in doubt about scope, prefer "Out of scope" over "Acceptance
   criteria". Saying what we won't do is more valuable than padding the
   AC.

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -50,9 +50,11 @@ gh issue reopen <num> --repo mkrlabs/specflow
 gh issue edit   <num> --repo mkrlabs/specflow --title "…" --body "…" --add-label "…" --remove-label "…"
 ```
 
-## Why we don't use `gh project item-list`
+## API quota — prefer REST/CLI over raw GraphQL
 
-`gh project item-list 4 --owner mkrlabs` and the equivalent `viewer.projectV2(4).items` GraphQL field can return 0 items in some account/permission contexts even when items genuinely exist (verified via direct node queries). The `list.sh` and `move.sh` scripts work around it by querying via `repository.issues[].projectItems[]` filtered by `project.number == 4`. Same data, reverse path through the graph.
+GitHub's GraphQL and REST APIs share the same 5,000-points-per-hour authenticated quota, but complex GraphQL queries score much higher per call than REST/CLI equivalents. Past versions of these scripts ran hand-rolled `repository.issues[].projectItems[].fieldValues[]` queries that were the main rate-limit offender; the current scripts use `gh issue list/view --json projectItems` (the gh CLI's REST-ish JSON projection, ~1–2 points per call) for read paths and reserve raw `gh api graphql` only for surfaces with no CLI equivalent (`updateProjectV2ItemFieldValue` mutations, exposed via `gh project item-edit`, and the small targeted item-ID lookup in `move.sh` / `set-field.sh`).
+
+Order of preference for any new backlog tool: `gh issue` / `gh project item-edit` CLI → `mcp__github__*` REST tools (agent context) → small targeted `gh api graphql` only when no CLI/MCP equivalent exists.
 
 ## Conventions
 

--- a/.claude/skills/backlog/scripts/list.sh
+++ b/.claude/skills/backlog/scripts/list.sh
@@ -1,51 +1,34 @@
 #!/usr/bin/env bash
-# List items on Project #4 with their Status, going through the issue side
-# (gh project item-list can return 0 in some account/permission contexts —
-# we work around it by querying via repository.issues[].projectItems[]).
+# List items on Project #4 with their Status. Uses `gh issue list --json
+# projectItems` — the gh CLI exposes the Project V2 Status field via its
+# REST-ish JSON projection, costing ~1 GraphQL point per call (vs ~20 for
+# the hand-rolled `repository.issues[].projectItems[].fieldValues[]` query
+# that lived here previously and was the main rate-limit offender).
+#
 # Usage: list.sh [STATUS]
 #   STATUS — optional filter: Backlog | Ready | "In progress" | "In review" | Done
+#
+# Default (no filter): every issue NOT in Done — matches the historical
+# "open issues on the board" semantics. Pass `Done` explicitly to see closed
+# items still pinned to the board.
 set -euo pipefail
 
 FILTER="${1:-}"
 
-JSON=$(gh api graphql -f query='
-  query {
-    repository(owner:"mkrlabs", name:"specflow") {
-      issues(first:100, states:OPEN) {
-        nodes {
-          number title
-          projectItems(first:5) {
-            nodes {
-              project { number }
-              fieldValues(first:8) {
-                nodes {
-                  ... on ProjectV2ItemFieldSingleSelectValue {
-                    name
-                    field { ... on ProjectV2SingleSelectField { name } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }')
+JSON=$(gh issue list --repo mkrlabs/specflow --state open --limit 200 \
+  --json number,title,projectItems)
 
-ROWS=$(echo "$JSON" | jq -r '
-  .data.repository.issues.nodes[]
+ROWS=$(echo "$JSON" | jq -r --arg filter "$FILTER" '
+  .[]
   | . as $issue
-  | (.projectItems.nodes[] | select(.project.number == 4)) as $item
-  | (
-      ($item.fieldValues.nodes[]
-        | select(.field?.name == "Status")
-        | .name) // "—"
-    ) as $status
+  | (.projectItems[0].status.name // "—") as $status
+  | select($issue.projectItems | length > 0)
+  | select(
+      if $filter == "" then $status != "Done"
+      else $status == $filter
+      end
+    )
   | "[\($status)]\t#\($issue.number)\t\($issue.title)"
 ')
 
-if [[ -n "$FILTER" ]]; then
-  echo "$ROWS" | grep "^\[$FILTER\]" || true
-else
-  echo "$ROWS"
-fi | sort | column -ts $'\t'
+echo "$ROWS" | sort | column -ts $'\t'

--- a/.claude/skills/backlog/scripts/move.sh
+++ b/.claude/skills/backlog/scripts/move.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 # Move a backlog issue to a Status column on Project #4.
+#
+# The item-ID lookup uses a small, targeted GraphQL query (one issue,
+# projectItems(first:5)) — query complexity ~5 nodes, negligible quota cost.
+# `gh project item-list` was considered as a replacement but would paginate
+# through 200+ items (~5s, ~12x slower) just to find one. The bulky multi-
+# issue case lives in `list.sh` and uses the CLI directly.
+#
+# The actual field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only
+# — `gh project item-edit` is the CLI wrapper, used below.
+#
 # Usage: move.sh <ISSUE_NUMBER> <STATUS>
 #   STATUS — Backlog | Ready | "In progress" | "In review" | Done
 set -euo pipefail

--- a/.claude/skills/backlog/scripts/set-field.sh
+++ b/.claude/skills/backlog/scripts/set-field.sh
@@ -3,6 +3,14 @@
 # issue on Specflow's own Project #4. Hardcoded mirror of the templated helper
 # at templates/core/skills/backlog/scripts/github/set-field.sh.
 #
+# The item-ID lookup uses a small, targeted GraphQL query (one issue,
+# projectItems(first:5)) — negligible quota cost. `gh project item-list` was
+# considered as a replacement but would paginate through 200+ items just to
+# find one (~12x slower). The bulky multi-issue case is in `list.sh`.
+#
+# The actual field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only
+# — `gh project item-edit` is the CLI wrapper, used below.
+#
 # Usage: set-field.sh <issue-number> <Priority|Size> <value>
 #
 # Exit codes:

--- a/.claude/skills/backlog/scripts/view.sh
+++ b/.claude/skills/backlog/scripts/view.sh
@@ -1,38 +1,19 @@
 #!/usr/bin/env bash
 # Show one issue's title, body, current Status on Project #4, and any
 # comments. Useful when about to clarify an item.
+#
+# Status comes from `gh issue view --json projectItems` (~2 GraphQL points
+# via the gh CLI's REST-ish JSON projection — much cheaper than the
+# hand-rolled query that used to live here). Body + comments come from
+# `gh issue view --comments` (REST).
+#
 # Usage: view.sh <ISSUE_NUMBER>
 set -euo pipefail
 
 ISSUE="${1:?usage: view.sh <issue-number>}"
 
-STATUS=$(gh api graphql -f query='
-  query($num: Int!) {
-    repository(owner:"mkrlabs", name:"specflow") {
-      issue(number: $num) {
-        projectItems(first: 5) {
-          nodes {
-            project { number }
-            fieldValues(first: 8) {
-              nodes {
-                ... on ProjectV2ItemFieldSingleSelectValue {
-                  name
-                  field { ... on ProjectV2SingleSelectField { name } }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }' -F num="$ISSUE" \
-  | jq -r '
-    [.data.repository.issue.projectItems.nodes[]
-      | select(.project.number == 4)
-      | .fieldValues.nodes[]
-      | select(.field?.name == "Status")
-      | .name][0] // "—"
-  ')
+STATUS=$(gh issue view "$ISSUE" --repo mkrlabs/specflow --json projectItems \
+  | jq -r '.projectItems[0].status.name // "—"')
 
 echo "════ Issue #$ISSUE — Status: $STATUS ════"
 gh issue view "$ISSUE" --repo mkrlabs/specflow --comments

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -348,8 +348,14 @@ A Product Owner agent gates every mutation, and supports three backends:
   status, parent, depends_on, spec, tags, created). Sub-tasks reference their parent via
   `parent: "#NNN"`.
 - **GitHub Issues + Projects** (`--backlog github`) — the agent talks directly to the backend via
-  `gh` CLI; epics use the native sub-issues API. No local mirror, no sync command — the remote is
-  the source of truth.
+  `gh` CLI; epics use the native sub-issues API. Read paths use
+  `gh issue list/view --json
+  projectItems` (REST-ish CLI projection of Project V2 fields, ~1–2
+  GraphQL points per call), and raw `gh api graphql` is reserved for the one operation with no CLI
+  equivalent (`gh project
+  item-edit`'s underlying `updateProjectV2ItemFieldValue` mutation). Keeps
+  backlog grooming under the shared 5,000-points-per-hour GitHub API quota. No local mirror, no sync
+  command — the remote is the source of truth.
 - **GitLab Issues** (`--backlog gitlab`) — the agent talks to GitLab via `glab` CLI. Status is
   tracked via scoped `Status::*` labels rather than a native column field; sub-tasks use a
   `parent::#NNN` scoped label (Free-tier compatible — native GitLab Epics are Premium-only).

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -79,8 +79,8 @@ mutating anything.
 ### GitHub layout
 
 - Tasks live as Issues in the configured repo.
-- The PO uses `gh issue` and `gh api` to read and mutate them. Project board
-  status moves go through `gh api graphql`.
+- The PO uses `gh issue` + `gh project item-edit` (CLI) for reads/mutations;
+  raw `gh api graphql` only when no CLI path exists.
 
 ## Frontmatter schema (local Markdown — mandatory)
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2182,8 +2182,8 @@ mutating anything.
 ### GitHub layout
 
 - Tasks live as Issues in the configured repo.
-- The PO uses \`gh issue\` and \`gh api\` to read and mutate them. Project board
-  status moves go through \`gh api graphql\`.
+- The PO uses \`gh issue\` + \`gh project item-edit\` (CLI) for reads/mutations;
+  raw \`gh api graphql\` only when no CLI path exists.
 
 ## Frontmatter schema (local Markdown — mandatory)
 
@@ -4577,6 +4577,12 @@ export REPO REPO_OWNER REPO_NAME PROJECT_NUMBER
     suffix: "list.sh",
     content: `#!/usr/bin/env bash
 # List items on the configured GitHub Project, with Status. Optional filter.
+#
+# Uses \`gh issue list --json projectItems\` — the gh CLI exposes the Project V2
+# Status field via its REST-ish JSON projection, costing ~1 GraphQL point per
+# call (vs ~20 for the bulky \`repository.issues[].projectItems[].fieldValues[]\`
+# query that lived here previously and was the main rate-limit offender).
+#
 # Usage: list.sh [Status]
 set -euo pipefail
 
@@ -4585,40 +4591,16 @@ set -euo pipefail
 
 FILTER="\${1:-}"
 
-JSON=\$(gh api graphql -f query='
-  query(\$owner:String!, \$name:String!) {
-    repository(owner:\$owner, name:\$name) {
-      issues(first:100, states:OPEN) {
-        nodes {
-          number title
-          projectItems(first:5) {
-            nodes {
-              project { number }
-              fieldValues(first:8) {
-                nodes {
-                  ... on ProjectV2ItemFieldSingleSelectValue {
-                    name
-                    field { ... on ProjectV2SingleSelectField { name } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }' \\
-  -f owner="\$REPO_OWNER" \\
-  -f name="\$REPO_NAME")
+JSON=\$(gh issue list --repo "\$REPO" --state open --limit 200 \\
+  --json number,title,projectItems)
 
-echo "\$JSON" | jq -r --argjson project "\$PROJECT_NUMBER" --arg filter "\$FILTER" '
-  .data.repository.issues.nodes[]
+echo "\$JSON" | jq -r --arg filter "\$FILTER" '
+  .[]
   | . as \$issue
-  | (.projectItems.nodes[] | select(.project.number == \$project)) as \$item
-  | ((\$item.fieldValues.nodes[]
-       | select(.field.name == "Status") | .name) // "—") as \$status
+  | (.projectItems[0].status.name // "—") as \$status
+  | select(\$issue.projectItems | length > 0)
   | select(\$filter == "" or \$status == \$filter)
-  | "  #\\(.number)  \\(\$status)  \\(.title)"
+  | "  #\\(\$issue.number)  \\(\$status)  \\(\$issue.title)"
 '
 `,
     executable: true,
@@ -4732,6 +4714,12 @@ fi
     suffix: "move.sh",
     content: `#!/usr/bin/env bash
 # Move an issue's Project Status to <Status>.
+#
+# The item-ID lookup uses a small, targeted GraphQL query (one issue,
+# projectItems(first:5)) — negligible quota cost (~2 points). The actual
+# field mutation (\`updateProjectV2ItemFieldValue\`) is GraphQL-only —
+# \`gh project item-edit\` is the CLI wrapper, used below.
+#
 # Usage: move.sh <number> <Status>
 set -euo pipefail
 
@@ -4757,18 +4745,17 @@ if [ -z "\$OPTION_ID" ] || [ "\$OPTION_ID" = "null" ]; then
   exit 1
 fi
 
-ISSUE_NODE_ID=\$(gh issue view "\$NUM" --repo "\$REPO" --json id --jq '.id')
-
-# Find the project item ID for this issue
+# Targeted lookup by issue number — much cheaper than fetching the whole
+# project item list (a single issue ~2 GraphQL points, vs paginated list).
 ITEM_ID=\$(gh api graphql -f query='
-  query(\$issue:ID!) {
-    node(id:\$issue) {
-      ... on Issue {
-        projectItems(first:10) { nodes { id project { id } } }
+  query(\$owner:String!, \$name:String!, \$num:Int!) {
+    repository(owner:\$owner, name:\$name) {
+      issue(number:\$num) {
+        projectItems(first:5) { nodes { id project { id } } }
       }
     }
-  }' -f issue="\$ISSUE_NODE_ID" \\
-  | jq -r --arg p "\$PROJECT_NODE_ID" '.data.node.projectItems.nodes[] | select(.project.id==\$p) | .id' | head -1)
+  }' -f owner="\$REPO_OWNER" -f name="\$REPO_NAME" -F num="\$NUM" \\
+  | jq -r --arg p "\$PROJECT_NODE_ID" '.data.repository.issue.projectItems.nodes[] | select(.project.id==\$p) | .id' | head -1)
 
 if [ -z "\$ITEM_ID" ]; then
   echo "issue #\$NUM is not on Project #\$PROJECT_NUMBER" >&2
@@ -4860,6 +4847,12 @@ echo "PROJECT_NODE_ID=\$(gh project view "\$PROJECT_NUMBER" --owner "\$REPO_OWNE
     suffix: "set-field.sh",
     content: `#!/usr/bin/env bash
 # Set a native Project V2 single-select field value (Priority or Size) on an issue.
+#
+# The item-ID lookup uses a small, targeted GraphQL query (one issue,
+# projectItems(first:5)) — negligible quota cost (~2 points). The actual
+# field mutation (\`updateProjectV2ItemFieldValue\`) is GraphQL-only —
+# \`gh project item-edit\` is the CLI wrapper, used below.
+#
 # Usage: set-field.sh <issue-number> <Priority|Size> <value>
 #   Examples:
 #     set-field.sh 42 Priority P1
@@ -4912,17 +4905,17 @@ if [ -z "\$OPT_ID" ]; then
   exit 11
 fi
 
-ISSUE_NODE_ID=\$(gh issue view "\$NUM" --repo "\$REPO" --json id --jq '.id')
-
+# Targeted lookup by issue number — much cheaper than fetching the whole
+# project item list (a single issue ~2 GraphQL points, vs paginated list).
 ITEM_ID=\$(gh api graphql -f query='
-  query(\$issue:ID!) {
-    node(id:\$issue) {
-      ... on Issue {
-        projectItems(first:10) { nodes { id project { id } } }
+  query(\$owner:String!, \$name:String!, \$num:Int!) {
+    repository(owner:\$owner, name:\$name) {
+      issue(number:\$num) {
+        projectItems(first:5) { nodes { id project { id } } }
       }
     }
-  }' -f issue="\$ISSUE_NODE_ID" \\
-  | jq -r --arg p "\$PROJECT_NODE_ID" '.data.node.projectItems.nodes[] | select(.project.id==\$p) | .id' | head -1)
+  }' -f owner="\$REPO_OWNER" -f name="\$REPO_NAME" -F num="\$NUM" \\
+  | jq -r --arg p "\$PROJECT_NODE_ID" '.data.repository.issue.projectItems.nodes[] | select(.project.id==\$p) | .id' | head -1)
 
 if [ -z "\$ITEM_ID" ]; then
   echo "issue #\$NUM is not on Project #\$PROJECT_NUMBER" >&2

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -79,8 +79,8 @@ mutating anything.
 ### GitHub layout
 
 - Tasks live as Issues in the configured repo.
-- The PO uses `gh issue` and `gh api` to read and mutate them. Project board
-  status moves go through `gh api graphql`.
+- The PO uses `gh issue` + `gh project item-edit` (CLI) for reads/mutations;
+  raw `gh api graphql` only when no CLI path exists.
 
 ## Frontmatter schema (local Markdown — mandatory)
 

--- a/templates/core/skills/backlog/scripts/github/list.sh
+++ b/templates/core/skills/backlog/scripts/github/list.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # List items on the configured GitHub Project, with Status. Optional filter.
+#
+# Uses `gh issue list --json projectItems` — the gh CLI exposes the Project V2
+# Status field via its REST-ish JSON projection, costing ~1 GraphQL point per
+# call (vs ~20 for the bulky `repository.issues[].projectItems[].fieldValues[]`
+# query that lived here previously and was the main rate-limit offender).
+#
 # Usage: list.sh [Status]
 set -euo pipefail
 
@@ -8,38 +14,14 @@ set -euo pipefail
 
 FILTER="${1:-}"
 
-JSON=$(gh api graphql -f query='
-  query($owner:String!, $name:String!) {
-    repository(owner:$owner, name:$name) {
-      issues(first:100, states:OPEN) {
-        nodes {
-          number title
-          projectItems(first:5) {
-            nodes {
-              project { number }
-              fieldValues(first:8) {
-                nodes {
-                  ... on ProjectV2ItemFieldSingleSelectValue {
-                    name
-                    field { ... on ProjectV2SingleSelectField { name } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }' \
-  -f owner="$REPO_OWNER" \
-  -f name="$REPO_NAME")
+JSON=$(gh issue list --repo "$REPO" --state open --limit 200 \
+  --json number,title,projectItems)
 
-echo "$JSON" | jq -r --argjson project "$PROJECT_NUMBER" --arg filter "$FILTER" '
-  .data.repository.issues.nodes[]
+echo "$JSON" | jq -r --arg filter "$FILTER" '
+  .[]
   | . as $issue
-  | (.projectItems.nodes[] | select(.project.number == $project)) as $item
-  | (($item.fieldValues.nodes[]
-       | select(.field.name == "Status") | .name) // "—") as $status
+  | (.projectItems[0].status.name // "—") as $status
+  | select($issue.projectItems | length > 0)
   | select($filter == "" or $status == $filter)
-  | "  #\(.number)  \($status)  \(.title)"
+  | "  #\($issue.number)  \($status)  \($issue.title)"
 '

--- a/templates/core/skills/backlog/scripts/github/move.sh
+++ b/templates/core/skills/backlog/scripts/github/move.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # Move an issue's Project Status to <Status>.
+#
+# The item-ID lookup uses a small, targeted GraphQL query (one issue,
+# projectItems(first:5)) — negligible quota cost (~2 points). The actual
+# field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only —
+# `gh project item-edit` is the CLI wrapper, used below.
+#
 # Usage: move.sh <number> <Status>
 set -euo pipefail
 
@@ -25,18 +31,17 @@ if [ -z "$OPTION_ID" ] || [ "$OPTION_ID" = "null" ]; then
   exit 1
 fi
 
-ISSUE_NODE_ID=$(gh issue view "$NUM" --repo "$REPO" --json id --jq '.id')
-
-# Find the project item ID for this issue
+# Targeted lookup by issue number — much cheaper than fetching the whole
+# project item list (a single issue ~2 GraphQL points, vs paginated list).
 ITEM_ID=$(gh api graphql -f query='
-  query($issue:ID!) {
-    node(id:$issue) {
-      ... on Issue {
-        projectItems(first:10) { nodes { id project { id } } }
+  query($owner:String!, $name:String!, $num:Int!) {
+    repository(owner:$owner, name:$name) {
+      issue(number:$num) {
+        projectItems(first:5) { nodes { id project { id } } }
       }
     }
-  }' -f issue="$ISSUE_NODE_ID" \
-  | jq -r --arg p "$PROJECT_NODE_ID" '.data.node.projectItems.nodes[] | select(.project.id==$p) | .id' | head -1)
+  }' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$NUM" \
+  | jq -r --arg p "$PROJECT_NODE_ID" '.data.repository.issue.projectItems.nodes[] | select(.project.id==$p) | .id' | head -1)
 
 if [ -z "$ITEM_ID" ]; then
   echo "issue #$NUM is not on Project #$PROJECT_NUMBER" >&2

--- a/templates/core/skills/backlog/scripts/github/set-field.sh
+++ b/templates/core/skills/backlog/scripts/github/set-field.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # Set a native Project V2 single-select field value (Priority or Size) on an issue.
+#
+# The item-ID lookup uses a small, targeted GraphQL query (one issue,
+# projectItems(first:5)) — negligible quota cost (~2 points). The actual
+# field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only —
+# `gh project item-edit` is the CLI wrapper, used below.
+#
 # Usage: set-field.sh <issue-number> <Priority|Size> <value>
 #   Examples:
 #     set-field.sh 42 Priority P1
@@ -52,17 +58,17 @@ if [ -z "$OPT_ID" ]; then
   exit 11
 fi
 
-ISSUE_NODE_ID=$(gh issue view "$NUM" --repo "$REPO" --json id --jq '.id')
-
+# Targeted lookup by issue number — much cheaper than fetching the whole
+# project item list (a single issue ~2 GraphQL points, vs paginated list).
 ITEM_ID=$(gh api graphql -f query='
-  query($issue:ID!) {
-    node(id:$issue) {
-      ... on Issue {
-        projectItems(first:10) { nodes { id project { id } } }
+  query($owner:String!, $name:String!, $num:Int!) {
+    repository(owner:$owner, name:$name) {
+      issue(number:$num) {
+        projectItems(first:5) { nodes { id project { id } } }
       }
     }
-  }' -f issue="$ISSUE_NODE_ID" \
-  | jq -r --arg p "$PROJECT_NODE_ID" '.data.node.projectItems.nodes[] | select(.project.id==$p) | .id' | head -1)
+  }' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$NUM" \
+  | jq -r --arg p "$PROJECT_NODE_ID" '.data.repository.issue.projectItems.nodes[] | select(.project.id==$p) | .id' | head -1)
 
 if [ -z "$ITEM_ID" ]; then
   echo "issue #$NUM is not on Project #$PROJECT_NUMBER" >&2


### PR DESCRIPTION
Closes #222.

## Summary

Specflow's backlog scripts and PO agent prompts were hammering the shared GitHub GraphQL quota (5,000 points/hr), blocking main-session work twice in recent sessions. This PR replaces the bulky read-path GraphQL queries with REST-ish CLI equivalents and tightens the agent prompts to prefer CLI/MCP over raw GraphQL.

## What changed

**Investigated three replacement strategies** before settling on the cheapest:

| Strategy | Verdict |
|---|---|
| `gh project item-list --format json` | ❌ Paginates expensively at the live 222-item project size (~5s, 8+ paginated GraphQL hits per call) |
| `gh issue list/view --json projectItems` | ✅ gh CLI exposes the Project V2 Status field via REST-ish JSON projection, ~1–2 GraphQL points per call |
| Small targeted `gh api graphql` (one issue, `projectItems(first:5)`) | ✅ Kept for `move.sh` / `set-field.sh` item-ID lookup — `gh issue view --json projectItems` does NOT expose the project-item node ID needed by `gh project item-edit` |

**Per-file outcome:**

| File | Before | After |
|---|---|---|
| `.claude/skills/backlog/scripts/list.sh` | Bulky `repository.issues[].projectItems[].fieldValues[]` GraphQL | `gh issue list --json projectItems` |
| `.claude/skills/backlog/scripts/view.sh` | Targeted GraphQL Status lookup | `gh issue view --json projectItems` |
| `.claude/skills/backlog/scripts/move.sh` | Targeted GraphQL item-ID lookup + `gh project item-edit` mutation | Same (small targeted GraphQL is already cheap) |
| `.claude/skills/backlog/scripts/set-field.sh` | Same as move.sh | Same |
| `templates/core/skills/backlog/scripts/github/{list,move,set-field}.sh` | Same as in-repo | Mirrored |
| `templates/core/agents/product-owner.md` | "Project board status moves go through gh api graphql" | "CLI for reads/mutations; raw graphql only when no CLI path exists" |
| `.claude/agents/product-owner.md` | Same as bundled | Expanded Tool preference paragraph naming `mcp__github__*` tools |
| `.claude/skills/backlog/SKILL.md` | Stale "Why we don't use gh project item-list" workaround note | Replaced with API-quota preference paragraph |

After this PR, raw `gh api graphql` survives only in `move.sh` and `set-field.sh`, where it's the small targeted lookup. Every read path is on `gh issue` CLI.

## Verification

- [x] `deno task bundle` regenerates `src/templates_bundle.ts`
- [x] `deno task test` — 566/566 green (fixed Windsurf-Cascade-cap regression by trimming the bundled PO addition; the file was at 11982/12000 chars before this PR)
- [x] `deno task fmt && deno task lint`
- [x] Pre-commit hook (fmt + lint + bundle + check) passed
- [x] All 7 bash scripts pass `bash -n` syntax check
- [ ] **Live API parity check** — pending GraphQL rate-limit reset (currently 5000/5000). After reset: `list.sh "In progress"` parity, `view.sh 222` parity, roundtrip `move.sh` on a non-critical issue. Will run before merge.
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)