### PR TITLE
feat(scaffold): bundle /specflow tag-version + release-version (#227 core)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Verify the tag-release pack scaffolds correctly on a fresh init and
+# that the scheme rewrite produces the right artifact per choice.
+#
+# Tests two paths:
+#   1. init --scheme semver  → tag.sh contains semver bump logic, no date logic
+#   2. init --scheme date    → tag.sh contains date logic, no semver logic
+# Then sanity-checks the stack-agnostic release.sh + the two phase docs.
+#
+# Usage: smoke-tag-release.sh <name>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-tag-release.sh <name>}"
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+trap 'bash "$SCRIPT_DIR/clean.sh" "${NAME}-semver" >/dev/null 2>&1 || true;
+      bash "$SCRIPT_DIR/clean.sh" "${NAME}-date"   >/dev/null 2>&1 || true' EXIT
+
+fails=0
+pass() { echo "✓ $1"; }
+fail() { echo "❌ $1 — $2"; fails=$((fails + 1)); }
+
+check() {
+  local desc="$1" cmd="$2"
+  if eval "$cmd" >/dev/null 2>&1; then pass "$desc"; else fail "$desc" "command: $cmd"; fi
+}
+
+run_init() {
+  local subname scheme dir
+  subname="$1"
+  scheme="$2"
+  dir="$ROOT/sandbox/${NAME}-${subname}"
+  bash "$SCRIPT_DIR/bootstrap-empty.sh" "${NAME}-${subname}" >/dev/null
+  (cd "$dir" && deno run --allow-all "$ROOT/src/main.ts" \
+    init --here --no-git --ai claude --backlog local --scheme "$scheme" \
+    >/dev/null 2>&1)
+}
+
+echo "═══ #227  scheme=semver scaffold ═══"
+run_init "semver" "semver"
+cd "$ROOT/sandbox/${NAME}-semver"
+
+check "phase doc tag-version.md scaffolded" \
+  '[ -f .claude/skills/specflow/phases/tag-version.md ]'
+check "phase doc release-version.md scaffolded" \
+  '[ -f .claude/skills/specflow/phases/release-version.md ]'
+check "tag.sh present + executable" \
+  '[ -x .specflow/scripts/release/tag.sh ]'
+check "release.sh present + executable" \
+  '[ -x .specflow/scripts/release/release.sh ]'
+check "tag.sh contains SemVer bump logic" \
+  'grep -q "v0.1.0" .specflow/scripts/release/tag.sh && grep -q "SemVer validation" .specflow/scripts/release/tag.sh'
+check "tag.sh does NOT contain date-scheme logic" \
+  '! grep -q "letter suffix exhausted" .specflow/scripts/release/tag.sh'
+check "tag.sh does NOT keep BEGIN/END scheme markers (rewrite stripped them)" \
+  '! grep -qE "^\s*#\s*(BEGIN|END):\s*scheme=" .specflow/scripts/release/tag.sh'
+check "release.sh contains 10-bucket classifier" \
+  'grep -q "Features" .specflow/scripts/release/release.sh && grep -q "Bug Fixes" .specflow/scripts/release/release.sh && grep -q "Build & CI" .specflow/scripts/release/release.sh'
+check "lock records version_scheme: semver" \
+  'grep -q "version_scheme: semver" .specflow/installed.lock'
+check "specflow SKILL.md references tag-version" \
+  'grep -q "tag-version" .claude/skills/specflow/SKILL.md'
+check "specflow SKILL.md references release-version" \
+  'grep -q "release-version" .claude/skills/specflow/SKILL.md'
+
+cd "$ROOT"
+
+echo
+echo "═══ #227  scheme=date scaffold ═══"
+run_init "date" "date"
+cd "$ROOT/sandbox/${NAME}-date"
+
+check "tag.sh contains date-scheme logic" \
+  'grep -q "letter suffix exhausted" .specflow/scripts/release/tag.sh && grep -q "date-based validation" .specflow/scripts/release/tag.sh'
+check "tag.sh does NOT contain SemVer bump logic" \
+  '! grep -q "v0.1.0" .specflow/scripts/release/tag.sh'
+check "tag.sh does NOT keep BEGIN/END scheme markers (rewrite stripped them)" \
+  '! grep -qE "^\s*#\s*(BEGIN|END):\s*scheme=" .specflow/scripts/release/tag.sh'
+check "lock records version_scheme: date" \
+  'grep -q "version_scheme: date" .specflow/installed.lock'
+check "release.sh is stack-agnostic across schemes (byte-equal between scaffolds)" \
+  'diff -q .specflow/scripts/release/release.sh "$ROOT/sandbox/${NAME}-semver/.specflow/scripts/release/release.sh"'
+
+cd "$ROOT"
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "═══ ALL TAG-RELEASE CHECKS PASSED ═══"
+  exit 0
+else
+  echo "═══ $fails CHECK(S) FAILED ═══"
+  exit 1
+fi

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -222,6 +222,26 @@ specflow init --here --no-git --ai cursor --backlog gitlab \
 Without those flags, `specflow init` shows an arrow-key picker (↑/↓ to move, space/enter to select)
 when stdin is a TTY, and falls back to a numeric prompt — or the defaults — when stdin is piped.
 
+### Pick a versioning scheme
+
+`specflow init` asks which scheme to use for the bundled `/specflow tag-version` and
+`/specflow release-version` commands. Two options:
+
+- **SemVer** (`v1.2.3`) — recommended for libraries / SDKs whose consumers reason about breaking
+  changes by version number.
+- **Date-based** (`vYY.M.Da`) — recommended for apps / SaaS / deployed products where the version
+  number is just a release identifier. No major/minor/patch guesswork; the letter suffix handles
+  same-day re-tags.
+
+Specflow detects whether the project looks like a library (`package.json` `exports` /
+`pyproject.toml` `[project]` / `Cargo.toml` `[lib]` / `composer.json` `type=library`) and
+pre-selects a sensible default — the user can always override at the picker. The choice is persisted
+by **rewriting the scaffolded skill** itself (the unchosen scheme's blocks are stripped at scaffold
+time), so the on-disk `.specflow/scripts/release/tag.sh` only contains the chosen scheme's logic. To
+switch schemes later, re-run `specflow init` and pick the other option.
+
+Pass `--scheme semver|date` to bypass the picker in non-TTY mode.
+
 ### Other commands
 
 ```bash
@@ -238,6 +258,23 @@ specflow self-update --check      # only report whether an update is available
 specflow --version                # print version
 specflow --help                   # full usage
 ```
+
+### Bundled tag + release commands
+
+Every scaffolded project ships two router commands under `/specflow`:
+
+- **`/specflow tag-version`** — creates an annotated git tag using the project's versioning scheme.
+  Bumps automatically (latest tag → next). For SemVer, `--bump major|minor|patch` controls the
+  direction (default `patch`); for date-based, the letter suffix increments. Pushes to `origin` if a
+  remote is configured, else stays local. Pass `--no-push` to skip.
+- **`/specflow release-version`** — generates **categorized release notes** for a tag (default:
+  latest) covering every commit since the previous tag. The output is the release-body Markdown, one
+  section per non-empty Conventional Commits bucket (Features / Bug Fixes / Performance / Refactors
+  / Documentation / Tests / Build & CI / Chores / Style / Other). Pipe the output into
+  `gh release create` / `glab release create` to publish.
+
+The scripts live at `.specflow/scripts/release/{tag,release}.sh` — the same path across all 8
+harnesses.
 
 ## Available harnesses
 

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -15,6 +15,8 @@ when_to_use: |
   - constitution: "update the constitution", "edit project rules"
   - checklist: "generate a checklist"
   - groom: "groom the backlog", "run a hygiene pass"
+  - tag-version: "tag a version", "create a release tag", "bump the version"
+  - release-version: "release", "publish a release", "create release notes"
 ---
 
 # Specflow router
@@ -41,6 +43,8 @@ If `$ARGUMENTS` is empty, render the **Workflow overview** below and stop. Do no
 | `constitution` | `phases/constitution.md` | Edit the project's `constitution.md` rules. |
 | `checklist` | `phases/checklist.md` | Generate a quality checklist for the current spec. |
 | `groom` | `phases/groom.md` | Backlog hygiene pass via the product-owner agent. |
+| `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
+| `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
 
 ## Routing
 
@@ -58,7 +62,7 @@ specify → clarify → plan → tasks → analyze → implement → review → 
                                                           STOP for pre-merge validation
 ```
 
-`constitution`, `checklist`, and `groom` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/plugin/skills/specflow/phases/release-version.md
+++ b/plugin/skills/specflow/phases/release-version.md
@@ -1,0 +1,81 @@
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+Common natural-language requests:
+
+- `/specflow release-version` — generate notes for the latest tag
+- `/specflow release-version v1.2.3` — generate notes for a specific tag
+- `/specflow release-version --baseline v1.2.0` — override the baseline
+  (use when the previous tag was never released and you want to skip
+  past it; default baseline is the previous tag chronologically)
+
+## What this command does
+
+Generates **categorized release notes** for the given tag (default:
+latest) covering every commit between a baseline tag and the target
+tag.
+
+The bundled script is stack-agnostic — it just emits the
+release-body Markdown to stdout, with one section per non-empty
+Conventional-Commits bucket. Run it like this:
+
+```bash
+bash .specflow/scripts/release/release.sh "$@"
+```
+
+## Buckets (fixed order, empty buckets omitted)
+
+1. **Features** — `feat:` / `feat(scope):` / `feat!:`
+2. **Bug Fixes** — `fix:` / `fix(scope):` / `fix!:`
+3. **Performance** — `perf:`
+4. **Refactors** — `refactor:`
+5. **Documentation** — `docs:`
+6. **Tests** — `test:`
+7. **Build & CI** — `build:` / `ci:`
+8. **Chores** — `chore:`
+9. **Style** — `style:`
+10. **Other** — anything that does not match a Conventional-Commits prefix
+
+Each commit appears as `- <short-sha> <subject>` under its bucket.
+
+## After the script runs
+
+The script writes the release body to **stdout**. What you do with it
+depends on how this project publishes releases:
+
+- **GitHub remote** — pipe it into `gh release create <tag>
+  --notes-file -` (or `--notes "$(...)"`).
+- **GitLab remote** — pipe it into `glab release create <tag>
+  --notes "..."`.
+- **Local-only** — copy the output somewhere readable (or echo it to
+  the user); there is no remote release to create.
+
+The per-backend wrapper scripts ship as separate Specflow features —
+when one is installed, prefer it to manually piping into `gh` / `glab`.
+
+## Important — release-notes contract
+
+The script emits the body verbatim. Do NOT:
+
+- Reword sections / re-categorize commits after the fact. If a commit
+  message is wrong (e.g. `feat:` for what's really a `fix:`), the
+  correct move is to amend the commit message **before** tagging,
+  not to hand-edit the release body.
+- Add a raw `git diff` or `git log` dump. The whole point of this
+  command is that the body is human-readable on its own.
+- Run release publication without showing the user the generated body
+  first when invoked interactively. The body is the production
+  artifact — surface it for review before posting.
+
+## Workflow
+
+```
+/specflow tag-version             → annotated tag created + pushed
+/specflow release-version         → categorized release notes (stdout)
+↳ pipe to gh/glab release create  → release published
+```

--- a/plugin/skills/specflow/phases/tag-version.md
+++ b/plugin/skills/specflow/phases/tag-version.md
@@ -1,0 +1,64 @@
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+Common natural-language requests:
+
+- `/specflow tag-version` — tag HEAD with the next version
+- `/specflow tag-version <sha>` — tag a specific commit
+- `/specflow tag-version --bump minor` — SemVer projects only: bump
+  minor instead of patch (also `--bump major` / `--bump patch`)
+- `/specflow tag-version --no-push` — skip pushing to `origin`
+
+## What this command does
+
+Creates an annotated git tag using the **versioning scheme baked into
+this project at `specflow init`** (one of SemVer `v1.2.3` or date-based
+`vYY.M.Da`).
+
+The bundled script does all the work:
+
+```bash
+bash .specflow/scripts/release/tag.sh "$@"
+```
+
+What the script does:
+
+1. Runs `git fetch --tags --quiet` so the next-tag computation sees
+   every tag that already exists on `origin`.
+2. Computes the next tag from the project's scheme:
+   - **SemVer** — finds the latest `v*.*.*` tag, applies the bump
+     direction from `--bump` (default `patch`), validates the result.
+   - **Date-based** — computes today's `vYY.M.D` prefix (no leading
+     zeros), scans existing tags for today, increments the letter
+     suffix (`a` → `b` → … → `z`, then errors out at 26 same-day tags).
+3. Creates an annotated tag with the commit subject in the message.
+4. Pushes to `origin` if a remote is configured (use `--no-push` to
+   skip).
+
+## What this command does NOT do
+
+- It does **not** create a GitHub / GitLab release — pushing a tag
+  alone does not publish a release. Run `/specflow release-version`
+  after this to publish the categorized release notes.
+- It does **not** edit version fields in `package.json` / `Cargo.toml`
+  / `pyproject.toml` / etc. The git tag **is** the version — single
+  source of truth.
+- It does **not** run tests, lint, or any quality gate. Run those
+  yourself before tagging if your project needs them — the contract
+  there is project-specific and lives outside Specflow's tag/release
+  flow.
+
+## After running
+
+If the script exits non-zero, read the stderr message — it says
+exactly what failed (validation regex, missing remote, exhausted
+letter suffix, missing tag).
+
+On success, suggest `/specflow release-version` as the natural next
+step. Do NOT run it automatically — releasing is an explicit,
+deliberate user action.

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -5,6 +5,7 @@ import type {
   InstalledLock,
   KnownHarness,
   LockEntry,
+  VersionScheme,
 } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
 import { TEMPLATES_VERSION } from "../templates_bundle.ts";
@@ -38,6 +39,7 @@ export type InitProjectDeps = {
   lockStore: LockStore;
   harness: Harness;
   backlogBackend: BacklogBackend;
+  versionScheme: VersionScheme;
   core: CoreBundle;
   /** Creates the target directory if it does not exist (idempotent). */
   ensureDir(path: string): Promise<void>;
@@ -54,12 +56,21 @@ export class InitProjectUseCase {
   constructor(private readonly deps: InitProjectDeps) {}
 
   async execute(input: InitProjectInput): Promise<InitResult> {
-    const { writer, git, lockStore, harness, backlogBackend, core, ensureDir } = this.deps;
+    const {
+      writer,
+      git,
+      lockStore,
+      harness,
+      backlogBackend,
+      versionScheme,
+      core,
+      ensureDir,
+    } = this.deps;
     const warnings: string[] = [];
 
     await ensureDir(input.targetDir);
 
-    const bundle = harness.mapBundle(core, { backlogBackend });
+    const bundle = harness.mapBundle(core, { backlogBackend, versionScheme });
 
     if (!input.force) {
       const conflicts = await writer.detectConflicts(bundle, input.targetDir);
@@ -108,6 +119,7 @@ export class InitProjectUseCase {
       version: 2,
       harness: harness.key as KnownHarness,
       backlogBackend,
+      versionScheme,
       templatesVersion: TEMPLATES_VERSION,
       entries: lockEntries,
     };

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -104,7 +104,7 @@ export interface PluginDetector {
 }
 
 import type { CoreBundle } from "../domain/core_bundle.ts";
-import type { BacklogBackend } from "../domain/installed_lock.ts";
+import type { BacklogBackend, VersionScheme } from "../domain/installed_lock.ts";
 
 export type BundleOptions = {
   /**
@@ -113,6 +113,12 @@ export type BundleOptions = {
    * the bundled SKILL.md is rendered with the matching markers stripped.
    */
   readonly backlogBackend: BacklogBackend;
+  /**
+   * Which versioning scheme the tag-release pack should compile down to.
+   * `phase-script` entries with `# BEGIN: scheme=X` markers are rendered
+   * against this value at bundle time.
+   */
+  readonly versionScheme: VersionScheme;
 };
 
 export interface Harness {

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -76,7 +76,10 @@ export class UpgradeProjectUseCase {
     if (!harness) {
       throw new Error(`unknown harness in lock: ${lock.harness}`);
     }
-    const fullBundle = harness.mapBundle(core, { backlogBackend: lock.backlogBackend });
+    const fullBundle = harness.mapBundle(core, {
+      backlogBackend: lock.backlogBackend,
+      versionScheme: lock.versionScheme,
+    });
 
     // JSON-merged files (e.g. `.claude/settings.json`) are user-owned: we
     // never overwrite them, only graft our entries in. They live outside
@@ -251,6 +254,7 @@ export class UpgradeProjectUseCase {
       version: 2,
       harness: lock.harness,
       backlogBackend: lock.backlogBackend,
+      versionScheme: lock.versionScheme,
       templatesVersion,
       entries: updatedEntries,
     };

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -8,8 +8,14 @@ import {
   pickBacklogBackendInteractive,
   promptKanbanURL,
 } from "../backlog_picker.ts";
+import {
+  DEFAULT_VERSION_SCHEME,
+  pickVersionScheme,
+  pickVersionSchemeInteractive,
+} from "../scheme_picker.ts";
 import { makeStdinSelectIO } from "../select.ts";
-import type { BacklogBackend } from "../../domain/installed_lock.ts";
+import type { BacklogBackend, VersionScheme } from "../../domain/installed_lock.ts";
+import { detectVersionScheme } from "../../domain/project_detection.ts";
 import { findBacklogStrategy } from "../../domain/backlog_strategies/registry.ts";
 import {
   type ParsedKanbanURL,
@@ -33,6 +39,8 @@ export type InitIntent = {
   backlogUrl: string | null;
   /** Optional `--backlog-repo` override for the GitHub `repo` field. */
   backlogRepo: string | null;
+  /** Explicit `--scheme` value (`semver` | `date`). Null = ask/detect. */
+  scheme: VersionScheme | null;
   force: boolean;
 };
 
@@ -67,6 +75,59 @@ async function resolveBacklogBackend(
     });
   }
   const picked = await pickBacklogBackendInteractive(makeStdinSelectIO());
+  if (picked === null) {
+    console.error(red("aborted."));
+    Deno.exit(130);
+  }
+  return picked;
+}
+
+/**
+ * Detects whether the user's project looks like a library by probing
+ * common manifest files at `targetDir`. The result is a soft suggestion
+ * pre-positioning the picker cursor — the user always has the final
+ * say via the prompt.
+ */
+function detectSchemeSuggestion(targetDir: string): VersionScheme {
+  const result = detectVersionScheme({
+    exists(rel) {
+      try {
+        Deno.statSync(`${targetDir}/${rel}`);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    readText(rel) {
+      try {
+        return Deno.readTextFileSync(`${targetDir}/${rel}`);
+      } catch {
+        return null;
+      }
+    },
+  });
+  return result.suggestedScheme;
+}
+
+async function resolveVersionScheme(
+  explicit: VersionScheme | null,
+  suggestion: VersionScheme,
+): Promise<VersionScheme> {
+  if (explicit !== null) return explicit;
+  if (!Deno.stdin.isTerminal()) {
+    return pickVersionScheme(
+      {
+        readLine: () => prompt("Choose [1-2]:"),
+        log: (s) => console.log(s),
+        errLog: (s) => console.error(red(s)),
+      },
+      suggestion,
+    );
+  }
+  const picked = await pickVersionSchemeInteractive(
+    makeStdinSelectIO(),
+    suggestion,
+  );
   if (picked === null) {
     console.error(red("aborted."));
     Deno.exit(130);
@@ -270,6 +331,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
     const lockStore = new FsLockStore();
     const probeBundle = harness.mapBundle(CORE_BUNDLE, {
       backlogBackend: "local",
+      versionScheme: DEFAULT_VERSION_SCHEME,
     });
     const conflicts = await writer.detectConflicts(probeBundle, targetDir);
     if (conflicts.length > 0) {
@@ -281,6 +343,11 @@ export async function runInit(intent: InitIntent): Promise<number> {
   }
 
   const backlogBackend = await resolveBacklogBackend(intent.backlog);
+  const schemeSuggestion = detectSchemeSuggestion(targetDir);
+  const versionScheme = await resolveVersionScheme(
+    intent.scheme,
+    schemeSuggestion,
+  );
 
   // Capture the Kanban URL up front (interactive prompt or --backlog-url
   // flag) so the populated config lands at init time and the PO never
@@ -315,6 +382,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
     lockStore: new FsLockStore(),
     harness,
     backlogBackend,
+    versionScheme,
     core: CORE_BUNDLE,
     ensureDir: (path) => Deno.mkdir(path, { recursive: true }),
   });
@@ -345,7 +413,10 @@ export async function runInit(intent: InitIntent): Promise<number> {
     // backlog backend chosen here may differ from the probe's "local"
     // default, but the managed count is invariant — backlog-script
     // entries are present regardless of backend.
-    const probeBundle = harness.mapBundle(CORE_BUNDLE, { backlogBackend });
+    const probeBundle = harness.mapBundle(CORE_BUNDLE, {
+      backlogBackend,
+      versionScheme,
+    });
     const totalManaged = countManagedFiles(probeBundle);
     printConflictsError(result.conflicts, result.lockExists, totalManaged);
     return 3;

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -44,8 +44,14 @@ export async function switchBacklogBackend(
   const harness = findHarness(lock.harness);
   if (!harness) throw new Error(`unknown harness in lock: ${lock.harness}`);
 
-  const newBundle = harness.mapBundle(CORE_BUNDLE, { backlogBackend: newBackend });
-  const oldBundle = harness.mapBundle(CORE_BUNDLE, { backlogBackend: from });
+  const newBundle = harness.mapBundle(CORE_BUNDLE, {
+    backlogBackend: newBackend,
+    versionScheme: lock.versionScheme,
+  });
+  const oldBundle = harness.mapBundle(CORE_BUNDLE, {
+    backlogBackend: from,
+    versionScheme: lock.versionScheme,
+  });
 
   const writer = new DenoFsWriter();
   const reader = new DenoFsReader();
@@ -108,6 +114,7 @@ export async function switchBacklogBackend(
     version: 2,
     harness: lock.harness,
     backlogBackend: newBackend,
+    versionScheme: lock.versionScheme,
     templatesVersion: lock.templatesVersion,
     entries: updatedEntries,
   };
@@ -260,7 +267,10 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     const lock = await lockStore.read(projectDir);
     const harness = lock ? findHarness(lock.harness) : null;
     const previewBundle = harness && lock
-      ? harness.mapBundle(CORE_BUNDLE, { backlogBackend: lock.backlogBackend })
+      ? harness.mapBundle(CORE_BUNDLE, {
+        backlogBackend: lock.backlogBackend,
+        versionScheme: lock.versionScheme,
+      })
       : {};
     for (const action of preserves) {
       const file = previewBundle[action.dest];

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,5 +1,10 @@
 import { parseArgs as stdParseArgs } from "@std/cli/parse-args";
-import { type BacklogBackend, KNOWN_BACKLOG_BACKENDS } from "../domain/installed_lock.ts";
+import {
+  type BacklogBackend,
+  KNOWN_BACKLOG_BACKENDS,
+  KNOWN_VERSION_SCHEMES,
+  type VersionScheme,
+} from "../domain/installed_lock.ts";
 
 function validateBacklogArg(
   raw: string | null,
@@ -9,6 +14,18 @@ function validateBacklogArg(
   if (raw === null) return { ok: true, value: null };
   if ((KNOWN_BACKLOG_BACKENDS as ReadonlyArray<string>).includes(raw)) {
     return { ok: true, value: raw as BacklogBackend };
+  }
+  return { ok: false };
+}
+
+function validateSchemeArg(
+  raw: string | null,
+):
+  | { ok: true; value: VersionScheme | null }
+  | { ok: false } {
+  if (raw === null) return { ok: true, value: null };
+  if ((KNOWN_VERSION_SCHEMES as ReadonlyArray<string>).includes(raw)) {
+    return { ok: true, value: raw as VersionScheme };
   }
   return { ok: false };
 }
@@ -56,6 +73,11 @@ export type Intent =
      * `git remote get-url origin`.
      */
     backlogRepo: string | null;
+    /**
+     * Explicit `--scheme` value. `null` triggers the interactive picker
+     * (TTY) or the auto-detection default (non-TTY).
+     */
+    scheme: "semver" | "date" | null;
     force: boolean;
   }
   | { kind: "self-update"; checkOnly: boolean }
@@ -93,7 +115,7 @@ export function parseArgs(argv: string[]): Intent {
       "project",
       "reset-baseline",
     ],
-    string: ["ai", "backlog", "backlog-url", "backlog-repo"],
+    string: ["ai", "backlog", "backlog-url", "backlog-repo", "scheme"],
     alias: { v: "version", h: "help" },
   });
 
@@ -129,6 +151,12 @@ export function parseArgs(argv: string[]): Intent {
     const backlogRepoRaw = typeof parsed["backlog-repo"] === "string"
       ? (parsed["backlog-repo"] as string)
       : null;
+    const schemeProvided = typeof parsed.scheme === "string";
+    const schemeRaw = schemeProvided ? (parsed.scheme as string) : null;
+    const schemeResult = validateSchemeArg(schemeRaw);
+    if (!schemeResult.ok) {
+      return { kind: "unknown", received: `init --scheme ${schemeRaw}` };
+    }
     return {
       kind: "init",
       projectName: rest[0] ?? null,
@@ -138,6 +166,7 @@ export function parseArgs(argv: string[]): Intent {
       backlog: backlogResult.value,
       backlogUrl: backlogUrlRaw,
       backlogRepo: backlogRepoRaw,
+      scheme: schemeResult.value,
       force: Boolean(parsed.force),
     };
   }

--- a/src/cli/scheme_picker.ts
+++ b/src/cli/scheme_picker.ts
@@ -1,0 +1,90 @@
+import { KNOWN_VERSION_SCHEMES, type VersionScheme } from "../domain/installed_lock.ts";
+import { selectInteractive, type SelectIO } from "./select.ts";
+
+export const DEFAULT_VERSION_SCHEME: VersionScheme = "semver";
+
+export type SchemePickerIO = {
+  readLine: () => string | null;
+  log: (s: string) => void;
+  errLog: (s: string) => void;
+};
+
+type SchemeMeta = {
+  readonly key: VersionScheme;
+  readonly displayName: string;
+  readonly hint: string;
+};
+
+const SCHEME_CATALOG: ReadonlyArray<SchemeMeta> = [
+  {
+    key: "semver",
+    displayName: "SemVer (v1.2.3)",
+    hint: "best for libraries / SDKs with external consumers",
+  },
+  {
+    key: "date",
+    displayName: "Date-based (vYY.M.Da)",
+    hint: "best for apps / SaaS — no MAJOR/MINOR/PATCH guesswork",
+  },
+];
+
+if (SCHEME_CATALOG.length !== KNOWN_VERSION_SCHEMES.length) {
+  throw new Error(
+    "SCHEME_CATALOG and KNOWN_VERSION_SCHEMES are out of sync",
+  );
+}
+
+/**
+ * Non-interactive picker — for non-TTY contexts. Defaults to
+ * `suggestion` on bare Enter, falls back to `DEFAULT_VERSION_SCHEME`
+ * when no suggestion is supplied.
+ */
+export function pickVersionScheme(
+  io: SchemePickerIO,
+  suggestion: VersionScheme = DEFAULT_VERSION_SCHEME,
+): VersionScheme {
+  io.log("Choose your versioning scheme (press Enter for default):");
+  for (let i = 0; i < SCHEME_CATALOG.length; i++) {
+    const s = SCHEME_CATALOG[i];
+    const marker = s.key === suggestion ? " (default)" : "";
+    io.log(`  ${i + 1}) ${s.displayName} — ${s.hint}${marker}`);
+  }
+  while (true) {
+    const raw = (io.readLine() ?? "").trim();
+    if (raw === "") return suggestion;
+    const idx = parseInt(raw, 10) - 1;
+    if (
+      Number.isInteger(idx) &&
+      idx >= 0 &&
+      idx < SCHEME_CATALOG.length
+    ) {
+      return SCHEME_CATALOG[idx].key;
+    }
+    io.errLog(
+      `invalid choice "${raw}" — expected 1-${SCHEME_CATALOG.length} or empty for default`,
+    );
+  }
+}
+
+/**
+ * Interactive arrow-key picker — for TTY contexts. The default cursor
+ * lands on `suggestion`. Returns `null` on Ctrl-C / Esc.
+ */
+export async function pickVersionSchemeInteractive(
+  io: SelectIO,
+  suggestion: VersionScheme = DEFAULT_VERSION_SCHEME,
+): Promise<VersionScheme | null> {
+  const defaultIdx = SCHEME_CATALOG.findIndex((s) => s.key === suggestion);
+  const items = SCHEME_CATALOG.map((s) => ({
+    key: s.key,
+    label: s.key === suggestion
+      ? `${s.displayName} — ${s.hint} (suggested)`
+      : `${s.displayName} — ${s.hint}`,
+  }));
+  return await selectInteractive(
+    items,
+    defaultIdx >= 0 ? defaultIdx : 0,
+    io,
+    "Choose your versioning scheme (↑/↓ to move, space/enter to select, Ctrl-C to cancel):",
+  );
+}

--- a/src/domain/conditional_render.ts
+++ b/src/domain/conditional_render.ts
@@ -1,5 +1,5 @@
-import type { BacklogBackend } from "./installed_lock.ts";
-import { KNOWN_BACKLOG_BACKENDS } from "./installed_lock.ts";
+import type { BacklogBackend, VersionScheme } from "./installed_lock.ts";
+import { KNOWN_BACKLOG_BACKENDS, KNOWN_VERSION_SCHEMES } from "./installed_lock.ts";
 
 const BEGIN_RE = /^\s*<!--\s*BEGIN:\s*backend=([a-zA-Z0-9_-]+)\s*-->\s*$/;
 const END_RE = /^\s*<!--\s*END:\s*backend=([a-zA-Z0-9_-]+)\s*-->\s*$/;
@@ -90,6 +90,90 @@ export function assertKnownBackend(s: string): asserts s is BacklogBackend {
   if (!KNOWN_BACKLOG_BACKENDS.includes(s as BacklogBackend)) {
     throw new Error(
       `unknown backlog backend '${s}' — known: ${KNOWN_BACKLOG_BACKENDS.join(", ")}`,
+    );
+  }
+}
+
+const SH_SCHEME_BEGIN_RE = /^\s*#\s*BEGIN:\s*scheme=([a-zA-Z0-9_-]+)\s*$/;
+const SH_SCHEME_END_RE = /^\s*#\s*END:\s*scheme=([a-zA-Z0-9_-]+)\s*$/;
+
+/**
+ * Strip scheme-conditional sections from a shell source.
+ *
+ * Markers are shell comments on their own line:
+ *   # BEGIN: scheme=date
+ *   ...content kept when scheme === "date"...
+ *   # END: scheme=date
+ *
+ * For the `active` scheme, the content is preserved and only the
+ * surrounding marker lines are removed. For any other scheme, the
+ * markers AND the content between them are removed.
+ *
+ * No fenced-code-block guard — shell sources don't have triple-backtick
+ * fences that would confuse marker scanning.
+ *
+ * Throws on unmatched markers (BEGIN without END, END without BEGIN)
+ * and on nested markers.
+ */
+export function renderScheme(source: string, active: VersionScheme): string {
+  const lines = source.split("\n");
+  const out: string[] = [];
+  let openScheme: string | null = null;
+  let openLine = -1;
+  let keepBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    const beginMatch = line.match(SH_SCHEME_BEGIN_RE);
+    if (beginMatch) {
+      if (openScheme !== null) {
+        throw new Error(
+          `nested scheme marker at line ${i + 1}: BEGIN ${beginMatch[1]} ` +
+            `inside open block ${openScheme} (started at line ${openLine + 1})`,
+        );
+      }
+      openScheme = beginMatch[1];
+      openLine = i;
+      keepBlock = openScheme === active;
+      continue;
+    }
+
+    const endMatch = line.match(SH_SCHEME_END_RE);
+    if (endMatch) {
+      if (openScheme === null) {
+        throw new Error(
+          `unmatched END marker at line ${i + 1}: scheme=${endMatch[1]}`,
+        );
+      }
+      if (endMatch[1] !== openScheme) {
+        throw new Error(
+          `mismatched END marker at line ${i + 1}: expected scheme=${openScheme} ` +
+            `(opened at line ${openLine + 1}), got scheme=${endMatch[1]}`,
+        );
+      }
+      openScheme = null;
+      keepBlock = false;
+      continue;
+    }
+
+    if (openScheme === null || keepBlock) out.push(line);
+  }
+
+  if (openScheme !== null) {
+    throw new Error(
+      `unmatched BEGIN marker at line ${openLine + 1}: scheme=${openScheme}`,
+    );
+  }
+
+  return out.join("\n");
+}
+
+/** Throws if `s` is not a known version scheme. */
+export function assertKnownScheme(s: string): asserts s is VersionScheme {
+  if (!KNOWN_VERSION_SCHEMES.includes(s as VersionScheme)) {
+    throw new Error(
+      `unknown version scheme '${s}' — known: ${KNOWN_VERSION_SCHEMES.join(", ")}`,
     );
   }
 }

--- a/src/domain/core_bundle.ts
+++ b/src/domain/core_bundle.ts
@@ -5,6 +5,7 @@ export type CoreCategory =
   | "agent-memory"
   | "skill"
   | "phase"
+  | "phase-script"
   | "spec-root"
   | "project-root"
   | "backlog-cmd"

--- a/src/domain/installed_lock.ts
+++ b/src/domain/installed_lock.ts
@@ -25,6 +25,12 @@ export const KNOWN_BACKLOG_BACKENDS: ReadonlyArray<BacklogBackend> = [
   "gitlab",
 ];
 
+export type VersionScheme = "semver" | "date";
+export const KNOWN_VERSION_SCHEMES: ReadonlyArray<VersionScheme> = [
+  "semver",
+  "date",
+];
+
 export type LockEntry = {
   readonly sha256: string;
   readonly installedAt: string;
@@ -35,6 +41,7 @@ export type InstalledLock = {
   readonly version: 2;
   readonly harness: KnownHarness;
   readonly backlogBackend: BacklogBackend;
+  readonly versionScheme: VersionScheme;
   readonly templatesVersion: string;
   readonly entries: ReadonlyMap<string, LockEntry>;
 };
@@ -77,6 +84,16 @@ export function parseLock(yaml: string): InstalledLock {
     ? (rawBackend as BacklogBackend)
     : "local";
 
+  // Default to "semver" when absent: existing locks pre-date the
+  // tag-release pack. SemVer is the safer default for unknown projects
+  // (a library mis-classified as date-based is more disruptive than the
+  // reverse — consumers downstream reason about version numbers).
+  const rawScheme = root.version_scheme;
+  const versionScheme: VersionScheme = typeof rawScheme === "string" &&
+      KNOWN_VERSION_SCHEMES.includes(rawScheme as VersionScheme)
+    ? (rawScheme as VersionScheme)
+    : "semver";
+
   const templatesVersion = root.templates_version;
   if (typeof templatesVersion !== "string") {
     throw new Error("missing top-level templates_version");
@@ -97,7 +114,14 @@ export function parseLock(yaml: string): InstalledLock {
     }
     entries.set(path, { sha256, installedAt, templatesVersion: ver });
   }
-  return { version: 2, harness, backlogBackend, templatesVersion, entries };
+  return {
+    version: 2,
+    harness,
+    backlogBackend,
+    versionScheme,
+    templatesVersion,
+    entries,
+  };
 }
 
 export function serializeLock(lock: InstalledLock): string {
@@ -115,6 +139,7 @@ export function serializeLock(lock: InstalledLock): string {
     version: 2,
     harness: lock.harness,
     backlog_backend: lock.backlogBackend,
+    version_scheme: lock.versionScheme,
     templates_version: lock.templatesVersion,
     entries: entriesObj,
   });

--- a/src/domain/project_detection.ts
+++ b/src/domain/project_detection.ts
@@ -1,0 +1,112 @@
+import type { VersionScheme } from "./installed_lock.ts";
+
+/**
+ * Tiny synchronous filesystem facade — just what `detectVersionScheme`
+ * needs. Implementations: a `Deno.statSync` / `Deno.readTextFileSync`
+ * adapter in production, a fake map in tests.
+ *
+ * Synchronous on purpose: the detection runs once at init time, the
+ * total work is reading a handful of small manifest files, and
+ * threading async through every helper just to satisfy Deno globals
+ * here would muddy the domain port.
+ */
+export type FsSnapshot = {
+  exists(rel: string): boolean;
+  readText(rel: string): string | null;
+};
+
+export type DetectionResult = {
+  readonly suggestedScheme: VersionScheme;
+  readonly evidence: ReadonlyArray<string>;
+};
+
+/**
+ * Detects whether the user's project looks like a published library or
+ * an app/SaaS by inspecting manifest files for "this is a library"
+ * markers.
+ *
+ *   - Library markers found → suggest SemVer (consumers reason about
+ *     breaking changes).
+ *   - None found → suggest date-based (simpler; matches the "I don't
+ *     want to think about major/minor/patch" SaaS use case).
+ *
+ * The user always sees the suggestion as a pre-selected default they
+ * can override — this is a UX shortcut, not a contract.
+ */
+export function detectVersionScheme(fs: FsSnapshot): DetectionResult {
+  const evidence: string[] = [];
+
+  // npm: a `package.json` with an `exports` or `main` field is a
+  // strong library signal. A bare `package.json` (Vite app, Next app,
+  // Express service) typically has neither.
+  if (fs.exists("package.json")) {
+    const raw = fs.readText("package.json");
+    if (raw !== null) {
+      try {
+        const pkg = JSON.parse(raw) as Record<string, unknown>;
+        if (typeof pkg.exports !== "undefined") {
+          evidence.push("package.json exports field");
+        } else if (typeof pkg.main === "string" && pkg.main.length > 0) {
+          // `main` alone is weaker — many CLIs ship it. Only count it
+          // when the package is also explicitly `private: false` or
+          // has a `publishConfig`.
+          if (pkg.private === false || typeof pkg.publishConfig === "object") {
+            evidence.push("package.json main + publish intent");
+          }
+        }
+      } catch {
+        // malformed JSON — ignore for detection purposes
+      }
+    }
+  }
+
+  // Python: `pyproject.toml` with `[project]` or `[tool.poetry]` block.
+  if (fs.exists("pyproject.toml")) {
+    const raw = fs.readText("pyproject.toml");
+    if (raw !== null) {
+      if (/^\s*\[project\]\s*$/m.test(raw)) {
+        evidence.push("pyproject.toml [project] block");
+      } else if (/^\s*\[tool\.poetry\]\s*$/m.test(raw)) {
+        evidence.push("pyproject.toml [tool.poetry] block");
+      }
+    }
+  }
+
+  // Rust: `Cargo.toml` with `[lib]`. Apps have `[[bin]]` instead.
+  if (fs.exists("Cargo.toml")) {
+    const raw = fs.readText("Cargo.toml");
+    if (raw !== null) {
+      if (/^\s*\[lib\]\s*$/m.test(raw)) {
+        evidence.push("Cargo.toml [lib] section");
+      }
+    }
+  }
+
+  // PHP: `composer.json` with `"type": "library"`.
+  if (fs.exists("composer.json")) {
+    const raw = fs.readText("composer.json");
+    if (raw !== null) {
+      try {
+        const pkg = JSON.parse(raw) as Record<string, unknown>;
+        if (pkg.type === "library") {
+          evidence.push('composer.json type="library"');
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  // Ruby: any `*.gemspec` at the repo root is a library marker.
+  // The FS snapshot doesn't enumerate; the caller passes a `*.gemspec`
+  // hint as a synthetic path. Implementation: convention — caller probes
+  // `__gemspec_present__` for a flag, or we ask for a directory listing.
+  // Simpler: skip ruby for v1; the heuristic is sufficient without it,
+  // and adding directory enumeration to the FS port for one detector is
+  // overkill. (Re-add when someone files an issue.)
+
+  if (evidence.length > 0) {
+    return { suggestedScheme: "semver", evidence };
+  }
+  return { suggestedScheme: "date", evidence: [] };
+}

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -4,6 +4,7 @@ import type { Bundle } from "../../domain/template.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 function toAntigravityWorkflowMarkdown(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -44,6 +45,8 @@ function destinationFor(entry: CoreEntry): string {
     case "phase":
       if (!entry.suffix) throw new Error(`phase needs suffix: ${entry.name}`);
       return `.agent/skills/specflow/phases/${entry.suffix}`;
+    case "phase-script":
+      return phaseScriptDestination(entry);
     case "backlog-script":
       return backlogScriptDestination(entry);
     case "agent-memory":
@@ -65,8 +68,9 @@ export class AntigravityHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -3,6 +3,7 @@ import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { ensureSkillFrontmatter } from "./skill_folder.ts";
 
 function destinationFor(entry: CoreEntry): string {
@@ -25,6 +26,8 @@ function destinationFor(entry: CoreEntry): string {
       // can load them via `phases/<phase>.md` from its own directory.
       if (!entry.suffix) throw new Error(`phase needs suffix: ${entry.name}`);
       return `.claude/skills/specflow/phases/${entry.suffix}`;
+    case "phase-script":
+      return phaseScriptDestination(entry);
     case "backlog-script":
       return backlogScriptDestination(entry);
     case "spec-root":
@@ -44,8 +47,9 @@ export class ClaudeHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
 
       // Skill-folder categories ship as `.claude/skills/<name>/SKILL.md`.
       // Claude Code derives the skill name from the folder, but we inject

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -6,6 +6,7 @@ import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 function parseAgentFrontmatter(content: string): { description: string; body: string } {
   const split = splitFrontmatter(content);
@@ -32,8 +33,9 @@ export class CodexHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       switch (entry.category) {
@@ -61,6 +63,12 @@ export class CodexHarness implements Harness {
           };
           break;
         }
+        case "phase-script":
+          out[phaseScriptDestination(entry)] = {
+            content: entry.content,
+            executable: entry.executable,
+          };
+          break;
         case "backlog-script":
           out[backlogScriptDestination(entry)] = {
             content: entry.content,

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -4,6 +4,7 @@ import type { Bundle } from "../../domain/template.ts";
 import { skillFolderName } from "./skill_folder.ts";
 import { splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 function toCopilotInstructionMarkdown(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -22,6 +23,8 @@ function destinationFor(entry: CoreEntry): string {
       // Copilot is flat — phase docs become sibling instruction files.
       if (!entry.suffix) throw new Error(`phase needs suffix: ${entry.name}`);
       return `.github/instructions/specflow-${entry.suffix.replace(/\.md$/, "")}.instructions.md`;
+    case "phase-script":
+      return phaseScriptDestination(entry);
     case "backlog-script":
       return backlogScriptDestination(entry);
     case "agent-memory":
@@ -43,8 +46,9 @@ export class CopilotHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -4,6 +4,7 @@ import type { Bundle, TemplateFile } from "../../domain/template.ts";
 import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 function destinationFor(entry: CoreEntry): string {
   switch (entry.category) {
@@ -15,6 +16,8 @@ function destinationFor(entry: CoreEntry): string {
     case "phase":
       if (!entry.suffix) throw new Error(`phase needs suffix: ${entry.name}`);
       return `.cursor/skills/specflow/phases/${entry.suffix}`;
+    case "phase-script":
+      return phaseScriptDestination(entry);
     case "backlog-script":
       return backlogScriptDestination(entry);
     case "agent-memory":
@@ -36,8 +39,9 @@ export class CursorHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);

--- a/src/infrastructure/harness/gemini_harness.ts
+++ b/src/infrastructure/harness/gemini_harness.ts
@@ -5,6 +5,7 @@ import type { Bundle } from "../../domain/template.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 function toGeminiCommandToml(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -32,8 +33,9 @@ export class GeminiHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       switch (entry.category) {
@@ -62,6 +64,12 @@ export class GeminiHarness implements Harness {
           };
           break;
         }
+        case "phase-script":
+          out[phaseScriptDestination(entry)] = {
+            content: entry.content,
+            executable: entry.executable,
+          };
+          break;
         case "backlog-script":
           out[backlogScriptDestination(entry)] = {
             content: entry.content,

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -4,6 +4,7 @@ import type { Bundle } from "../../domain/template.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 type PermissionValue = "allow" | "ask" | "deny" | { "*": "ask" | "allow" | "deny" };
 type PermissionMap = Record<string, PermissionValue>;
@@ -107,6 +108,8 @@ function destinationFor(entry: CoreEntry): string {
     case "phase":
       if (!entry.suffix) throw new Error(`phase needs suffix: ${entry.name}`);
       return `.opencode/skills/specflow/phases/${entry.suffix}`;
+    case "phase-script":
+      return phaseScriptDestination(entry);
     case "backlog-script":
       return backlogScriptDestination(entry);
     case "agent-memory":
@@ -128,8 +131,9 @@ export class OpenCodeHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       const dest = destinationFor(entry);

--- a/src/infrastructure/harness/scheme_filter.ts
+++ b/src/infrastructure/harness/scheme_filter.ts
@@ -1,0 +1,37 @@
+import type { CoreEntry } from "../../domain/core_bundle.ts";
+import type { BundleOptions } from "../../application/ports.ts";
+import { renderScheme } from "../../domain/conditional_render.ts";
+
+/**
+ * Renders `# BEGIN: scheme=X` blocks in a `phase-script` entry against
+ * the active versioning scheme. Entries from other categories pass
+ * through unchanged.
+ *
+ * Idempotent and pure — no IO, no Deno globals.
+ */
+export function applyScheme(entry: CoreEntry, opts: BundleOptions): CoreEntry {
+  if (entry.category !== "phase-script") return entry;
+  return {
+    ...entry,
+    content: renderScheme(entry.content, opts.versionScheme),
+  };
+}
+
+/**
+ * Uniform destination for any `phase-script` entry — same path for every
+ * harness. The phase docs reference scripts via this path so the
+ * scaffolded tag/release commands stay portable across harnesses
+ * (including the flat ones like Windsurf and Copilot that don't have a
+ * `skills/<name>/` layout). Mirrors the `backlog-script` convention.
+ */
+export function phaseScriptDestination(entry: CoreEntry): string {
+  if (entry.category !== "phase-script") {
+    throw new Error(
+      `phaseScriptDestination called on non-phase-script entry: ${entry.category}`,
+    );
+  }
+  if (!entry.suffix) {
+    throw new Error(`phase-script needs suffix: ${entry.name}`);
+  }
+  return `.specflow/scripts/release/${entry.suffix}`;
+}

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -3,6 +3,7 @@ import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { skillFolderName } from "./skill_folder.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
+import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
 /**
  * Windsurf's per-workflow character cap. Cascade silently truncates at this
@@ -25,6 +26,8 @@ function destinationFor(entry: CoreEntry): string {
       // becomes a sibling workflow file the router references by name.
       if (!entry.suffix) throw new Error(`phase needs suffix: ${entry.name}`);
       return `.windsurf/workflows/specflow-${entry.suffix.replace(/\.md$/, "")}.md`;
+    case "phase-script":
+      return phaseScriptDestination(entry);
     case "backlog-script":
       return backlogScriptDestination(entry);
     case "agent-memory":
@@ -46,8 +49,9 @@ export class WindsurfHarness implements Harness {
   mapBundle(core: CoreBundle, opts: BundleOptions): Bundle {
     const out: Bundle = {};
     for (const raw of core) {
-      const entry = applyBackend(raw, opts);
-      if (entry === null) continue;
+      const backendApplied = applyBackend(raw, opts);
+      if (backendApplied === null) continue;
+      const entry = applyScheme(backendApplied, opts);
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       out[destinationFor(entry)] = {

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11,8 +11,8 @@ export const CORE_BUNDLE: CoreBundle = [
     suffix: null,
     content: `---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). \`/specflow\` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version). \`/specflow\` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -26,6 +26,8 @@ when_to_use: |
   - constitution: "update the constitution", "edit project rules"
   - checklist: "generate a checklist"
   - groom: "groom the backlog", "run a hygiene pass"
+  - tag-version: "tag a version", "create a release tag", "bump the version"
+  - release-version: "release", "publish a release", "create release notes"
 ---
 
 # Specflow router
@@ -52,6 +54,8 @@ If \`\$ARGUMENTS\` is empty, render the **Workflow overview** below and stop. Do
 | \`constitution\` | \`phases/constitution.md\` | Edit the project's \`constitution.md\` rules. |
 | \`checklist\` | \`phases/checklist.md\` | Generate a quality checklist for the current spec. |
 | \`groom\` | \`phases/groom.md\` | Backlog hygiene pass via the product-owner agent. |
+| \`tag-version\` | \`phases/tag-version.md\` | Bump + create an annotated git tag using the project's versioning scheme. |
+| \`release-version\` | \`phases/release-version.md\` | Generate categorized release notes for a tag (default: latest). |
 
 ## Routing
 
@@ -69,7 +73,7 @@ specify → clarify → plan → tasks → analyze → implement → review → 
                                                           STOP for pre-merge validation
 \`\`\`
 
-\`constitution\`, \`checklist\`, and \`groom\` are out-of-band utilities, not part of the linear flow.
+\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, and \`release-version\` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
@@ -1990,6 +1994,429 @@ to be a **no-op when the project is healthy**.
 - For implementing a spec → invoke \`/specflow implement\` directly.
 `,
     executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "tag-version",
+    suffix: "tag-version.md",
+    content: `
+## User Input
+
+\`\`\`text
+\$ARGUMENTS
+\`\`\`
+
+You **MUST** consider the user input before proceeding (if not empty).
+Common natural-language requests:
+
+- \`/specflow tag-version\` — tag HEAD with the next version
+- \`/specflow tag-version <sha>\` — tag a specific commit
+- \`/specflow tag-version --bump minor\` — SemVer projects only: bump
+  minor instead of patch (also \`--bump major\` / \`--bump patch\`)
+- \`/specflow tag-version --no-push\` — skip pushing to \`origin\`
+
+## What this command does
+
+Creates an annotated git tag using the **versioning scheme baked into
+this project at \`specflow init\`** (one of SemVer \`v1.2.3\` or date-based
+\`vYY.M.Da\`).
+
+The bundled script does all the work:
+
+\`\`\`bash
+bash .specflow/scripts/release/tag.sh "\$@"
+\`\`\`
+
+What the script does:
+
+1. Runs \`git fetch --tags --quiet\` so the next-tag computation sees
+   every tag that already exists on \`origin\`.
+2. Computes the next tag from the project's scheme:
+   - **SemVer** — finds the latest \`v*.*.*\` tag, applies the bump
+     direction from \`--bump\` (default \`patch\`), validates the result.
+   - **Date-based** — computes today's \`vYY.M.D\` prefix (no leading
+     zeros), scans existing tags for today, increments the letter
+     suffix (\`a\` → \`b\` → … → \`z\`, then errors out at 26 same-day tags).
+3. Creates an annotated tag with the commit subject in the message.
+4. Pushes to \`origin\` if a remote is configured (use \`--no-push\` to
+   skip).
+
+## What this command does NOT do
+
+- It does **not** create a GitHub / GitLab release — pushing a tag
+  alone does not publish a release. Run \`/specflow release-version\`
+  after this to publish the categorized release notes.
+- It does **not** edit version fields in \`package.json\` / \`Cargo.toml\`
+  / \`pyproject.toml\` / etc. The git tag **is** the version — single
+  source of truth.
+- It does **not** run tests, lint, or any quality gate. Run those
+  yourself before tagging if your project needs them — the contract
+  there is project-specific and lives outside Specflow's tag/release
+  flow.
+
+## After running
+
+If the script exits non-zero, read the stderr message — it says
+exactly what failed (validation regex, missing remote, exhausted
+letter suffix, missing tag).
+
+On success, suggest \`/specflow release-version\` as the natural next
+step. Do NOT run it automatically — releasing is an explicit,
+deliberate user action.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "release-version",
+    suffix: "release-version.md",
+    content: `
+## User Input
+
+\`\`\`text
+\$ARGUMENTS
+\`\`\`
+
+You **MUST** consider the user input before proceeding (if not empty).
+Common natural-language requests:
+
+- \`/specflow release-version\` — generate notes for the latest tag
+- \`/specflow release-version v1.2.3\` — generate notes for a specific tag
+- \`/specflow release-version --baseline v1.2.0\` — override the baseline
+  (use when the previous tag was never released and you want to skip
+  past it; default baseline is the previous tag chronologically)
+
+## What this command does
+
+Generates **categorized release notes** for the given tag (default:
+latest) covering every commit between a baseline tag and the target
+tag.
+
+The bundled script is stack-agnostic — it just emits the
+release-body Markdown to stdout, with one section per non-empty
+Conventional-Commits bucket. Run it like this:
+
+\`\`\`bash
+bash .specflow/scripts/release/release.sh "\$@"
+\`\`\`
+
+## Buckets (fixed order, empty buckets omitted)
+
+1. **Features** — \`feat:\` / \`feat(scope):\` / \`feat!:\`
+2. **Bug Fixes** — \`fix:\` / \`fix(scope):\` / \`fix!:\`
+3. **Performance** — \`perf:\`
+4. **Refactors** — \`refactor:\`
+5. **Documentation** — \`docs:\`
+6. **Tests** — \`test:\`
+7. **Build & CI** — \`build:\` / \`ci:\`
+8. **Chores** — \`chore:\`
+9. **Style** — \`style:\`
+10. **Other** — anything that does not match a Conventional-Commits prefix
+
+Each commit appears as \`- <short-sha> <subject>\` under its bucket.
+
+## After the script runs
+
+The script writes the release body to **stdout**. What you do with it
+depends on how this project publishes releases:
+
+- **GitHub remote** — pipe it into \`gh release create <tag>
+  --notes-file -\` (or \`--notes "\$(...)"\`).
+- **GitLab remote** — pipe it into \`glab release create <tag>
+  --notes "..."\`.
+- **Local-only** — copy the output somewhere readable (or echo it to
+  the user); there is no remote release to create.
+
+The per-backend wrapper scripts ship as separate Specflow features —
+when one is installed, prefer it to manually piping into \`gh\` / \`glab\`.
+
+## Important — release-notes contract
+
+The script emits the body verbatim. Do NOT:
+
+- Reword sections / re-categorize commits after the fact. If a commit
+  message is wrong (e.g. \`feat:\` for what's really a \`fix:\`), the
+  correct move is to amend the commit message **before** tagging,
+  not to hand-edit the release body.
+- Add a raw \`git diff\` or \`git log\` dump. The whole point of this
+  command is that the body is human-readable on its own.
+- Run release publication without showing the user the generated body
+  first when invoked interactively. The body is the production
+  artifact — surface it for review before posting.
+
+## Workflow
+
+\`\`\`
+/specflow tag-version             → annotated tag created + pushed
+/specflow release-version         → categorized release notes (stdout)
+↳ pipe to gh/glab release create  → release published
+\`\`\`
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase-script",
+    name: "tag",
+    suffix: "tag.sh",
+    content: `#!/usr/bin/env bash
+# Create an annotated git tag using the project's versioning scheme.
+#
+# The scheme is baked at scaffold time — the \`# BEGIN: scheme=X\` blocks
+# below are stripped by the Specflow bundler so only the chosen scheme's
+# logic ships on disk. To change schemes after init, re-run
+# \`specflow init\` and pick the other option.
+#
+# Usage: tag.sh [--no-push] [--bump <major|minor|patch>] [<commit-sha>]
+set -euo pipefail
+
+NO_PUSH=false
+BUMP="patch"
+COMMIT=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --no-push) NO_PUSH=true; shift ;;
+    --bump) BUMP="\$2"; shift 2 ;;
+    --bump=*) BUMP="\${1#--bump=}"; shift ;;
+    --help|-h)
+      echo "usage: tag.sh [--no-push] [--bump <major|minor|patch>] [<commit-sha>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: \$1" >&2; exit 2 ;;
+    *) COMMIT="\$1"; shift ;;
+  esac
+done
+
+COMMIT="\${COMMIT:-HEAD}"
+COMMIT_SHA=\$(git rev-parse "\$COMMIT")
+git fetch --tags --quiet 2>/dev/null || true
+
+# BEGIN: scheme=semver
+# SemVer scheme: vMAJOR.MINOR.PATCH. The --bump flag picks the bump
+# direction (default patch). When no tag exists yet, start at v0.1.0.
+LATEST=\$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)
+if [ -z "\$LATEST" ]; then
+  NEW="v0.1.0"
+  echo "no previous semver tag — starting at \$NEW"
+else
+  raw="\${LATEST#v}"
+  IFS='.' read -r MAJOR MINOR PATCH <<<"\$raw"
+  case "\$BUMP" in
+    major) MAJOR=\$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=\$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=\$((PATCH + 1)) ;;
+    *) echo "invalid --bump '\$BUMP' (expected major|minor|patch)" >&2; exit 2 ;;
+  esac
+  NEW="v\${MAJOR}.\${MINOR}.\${PATCH}"
+fi
+
+if ! printf '%s' "\$NEW" | grep -qE '^v[0-9]+\\.[0-9]+\\.[0-9]+\$'; then
+  echo "computed tag '\$NEW' failed SemVer validation" >&2
+  exit 1
+fi
+# END: scheme=semver
+
+# BEGIN: scheme=date
+# Date-based scheme: vYY.M.D[a-z]. No leading zeros on month/day; letter
+# suffix increments for same-day re-tags (a..z; 26th tag in one day
+# aborts — wait for tomorrow or tag manually).
+YY=\$(date +%y)
+M=\$((10#\$(date +%m)))
+D=\$((10#\$(date +%d)))
+PREFIX="v\${YY}.\${M}.\${D}"
+
+LATEST_LETTER=\$(git tag --list "\${PREFIX}[a-z]" | sed -E "s|^\${PREFIX}||" | sort | tail -n1 || true)
+if [ -z "\$LATEST_LETTER" ]; then
+  NEW="\${PREFIX}a"
+elif [ "\$LATEST_LETTER" = "z" ]; then
+  echo "letter suffix exhausted (z) for \$PREFIX — wait for tomorrow or tag manually" >&2
+  exit 1
+else
+  NEXT_LETTER=\$(printf '%s' "\$LATEST_LETTER" | tr 'a-y' 'b-z')
+  NEW="\${PREFIX}\${NEXT_LETTER}"
+fi
+
+if ! printf '%s' "\$NEW" | grep -qE '^v[0-9]{2}\\.([1-9]|1[0-2])\\.([1-9]|[12][0-9]|3[01])[a-z]\$'; then
+  echo "computed tag '\$NEW' failed date-based validation" >&2
+  exit 1
+fi
+# END: scheme=date
+
+if git rev-parse "\$NEW" >/dev/null 2>&1; then
+  echo "tag '\$NEW' already exists — refusing to clobber" >&2
+  exit 1
+fi
+
+SUBJECT=\$(git log -1 --format=%s "\$COMMIT_SHA")
+echo "creating annotated tag \$NEW on \$COMMIT_SHA"
+echo "  subject: \$SUBJECT"
+git tag -a "\$NEW" -m "Release \$NEW
+
+\$SUBJECT" "\$COMMIT_SHA"
+
+if [ "\$NO_PUSH" = "true" ]; then
+  echo "✓ tagged \$NEW (local only — --no-push)"
+elif git remote get-url origin >/dev/null 2>&1; then
+  git push origin "\$NEW"
+  echo "✓ tagged \$NEW and pushed to origin"
+else
+  echo "✓ tagged \$NEW (no origin configured — tag is local-only)"
+fi
+`,
+    executable: true,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase-script",
+    name: "release",
+    suffix: "release.sh",
+    content: `#!/usr/bin/env bash
+# Generate categorized release notes for commits in <baseline>..<tag>.
+#
+# Stack-agnostic: emits the release-body Markdown to stdout. Per-backend
+# wrappers (release-github.sh, release-gitlab.sh) consume this output
+# and POST it to the respective Releases API.
+#
+# Usage: release.sh [--baseline <tag>] [<tag>]
+#   <tag>           default: latest tag (git describe --tags --abbrev=0)
+#   --baseline      default: previous tag chronologically before <tag>;
+#                   per-backend wrappers override this to "previous
+#                   tag that has a published release attached" so commits
+#                   landed under undeployed tags are not silently skipped.
+set -euo pipefail
+
+BASELINE=""
+TAG=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --baseline) BASELINE="\$2"; shift 2 ;;
+    --baseline=*) BASELINE="\${1#--baseline=}"; shift ;;
+    --help|-h)
+      echo "usage: release.sh [--baseline <tag>] [<tag>]"
+      echo
+      echo "  Emits categorized release-note Markdown to stdout for"
+      echo "  commits in <baseline>..<tag>. Default tag = latest tag."
+      echo "  Default baseline = previous tag chronologically."
+      exit 0
+      ;;
+    -*) echo "unknown flag: \$1" >&2; exit 2 ;;
+    *) TAG="\$1"; shift ;;
+  esac
+done
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if [ -z "\$TAG" ]; then
+  TAG=\$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "\$TAG" ]; then
+    echo "no tags found in this repository — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "\$TAG" >/dev/null 2>&1; then
+  echo "tag '\$TAG' not found" >&2
+  exit 1
+fi
+
+if [ -z "\$BASELINE" ]; then
+  BASELINE=\$(git tag --sort=-creatordate \\
+    | awk -v cur="\$TAG" 'BEGIN{found=0} \$0==cur{found=1;next} found==1{print;exit}')
+fi
+
+if [ -n "\$BASELINE" ] && ! git rev-parse "\$BASELINE" >/dev/null 2>&1; then
+  echo "baseline tag '\$BASELINE' not found" >&2
+  exit 1
+fi
+
+if [ -z "\$BASELINE" ]; then
+  RANGE_LABEL="_Initial release — all commits up to \\\`\$TAG\\\`._"
+  COMMITS=\$(git log --format='%h %s' "\$TAG")
+else
+  RANGE_LABEL="_Changes from \\\`\$BASELINE\\\` to \\\`\$TAG\\\`._"
+  COMMITS=\$(git log --format='%h %s' "\$BASELINE..\$TAG")
+fi
+
+classify() {
+  # Conventional Commits prefix matching. The \`!\` breaking-change marker
+  # does not change the bucket — \`feat!:\` is still Features.
+  case "\$1" in
+    feat:*|feat\\(*\\)*:*|feat!:*|feat\\(*\\)!:*) printf 'Features' ;;
+    fix:*|fix\\(*\\)*:*|fix!:*|fix\\(*\\)!:*) printf 'Bug Fixes' ;;
+    perf:*|perf\\(*\\)*:*|perf!:*|perf\\(*\\)!:*) printf 'Performance' ;;
+    refactor:*|refactor\\(*\\)*:*|refactor!:*|refactor\\(*\\)!:*) printf 'Refactors' ;;
+    docs:*|docs\\(*\\)*:*|docs!:*|docs\\(*\\)!:*) printf 'Documentation' ;;
+    test:*|test\\(*\\)*:*|test!:*|test\\(*\\)!:*) printf 'Tests' ;;
+    build:*|build\\(*\\)*:*|build!:*|build\\(*\\)!:*|ci:*|ci\\(*\\)*:*|ci!:*|ci\\(*\\)!:*) printf 'Build & CI' ;;
+    chore:*|chore\\(*\\)*:*|chore!:*|chore\\(*\\)!:*) printf 'Chores' ;;
+    style:*|style\\(*\\)*:*|style!:*|style\\(*\\)!:*) printf 'Style' ;;
+    *) printf 'Other' ;;
+  esac
+}
+
+BUCKET_FEATURES=""
+BUCKET_FIXES=""
+BUCKET_PERF=""
+BUCKET_REFACTORS=""
+BUCKET_DOCS=""
+BUCKET_TESTS=""
+BUCKET_BUILD=""
+BUCKET_CHORES=""
+BUCKET_STYLE=""
+BUCKET_OTHER=""
+
+while IFS= read -r line; do
+  [ -z "\$line" ] && continue
+  sha="\${line%% *}"
+  subject="\${line#* }"
+  bucket=\$(classify "\$subject")
+  entry="- \${sha} \${subject}"
+  case "\$bucket" in
+    Features) BUCKET_FEATURES+="\${entry}"\$'\\n' ;;
+    "Bug Fixes") BUCKET_FIXES+="\${entry}"\$'\\n' ;;
+    Performance) BUCKET_PERF+="\${entry}"\$'\\n' ;;
+    Refactors) BUCKET_REFACTORS+="\${entry}"\$'\\n' ;;
+    Documentation) BUCKET_DOCS+="\${entry}"\$'\\n' ;;
+    Tests) BUCKET_TESTS+="\${entry}"\$'\\n' ;;
+    "Build & CI") BUCKET_BUILD+="\${entry}"\$'\\n' ;;
+    Chores) BUCKET_CHORES+="\${entry}"\$'\\n' ;;
+    Style) BUCKET_STYLE+="\${entry}"\$'\\n' ;;
+    *) BUCKET_OTHER+="\${entry}"\$'\\n' ;;
+  esac
+done <<<"\$COMMITS"
+
+emit_bucket() {
+  local label="\$1"
+  local content="\$2"
+  [ -z "\$content" ] && return
+  printf '### %s\\n\\n%s\\n' "\$label" "\$content"
+}
+
+TAG_COMMIT=\$(git rev-parse "\$TAG^{}" 2>/dev/null || git rev-parse "\$TAG")
+TAG_SHORT=\$(git rev-parse --short "\$TAG_COMMIT")
+
+printf '## What'\\''s changed in %s\\n\\n' "\$TAG"
+printf '%s\\n\\n' "\$RANGE_LABEL"
+emit_bucket "Features" "\$BUCKET_FEATURES"
+emit_bucket "Bug Fixes" "\$BUCKET_FIXES"
+emit_bucket "Performance" "\$BUCKET_PERF"
+emit_bucket "Refactors" "\$BUCKET_REFACTORS"
+emit_bucket "Documentation" "\$BUCKET_DOCS"
+emit_bucket "Tests" "\$BUCKET_TESTS"
+emit_bucket "Build & CI" "\$BUCKET_BUILD"
+emit_bucket "Chores" "\$BUCKET_CHORES"
+emit_bucket "Style" "\$BUCKET_STYLE"
+emit_bucket "Other" "\$BUCKET_OTHER"
+
+printf -- '---\\nCommit: \`%s\`\\n' "\$TAG_SHORT"
+`,
+    executable: true,
     backend: null,
     skipIfExists: false,
   },

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -15,6 +15,8 @@ when_to_use: |
   - constitution: "update the constitution", "edit project rules"
   - checklist: "generate a checklist"
   - groom: "groom the backlog", "run a hygiene pass"
+  - tag-version: "tag a version", "create a release tag", "bump the version"
+  - release-version: "release", "publish a release", "create release notes"
 ---
 
 # Specflow router
@@ -41,6 +43,8 @@ If `$ARGUMENTS` is empty, render the **Workflow overview** below and stop. Do no
 | `constitution` | `phases/constitution.md` | Edit the project's `constitution.md` rules. |
 | `checklist` | `phases/checklist.md` | Generate a quality checklist for the current spec. |
 | `groom` | `phases/groom.md` | Backlog hygiene pass via the product-owner agent. |
+| `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
+| `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
 
 ## Routing
 
@@ -58,7 +62,7 @@ specify → clarify → plan → tasks → analyze → implement → review → 
                                                           STOP for pre-merge validation
 ```
 
-`constitution`, `checklist`, and `groom` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/templates/core/skills/specflow/phases/release-version.md
+++ b/templates/core/skills/specflow/phases/release-version.md
@@ -1,0 +1,81 @@
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+Common natural-language requests:
+
+- `/specflow release-version` — generate notes for the latest tag
+- `/specflow release-version v1.2.3` — generate notes for a specific tag
+- `/specflow release-version --baseline v1.2.0` — override the baseline
+  (use when the previous tag was never released and you want to skip
+  past it; default baseline is the previous tag chronologically)
+
+## What this command does
+
+Generates **categorized release notes** for the given tag (default:
+latest) covering every commit between a baseline tag and the target
+tag.
+
+The bundled script is stack-agnostic — it just emits the
+release-body Markdown to stdout, with one section per non-empty
+Conventional-Commits bucket. Run it like this:
+
+```bash
+bash .specflow/scripts/release/release.sh "$@"
+```
+
+## Buckets (fixed order, empty buckets omitted)
+
+1. **Features** — `feat:` / `feat(scope):` / `feat!:`
+2. **Bug Fixes** — `fix:` / `fix(scope):` / `fix!:`
+3. **Performance** — `perf:`
+4. **Refactors** — `refactor:`
+5. **Documentation** — `docs:`
+6. **Tests** — `test:`
+7. **Build & CI** — `build:` / `ci:`
+8. **Chores** — `chore:`
+9. **Style** — `style:`
+10. **Other** — anything that does not match a Conventional-Commits prefix
+
+Each commit appears as `- <short-sha> <subject>` under its bucket.
+
+## After the script runs
+
+The script writes the release body to **stdout**. What you do with it
+depends on how this project publishes releases:
+
+- **GitHub remote** — pipe it into `gh release create <tag>
+  --notes-file -` (or `--notes "$(...)"`).
+- **GitLab remote** — pipe it into `glab release create <tag>
+  --notes "..."`.
+- **Local-only** — copy the output somewhere readable (or echo it to
+  the user); there is no remote release to create.
+
+The per-backend wrapper scripts ship as separate Specflow features —
+when one is installed, prefer it to manually piping into `gh` / `glab`.
+
+## Important — release-notes contract
+
+The script emits the body verbatim. Do NOT:
+
+- Reword sections / re-categorize commits after the fact. If a commit
+  message is wrong (e.g. `feat:` for what's really a `fix:`), the
+  correct move is to amend the commit message **before** tagging,
+  not to hand-edit the release body.
+- Add a raw `git diff` or `git log` dump. The whole point of this
+  command is that the body is human-readable on its own.
+- Run release publication without showing the user the generated body
+  first when invoked interactively. The body is the production
+  artifact — surface it for review before posting.
+
+## Workflow
+
+```
+/specflow tag-version             → annotated tag created + pushed
+/specflow release-version         → categorized release notes (stdout)
+↳ pipe to gh/glab release create  → release published
+```

--- a/templates/core/skills/specflow/phases/tag-version.md
+++ b/templates/core/skills/specflow/phases/tag-version.md
@@ -1,0 +1,64 @@
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+Common natural-language requests:
+
+- `/specflow tag-version` — tag HEAD with the next version
+- `/specflow tag-version <sha>` — tag a specific commit
+- `/specflow tag-version --bump minor` — SemVer projects only: bump
+  minor instead of patch (also `--bump major` / `--bump patch`)
+- `/specflow tag-version --no-push` — skip pushing to `origin`
+
+## What this command does
+
+Creates an annotated git tag using the **versioning scheme baked into
+this project at `specflow init`** (one of SemVer `v1.2.3` or date-based
+`vYY.M.Da`).
+
+The bundled script does all the work:
+
+```bash
+bash .specflow/scripts/release/tag.sh "$@"
+```
+
+What the script does:
+
+1. Runs `git fetch --tags --quiet` so the next-tag computation sees
+   every tag that already exists on `origin`.
+2. Computes the next tag from the project's scheme:
+   - **SemVer** — finds the latest `v*.*.*` tag, applies the bump
+     direction from `--bump` (default `patch`), validates the result.
+   - **Date-based** — computes today's `vYY.M.D` prefix (no leading
+     zeros), scans existing tags for today, increments the letter
+     suffix (`a` → `b` → … → `z`, then errors out at 26 same-day tags).
+3. Creates an annotated tag with the commit subject in the message.
+4. Pushes to `origin` if a remote is configured (use `--no-push` to
+   skip).
+
+## What this command does NOT do
+
+- It does **not** create a GitHub / GitLab release — pushing a tag
+  alone does not publish a release. Run `/specflow release-version`
+  after this to publish the categorized release notes.
+- It does **not** edit version fields in `package.json` / `Cargo.toml`
+  / `pyproject.toml` / etc. The git tag **is** the version — single
+  source of truth.
+- It does **not** run tests, lint, or any quality gate. Run those
+  yourself before tagging if your project needs them — the contract
+  there is project-specific and lives outside Specflow's tag/release
+  flow.
+
+## After running
+
+If the script exits non-zero, read the stderr message — it says
+exactly what failed (validation regex, missing remote, exhausted
+letter suffix, missing tag).
+
+On success, suggest `/specflow release-version` as the natural next
+step. Do NOT run it automatically — releasing is an explicit,
+deliberate user action.

--- a/templates/core/skills/specflow/scripts/release.sh
+++ b/templates/core/skills/specflow/scripts/release.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Generate categorized release notes for commits in <baseline>..<tag>.
+#
+# Stack-agnostic: emits the release-body Markdown to stdout. Per-backend
+# wrappers (release-github.sh, release-gitlab.sh) consume this output
+# and POST it to the respective Releases API.
+#
+# Usage: release.sh [--baseline <tag>] [<tag>]
+#   <tag>           default: latest tag (git describe --tags --abbrev=0)
+#   --baseline      default: previous tag chronologically before <tag>;
+#                   per-backend wrappers override this to "previous
+#                   tag that has a published release attached" so commits
+#                   landed under undeployed tags are not silently skipped.
+set -euo pipefail
+
+BASELINE=""
+TAG=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --baseline) BASELINE="$2"; shift 2 ;;
+    --baseline=*) BASELINE="${1#--baseline=}"; shift ;;
+    --help|-h)
+      echo "usage: release.sh [--baseline <tag>] [<tag>]"
+      echo
+      echo "  Emits categorized release-note Markdown to stdout for"
+      echo "  commits in <baseline>..<tag>. Default tag = latest tag."
+      echo "  Default baseline = previous tag chronologically."
+      exit 0
+      ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) TAG="$1"; shift ;;
+  esac
+done
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if [ -z "$TAG" ]; then
+  TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "$TAG" ]; then
+    echo "no tags found in this repository — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo "tag '$TAG' not found" >&2
+  exit 1
+fi
+
+if [ -z "$BASELINE" ]; then
+  BASELINE=$(git tag --sort=-creatordate \
+    | awk -v cur="$TAG" 'BEGIN{found=0} $0==cur{found=1;next} found==1{print;exit}')
+fi
+
+if [ -n "$BASELINE" ] && ! git rev-parse "$BASELINE" >/dev/null 2>&1; then
+  echo "baseline tag '$BASELINE' not found" >&2
+  exit 1
+fi
+
+if [ -z "$BASELINE" ]; then
+  RANGE_LABEL="_Initial release — all commits up to \`$TAG\`._"
+  COMMITS=$(git log --format='%h %s' "$TAG")
+else
+  RANGE_LABEL="_Changes from \`$BASELINE\` to \`$TAG\`._"
+  COMMITS=$(git log --format='%h %s' "$BASELINE..$TAG")
+fi
+
+classify() {
+  # Conventional Commits prefix matching. The `!` breaking-change marker
+  # does not change the bucket — `feat!:` is still Features.
+  case "$1" in
+    feat:*|feat\(*\)*:*|feat!:*|feat\(*\)!:*) printf 'Features' ;;
+    fix:*|fix\(*\)*:*|fix!:*|fix\(*\)!:*) printf 'Bug Fixes' ;;
+    perf:*|perf\(*\)*:*|perf!:*|perf\(*\)!:*) printf 'Performance' ;;
+    refactor:*|refactor\(*\)*:*|refactor!:*|refactor\(*\)!:*) printf 'Refactors' ;;
+    docs:*|docs\(*\)*:*|docs!:*|docs\(*\)!:*) printf 'Documentation' ;;
+    test:*|test\(*\)*:*|test!:*|test\(*\)!:*) printf 'Tests' ;;
+    build:*|build\(*\)*:*|build!:*|build\(*\)!:*|ci:*|ci\(*\)*:*|ci!:*|ci\(*\)!:*) printf 'Build & CI' ;;
+    chore:*|chore\(*\)*:*|chore!:*|chore\(*\)!:*) printf 'Chores' ;;
+    style:*|style\(*\)*:*|style!:*|style\(*\)!:*) printf 'Style' ;;
+    *) printf 'Other' ;;
+  esac
+}
+
+BUCKET_FEATURES=""
+BUCKET_FIXES=""
+BUCKET_PERF=""
+BUCKET_REFACTORS=""
+BUCKET_DOCS=""
+BUCKET_TESTS=""
+BUCKET_BUILD=""
+BUCKET_CHORES=""
+BUCKET_STYLE=""
+BUCKET_OTHER=""
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  sha="${line%% *}"
+  subject="${line#* }"
+  bucket=$(classify "$subject")
+  entry="- ${sha} ${subject}"
+  case "$bucket" in
+    Features) BUCKET_FEATURES+="${entry}"$'\n' ;;
+    "Bug Fixes") BUCKET_FIXES+="${entry}"$'\n' ;;
+    Performance) BUCKET_PERF+="${entry}"$'\n' ;;
+    Refactors) BUCKET_REFACTORS+="${entry}"$'\n' ;;
+    Documentation) BUCKET_DOCS+="${entry}"$'\n' ;;
+    Tests) BUCKET_TESTS+="${entry}"$'\n' ;;
+    "Build & CI") BUCKET_BUILD+="${entry}"$'\n' ;;
+    Chores) BUCKET_CHORES+="${entry}"$'\n' ;;
+    Style) BUCKET_STYLE+="${entry}"$'\n' ;;
+    *) BUCKET_OTHER+="${entry}"$'\n' ;;
+  esac
+done <<<"$COMMITS"
+
+emit_bucket() {
+  local label="$1"
+  local content="$2"
+  [ -z "$content" ] && return
+  printf '### %s\n\n%s\n' "$label" "$content"
+}
+
+TAG_COMMIT=$(git rev-parse "$TAG^{}" 2>/dev/null || git rev-parse "$TAG")
+TAG_SHORT=$(git rev-parse --short "$TAG_COMMIT")
+
+printf '## What'\''s changed in %s\n\n' "$TAG"
+printf '%s\n\n' "$RANGE_LABEL"
+emit_bucket "Features" "$BUCKET_FEATURES"
+emit_bucket "Bug Fixes" "$BUCKET_FIXES"
+emit_bucket "Performance" "$BUCKET_PERF"
+emit_bucket "Refactors" "$BUCKET_REFACTORS"
+emit_bucket "Documentation" "$BUCKET_DOCS"
+emit_bucket "Tests" "$BUCKET_TESTS"
+emit_bucket "Build & CI" "$BUCKET_BUILD"
+emit_bucket "Chores" "$BUCKET_CHORES"
+emit_bucket "Style" "$BUCKET_STYLE"
+emit_bucket "Other" "$BUCKET_OTHER"
+
+printf -- '---\nCommit: `%s`\n' "$TAG_SHORT"

--- a/templates/core/skills/specflow/scripts/tag.sh
+++ b/templates/core/skills/specflow/scripts/tag.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Create an annotated git tag using the project's versioning scheme.
+#
+# The scheme is baked at scaffold time — the `# BEGIN: scheme=X` blocks
+# below are stripped by the Specflow bundler so only the chosen scheme's
+# logic ships on disk. To change schemes after init, re-run
+# `specflow init` and pick the other option.
+#
+# Usage: tag.sh [--no-push] [--bump <major|minor|patch>] [<commit-sha>]
+set -euo pipefail
+
+NO_PUSH=false
+BUMP="patch"
+COMMIT=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-push) NO_PUSH=true; shift ;;
+    --bump) BUMP="$2"; shift 2 ;;
+    --bump=*) BUMP="${1#--bump=}"; shift ;;
+    --help|-h)
+      echo "usage: tag.sh [--no-push] [--bump <major|minor|patch>] [<commit-sha>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) COMMIT="$1"; shift ;;
+  esac
+done
+
+COMMIT="${COMMIT:-HEAD}"
+COMMIT_SHA=$(git rev-parse "$COMMIT")
+git fetch --tags --quiet 2>/dev/null || true
+
+# BEGIN: scheme=semver
+# SemVer scheme: vMAJOR.MINOR.PATCH. The --bump flag picks the bump
+# direction (default patch). When no tag exists yet, start at v0.1.0.
+LATEST=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)
+if [ -z "$LATEST" ]; then
+  NEW="v0.1.0"
+  echo "no previous semver tag — starting at $NEW"
+else
+  raw="${LATEST#v}"
+  IFS='.' read -r MAJOR MINOR PATCH <<<"$raw"
+  case "$BUMP" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+    *) echo "invalid --bump '$BUMP' (expected major|minor|patch)" >&2; exit 2 ;;
+  esac
+  NEW="v${MAJOR}.${MINOR}.${PATCH}"
+fi
+
+if ! printf '%s' "$NEW" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "computed tag '$NEW' failed SemVer validation" >&2
+  exit 1
+fi
+# END: scheme=semver
+
+# BEGIN: scheme=date
+# Date-based scheme: vYY.M.D[a-z]. No leading zeros on month/day; letter
+# suffix increments for same-day re-tags (a..z; 26th tag in one day
+# aborts — wait for tomorrow or tag manually).
+YY=$(date +%y)
+M=$((10#$(date +%m)))
+D=$((10#$(date +%d)))
+PREFIX="v${YY}.${M}.${D}"
+
+LATEST_LETTER=$(git tag --list "${PREFIX}[a-z]" | sed -E "s|^${PREFIX}||" | sort | tail -n1 || true)
+if [ -z "$LATEST_LETTER" ]; then
+  NEW="${PREFIX}a"
+elif [ "$LATEST_LETTER" = "z" ]; then
+  echo "letter suffix exhausted (z) for $PREFIX — wait for tomorrow or tag manually" >&2
+  exit 1
+else
+  NEXT_LETTER=$(printf '%s' "$LATEST_LETTER" | tr 'a-y' 'b-z')
+  NEW="${PREFIX}${NEXT_LETTER}"
+fi
+
+if ! printf '%s' "$NEW" | grep -qE '^v[0-9]{2}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])[a-z]$'; then
+  echo "computed tag '$NEW' failed date-based validation" >&2
+  exit 1
+fi
+# END: scheme=date
+
+if git rev-parse "$NEW" >/dev/null 2>&1; then
+  echo "tag '$NEW' already exists — refusing to clobber" >&2
+  exit 1
+fi
+
+SUBJECT=$(git log -1 --format=%s "$COMMIT_SHA")
+echo "creating annotated tag $NEW on $COMMIT_SHA"
+echo "  subject: $SUBJECT"
+git tag -a "$NEW" -m "Release $NEW
+
+$SUBJECT" "$COMMIT_SHA"
+
+if [ "$NO_PUSH" = "true" ]; then
+  echo "✓ tagged $NEW (local only — --no-push)"
+elif git remote get-url origin >/dev/null 2>&1; then
+  git push origin "$NEW"
+  echo "✓ tagged $NEW and pushed to origin"
+else
+  echo "✓ tagged $NEW (no origin configured — tag is local-only)"
+fi

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -13,6 +13,10 @@
     { "category": "phase", "name": "constitution", "suffix": "constitution.md", "source": "core/skills/specflow/phases/constitution.md" },
     { "category": "phase", "name": "checklist", "suffix": "checklist.md", "source": "core/skills/specflow/phases/checklist.md" },
     { "category": "phase", "name": "groom", "suffix": "groom.md", "source": "core/skills/specflow/phases/groom.md" },
+    { "category": "phase", "name": "tag-version", "suffix": "tag-version.md", "source": "core/skills/specflow/phases/tag-version.md" },
+    { "category": "phase", "name": "release-version", "suffix": "release-version.md", "source": "core/skills/specflow/phases/release-version.md" },
+    { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
+    { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -82,6 +82,7 @@ Deno.test("InitProjectUseCase writes the bundle to the target dir (happy path)",
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -105,6 +106,7 @@ Deno.test("InitProjectUseCase fails with 'conflicts' when target already has spe
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -126,6 +128,7 @@ Deno.test("InitProjectUseCase reports lockExists=true when conflicts hit a previ
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.0.0",
     entries: new Map(),
   };
@@ -135,6 +138,7 @@ Deno.test("InitProjectUseCase reports lockExists=true when conflicts hit a previ
     lockStore: fakeLockStore({ existing: existingLock }),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -157,6 +161,7 @@ Deno.test("InitProjectUseCase calls git.init when repo not initialized and initG
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -172,6 +177,7 @@ Deno.test("InitProjectUseCase skips git.init when initGit=false", async () => {
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -187,6 +193,7 @@ Deno.test("InitProjectUseCase skips git.init when git not available", async () =
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -207,6 +214,7 @@ Deno.test("InitProjectUseCase skips git.init when repo already initialized", asy
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -232,6 +240,7 @@ Deno.test("InitProjectUseCase with force=true skips conflict detection and reque
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -262,6 +271,7 @@ Deno.test("InitProjectUseCase returns backups array from writer report", async (
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -283,6 +293,7 @@ Deno.test("InitProjectUseCase persists an installed.lock with SHA256 of every fi
     lockStore,
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: [
       {
         category: "project-root",
@@ -324,6 +335,7 @@ Deno.test("InitProjectUseCase records harness.key in the installed lock", async 
     lockStore,
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -339,6 +351,7 @@ Deno.test("InitProjectUseCase uses harness.mapBundle output as the file tree", a
     lockStore: fakeLockStore(),
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
+    versionScheme: "semver",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });

--- a/tests/application/upgrade_project_test.ts
+++ b/tests/application/upgrade_project_test.ts
@@ -129,6 +129,7 @@ Deno.test("UpgradeProjectUseCase returns up-to-date when disk + lock + bundle al
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.3.0",
     entries: new Map([["a.md", {
       sha256: sha,
@@ -156,6 +157,7 @@ Deno.test("UpgradeProjectUseCase returns planned (no writes) in dry-run", async 
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.2.0",
     entries: new Map([["a.md", {
       sha256: oldSha,
@@ -186,6 +188,7 @@ Deno.test("UpgradeProjectUseCase applies auto-update and skips preserve", async 
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.2.0",
     entries: new Map([
       ["clean.md", {
@@ -226,6 +229,7 @@ Deno.test("UpgradeProjectUseCase with --force overwrites preserve actions with b
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.2.0",
     entries: new Map([["a.md", {
       sha256: await sha256Hex("ORIGINAL"),
@@ -255,6 +259,7 @@ Deno.test("UpgradeProjectUseCase deletes clean orphans (lock entry + on disk + m
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["a.md", {
@@ -289,6 +294,7 @@ Deno.test("UpgradeProjectUseCase preserves customized orphan without --force, dr
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["a.md", {
@@ -327,6 +333,7 @@ Deno.test("UpgradeProjectUseCase with --force deletes customized orphan with bac
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["orphan.md", {
@@ -365,6 +372,7 @@ Deno.test("UpgradeProjectUseCase: vanilla on-disk + plugin installed → backed 
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -400,6 +408,7 @@ Deno.test("UpgradeProjectUseCase: customized on-disk + plugin installed → pres
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -444,6 +453,7 @@ Deno.test("UpgradeProjectUseCase: missing on-disk + plugin installed → deferre
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -481,6 +491,7 @@ Deno.test("UpgradeProjectUseCase: vanilla on-disk + plugin NOT installed → exi
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -22,6 +22,7 @@ Deno.test("parseArgs returns init intent with a project name", () => {
     backlog: null,
     backlogUrl: null,
     backlogRepo: null,
+    scheme: null,
     force: false,
   });
 });
@@ -36,6 +37,7 @@ Deno.test("parseArgs returns init intent with --here", () => {
     backlog: null,
     backlogUrl: null,
     backlogRepo: null,
+    scheme: null,
     force: false,
   });
 });
@@ -50,6 +52,7 @@ Deno.test("parseArgs returns init intent with --no-git", () => {
     backlog: null,
     backlogUrl: null,
     backlogRepo: null,
+    scheme: null,
     force: false,
   });
 });
@@ -90,6 +93,7 @@ Deno.test("parseArgs init with --force", () => {
     backlog: null,
     backlogUrl: null,
     backlogRepo: null,
+    scheme: null,
     force: true,
   });
 });

--- a/tests/cli/scheme_picker_test.ts
+++ b/tests/cli/scheme_picker_test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "@std/assert";
+import { DEFAULT_VERSION_SCHEME, pickVersionScheme } from "../../src/cli/scheme_picker.ts";
+
+function fakeIO(lines: ReadonlyArray<string>): {
+  io: {
+    readLine: () => string | null;
+    log: (s: string) => void;
+    errLog: (s: string) => void;
+  };
+  logs: string[];
+  errs: string[];
+} {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  let i = 0;
+  return {
+    io: {
+      readLine: () => (i < lines.length ? lines[i++] : null),
+      log: (s) => logs.push(s),
+      errLog: (s) => errs.push(s),
+    },
+    logs,
+    errs,
+  };
+}
+
+Deno.test("pickVersionScheme returns the suggestion on bare Enter", () => {
+  const { io } = fakeIO([""]);
+  assertEquals(pickVersionScheme(io, "date"), "date");
+});
+
+Deno.test("pickVersionScheme falls back to DEFAULT_VERSION_SCHEME without a suggestion", () => {
+  const { io } = fakeIO([""]);
+  assertEquals(pickVersionScheme(io), DEFAULT_VERSION_SCHEME);
+});
+
+Deno.test("pickVersionScheme accepts numeric choice 1 (semver)", () => {
+  const { io } = fakeIO(["1"]);
+  assertEquals(pickVersionScheme(io), "semver");
+});
+
+Deno.test("pickVersionScheme accepts numeric choice 2 (date)", () => {
+  const { io } = fakeIO(["2"]);
+  assertEquals(pickVersionScheme(io), "date");
+});
+
+Deno.test("pickVersionScheme re-prompts on invalid input", () => {
+  const { io, errs } = fakeIO(["banana", "2"]);
+  assertEquals(pickVersionScheme(io), "date");
+  assertEquals(errs.length, 1);
+  assertEquals(errs[0].includes("invalid choice"), true);
+});

--- a/tests/domain/conditional_render_scheme_test.ts
+++ b/tests/domain/conditional_render_scheme_test.ts
@@ -1,0 +1,88 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { renderScheme } from "../../src/domain/conditional_render.ts";
+
+Deno.test("renderScheme keeps only the active scheme's block", () => {
+  const src = [
+    "echo before",
+    "# BEGIN: scheme=semver",
+    "echo SEMVER LOGIC",
+    "# END: scheme=semver",
+    "# BEGIN: scheme=date",
+    "echo DATE LOGIC",
+    "# END: scheme=date",
+    "echo after",
+  ].join("\n");
+
+  assertEquals(
+    renderScheme(src, "semver"),
+    ["echo before", "echo SEMVER LOGIC", "echo after"].join("\n"),
+  );
+  assertEquals(
+    renderScheme(src, "date"),
+    ["echo before", "echo DATE LOGIC", "echo after"].join("\n"),
+  );
+});
+
+Deno.test("renderScheme is a no-op when no scheme markers are present", () => {
+  const src = "echo plain\nexit 0\n";
+  assertEquals(renderScheme(src, "semver"), src);
+  assertEquals(renderScheme(src, "date"), src);
+});
+
+Deno.test("renderScheme rejects unmatched BEGIN", () => {
+  const src = "# BEGIN: scheme=semver\necho oops\n";
+  assertThrows(() => renderScheme(src, "semver"), Error, "unmatched BEGIN");
+});
+
+Deno.test("renderScheme rejects unmatched END", () => {
+  const src = "echo before\n# END: scheme=semver\n";
+  assertThrows(() => renderScheme(src, "semver"), Error, "unmatched END");
+});
+
+Deno.test("renderScheme rejects nested markers", () => {
+  const src = [
+    "# BEGIN: scheme=semver",
+    "# BEGIN: scheme=date",
+    "echo nested",
+    "# END: scheme=date",
+    "# END: scheme=semver",
+  ].join("\n");
+  assertThrows(() => renderScheme(src, "semver"), Error, "nested scheme marker");
+});
+
+Deno.test("renderScheme rejects mismatched END", () => {
+  const src = [
+    "# BEGIN: scheme=semver",
+    "echo wrong-end",
+    "# END: scheme=date",
+  ].join("\n");
+  assertThrows(() => renderScheme(src, "semver"), Error, "mismatched END");
+});
+
+Deno.test("renderScheme drops a block whose scheme differs from active", () => {
+  const src = [
+    "echo before",
+    "# BEGIN: scheme=date",
+    "echo DATE",
+    "# END: scheme=date",
+    "echo after",
+  ].join("\n");
+  assertEquals(
+    renderScheme(src, "semver"),
+    ["echo before", "echo after"].join("\n"),
+  );
+});
+
+Deno.test("renderScheme preserves indentation inside kept blocks", () => {
+  const src = [
+    "if true; then",
+    "  # BEGIN: scheme=semver",
+    "  echo indented",
+    "  # END: scheme=semver",
+    "fi",
+  ].join("\n");
+  assertEquals(
+    renderScheme(src, "semver"),
+    ["if true; then", "  echo indented", "fi"].join("\n"),
+  );
+});

--- a/tests/domain/installed_lock_test.ts
+++ b/tests/domain/installed_lock_test.ts
@@ -44,6 +44,7 @@ Deno.test("serializeLock round-trips", () => {
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.3.0",
     entries: new Map<string, LockEntry>([
       ["CLAUDE.md", {
@@ -105,6 +106,7 @@ Deno.test("serializeLock writes version 2 with harness field", () => {
     version: 2,
     harness: "cursor",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.3.0",
     entries: new Map(),
   };

--- a/tests/domain/project_detection_test.ts
+++ b/tests/domain/project_detection_test.ts
@@ -1,0 +1,95 @@
+import { assertEquals } from "@std/assert";
+import { detectVersionScheme, type FsSnapshot } from "../../src/domain/project_detection.ts";
+
+function fakeFs(files: Record<string, string>): FsSnapshot {
+  return {
+    exists(rel) {
+      return Object.prototype.hasOwnProperty.call(files, rel);
+    },
+    readText(rel) {
+      return Object.prototype.hasOwnProperty.call(files, rel) ? files[rel] : null;
+    },
+  };
+}
+
+Deno.test("detectVersionScheme defaults to date when no library markers exist", () => {
+  const r = detectVersionScheme(fakeFs({}));
+  assertEquals(r.suggestedScheme, "date");
+  assertEquals(r.evidence, []);
+});
+
+Deno.test("detectVersionScheme suggests semver when package.json has exports", () => {
+  const r = detectVersionScheme(fakeFs({
+    "package.json": JSON.stringify({
+      name: "my-lib",
+      exports: { ".": "./index.js" },
+    }),
+  }));
+  assertEquals(r.suggestedScheme, "semver");
+  assertEquals(r.evidence.length, 1);
+});
+
+Deno.test("detectVersionScheme does NOT suggest semver for a private app package.json", () => {
+  // Private app projects (Vite, Next, Express) typically have neither
+  // `exports`, `publishConfig`, nor `private: false`.
+  const r = detectVersionScheme(fakeFs({
+    "package.json": JSON.stringify({
+      name: "my-app",
+      private: true,
+      scripts: { dev: "vite" },
+    }),
+  }));
+  assertEquals(r.suggestedScheme, "date");
+});
+
+Deno.test("detectVersionScheme suggests semver when pyproject.toml has [project]", () => {
+  const r = detectVersionScheme(fakeFs({
+    "pyproject.toml": '[project]\nname = "my-pkg"\n',
+  }));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme suggests semver when pyproject.toml has [tool.poetry]", () => {
+  const r = detectVersionScheme(fakeFs({
+    "pyproject.toml": '[tool.poetry]\nname = "my-pkg"\n',
+  }));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme suggests semver when Cargo.toml has [lib]", () => {
+  const r = detectVersionScheme(fakeFs({
+    "Cargo.toml": '[package]\nname = "foo"\n\n[lib]\nname = "foo"\n',
+  }));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme stays at date when Cargo.toml is bin-only", () => {
+  const r = detectVersionScheme(fakeFs({
+    "Cargo.toml": '[package]\nname = "foo"\n\n[[bin]]\nname = "foo"\n',
+  }));
+  assertEquals(r.suggestedScheme, "date");
+});
+
+Deno.test("detectVersionScheme suggests semver when composer.json type=library", () => {
+  const r = detectVersionScheme(fakeFs({
+    "composer.json": JSON.stringify({ name: "foo/bar", type: "library" }),
+  }));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme ignores malformed JSON gracefully", () => {
+  const r = detectVersionScheme(fakeFs({
+    "package.json": "{ this is not valid JSON",
+  }));
+  // No library marker extractable → date default, no evidence added.
+  assertEquals(r.suggestedScheme, "date");
+});
+
+Deno.test("detectVersionScheme collects multiple evidence lines when several markers exist", () => {
+  const r = detectVersionScheme(fakeFs({
+    "package.json": JSON.stringify({ exports: { ".": "./index.js" } }),
+    "pyproject.toml": '[project]\nname = "foo"\n',
+  }));
+  assertEquals(r.suggestedScheme, "semver");
+  assertEquals(r.evidence.length, 2);
+});

--- a/tests/domain/upgrade_plan_test.ts
+++ b/tests/domain/upgrade_plan_test.ts
@@ -7,6 +7,7 @@ const emptyLock: InstalledLock = {
   version: 2,
   harness: "claude",
   backlogBackend: "local",
+  versionScheme: "semver",
   templatesVersion: "0.1.0",
   entries: new Map(),
 };
@@ -16,6 +17,7 @@ function lockWith(path: string, sha: string): InstalledLock {
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.1.0",
     entries: new Map([[
       path,
@@ -118,6 +120,7 @@ Deno.test("computeUpgradePlan emits remove for clean orphan (lock + on disk + ma
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["a.md", {
@@ -151,6 +154,7 @@ Deno.test("computeUpgradePlan emits remove with wasCustomized=true when disk div
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["orphan.md", {
@@ -177,6 +181,7 @@ Deno.test("computeUpgradePlan emits no action for orphan-not-on-disk (user alrea
     version: 2,
     harness: "claude",
     backlogBackend: "local",
+    versionScheme: "semver",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["orphan.md", {

--- a/tests/infrastructure/fs_lock_store_test.ts
+++ b/tests/infrastructure/fs_lock_store_test.ts
@@ -16,6 +16,7 @@ const SAMPLE: InstalledLock = {
   version: 2,
   harness: "claude",
   backlogBackend: "local",
+  versionScheme: "semver",
   templatesVersion: "0.3.0",
   entries: new Map([
     ["CLAUDE.md", {

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -10,7 +10,7 @@ Deno.test("ClaudeHarness.key and displayName", () => {
 
 Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver" });
   // Router skill + 11 phase docs + specflow-auto + specflow-review alias +
   // backlog skill + 1 backlog cmd + 9 agents + 5 agent-memory stubs +
   // 16 spec-root entries + AGENTS.md + .gitignore + 5 backlog scripts +
@@ -45,7 +45,7 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
 
 Deno.test("ClaudeHarness includes HARNESS_STATIC claude files (.claude/CLAUDE.md)", () => {
   const h = new ClaudeHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver" });
   const claudeMd = mapped[".claude/CLAUDE.md"];
   const staticClaude = HARNESS_STATIC.claude[".claude/CLAUDE.md"];
   assertEquals(claudeMd?.content, staticClaude?.content);

--- a/tests/infrastructure/harness/codex_harness_test.ts
+++ b/tests/infrastructure/harness/codex_harness_test.ts
@@ -64,31 +64,31 @@ Deno.test("CodexHarness.key and displayName", () => {
 
 Deno.test("CodexHarness maps router skill to .agents/skills/specflow/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".agents/skills/specflow/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps phase docs under .agents/skills/specflow/phases/", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".agents/skills/specflow/phases/specify.md" in mapped);
 });
 
 Deno.test("CodexHarness maps backlog-cmd to .agents/skills/specflow-backlog/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".agents/skills/specflow-backlog/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps skill to .agents/skills/specflow-<name>/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".agents/skills/specflow-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps agent to .codex/agents/<name>.toml with valid TOML", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const agentToml = mapped[".codex/agents/product-owner.toml"];
   assert(agentToml, "agent TOML not emitted");
   const parsed = parseToml(agentToml.content);
@@ -106,14 +106,14 @@ Deno.test("CodexHarness maps agent to .codex/agents/<name>.toml with valid TOML"
 
 Deno.test("CodexHarness maps spec-root to .specflow/<suffix> and project-root to <suffix>", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".specflow/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CodexHarness emits no Claude/Cursor artefacts", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/ keys allowed");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/ keys allowed");
@@ -129,7 +129,7 @@ Deno.test("CodexHarness injects name+description into SKILL.md when absent", () 
     executable: false,
   }];
   const h = new CodexHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local" });
+  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver" });
   const skill = mapped[".agents/skills/specflow-auto/SKILL.md"];
   assert(skill?.content.startsWith("---\n"));
   assert(skill?.content.includes("name: specflow-auto"));

--- a/tests/infrastructure/harness/copilot_harness_test.ts
+++ b/tests/infrastructure/harness/copilot_harness_test.ts
@@ -64,37 +64,37 @@ Deno.test("CopilotHarness.key and displayName", () => {
 
 Deno.test("CopilotHarness maps router skill to .github/instructions/specflow.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".github/instructions/specflow.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps phase docs to .github/instructions/specflow-<phase>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".github/instructions/specflow-specify.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps backlog-cmd to .github/instructions/specflow-backlog.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".github/instructions/specflow-backlog.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps skill to .github/instructions/specflow-<name>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".github/instructions/specflow-auto.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps agents to .github/instructions/specflow-agent-<name>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".github/instructions/specflow-agent-product-owner.instructions.md" in mapped);
 });
 
 Deno.test('CopilotHarness rewrites instruction frontmatter to applyTo: "**" and strips Claude fields', () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const cmd = mapped[".github/instructions/specflow.instructions.md"];
   assert(cmd, "instruction file not emitted");
   assert(cmd.content.startsWith("---\n"));
@@ -107,14 +107,14 @@ Deno.test('CopilotHarness rewrites instruction frontmatter to applyTo: "**" and 
 
 Deno.test("CopilotHarness maps spec-root to .specflow/<suffix> and project-root to <suffix>", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".specflow/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CopilotHarness emits no Claude/Cursor/Codex/Gemini/Windsurf artefacts", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");

--- a/tests/infrastructure/harness/cursor_harness_test.ts
+++ b/tests/infrastructure/harness/cursor_harness_test.ts
@@ -62,43 +62,43 @@ Deno.test("CursorHarness.key and displayName", () => {
 
 Deno.test("CursorHarness maps router skill to .cursor/skills/specflow/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".cursor/skills/specflow/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps phase docs under .cursor/skills/specflow/phases/", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".cursor/skills/specflow/phases/specify.md" in mapped);
 });
 
 Deno.test("CursorHarness maps the backlog command to .cursor/skills/specflow-backlog/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".cursor/skills/specflow-backlog/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps agents to .cursor/skills/specflow-agent-<name>/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".cursor/skills/specflow-agent-product-owner/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps skills to .cursor/skills/specflow-<name>/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".cursor/skills/specflow-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps spec-root to .specflow/ and project-root unchanged", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".specflow/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CursorHarness includes .cursor/rules/specify-rules.mdc from HARNESS_STATIC", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".cursor/rules/specify-rules.mdc" in mapped);
 });

--- a/tests/infrastructure/harness/gemini_harness_test.ts
+++ b/tests/infrastructure/harness/gemini_harness_test.ts
@@ -64,31 +64,31 @@ Deno.test("GeminiHarness.key and displayName", () => {
 
 Deno.test("GeminiHarness maps router skill to .gemini/skills/specflow/SKILL.md", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".gemini/skills/specflow/SKILL.md" in mapped);
 });
 
 Deno.test("GeminiHarness maps phase docs under .gemini/skills/specflow/phases/", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".gemini/skills/specflow/phases/specify.md" in mapped);
 });
 
 Deno.test("GeminiHarness maps backlog-cmd to .gemini/commands/specflow-backlog.toml", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".gemini/commands/specflow-backlog.toml" in mapped);
 });
 
 Deno.test("GeminiHarness maps skill to .gemini/skills/specflow-<name>/SKILL.md", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".gemini/skills/specflow-auto/SKILL.md" in mapped);
 });
 
 Deno.test("GeminiHarness maps agent to .gemini/agents/<name>.md with stripped frontmatter", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const agent = mapped[".gemini/agents/product-owner.md"];
   assert(agent, "agent markdown not emitted");
   assert(agent.content.startsWith("---\n"), "missing frontmatter");
@@ -104,14 +104,14 @@ Deno.test("GeminiHarness maps agent to .gemini/agents/<name>.md with stripped fr
 
 Deno.test("GeminiHarness maps spec-root to .specflow/<suffix> and project-root to <suffix>", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".specflow/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("GeminiHarness emits no Claude/Cursor/Codex artefacts", () => {
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");
@@ -129,7 +129,7 @@ Deno.test("GeminiHarness omits TOML description when source frontmatter has none
     executable: false,
   }];
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local" });
+  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver" });
   const parsed = parseToml(
     mapped[".gemini/commands/specflow-backlog.toml"].content,
   );
@@ -146,7 +146,7 @@ Deno.test("GeminiHarness synthesises agent description when source has none", ()
     executable: false,
   }];
   const h = new GeminiHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local" });
+  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver" });
   const agent = mapped[".gemini/agents/lonely-agent.md"];
   assert(agent.content.includes("name: lonely-agent"));
   assert(agent.content.includes("description: Specflow lonely-agent agent"));

--- a/tests/infrastructure/harness/opencode_harness_test.ts
+++ b/tests/infrastructure/harness/opencode_harness_test.ts
@@ -48,14 +48,20 @@ function skillEntry(name: string): CoreBundle[number] {
 }
 
 Deno.test("router skill emits to .opencode/skills/specflow/SKILL.md", () => {
-  const bundle = harness.mapBundle([routerSkillEntry()], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([routerSkillEntry()], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+  });
   const dest = ".opencode/skills/specflow/SKILL.md";
   assertEquals(Object.keys(bundle), [dest]);
   assertStringIncludes(bundle[dest].content, "name: specflow");
 });
 
 Deno.test("phase emits to .opencode/skills/specflow/phases/<name>.md", () => {
-  const bundle = harness.mapBundle([phaseEntry("specify")], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([phaseEntry("specify")], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+  });
   const dest = ".opencode/skills/specflow/phases/specify.md";
   assertEquals(Object.keys(bundle), [dest]);
   assertStringIncludes(bundle[dest].content, "Body content");
@@ -69,14 +75,14 @@ Deno.test("backlog-cmd emits to .opencode/commands/backlog.md", () => {
     content: `---\ndescription: Backlog\n---\nBody`,
     executable: false,
   };
-  const bundle = harness.mapBundle([entry], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([entry], { backlogBackend: "local", versionScheme: "semver" });
   assertEquals(Object.keys(bundle), [".opencode/commands/backlog.md"]);
 });
 
 Deno.test("agent emits to .opencode/agents/specflow-<name>.md with mode: subagent", () => {
   const bundle = harness.mapBundle([
     agentEntry("developer", "Read, Write, Edit, Grep, Glob, Bash"),
-  ], { backlogBackend: "local" });
+  ], { backlogBackend: "local", versionScheme: "semver" });
   const dest = ".opencode/agents/specflow-developer.md";
   assertEquals(Object.keys(bundle), [dest]);
   assertStringIncludes(bundle[dest].content, "description: developer agent");
@@ -88,6 +94,7 @@ Deno.test("agent emits to .opencode/agents/specflow-<name>.md with mode: subagen
 Deno.test("agent translates Read+Write+Edit+Bash to permission block", () => {
   const bundle = harness.mapBundle([agentEntry("dev", "Read, Write, Edit, Bash")], {
     backlogBackend: "local",
+    versionScheme: "semver",
   });
   const content = bundle[".opencode/agents/specflow-dev.md"].content;
   assertStringIncludes(content, "read: allow");
@@ -100,6 +107,7 @@ Deno.test("agent translates Read+Write+Edit+Bash to permission block", () => {
 Deno.test("agent de-dups Edit+MultiEdit into single edit permission", () => {
   const bundle = harness.mapBundle([agentEntry("dev", "Edit, MultiEdit")], {
     backlogBackend: "local",
+    versionScheme: "semver",
   });
   const content = bundle[".opencode/agents/specflow-dev.md"].content;
   assertEquals(content.match(/edit: allow/g)?.length, 1);
@@ -108,7 +116,7 @@ Deno.test("agent de-dups Edit+MultiEdit into single edit permission", () => {
 Deno.test("agent omits Grep/Glob/Task/TodoWrite/NotebookEdit and unknowns", () => {
   const bundle = harness.mapBundle([
     agentEntry("dev", "Grep, Glob, Task, TodoWrite, NotebookEdit, Mystery"),
-  ], { backlogBackend: "local" });
+  ], { backlogBackend: "local", versionScheme: "semver" });
   const content = bundle[".opencode/agents/specflow-dev.md"].content;
   assertEquals(content.includes("permission:"), false);
 });
@@ -116,6 +124,7 @@ Deno.test("agent omits Grep/Glob/Task/TodoWrite/NotebookEdit and unknowns", () =
 Deno.test("agent strips Bash(git log *) parenthesized variants to Bash", () => {
   const bundle = harness.mapBundle([agentEntry("po", "Read, Bash(git log *), Bash(git diff *)")], {
     backlogBackend: "local",
+    versionScheme: "semver",
   });
   const content = bundle[".opencode/agents/specflow-po.md"].content;
   assertStringIncludes(content, "read: allow");
@@ -127,19 +136,25 @@ Deno.test("agent strips Bash(git log *) parenthesized variants to Bash", () => {
 Deno.test("agent strips Agent(...) entries (subagent dispatch is native)", () => {
   const bundle = harness.mapBundle([
     agentEntry("wf", "Read, Bash, Agent(code-reviewer, security-auditor)"),
-  ], { backlogBackend: "local" });
+  ], { backlogBackend: "local", versionScheme: "semver" });
   const content = bundle[".opencode/agents/specflow-wf.md"].content;
   assertEquals(content.includes("agent:"), false);
 });
 
 Deno.test("agent with no tools field emits no permission block", () => {
-  const bundle = harness.mapBundle([agentEntry("dev", null)], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([agentEntry("dev", null)], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+  });
   const content = bundle[".opencode/agents/specflow-dev.md"].content;
   assertEquals(content.includes("permission:"), false);
 });
 
 Deno.test("skill emits to .opencode/skills/specflow-<name>/SKILL.md with name+description", () => {
-  const bundle = harness.mapBundle([skillEntry("specflow-auto")], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([skillEntry("specflow-auto")], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+  });
   const dest = ".opencode/skills/specflow-auto/SKILL.md";
   assertEquals(Object.keys(bundle), [dest]);
   assertStringIncludes(bundle[dest].content, "name: specflow-auto");
@@ -147,7 +162,10 @@ Deno.test("skill emits to .opencode/skills/specflow-<name>/SKILL.md with name+de
 });
 
 Deno.test("router skill named 'specflow' is not double-prefixed", () => {
-  const bundle = harness.mapBundle([routerSkillEntry()], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([routerSkillEntry()], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+  });
   assertEquals(Object.keys(bundle), [".opencode/skills/specflow/SKILL.md"]);
 });
 
@@ -166,7 +184,10 @@ Deno.test("spec-root and project-root pass through unchanged", () => {
     content: "raw AGENTS",
     executable: false,
   };
-  const bundle = harness.mapBundle([specRoot, projectRoot], { backlogBackend: "local" });
+  const bundle = harness.mapBundle([specRoot, projectRoot], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+  });
   assertEquals(bundle[".specflow/memory/constitution.md"].content, "raw constitution");
   assertEquals(bundle["AGENTS.md"].content, "raw AGENTS");
 });

--- a/tests/infrastructure/harness/windsurf_harness_test.ts
+++ b/tests/infrastructure/harness/windsurf_harness_test.ts
@@ -64,44 +64,44 @@ Deno.test("WindsurfHarness.key and displayName", () => {
 
 Deno.test("WindsurfHarness maps router skill to .windsurf/workflows/specflow.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".windsurf/workflows/specflow.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps phase docs to sibling specflow-<phase>.md files", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".windsurf/workflows/specflow-specify.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps backlog-cmd to .windsurf/workflows/specflow-backlog.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".windsurf/workflows/specflow-backlog.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps skill to .windsurf/workflows/specflow-<name>.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".windsurf/workflows/specflow-auto.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps agents to .windsurf/workflows/specflow-agent-<name>.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".windsurf/workflows/specflow-agent-product-owner.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps spec-root to .specflow/<suffix> and project-root to <suffix>", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   assert(".specflow/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("WindsurfHarness emits content byte-identical to entry.content (no frontmatter rewrite)", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const router = mapped[".windsurf/workflows/specflow.md"];
   assertEquals(router.content, SAMPLE[0].content);
   const phase = mapped[".windsurf/workflows/specflow-specify.md"];
@@ -110,7 +110,7 @@ Deno.test("WindsurfHarness emits content byte-identical to entry.content (no fro
 
 Deno.test("WindsurfHarness emits no Claude/Cursor/Codex/Gemini artefacts", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");
@@ -122,7 +122,7 @@ Deno.test("WindsurfHarness emits no Claude/Cursor/Codex/Gemini artefacts", () =>
 
 Deno.test("WindsurfHarness emits no workflow exceeding the Cascade cap", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local" });
+  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver" });
   for (const [path, file] of Object.entries(mapped)) {
     if (!path.startsWith(".windsurf/workflows/")) continue;
     assert(

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,11 +82,12 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 11 phases + specflow-auto + specflow-review + backlog + 11 agents = 25.
+    // Router + 13 phases (11 original + tag-version + release-version) +
+    // specflow-auto + specflow-review + backlog + 11 agents = 27.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 25);
+    assertEquals(instructionsCount, 27);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,12 +74,12 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 11 phases + specflow-auto + specflow-review alias + backlog +
-    // 11 agent workflows = 25.
+    // Router + 13 phases (11 original + tag-version + release-version) +
+    // specflow-auto + specflow-review alias + backlog + 11 agent workflows = 27.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 25);
+    assertEquals(workflowsCount, 27);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -17,7 +17,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow/SKILL.md",
     source: "templates/core/skills/specflow/SKILL.md",
   },
-  // 11 phase reference docs, loaded by the router on demand.
+  // 13 phase reference docs, loaded by the router on demand.
   ...[
     "specify",
     "clarify",
@@ -30,6 +30,8 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "constitution",
     "checklist",
     "groom",
+    "tag-version",
+    "release-version",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,


### PR DESCRIPTION
## Summary

Core foundation for the tag-release epic (#226). Ships two new commands under the `/specflow` router across all 8 harnesses:

- **`/specflow tag-version`** — creates an annotated git tag using the project's versioning scheme (SemVer or date-based)
- **`/specflow release-version`** — generates categorized release notes (10-bucket Conventional Commits classifier) for a tag

## Versioning scheme — chosen at init, persisted by skill rewrite

The scheme is picked at `specflow init` time and **baked into the scaffolded skill** itself (mirrors the backlog-backend scaffolder pattern). Two schemes ship:

- **SemVer** `v1.2.3` — recommended for libraries / SDKs
- **Date-based** `v26.5.14a` — recommended for apps / SaaS

The picker pre-selects a smart default based on library-marker detection (`package.json` exports / `Cargo.toml [lib]` / `pyproject.toml [project]` / `composer.json type=library`). The user can always override.

## Infrastructure

- New `phase-script` core category — scheme-rendered scripts land at `.specflow/scripts/release/{tag,release}.sh` (uniform path across all 8 harnesses, like `backlog-script`)
- `renderScheme()` in `conditional_render.ts` — shell-comment marker stripping (`# BEGIN: scheme=X`)
- `detectVersionScheme()` in `project_detection.ts` — pure-function library detector
- `scheme_picker.ts` — numeric + interactive arrow-key picker
- `--scheme semver|date` CLI flag for `specflow init`
- `version_scheme` field on the installed lock (back-compat default `semver`)

## End-to-end verified

```
$ bash tag.sh --no-push
no previous semver tag — starting at v0.1.0
✓ tagged v0.1.0 (local only — --no-push)
$ bash tag.sh --no-push --bump minor
✓ tagged v0.2.0 (local only — --no-push)
$ bash release.sh
## What's changed in v0.2.0

_Changes from \`v0.1.0\` to \`v0.2.0\`._

### Features
- ce7f38c feat(api): add endpoint

### Performance
- 3f319c5 perf!: drop slow path

### Documentation
- 7283cf5 docs: update README

---
Commit: \`3f319c5\`
```

Date-based variant of `tag.sh` also verified (`v26.5.14a` → `v26.5.14b` letter increment).

Closes #227

## Test plan

- [x] `deno task test` — 594 passed, 0 failed (includes 23 new unit tests + 17 new smoke assertions)
- [x] `smoke-tag-release.sh` — both schemes scaffold correctly, BEGIN/END markers stripped, lock records scheme
- [x] End-to-end roundtrip in throwaway repo: tag.sh creates tags, release.sh emits clean categorized body
- [x] Pre-commit fmt + lint + bundle + check — green

## Out of scope (follow-up children)

- **#228** — GitHub remote backend (`release-github.sh` wrapper for `gh release create`)
- **#229** — GitLab remote backend (`release-gitlab.sh` wrapper for `glab release create`)
- **#230** — Local-only mode (no remote release object; tag-only flow)
- **#231** — All-harness smoke + bundle integrity
- **#232** — Docs update (`docs/llms.md` + per-harness refs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)