### PR TITLE
feat(scaffold): bundle release-gitlab.sh wrapper (#229 GitLab backend)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
@@ -65,6 +65,14 @@ check "#228 release-github.sh detects previous DEPLOYED tag (not by date)" \
   'grep -q "previous DEPLOYED tag" .specflow/scripts/release/release-github.sh && grep -q "gh release list" .specflow/scripts/release/release-github.sh'
 check "#228 release-github.sh is idempotent (re-run on existing release exits 0)" \
   'grep -q "already exists" .specflow/scripts/release/release-github.sh'
+check "#229 release-gitlab.sh present + executable" \
+  '[ -x .specflow/scripts/release/release-gitlab.sh ]'
+check "#229 release-gitlab.sh wraps glab release create" \
+  'grep -q "glab release create" .specflow/scripts/release/release-gitlab.sh'
+check "#229 release-gitlab.sh queries projects/:id/releases for baseline detection" \
+  'grep -q "projects/:id/releases" .specflow/scripts/release/release-gitlab.sh'
+check "#229 release-gitlab.sh is idempotent (re-run on existing release exits 0)" \
+  'grep -q "already exists" .specflow/scripts/release/release-gitlab.sh'
 check "lock records version_scheme: semver" \
   'grep -q "version_scheme: semver" .specflow/installed.lock'
 check "specflow SKILL.md references tag-version" \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -276,18 +276,25 @@ Every scaffolded project ships two router commands under `/specflow`:
 The scripts live at `.specflow/scripts/release/{tag,release}.sh` — the same path across all 8
 harnesses.
 
-For GitHub-hosted projects, the bundled `release-github.sh` wrapper is the one-command path:
+For **GitHub**-hosted projects, the bundled `release-github.sh` wrapper is the one-command path:
 
 ```bash
 bash .specflow/scripts/release/release-github.sh           # latest tag, auto-baseline, publish
 bash .specflow/scripts/release/release-github.sh --draft   # create as draft
 ```
 
-The wrapper computes the baseline as **the previous tag with a published GitHub Release attached**
-(not the previous tag by date) — tags pushed without a release are "subsumed" and their commits land
-in this release, with the subsumed tag names listed inline. Pushes the tag to `origin` if needed,
-then calls `gh release create`. Idempotent: a second run against an already-released tag exits 0 and
-prints the existing URL.
+For **GitLab**-hosted projects, `release-gitlab.sh` mirrors the same contract:
+
+```bash
+bash .specflow/scripts/release/release-gitlab.sh           # latest tag
+bash .specflow/scripts/release/release-gitlab.sh v1.2.3    # specific tag
+```
+
+Both wrappers compute the baseline as **the previous tag with a published release attached** (not
+the previous tag by date) — tags pushed without a release are "subsumed" and their commits land in
+this release, with the subsumed tag names listed inline. They push the tag to `origin` if needed,
+then call `gh release create` / `glab release create`. Idempotent: a second run against an
+already-released tag exits 0 with an explanatory message.
 
 ## Available harnesses
 

--- a/plugin/skills/specflow/phases/release-version.md
+++ b/plugin/skills/specflow/phases/release-version.md
@@ -78,12 +78,29 @@ What the wrapper does on top of `release.sh`:
 Idempotent — re-running against a tag that already has a release
 prints the existing URL and exits 0.
 
-### Other backends (no wrapper installed)
+### GitLab remote — prefer the bundled wrapper
 
-- **GitLab remote** — pipe `release.sh` output into
-  `glab release create <tag> --notes "$(bash .specflow/scripts/release/release.sh <tag>)"`.
+If the project ships releases on GitLab, the bundled `release-gitlab.sh`
+wrapper mirrors the GitHub one:
+
+```bash
+bash .specflow/scripts/release/release-gitlab.sh           # latest tag
+bash .specflow/scripts/release/release-gitlab.sh v1.2.3    # specific tag
+bash .specflow/scripts/release/release-gitlab.sh \
+  --baseline v1.0.0 v1.2.3                                 # override baseline
+```
+
+Same contract as `release-github.sh`: previous-DEPLOYED-tag baseline
+(via `glab api projects/:id/releases`), subsumed-tag listing, tag
+auto-push, idempotency. Requires `glab` CLI installed + authenticated
+(`glab auth login`).
+
+### Local-only / other backends (no wrapper)
+
 - **Local-only** — copy `release.sh` output somewhere readable; there
   is no remote release object to create.
+- **Custom CI / other remote** — capture `release.sh` output and feed it
+  into whatever your pipeline expects.
 
 ## Important — release-notes contract
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2154,12 +2154,29 @@ What the wrapper does on top of \`release.sh\`:
 Idempotent — re-running against a tag that already has a release
 prints the existing URL and exits 0.
 
-### Other backends (no wrapper installed)
+### GitLab remote — prefer the bundled wrapper
 
-- **GitLab remote** — pipe \`release.sh\` output into
-  \`glab release create <tag> --notes "\$(bash .specflow/scripts/release/release.sh <tag>)"\`.
+If the project ships releases on GitLab, the bundled \`release-gitlab.sh\`
+wrapper mirrors the GitHub one:
+
+\`\`\`bash
+bash .specflow/scripts/release/release-gitlab.sh           # latest tag
+bash .specflow/scripts/release/release-gitlab.sh v1.2.3    # specific tag
+bash .specflow/scripts/release/release-gitlab.sh \\
+  --baseline v1.0.0 v1.2.3                                 # override baseline
+\`\`\`
+
+Same contract as \`release-github.sh\`: previous-DEPLOYED-tag baseline
+(via \`glab api projects/:id/releases\`), subsumed-tag listing, tag
+auto-push, idempotency. Requires \`glab\` CLI installed + authenticated
+(\`glab auth login\`).
+
+### Local-only / other backends (no wrapper)
+
 - **Local-only** — copy \`release.sh\` output somewhere readable; there
   is no remote release object to create.
+- **Custom CI / other remote** — capture \`release.sh\` output and feed it
+  into whatever your pipeline expects.
 
 ## Important — release-notes contract
 
@@ -2577,6 +2594,138 @@ GH_ARGS=("\$TAG" "--title" "\$TAG" "--notes-file" "-")
 [ "\$DRAFT" = "true" ] && GH_ARGS+=("--draft")
 URL=\$(printf '%s' "\$BODY" | gh release create "\${GH_ARGS[@]}")
 echo "✓ published release: \$URL"
+`,
+    executable: true,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase-script",
+    name: "release-gitlab",
+    suffix: "release-gitlab.sh",
+    content: `#!/usr/bin/env bash
+# Publish a GitLab Release for a tag, using release.sh to generate the body.
+#
+# Mirrors release-github.sh: baseline = previous DEPLOYED tag (the most
+# recent tag with a published GitLab release attached), NOT the previous
+# tag by date. Tags pushed without a release are "subsumed" — their
+# commits land in this release and the subsumed tag names appear inline
+# in the body.
+#
+# Usage: release-gitlab.sh [--baseline <tag>] [<tag>]
+#   <tag>        default: latest tag (git describe --tags --abbrev=0)
+#   --baseline   override the auto-detected previous-deployed baseline
+set -euo pipefail
+
+TAG=""
+EXPLICIT_BASELINE=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --baseline) EXPLICIT_BASELINE="\$2"; shift 2 ;;
+    --baseline=*) EXPLICIT_BASELINE="\${1#--baseline=}"; shift ;;
+    --help|-h)
+      echo "usage: release-gitlab.sh [--baseline <tag>] [<tag>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: \$1" >&2; exit 2 ;;
+    *) TAG="\$1"; shift ;;
+  esac
+done
+
+SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+
+# Preflight: glab CLI must be installed + authenticated.
+if ! command -v glab >/dev/null 2>&1; then
+  echo "glab CLI not found on PATH — install from https://gitlab.com/gitlab-org/cli" >&2
+  exit 1
+fi
+if ! glab auth status >/dev/null 2>&1; then
+  echo "glab CLI not authenticated — run: glab auth login" >&2
+  exit 1
+fi
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if [ -z "\$TAG" ]; then
+  TAG=\$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "\$TAG" ]; then
+    echo "no tags found — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "\$TAG" >/dev/null 2>&1; then
+  echo "tag '\$TAG' not found locally" >&2
+  exit 1
+fi
+
+# Idempotency: skip if a release already exists for \$TAG.
+if glab release view "\$TAG" >/dev/null 2>&1; then
+  echo "release for \$TAG already exists on GitLab"
+  exit 0
+fi
+
+# Compute baseline = previous DEPLOYED tag. Uses glab's project release
+# API (stable across glab versions). Errors are swallowed → empty
+# RELEASE_TAGS → graceful fallback to release.sh's default (previous
+# tag by date).
+if [ -n "\$EXPLICIT_BASELINE" ]; then
+  BASELINE="\$EXPLICIT_BASELINE"
+  SUBSUMED=""
+else
+  RELEASE_TAGS=\$(glab api 'projects/:id/releases?per_page=100' 2>/dev/null \\
+    | jq -r '.[].tag_name' 2>/dev/null \\
+    | tr '\\n' ' ' || true)
+  BASELINE=""
+  SUBSUMED_LIST=""
+  SEEN_CURRENT=false
+  for t in \$(git tag --sort=-creatordate); do
+    if [ "\$t" = "\$TAG" ]; then
+      SEEN_CURRENT=true
+      continue
+    fi
+    [ "\$SEEN_CURRENT" = "true" ] || continue
+    if printf ' %s ' "\$RELEASE_TAGS" | grep -q " \$t "; then
+      BASELINE="\$t"
+      break
+    fi
+    SUBSUMED_LIST="\${SUBSUMED_LIST}\\\`\$t\\\`, "
+  done
+  SUBSUMED="\${SUBSUMED_LIST%, }"
+fi
+
+# Push the tag if it isn't on origin yet — GitLab's Releases API needs
+# the tag on the remote, otherwise the release points at a phantom ref.
+if ! git ls-remote --tags origin "\$TAG" 2>/dev/null | grep -q "refs/tags/\$TAG\$"; then
+  if git remote get-url origin >/dev/null 2>&1; then
+    git push origin "\$TAG"
+  else
+    echo "no origin remote configured — cannot push tag" >&2
+    exit 1
+  fi
+fi
+
+# Generate body via stack-agnostic release.sh
+if [ -n "\$BASELINE" ]; then
+  BODY=\$(bash "\$SCRIPT_DIR/release.sh" --baseline "\$BASELINE" "\$TAG")
+else
+  BODY=\$(bash "\$SCRIPT_DIR/release.sh" "\$TAG")
+fi
+
+if [ -n "\$SUBSUMED" ]; then
+  BODY=\$(printf '%s\\n' "\$BODY" \\
+    | awk -v note="_This release subsumes undeployed tags: \$SUBSUMED._" \\
+        'BEGIN{inserted=0} /^---\$/ && !inserted {print note "\\n"; inserted=1} {print}')
+fi
+
+# Write the body to a tempfile so \`--notes-file\` consumes it verbatim
+# (avoids shell-escaping pitfalls with \`--notes "\$BODY"\`).
+NOTES_FILE=\$(mktemp)
+trap 'rm -f "\$NOTES_FILE"' EXIT
+printf '%s' "\$BODY" > "\$NOTES_FILE"
+
+glab release create "\$TAG" --name "\$TAG" --notes-file "\$NOTES_FILE"
+echo "✓ published GitLab release for \$TAG"
 `,
     executable: true,
     backend: null,

--- a/templates/core/skills/specflow/phases/release-version.md
+++ b/templates/core/skills/specflow/phases/release-version.md
@@ -78,12 +78,29 @@ What the wrapper does on top of `release.sh`:
 Idempotent — re-running against a tag that already has a release
 prints the existing URL and exits 0.
 
-### Other backends (no wrapper installed)
+### GitLab remote — prefer the bundled wrapper
 
-- **GitLab remote** — pipe `release.sh` output into
-  `glab release create <tag> --notes "$(bash .specflow/scripts/release/release.sh <tag>)"`.
+If the project ships releases on GitLab, the bundled `release-gitlab.sh`
+wrapper mirrors the GitHub one:
+
+```bash
+bash .specflow/scripts/release/release-gitlab.sh           # latest tag
+bash .specflow/scripts/release/release-gitlab.sh v1.2.3    # specific tag
+bash .specflow/scripts/release/release-gitlab.sh \
+  --baseline v1.0.0 v1.2.3                                 # override baseline
+```
+
+Same contract as `release-github.sh`: previous-DEPLOYED-tag baseline
+(via `glab api projects/:id/releases`), subsumed-tag listing, tag
+auto-push, idempotency. Requires `glab` CLI installed + authenticated
+(`glab auth login`).
+
+### Local-only / other backends (no wrapper)
+
 - **Local-only** — copy `release.sh` output somewhere readable; there
   is no remote release object to create.
+- **Custom CI / other remote** — capture `release.sh` output and feed it
+  into whatever your pipeline expects.
 
 ## Important — release-notes contract
 

--- a/templates/core/skills/specflow/scripts/release-gitlab.sh
+++ b/templates/core/skills/specflow/scripts/release-gitlab.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Publish a GitLab Release for a tag, using release.sh to generate the body.
+#
+# Mirrors release-github.sh: baseline = previous DEPLOYED tag (the most
+# recent tag with a published GitLab release attached), NOT the previous
+# tag by date. Tags pushed without a release are "subsumed" — their
+# commits land in this release and the subsumed tag names appear inline
+# in the body.
+#
+# Usage: release-gitlab.sh [--baseline <tag>] [<tag>]
+#   <tag>        default: latest tag (git describe --tags --abbrev=0)
+#   --baseline   override the auto-detected previous-deployed baseline
+set -euo pipefail
+
+TAG=""
+EXPLICIT_BASELINE=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --baseline) EXPLICIT_BASELINE="$2"; shift 2 ;;
+    --baseline=*) EXPLICIT_BASELINE="${1#--baseline=}"; shift ;;
+    --help|-h)
+      echo "usage: release-gitlab.sh [--baseline <tag>] [<tag>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) TAG="$1"; shift ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Preflight: glab CLI must be installed + authenticated.
+if ! command -v glab >/dev/null 2>&1; then
+  echo "glab CLI not found on PATH — install from https://gitlab.com/gitlab-org/cli" >&2
+  exit 1
+fi
+if ! glab auth status >/dev/null 2>&1; then
+  echo "glab CLI not authenticated — run: glab auth login" >&2
+  exit 1
+fi
+
+git fetch --tags --quiet 2>/dev/null || true
+
+if [ -z "$TAG" ]; then
+  TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "$TAG" ]; then
+    echo "no tags found — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo "tag '$TAG' not found locally" >&2
+  exit 1
+fi
+
+# Idempotency: skip if a release already exists for $TAG.
+if glab release view "$TAG" >/dev/null 2>&1; then
+  echo "release for $TAG already exists on GitLab"
+  exit 0
+fi
+
+# Compute baseline = previous DEPLOYED tag. Uses glab's project release
+# API (stable across glab versions). Errors are swallowed → empty
+# RELEASE_TAGS → graceful fallback to release.sh's default (previous
+# tag by date).
+if [ -n "$EXPLICIT_BASELINE" ]; then
+  BASELINE="$EXPLICIT_BASELINE"
+  SUBSUMED=""
+else
+  RELEASE_TAGS=$(glab api 'projects/:id/releases?per_page=100' 2>/dev/null \
+    | jq -r '.[].tag_name' 2>/dev/null \
+    | tr '\n' ' ' || true)
+  BASELINE=""
+  SUBSUMED_LIST=""
+  SEEN_CURRENT=false
+  for t in $(git tag --sort=-creatordate); do
+    if [ "$t" = "$TAG" ]; then
+      SEEN_CURRENT=true
+      continue
+    fi
+    [ "$SEEN_CURRENT" = "true" ] || continue
+    if printf ' %s ' "$RELEASE_TAGS" | grep -q " $t "; then
+      BASELINE="$t"
+      break
+    fi
+    SUBSUMED_LIST="${SUBSUMED_LIST}\`$t\`, "
+  done
+  SUBSUMED="${SUBSUMED_LIST%, }"
+fi
+
+# Push the tag if it isn't on origin yet — GitLab's Releases API needs
+# the tag on the remote, otherwise the release points at a phantom ref.
+if ! git ls-remote --tags origin "$TAG" 2>/dev/null | grep -q "refs/tags/$TAG$"; then
+  if git remote get-url origin >/dev/null 2>&1; then
+    git push origin "$TAG"
+  else
+    echo "no origin remote configured — cannot push tag" >&2
+    exit 1
+  fi
+fi
+
+# Generate body via stack-agnostic release.sh
+if [ -n "$BASELINE" ]; then
+  BODY=$(bash "$SCRIPT_DIR/release.sh" --baseline "$BASELINE" "$TAG")
+else
+  BODY=$(bash "$SCRIPT_DIR/release.sh" "$TAG")
+fi
+
+if [ -n "$SUBSUMED" ]; then
+  BODY=$(printf '%s\n' "$BODY" \
+    | awk -v note="_This release subsumes undeployed tags: $SUBSUMED._" \
+        'BEGIN{inserted=0} /^---$/ && !inserted {print note "\n"; inserted=1} {print}')
+fi
+
+# Write the body to a tempfile so `--notes-file` consumes it verbatim
+# (avoids shell-escaping pitfalls with `--notes "$BODY"`).
+NOTES_FILE=$(mktemp)
+trap 'rm -f "$NOTES_FILE"' EXIT
+printf '%s' "$BODY" > "$NOTES_FILE"
+
+glab release create "$TAG" --name "$TAG" --notes-file "$NOTES_FILE"
+echo "✓ published GitLab release for $TAG"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -18,6 +18,7 @@
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },
+    { "category": "phase-script", "name": "release-gitlab", "suffix": "release-gitlab.sh", "source": "core/skills/specflow/scripts/release-gitlab.sh", "executable": true },
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 


### PR DESCRIPTION
## Summary

Third child of epic #226. Ships `release-gitlab.sh` — mirrors PR #234's GitHub wrapper for GitLab-hosted projects via the `glab` CLI.

## What's identical to release-github.sh

- Auth preflight (errors out if `glab` is absent / unauthenticated)
- Previous-DEPLOYED-tag baseline (vs previous-by-date), with subsumed-tag listing inline
- Auto-push of the tag to `origin` before publishing
- Idempotent on re-run
- `--baseline` override flag

## GitLab-specific bits

- Uses `glab api projects/:id/releases?per_page=100` — the stable GitLab REST endpoint, one call for the full list, project auto-resolved from the current git remote
- Writes the body to a tempfile and passes via `--notes-file` (avoids shell escaping issues with markdown content)
- No `--draft` flag (GitLab's release UX is different; can be added later if a user asks)

## Files

- `templates/core/skills/specflow/scripts/release-gitlab.sh` (new)
- `templates/manifest.json` — new `phase-script` entry
- `templates/core/skills/specflow/phases/release-version.md` — lists both wrappers
- `plugin/skills/specflow/phases/release-version.md` — mirrored
- `docs/llms.md` — documents both wrappers together
- `.claude/skills/test-sandbox/scripts/smoke-tag-release.sh` — 4 new assertions (now 26 checks)

Closes #229

## Test plan

- [x] `deno task test` — 594 passed, 0 failed
- [x] `smoke-tag-release.sh` — all 26 checks pass
- [x] `release-gitlab.sh --help` prints the usage line correctly
- [x] Pre-commit fmt + lint + bundle + check — green

## Next

- **#230** — local-only mode (last open child of epic #226)

🤖 Generated with [Claude Code](https://claude.com/claude-code)