### PR TITLE
fix(init): accept /views/<N> suffix in GitHub Project URL parser

### DIFF
--- a/src/domain/backlog_strategies/kanban_url_parser.ts
+++ b/src/domain/backlog_strategies/kanban_url_parser.ts
@@ -6,10 +6,13 @@
  *
  *   - GitHub org-owned project:
  *     `https://github.com/orgs/<org>/projects/<N>`
+ *     (a trailing `/views/<M>` is tolerated — that's what the browser
+ *     address bar always contains when viewing a Project V2 board)
  *     → `{ kind: "github", owner: "<org>", ownerType: "org", projectNumber: N }`
  *
  *   - GitHub user-owned project:
- *     `https://github.com/users/<user>/projects/<N>`
+ *     `https://github.com/users/<user>/projects/<N>` (same `/views/<M>`
+ *     tolerance as above)
  *     → `{ kind: "github", owner: "<user>", ownerType: "user", projectNumber: N }`
  *
  *   - GitLab project URL (project page = backlog board, no separate URL):
@@ -49,8 +52,15 @@ export function parseKanbanURL(raw: string): ParsedKanbanURL | null {
   const segments = u.pathname.split("/").filter((s) => s.length > 0);
 
   if (u.host === "github.com") {
-    // GitHub: must be /orgs/<owner>/projects/<N> or /users/<owner>/projects/<N>
-    if (segments.length !== 4) return null;
+    // GitHub: must be /orgs/<owner>/projects/<N> or /users/<owner>/projects/<N>,
+    // optionally followed by /views/<M> (the browser address bar always
+    // appends a view ID when looking at a Project V2 board).
+    if (
+      segments.length !== 4 &&
+      !(segments.length === 6 && segments[4] === "views")
+    ) {
+      return null;
+    }
     const [kindSeg, owner, projectsSeg, numSeg] = segments;
     if (kindSeg !== "orgs" && kindSeg !== "users") return null;
     if (projectsSeg !== "projects") return null;

--- a/tests/domain/kanban_url_parser_test.ts
+++ b/tests/domain/kanban_url_parser_test.ts
@@ -39,6 +39,49 @@ Deno.test("parseKanbanURL parses self-hosted GitLab URL", () => {
   });
 });
 
+Deno.test("parseKanbanURL accepts /views/<N> suffix on org-owned project URL", () => {
+  // GitHub's address bar always appends /views/<M> when viewing a Project V2.
+  const r = parseKanbanURL(
+    "https://github.com/orgs/confeature/projects/1/views/1",
+  );
+  assertEquals(r, {
+    kind: "github",
+    owner: "confeature",
+    ownerType: "org",
+    projectNumber: 1,
+  });
+});
+
+Deno.test("parseKanbanURL accepts /views/<N> suffix on user-owned project URL", () => {
+  const r = parseKanbanURL(
+    "https://github.com/users/alice/projects/12/views/7",
+  );
+  assertEquals(r, {
+    kind: "github",
+    owner: "alice",
+    ownerType: "user",
+    projectNumber: 12,
+  });
+});
+
+Deno.test("parseKanbanURL rejects unknown trailing segment (not /views/)", () => {
+  // Only /views/<M> is tolerated — guard against accidentally loosening too far.
+  assertEquals(
+    parseKanbanURL("https://github.com/orgs/mkrlabs/projects/6/settings/1"),
+    null,
+  );
+  assertEquals(
+    parseKanbanURL("https://github.com/orgs/mkrlabs/projects/6/extra"),
+    null,
+  );
+  assertEquals(
+    parseKanbanURL(
+      "https://github.com/orgs/mkrlabs/projects/6/views/1/anything",
+    ),
+    null,
+  );
+});
+
 Deno.test("parseKanbanURL trims whitespace", () => {
   const r = parseKanbanURL("  https://github.com/orgs/mkrlabs/projects/6  ");
   assertEquals(r, {


### PR DESCRIPTION
## Summary

- Real-world Project V2 URLs in the browser always have a `/views/<M>` trailing segment (you're always looking at *a view*).
- The interactive `specflow init` URL prompt rejected such URLs with `couldn't parse "…" — expected https://github.com/orgs/<org>/projects/<N>` because the parser demanded exactly 4 path segments.
- Now `parseKanbanURL` accepts the canonical 4-segment form **and** the 6-segment `…/views/<M>` form, for both `orgs` and `users` owners.

## Repro (pre-fix)

```
specflow init --here
...
Paste your github project URL (Enter to skip):
> https://github.com/orgs/confeature/projects/1/views/1
couldn't parse "https://github.com/orgs/confeature/projects/1/views/1" — …
```

Closes #224

## Test plan

- [x] `deno test tests/domain/kanban_url_parser_test.ts` — 16 passed (3 new cases + 13 existing)
- [x] `deno task test` — 569 passed, 0 failed
- [x] Pre-commit fmt + lint + bundle + check — green
- [x] Negative cases preserved: unknown trailing segments (`/settings/1`, `/extra`, `/views/1/anything`) still return `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)