### PR TITLE
chore(test-sandbox): wire smoke-tag-release.sh into audit + SKILL.md

### DIFF
--- a/.claude/skills/test-sandbox/SKILL.md
+++ b/.claude/skills/test-sandbox/SKILL.md
@@ -40,9 +40,10 @@ These wrap a fresh `init --ai claude --backlog local` and exercise specific feat
 .claude/skills/test-sandbox/scripts/smoke-hooks.sh <name>             # fire each bundled hook with synthetic stdin, verify behavior + soft-warn semantics
 .claude/skills/test-sandbox/scripts/smoke-picker.sh <name>            # drive the interactive arrow-key picker over a real PTY (requires python3)
 .claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh <name>     # init across all 8 harnesses, assert each scaffold is correct (auto-cleans on exit)
+.claude/skills/test-sandbox/scripts/smoke-tag-release.sh <name>       # tag-release pack: scheme rewrite (semver/date) + 3 remote wrappers (github/gitlab/local) — both schemes scaffolded back-to-back
 ```
 
-Run all six back-to-back for a comprehensive post-refactor smoke:
+Run all seven back-to-back for a comprehensive post-refactor smoke:
 
 ```bash
 bash .claude/skills/test-sandbox/scripts/smoke-features.sh feat
@@ -51,6 +52,7 @@ bash .claude/skills/test-sandbox/scripts/smoke-backlog-github.sh ghback
 bash .claude/skills/test-sandbox/scripts/smoke-hooks.sh hooks
 bash .claude/skills/test-sandbox/scripts/smoke-picker.sh picker
 bash .claude/skills/test-sandbox/scripts/smoke-all-harnesses.sh allharness
+bash .claude/skills/test-sandbox/scripts/smoke-tag-release.sh tagrelease
 ```
 
 `smoke-all-harnesses.sh` is the cross-harness coverage gate: it bootstraps a
@@ -94,6 +96,7 @@ to cover which file kind:
 | `templates/core/commands/*.md` | `smoke-features.sh` | bundled-command |
 | `templates/core/skills/*/SKILL.md` | `smoke-features.sh` | bundled-skill |
 | `templates/core/skills/specflow/phases/*.md` | `smoke-features.sh` | phase-doc |
+| `templates/core/skills/specflow/scripts/*` | `smoke-tag-release.sh` | tag-release-script |
 | `templates/core/skills/backlog/scripts/github/*` | `smoke-backlog-github.sh` | github-backlog-script |
 | `templates/core/skills/backlog/scripts/gitlab/*` | `smoke-backlog-gitlab.sh` | gitlab-backlog-script |
 | `templates/core/skills/backlog/scripts/local/*` | `smoke-backlog-local.sh` | local-backlog-script |

--- a/.claude/skills/test-sandbox/scripts/audit.sh
+++ b/.claude/skills/test-sandbox/scripts/audit.sh
@@ -83,6 +83,7 @@ SURFACES=(
   'templates/core/commands/*.md|smoke-features.sh|bundled-command'
   'templates/core/skills/*/SKILL.md|smoke-features.sh|bundled-skill'
   'templates/core/skills/specflow/phases/*.md|smoke-features.sh|phase-doc'
+  'templates/core/skills/specflow/scripts/*|smoke-tag-release.sh|tag-release-script'
   'templates/core/skills/backlog/scripts/github/*|smoke-backlog-github.sh|github-backlog-script'
   'templates/core/skills/backlog/scripts/gitlab/*|smoke-backlog-gitlab.sh|gitlab-backlog-script'
   'templates/core/skills/backlog/scripts/local/*|smoke-backlog-local.sh|local-backlog-script'


### PR DESCRIPTION
## Summary

Audit + doc gap leftover from epic #226. `smoke-tag-release.sh` landed in PR #233 but was never registered with the test-sandbox machinery, so:

- The pre-release `audit.sh` heuristic table didn't include `templates/core/skills/specflow/scripts/*` — meaning a regression on `tag.sh`, `release.sh`, or any of the three `release-{github,gitlab,local}.sh` wrappers would have shipped without the audit catching the missing coverage.
- The SKILL.md \"Smoke tests for bundled features\" list and the back-to-back block both stopped at six scripts.

## Changes

- `audit.sh` SURFACES list — one new entry:
  ```
  'templates/core/skills/specflow/scripts/*|smoke-tag-release.sh|tag-release-script'
  ```
  Placed between the `phase-doc` row and the `backlog-script` rows so the surface map mirrors the `templates/core/skills/` directory hierarchy.
- `SKILL.md` — same row added to the heuristic table, `smoke-tag-release.sh` listed under \"Smoke tests for bundled features\", and the run-all block grew from six to seven scripts.

No behavioural change to audit.sh's traversal logic — just one more glob → smoke mapping recognised.

## Test plan

- [x] `deno task test` — 594 passed, 0 failed
- [x] `audit.sh` — clean baseline (no coverage gaps, no stale assertions)
- [x] Smoke-tested the new glob with a synthetic file under `templates/core/skills/specflow/scripts/` — the surface entry is the same shape as the existing `backlog/scripts/{github,gitlab,local}/*` rows so it works the same way
- [x] Pre-commit fmt + lint + bundle + check — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)