### PR TITLE
feat(scaffold): bundle release-github.sh wrapper (#228 GitHub backend)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
@@ -57,6 +57,14 @@ check "tag.sh does NOT keep BEGIN/END scheme markers (rewrite stripped them)" \
   '! grep -qE "^\s*#\s*(BEGIN|END):\s*scheme=" .specflow/scripts/release/tag.sh'
 check "release.sh contains 10-bucket classifier" \
   'grep -q "Features" .specflow/scripts/release/release.sh && grep -q "Bug Fixes" .specflow/scripts/release/release.sh && grep -q "Build & CI" .specflow/scripts/release/release.sh'
+check "#228 release-github.sh present + executable" \
+  '[ -x .specflow/scripts/release/release-github.sh ]'
+check "#228 release-github.sh wraps gh release create" \
+  'grep -q "gh release create" .specflow/scripts/release/release-github.sh'
+check "#228 release-github.sh detects previous DEPLOYED tag (not by date)" \
+  'grep -q "previous DEPLOYED tag" .specflow/scripts/release/release-github.sh && grep -q "gh release list" .specflow/scripts/release/release-github.sh'
+check "#228 release-github.sh is idempotent (re-run on existing release exits 0)" \
+  'grep -q "already exists" .specflow/scripts/release/release-github.sh'
 check "lock records version_scheme: semver" \
   'grep -q "version_scheme: semver" .specflow/installed.lock'
 check "specflow SKILL.md references tag-version" \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -276,6 +276,19 @@ Every scaffolded project ships two router commands under `/specflow`:
 The scripts live at `.specflow/scripts/release/{tag,release}.sh` — the same path across all 8
 harnesses.
 
+For GitHub-hosted projects, the bundled `release-github.sh` wrapper is the one-command path:
+
+```bash
+bash .specflow/scripts/release/release-github.sh           # latest tag, auto-baseline, publish
+bash .specflow/scripts/release/release-github.sh --draft   # create as draft
+```
+
+The wrapper computes the baseline as **the previous tag with a published GitHub Release attached**
+(not the previous tag by date) — tags pushed without a release are "subsumed" and their commits land
+in this release, with the subsumed tag names listed inline. Pushes the tag to `origin` if needed,
+then calls `gh release create`. Idempotent: a second run against an already-released tag exits 0 and
+prints the existing URL.
+
 ## Available harnesses
 
 | Key           | Display name       | Output root             |

--- a/plugin/skills/specflow/phases/release-version.md
+++ b/plugin/skills/specflow/phases/release-version.md
@@ -46,17 +46,44 @@ Each commit appears as `- <short-sha> <subject>` under its bucket.
 ## After the script runs
 
 The script writes the release body to **stdout**. What you do with it
-depends on how this project publishes releases:
+depends on how this project publishes releases.
 
-- **GitHub remote** — pipe it into `gh release create <tag>
-  --notes-file -` (or `--notes "$(...)"`).
-- **GitLab remote** — pipe it into `glab release create <tag>
-  --notes "..."`.
-- **Local-only** — copy the output somewhere readable (or echo it to
-  the user); there is no remote release to create.
+### GitHub remote — prefer the bundled wrapper
 
-The per-backend wrapper scripts ship as separate Specflow features —
-when one is installed, prefer it to manually piping into `gh` / `glab`.
+If the project ships releases on GitHub, the bundled
+`release-github.sh` wrapper is the one-command path:
+
+```bash
+bash .specflow/scripts/release/release-github.sh           # latest tag
+bash .specflow/scripts/release/release-github.sh v1.2.3    # specific tag
+bash .specflow/scripts/release/release-github.sh --draft   # create as draft
+bash .specflow/scripts/release/release-github.sh \
+  --baseline v1.0.0 v1.2.3                                 # override baseline
+```
+
+What the wrapper does on top of `release.sh`:
+
+1. Verifies `gh` CLI is installed + authenticated.
+2. **Computes the baseline = previous DEPLOYED tag** (the most recent
+   tag with a published GitHub Release attached, NOT the previous
+   tag by date). Tags pushed without a release are "subsumed" —
+   their commits land in this release and the subsumed tag names
+   are listed inline.
+3. Pushes the tag to `origin` if not already there (the GitHub
+   Releases API needs the tag on the remote).
+4. Generates the body via `release.sh` with the computed baseline.
+5. Calls `gh release create <tag> --notes-file -` to publish.
+6. Prints the published release URL.
+
+Idempotent — re-running against a tag that already has a release
+prints the existing URL and exits 0.
+
+### Other backends (no wrapper installed)
+
+- **GitLab remote** — pipe `release.sh` output into
+  `glab release create <tag> --notes "$(bash .specflow/scripts/release/release.sh <tag>)"`.
+- **Local-only** — copy `release.sh` output somewhere readable; there
+  is no remote release object to create.
 
 ## Important — release-notes contract
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2122,17 +2122,44 @@ Each commit appears as \`- <short-sha> <subject>\` under its bucket.
 ## After the script runs
 
 The script writes the release body to **stdout**. What you do with it
-depends on how this project publishes releases:
+depends on how this project publishes releases.
 
-- **GitHub remote** — pipe it into \`gh release create <tag>
-  --notes-file -\` (or \`--notes "\$(...)"\`).
-- **GitLab remote** — pipe it into \`glab release create <tag>
-  --notes "..."\`.
-- **Local-only** — copy the output somewhere readable (or echo it to
-  the user); there is no remote release to create.
+### GitHub remote — prefer the bundled wrapper
 
-The per-backend wrapper scripts ship as separate Specflow features —
-when one is installed, prefer it to manually piping into \`gh\` / \`glab\`.
+If the project ships releases on GitHub, the bundled
+\`release-github.sh\` wrapper is the one-command path:
+
+\`\`\`bash
+bash .specflow/scripts/release/release-github.sh           # latest tag
+bash .specflow/scripts/release/release-github.sh v1.2.3    # specific tag
+bash .specflow/scripts/release/release-github.sh --draft   # create as draft
+bash .specflow/scripts/release/release-github.sh \\
+  --baseline v1.0.0 v1.2.3                                 # override baseline
+\`\`\`
+
+What the wrapper does on top of \`release.sh\`:
+
+1. Verifies \`gh\` CLI is installed + authenticated.
+2. **Computes the baseline = previous DEPLOYED tag** (the most recent
+   tag with a published GitHub Release attached, NOT the previous
+   tag by date). Tags pushed without a release are "subsumed" —
+   their commits land in this release and the subsumed tag names
+   are listed inline.
+3. Pushes the tag to \`origin\` if not already there (the GitHub
+   Releases API needs the tag on the remote).
+4. Generates the body via \`release.sh\` with the computed baseline.
+5. Calls \`gh release create <tag> --notes-file -\` to publish.
+6. Prints the published release URL.
+
+Idempotent — re-running against a tag that already has a release
+prints the existing URL and exits 0.
+
+### Other backends (no wrapper installed)
+
+- **GitLab remote** — pipe \`release.sh\` output into
+  \`glab release create <tag> --notes "\$(bash .specflow/scripts/release/release.sh <tag>)"\`.
+- **Local-only** — copy \`release.sh\` output somewhere readable; there
+  is no remote release object to create.
 
 ## Important — release-notes contract
 
@@ -2415,6 +2442,141 @@ emit_bucket "Style" "\$BUCKET_STYLE"
 emit_bucket "Other" "\$BUCKET_OTHER"
 
 printf -- '---\\nCommit: \`%s\`\\n' "\$TAG_SHORT"
+`,
+    executable: true,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase-script",
+    name: "release-github",
+    suffix: "release-github.sh",
+    content: `#!/usr/bin/env bash
+# Publish a GitHub Release for a tag, using release.sh to generate the body.
+#
+# The baseline is the **previous DEPLOYED tag** (last tag with a published
+# GitHub release attached), NOT the previous tag by date. Tags pushed
+# without a release attached are "subsumed" — their commits land in this
+# release and the subsumed tag names are listed inline so the operator
+# can see what got rolled in. Override with --baseline if needed.
+#
+# Usage: release-github.sh [--baseline <tag>] [--draft] [<tag>]
+#   <tag>        default: latest tag (git describe --tags --abbrev=0)
+#   --baseline   override the auto-detected previous-deployed baseline
+#   --draft      create the release as draft instead of publishing
+set -euo pipefail
+
+TAG=""
+EXPLICIT_BASELINE=""
+DRAFT=false
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --baseline) EXPLICIT_BASELINE="\$2"; shift 2 ;;
+    --baseline=*) EXPLICIT_BASELINE="\${1#--baseline=}"; shift ;;
+    --draft) DRAFT=true; shift ;;
+    --help|-h)
+      echo "usage: release-github.sh [--baseline <tag>] [--draft] [<tag>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: \$1" >&2; exit 2 ;;
+    *) TAG="\$1"; shift ;;
+  esac
+done
+
+SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+
+# Preflight: gh CLI must be installed + authenticated.
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found on PATH — install from https://cli.github.com/" >&2
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh CLI not authenticated — run: gh auth login" >&2
+  exit 1
+fi
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if [ -z "\$TAG" ]; then
+  TAG=\$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "\$TAG" ]; then
+    echo "no tags found — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "\$TAG" >/dev/null 2>&1; then
+  echo "tag '\$TAG' not found locally" >&2
+  exit 1
+fi
+
+# Idempotency: if a release already exists for \$TAG, surface its URL
+# and exit 0 — re-running the script in a recovery scenario should
+# never error out on the second pass.
+if gh release view "\$TAG" >/dev/null 2>&1; then
+  URL=\$(gh release view "\$TAG" --json url --jq '.url')
+  echo "release for \$TAG already exists: \$URL"
+  exit 0
+fi
+
+# Compute the baseline = previous DEPLOYED tag, and collect subsumed
+# tags between the baseline and \$TAG. One gh API call (release list)
+# rather than per-tag probes.
+if [ -n "\$EXPLICIT_BASELINE" ]; then
+  BASELINE="\$EXPLICIT_BASELINE"
+  SUBSUMED=""
+else
+  RELEASE_TAGS=\$(gh release list --limit 200 --json tagName --jq '.[].tagName' | tr '\\n' ' ')
+  BASELINE=""
+  SUBSUMED_LIST=""
+  SEEN_CURRENT=false
+  for t in \$(git tag --sort=-creatordate); do
+    if [ "\$t" = "\$TAG" ]; then
+      SEEN_CURRENT=true
+      continue
+    fi
+    [ "\$SEEN_CURRENT" = "true" ] || continue
+    # Match exact tag name in the release-tag set (space-padded to
+    # avoid partial-prefix false positives).
+    if printf ' %s ' "\$RELEASE_TAGS" | grep -q " \$t "; then
+      BASELINE="\$t"
+      break
+    fi
+    SUBSUMED_LIST="\${SUBSUMED_LIST}\\\`\$t\\\`, "
+  done
+  SUBSUMED="\${SUBSUMED_LIST%, }"
+fi
+
+# Push the tag if it isn't on origin yet — gh release create needs it
+# on the remote, otherwise the release points at a phantom ref.
+if ! git ls-remote --tags origin "\$TAG" 2>/dev/null | grep -q "refs/tags/\$TAG\$"; then
+  if git remote get-url origin >/dev/null 2>&1; then
+    git push origin "\$TAG"
+  else
+    echo "no origin remote configured — cannot push tag" >&2
+    exit 1
+  fi
+fi
+
+# Generate the body via the stack-agnostic release.sh
+if [ -n "\$BASELINE" ]; then
+  BODY=\$(bash "\$SCRIPT_DIR/release.sh" --baseline "\$BASELINE" "\$TAG")
+else
+  BODY=\$(bash "\$SCRIPT_DIR/release.sh" "\$TAG")
+fi
+
+# Inject the subsumed-tags note above the metadata footer if any
+if [ -n "\$SUBSUMED" ]; then
+  BODY=\$(printf '%s\\n' "\$BODY" \\
+    | awk -v note="_This release subsumes undeployed tags: \$SUBSUMED._" \\
+        'BEGIN{inserted=0} /^---\$/ && !inserted {print note "\\n"; inserted=1} {print}')
+fi
+
+# Create the release.
+GH_ARGS=("\$TAG" "--title" "\$TAG" "--notes-file" "-")
+[ "\$DRAFT" = "true" ] && GH_ARGS+=("--draft")
+URL=\$(printf '%s' "\$BODY" | gh release create "\${GH_ARGS[@]}")
+echo "✓ published release: \$URL"
 `,
     executable: true,
     backend: null,

--- a/templates/core/skills/specflow/phases/release-version.md
+++ b/templates/core/skills/specflow/phases/release-version.md
@@ -46,17 +46,44 @@ Each commit appears as `- <short-sha> <subject>` under its bucket.
 ## After the script runs
 
 The script writes the release body to **stdout**. What you do with it
-depends on how this project publishes releases:
+depends on how this project publishes releases.
 
-- **GitHub remote** — pipe it into `gh release create <tag>
-  --notes-file -` (or `--notes "$(...)"`).
-- **GitLab remote** — pipe it into `glab release create <tag>
-  --notes "..."`.
-- **Local-only** — copy the output somewhere readable (or echo it to
-  the user); there is no remote release to create.
+### GitHub remote — prefer the bundled wrapper
 
-The per-backend wrapper scripts ship as separate Specflow features —
-when one is installed, prefer it to manually piping into `gh` / `glab`.
+If the project ships releases on GitHub, the bundled
+`release-github.sh` wrapper is the one-command path:
+
+```bash
+bash .specflow/scripts/release/release-github.sh           # latest tag
+bash .specflow/scripts/release/release-github.sh v1.2.3    # specific tag
+bash .specflow/scripts/release/release-github.sh --draft   # create as draft
+bash .specflow/scripts/release/release-github.sh \
+  --baseline v1.0.0 v1.2.3                                 # override baseline
+```
+
+What the wrapper does on top of `release.sh`:
+
+1. Verifies `gh` CLI is installed + authenticated.
+2. **Computes the baseline = previous DEPLOYED tag** (the most recent
+   tag with a published GitHub Release attached, NOT the previous
+   tag by date). Tags pushed without a release are "subsumed" —
+   their commits land in this release and the subsumed tag names
+   are listed inline.
+3. Pushes the tag to `origin` if not already there (the GitHub
+   Releases API needs the tag on the remote).
+4. Generates the body via `release.sh` with the computed baseline.
+5. Calls `gh release create <tag> --notes-file -` to publish.
+6. Prints the published release URL.
+
+Idempotent — re-running against a tag that already has a release
+prints the existing URL and exits 0.
+
+### Other backends (no wrapper installed)
+
+- **GitLab remote** — pipe `release.sh` output into
+  `glab release create <tag> --notes "$(bash .specflow/scripts/release/release.sh <tag>)"`.
+- **Local-only** — copy `release.sh` output somewhere readable; there
+  is no remote release object to create.
 
 ## Important — release-notes contract
 

--- a/templates/core/skills/specflow/scripts/release-github.sh
+++ b/templates/core/skills/specflow/scripts/release-github.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Publish a GitHub Release for a tag, using release.sh to generate the body.
+#
+# The baseline is the **previous DEPLOYED tag** (last tag with a published
+# GitHub release attached), NOT the previous tag by date. Tags pushed
+# without a release attached are "subsumed" — their commits land in this
+# release and the subsumed tag names are listed inline so the operator
+# can see what got rolled in. Override with --baseline if needed.
+#
+# Usage: release-github.sh [--baseline <tag>] [--draft] [<tag>]
+#   <tag>        default: latest tag (git describe --tags --abbrev=0)
+#   --baseline   override the auto-detected previous-deployed baseline
+#   --draft      create the release as draft instead of publishing
+set -euo pipefail
+
+TAG=""
+EXPLICIT_BASELINE=""
+DRAFT=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --baseline) EXPLICIT_BASELINE="$2"; shift 2 ;;
+    --baseline=*) EXPLICIT_BASELINE="${1#--baseline=}"; shift ;;
+    --draft) DRAFT=true; shift ;;
+    --help|-h)
+      echo "usage: release-github.sh [--baseline <tag>] [--draft] [<tag>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) TAG="$1"; shift ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Preflight: gh CLI must be installed + authenticated.
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI not found on PATH — install from https://cli.github.com/" >&2
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh CLI not authenticated — run: gh auth login" >&2
+  exit 1
+fi
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if [ -z "$TAG" ]; then
+  TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "$TAG" ]; then
+    echo "no tags found — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo "tag '$TAG' not found locally" >&2
+  exit 1
+fi
+
+# Idempotency: if a release already exists for $TAG, surface its URL
+# and exit 0 — re-running the script in a recovery scenario should
+# never error out on the second pass.
+if gh release view "$TAG" >/dev/null 2>&1; then
+  URL=$(gh release view "$TAG" --json url --jq '.url')
+  echo "release for $TAG already exists: $URL"
+  exit 0
+fi
+
+# Compute the baseline = previous DEPLOYED tag, and collect subsumed
+# tags between the baseline and $TAG. One gh API call (release list)
+# rather than per-tag probes.
+if [ -n "$EXPLICIT_BASELINE" ]; then
+  BASELINE="$EXPLICIT_BASELINE"
+  SUBSUMED=""
+else
+  RELEASE_TAGS=$(gh release list --limit 200 --json tagName --jq '.[].tagName' | tr '\n' ' ')
+  BASELINE=""
+  SUBSUMED_LIST=""
+  SEEN_CURRENT=false
+  for t in $(git tag --sort=-creatordate); do
+    if [ "$t" = "$TAG" ]; then
+      SEEN_CURRENT=true
+      continue
+    fi
+    [ "$SEEN_CURRENT" = "true" ] || continue
+    # Match exact tag name in the release-tag set (space-padded to
+    # avoid partial-prefix false positives).
+    if printf ' %s ' "$RELEASE_TAGS" | grep -q " $t "; then
+      BASELINE="$t"
+      break
+    fi
+    SUBSUMED_LIST="${SUBSUMED_LIST}\`$t\`, "
+  done
+  SUBSUMED="${SUBSUMED_LIST%, }"
+fi
+
+# Push the tag if it isn't on origin yet — gh release create needs it
+# on the remote, otherwise the release points at a phantom ref.
+if ! git ls-remote --tags origin "$TAG" 2>/dev/null | grep -q "refs/tags/$TAG$"; then
+  if git remote get-url origin >/dev/null 2>&1; then
+    git push origin "$TAG"
+  else
+    echo "no origin remote configured — cannot push tag" >&2
+    exit 1
+  fi
+fi
+
+# Generate the body via the stack-agnostic release.sh
+if [ -n "$BASELINE" ]; then
+  BODY=$(bash "$SCRIPT_DIR/release.sh" --baseline "$BASELINE" "$TAG")
+else
+  BODY=$(bash "$SCRIPT_DIR/release.sh" "$TAG")
+fi
+
+# Inject the subsumed-tags note above the metadata footer if any
+if [ -n "$SUBSUMED" ]; then
+  BODY=$(printf '%s\n' "$BODY" \
+    | awk -v note="_This release subsumes undeployed tags: $SUBSUMED._" \
+        'BEGIN{inserted=0} /^---$/ && !inserted {print note "\n"; inserted=1} {print}')
+fi
+
+# Create the release.
+GH_ARGS=("$TAG" "--title" "$TAG" "--notes-file" "-")
+[ "$DRAFT" = "true" ] && GH_ARGS+=("--draft")
+URL=$(printf '%s' "$BODY" | gh release create "${GH_ARGS[@]}")
+echo "✓ published release: $URL"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -17,6 +17,7 @@
     { "category": "phase", "name": "release-version", "suffix": "release-version.md", "source": "core/skills/specflow/phases/release-version.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
+    { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 


### PR DESCRIPTION
## Summary

Second child of epic #226. Ships `release-github.sh` — the GitHub-specific wrapper around #227's stack-agnostic `release.sh`.

## What the wrapper adds on top of `release.sh`

- **Auth preflight** — `gh` CLI installed + authenticated, errors out actionably otherwise
- **Previous DEPLOYED tag detection** — baseline is the most recent tag with a published GitHub Release attached, NOT the previous tag by date. Tags pushed without a release are \"subsumed\" — their commits land in this release and the subsumed tag names appear inline in the body
- **Auto-push** — pushes the tag to `origin` if not already there (the Releases API needs it on the remote)
- **Single API call** — `gh release list --limit 200` for the entire baseline detection; no per-tag probes
- **Idempotent** — re-running against an already-released tag prints the URL and exits 0
- **`--draft` flag** for unpublished drafts
- **`--baseline` override** for cases where auto-detect picks wrong

## Files

- `templates/core/skills/specflow/scripts/release-github.sh` (new)
- `templates/manifest.json` — new `phase-script` entry
- `templates/core/skills/specflow/phases/release-version.md` — wrapper documented as the one-command path for GitHub projects
- `plugin/skills/specflow/phases/release-version.md` — mirrored
- `docs/llms.md` — wrapper documented in the \"Bundled tag + release commands\" section
- `.claude/skills/test-sandbox/scripts/smoke-tag-release.sh` — 4 new structural assertions

Closes #228

## Test plan

- [x] `deno task test` — 594 passed, 0 failed
- [x] `smoke-tag-release.sh` — all assertions pass (now 22 checks; previously 17)
- [x] `release-github.sh --help` prints the usage line correctly
- [x] Pre-commit fmt + lint + bundle + check — green

## Follow-up (children of epic #226)

- **#229** — GitLab remote backend (`release-gitlab.sh` wrapper)
- **#230** — Local-only mode (no remote release — tag-only flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)