### PR TITLE
feat(scaffold): bundle release-local.sh wrapper (#230 local-only mode)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-tag-release.sh
@@ -73,6 +73,14 @@ check "#229 release-gitlab.sh queries projects/:id/releases for baseline detecti
   'grep -q "projects/:id/releases" .specflow/scripts/release/release-gitlab.sh'
 check "#229 release-gitlab.sh is idempotent (re-run on existing release exits 0)" \
   'grep -q "already exists" .specflow/scripts/release/release-gitlab.sh'
+check "#230 release-local.sh present + executable" \
+  '[ -x .specflow/scripts/release/release-local.sh ]'
+check "#230 release-local.sh writes RELEASE_NOTES_<tag>.md by default" \
+  'grep -q "RELEASE_NOTES_" .specflow/scripts/release/release-local.sh'
+check "#230 release-local.sh accepts --out flag" \
+  'grep -q -- "--out" .specflow/scripts/release/release-local.sh'
+check "#230 release-local.sh makes NO remote API calls" \
+  '! grep -E "(gh|glab) (api|release create)" .specflow/scripts/release/release-local.sh'
 check "lock records version_scheme: semver" \
   'grep -q "version_scheme: semver" .specflow/installed.lock'
 check "specflow SKILL.md references tag-version" \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -296,6 +296,17 @@ this release, with the subsumed tag names listed inline. They push the tag to `o
 then call `gh release create` / `glab release create`. Idempotent: a second run against an
 already-released tag exits 0 with an explanatory message.
 
+For **local-only** projects (no remote, or you just want a Markdown artifact), the bundled
+`release-local.sh` wrapper writes the categorized body to a file:
+
+```bash
+bash .specflow/scripts/release/release-local.sh             # latest tag → RELEASE_NOTES_<tag>.md
+bash .specflow/scripts/release/release-local.sh --out NOTES.md v1.2.3
+```
+
+No remote API calls, no auth — paste the output into any release UI, attach to a deploy email, or
+pipe to a custom publisher.
+
 ## Available harnesses
 
 | Key           | Display name       | Output root             |

--- a/plugin/skills/specflow/phases/release-version.md
+++ b/plugin/skills/specflow/phases/release-version.md
@@ -95,12 +95,32 @@ Same contract as `release-github.sh`: previous-DEPLOYED-tag baseline
 auto-push, idempotency. Requires `glab` CLI installed + authenticated
 (`glab auth login`).
 
-### Local-only / other backends (no wrapper)
+### Local-only — use the `release-local.sh` wrapper
 
-- **Local-only** — copy `release.sh` output somewhere readable; there
-  is no remote release object to create.
-- **Custom CI / other remote** — capture `release.sh` output and feed it
-  into whatever your pipeline expects.
+If the project has no remote (or you just want a Markdown artifact to
+paste into any release UI), the bundled `release-local.sh` wrapper
+writes the categorized body to a file in the current directory:
+
+```bash
+bash .specflow/scripts/release/release-local.sh             # latest tag → RELEASE_NOTES_<tag>.md
+bash .specflow/scripts/release/release-local.sh v1.2.3      # specific tag
+bash .specflow/scripts/release/release-local.sh --out NOTES.md v1.2.3
+```
+
+No remote API calls, no auth, no tag pushing. The output file is the
+release-body Markdown — paste it into any release UI, attach it to a
+deploy email, or pipe it to a custom publisher. Default output path:
+`RELEASE_NOTES_<tag>.md`.
+
+### Custom CI / other remote
+
+Capture `release.sh` output and feed it into whatever your pipeline
+expects:
+
+```bash
+BODY=$(bash .specflow/scripts/release/release.sh v1.2.3)
+# … hand `$BODY` to your custom publisher
+```
 
 ## Important — release-notes contract
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2171,12 +2171,32 @@ Same contract as \`release-github.sh\`: previous-DEPLOYED-tag baseline
 auto-push, idempotency. Requires \`glab\` CLI installed + authenticated
 (\`glab auth login\`).
 
-### Local-only / other backends (no wrapper)
+### Local-only — use the \`release-local.sh\` wrapper
 
-- **Local-only** — copy \`release.sh\` output somewhere readable; there
-  is no remote release object to create.
-- **Custom CI / other remote** — capture \`release.sh\` output and feed it
-  into whatever your pipeline expects.
+If the project has no remote (or you just want a Markdown artifact to
+paste into any release UI), the bundled \`release-local.sh\` wrapper
+writes the categorized body to a file in the current directory:
+
+\`\`\`bash
+bash .specflow/scripts/release/release-local.sh             # latest tag → RELEASE_NOTES_<tag>.md
+bash .specflow/scripts/release/release-local.sh v1.2.3      # specific tag
+bash .specflow/scripts/release/release-local.sh --out NOTES.md v1.2.3
+\`\`\`
+
+No remote API calls, no auth, no tag pushing. The output file is the
+release-body Markdown — paste it into any release UI, attach it to a
+deploy email, or pipe it to a custom publisher. Default output path:
+\`RELEASE_NOTES_<tag>.md\`.
+
+### Custom CI / other remote
+
+Capture \`release.sh\` output and feed it into whatever your pipeline
+expects:
+
+\`\`\`bash
+BODY=\$(bash .specflow/scripts/release/release.sh v1.2.3)
+# … hand \`\$BODY\` to your custom publisher
+\`\`\`
 
 ## Important — release-notes contract
 
@@ -2726,6 +2746,79 @@ printf '%s' "\$BODY" > "\$NOTES_FILE"
 
 glab release create "\$TAG" --name "\$TAG" --notes-file "\$NOTES_FILE"
 echo "✓ published GitLab release for \$TAG"
+`,
+    executable: true,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase-script",
+    name: "release-local",
+    suffix: "release-local.sh",
+    content: `#!/usr/bin/env bash
+# Local-only release flow: generate categorized release notes for a tag
+# and write them to a Markdown file in the current directory. No remote
+# API calls. No tag pushing. Use when the project has no GitHub/GitLab
+# remote — or when you just want a Markdown artifact you can paste into
+# any release UI or attach to a deploy email.
+#
+# Usage: release-local.sh [--baseline <tag>] [--out <path>] [<tag>]
+#   <tag>           default: latest tag (git describe --tags --abbrev=0)
+#   --baseline      override the auto-detected baseline (default: previous
+#                   tag by date — there is no "deployed" notion for local)
+#   --out           output path (default: RELEASE_NOTES_<tag>.md)
+set -euo pipefail
+
+TAG=""
+BASELINE=""
+OUT=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --baseline) BASELINE="\$2"; shift 2 ;;
+    --baseline=*) BASELINE="\${1#--baseline=}"; shift ;;
+    --out) OUT="\$2"; shift 2 ;;
+    --out=*) OUT="\${1#--out=}"; shift ;;
+    --help|-h)
+      echo "usage: release-local.sh [--baseline <tag>] [--out <path>] [<tag>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: \$1" >&2; exit 2 ;;
+    *) TAG="\$1"; shift ;;
+  esac
+done
+
+SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+
+if [ -z "\$TAG" ]; then
+  TAG=\$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "\$TAG" ]; then
+    echo "no tags found — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "\$TAG" >/dev/null 2>&1; then
+  echo "tag '\$TAG' not found locally" >&2
+  exit 1
+fi
+
+# Compose release.sh args
+ARGS=()
+[ -n "\$BASELINE" ] && ARGS+=(--baseline "\$BASELINE")
+ARGS+=("\$TAG")
+
+BODY=\$(bash "\$SCRIPT_DIR/release.sh" "\${ARGS[@]}")
+
+if [ -z "\$OUT" ]; then
+  OUT="RELEASE_NOTES_\${TAG}.md"
+fi
+
+printf '%s\\n' "\$BODY" > "\$OUT"
+
+LINES=\$(wc -l < "\$OUT" | tr -d ' ')
+echo "✓ wrote \$OUT (\$LINES lines)"
+echo "  paste contents into your release UI, attach to a deploy email,"
+echo "  or pipe to a custom publisher"
 `,
     executable: true,
     backend: null,

--- a/templates/core/skills/specflow/phases/release-version.md
+++ b/templates/core/skills/specflow/phases/release-version.md
@@ -95,12 +95,32 @@ Same contract as `release-github.sh`: previous-DEPLOYED-tag baseline
 auto-push, idempotency. Requires `glab` CLI installed + authenticated
 (`glab auth login`).
 
-### Local-only / other backends (no wrapper)
+### Local-only — use the `release-local.sh` wrapper
 
-- **Local-only** — copy `release.sh` output somewhere readable; there
-  is no remote release object to create.
-- **Custom CI / other remote** — capture `release.sh` output and feed it
-  into whatever your pipeline expects.
+If the project has no remote (or you just want a Markdown artifact to
+paste into any release UI), the bundled `release-local.sh` wrapper
+writes the categorized body to a file in the current directory:
+
+```bash
+bash .specflow/scripts/release/release-local.sh             # latest tag → RELEASE_NOTES_<tag>.md
+bash .specflow/scripts/release/release-local.sh v1.2.3      # specific tag
+bash .specflow/scripts/release/release-local.sh --out NOTES.md v1.2.3
+```
+
+No remote API calls, no auth, no tag pushing. The output file is the
+release-body Markdown — paste it into any release UI, attach it to a
+deploy email, or pipe it to a custom publisher. Default output path:
+`RELEASE_NOTES_<tag>.md`.
+
+### Custom CI / other remote
+
+Capture `release.sh` output and feed it into whatever your pipeline
+expects:
+
+```bash
+BODY=$(bash .specflow/scripts/release/release.sh v1.2.3)
+# … hand `$BODY` to your custom publisher
+```
 
 ## Important — release-notes contract
 

--- a/templates/core/skills/specflow/scripts/release-local.sh
+++ b/templates/core/skills/specflow/scripts/release-local.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Local-only release flow: generate categorized release notes for a tag
+# and write them to a Markdown file in the current directory. No remote
+# API calls. No tag pushing. Use when the project has no GitHub/GitLab
+# remote — or when you just want a Markdown artifact you can paste into
+# any release UI or attach to a deploy email.
+#
+# Usage: release-local.sh [--baseline <tag>] [--out <path>] [<tag>]
+#   <tag>           default: latest tag (git describe --tags --abbrev=0)
+#   --baseline      override the auto-detected baseline (default: previous
+#                   tag by date — there is no "deployed" notion for local)
+#   --out           output path (default: RELEASE_NOTES_<tag>.md)
+set -euo pipefail
+
+TAG=""
+BASELINE=""
+OUT=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --baseline) BASELINE="$2"; shift 2 ;;
+    --baseline=*) BASELINE="${1#--baseline=}"; shift ;;
+    --out) OUT="$2"; shift 2 ;;
+    --out=*) OUT="${1#--out=}"; shift ;;
+    --help|-h)
+      echo "usage: release-local.sh [--baseline <tag>] [--out <path>] [<tag>]"
+      exit 0
+      ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) TAG="$1"; shift ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -z "$TAG" ]; then
+  TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+  if [ -z "$TAG" ]; then
+    echo "no tags found — create one first with tag.sh" >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+  echo "tag '$TAG' not found locally" >&2
+  exit 1
+fi
+
+# Compose release.sh args
+ARGS=()
+[ -n "$BASELINE" ] && ARGS+=(--baseline "$BASELINE")
+ARGS+=("$TAG")
+
+BODY=$(bash "$SCRIPT_DIR/release.sh" "${ARGS[@]}")
+
+if [ -z "$OUT" ]; then
+  OUT="RELEASE_NOTES_${TAG}.md"
+fi
+
+printf '%s\n' "$BODY" > "$OUT"
+
+LINES=$(wc -l < "$OUT" | tr -d ' ')
+echo "✓ wrote $OUT ($LINES lines)"
+echo "  paste contents into your release UI, attach to a deploy email,"
+echo "  or pipe to a custom publisher"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -19,6 +19,7 @@
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },
     { "category": "phase-script", "name": "release-gitlab", "suffix": "release-gitlab.sh", "source": "core/skills/specflow/scripts/release-gitlab.sh", "executable": true },
+    { "category": "phase-script", "name": "release-local", "suffix": "release-local.sh", "source": "core/skills/specflow/scripts/release-local.sh", "executable": true },
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 


### PR DESCRIPTION
## Summary

Last child of epic #226. Ships `release-local.sh` — for projects with no GitHub/GitLab remote, or when the user just wants a Markdown file to paste into any release UI.

## What it does

- Calls `release.sh` to generate the categorized release body (10-bucket Conventional Commits classifier — same as the remote wrappers)
- Writes the result to `RELEASE_NOTES_<tag>.md` in the current directory (override with `--out <path>`)
- **Zero remote API calls**, never pushes the tag, no auth required

## What it does NOT do

- No remote create / push / publish — there's no remote to publish to in this mode
- No idempotency check (the file overwrites locally; cheap operation)
- No "previous deployed tag" baseline — falls back to release.sh's default (previous tag by date), since there's no "deployed" notion when local-only

## Live verification

```
$ bash release-local.sh
✓ wrote RELEASE_NOTES_v26.5.14b.md (14 lines)
  paste contents into your release UI, attach to a deploy email,
  or pipe to a custom publisher

$ cat RELEASE_NOTES_v26.5.14b.md
## What's changed in v26.5.14b
_Initial release — all commits up to \`v26.5.14b\`._
### Features
- 55e1545 feat: x
### Chores
- 3f761b5 chore: first
---
Commit: \`55e1545\`
```

## Files

- `templates/core/skills/specflow/scripts/release-local.sh` (new)
- `templates/manifest.json` — new `phase-script` entry
- `templates/core/skills/specflow/phases/release-version.md` — all three wrappers documented with parallel structure
- `plugin/skills/specflow/phases/release-version.md` — mirrored
- `docs/llms.md` — adds the local wrapper alongside the GitHub + GitLab ones
- `.claude/skills/test-sandbox/scripts/smoke-tag-release.sh` — 4 new assertions (30 checks total)

Closes #230

## Test plan

- [x] `deno task test` — 594 passed, 0 failed
- [x] `smoke-tag-release.sh` — 30/30 checks green
- [x] End-to-end roundtrip on a throwaway date-based-tag repo — clean categorized body written to disk
- [x] Pre-commit fmt + lint + bundle + check — green

## Epic #226 status after merge

| Child | Status |
|-------|--------|
| #227 core | ✅ shipped (#233) |
| #228 GitHub | ✅ shipped (#234) |
| #229 GitLab | ✅ shipped (#235) |
| **#230 local** | ✅ this PR (#236) |
| #231 bundle/smoke | ❌ not_planned (subsumed) |
| #232 docs | ❌ not_planned (subsumed) |

Once this merges, epic #226 is fully done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)