### PR TITLE
feat(agents): give each bundled agent a distinct color

### DIFF
--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -4,6 +4,7 @@ description: Reviews code quality, architecture, DRY/YAGNI, readability, and con
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
+color: yellow
 ---
 
 You are a **senior code reviewer**. Review ONLY the files provided. Do not

--- a/plugin/agents/developer.md
+++ b/plugin/agents/developer.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
+color: blue
 ---
 
 You are a **senior developer** on this project. Your sole mission is to

--- a/plugin/agents/devops-sre.md
+++ b/plugin/agents/devops-sre.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
+color: orange
 ---
 
 You are the **DevOps / SRE** for this project. Your remit is everything

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -4,6 +4,7 @@ description: Product Owner and business guardian. Owns the product backlog, all 
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
 maxTurns: 30
+color: cyan
 ---
 
 You are the **Product Owner** for this project — the single source of truth

--- a/plugin/agents/qa-tester.md
+++ b/plugin/agents/qa-tester.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
+color: green
 ---
 
 You are the **QA tester** for this project.

--- a/plugin/agents/review-coordinator.md
+++ b/plugin/agents/review-coordinator.md
@@ -4,6 +4,7 @@ description: Coordinates parallel structural review agents (code, security, test
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 maxTurns: 30
+color: purple
 ---
 
 You are the **review coordinator**. Your only job is to run structural review

--- a/plugin/agents/security-auditor.md
+++ b/plugin/agents/security-auditor.md
@@ -4,6 +4,7 @@ description: Reviews code for security issues — input validation, authz, secre
 model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 20
+color: red
 ---
 
 You are a **security auditor**. You operate in one of two modes depending

--- a/plugin/agents/specflow-expert.md
+++ b/plugin/agents/specflow-expert.md
@@ -13,6 +13,7 @@ tools: Read, WebFetch, Grep, Glob
 permissionMode: default
 maxTurns: 10
 disable-model-invocation: false
+color: pink
 ---
 
 You are the **Specflow expert**. Your job is to explain how Specflow

--- a/plugin/agents/test-reviewer.md
+++ b/plugin/agents/test-reviewer.md
@@ -4,6 +4,7 @@ description: Reviews test coverage and quality for changed code. Spawned by the 
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
+color: yellow
 ---
 
 You are a **test reviewer**. Review ONLY the test files in the diff, cross-

--- a/plugin/agents/ui-ux-designer.md
+++ b/plugin/agents/ui-ux-designer.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Edit, Write, Glob, Grep
 maxTurns: 30
 disable-model-invocation: true
+color: pink
 ---
 
 You are a **UI/UX designer**. You own a single source of truth — the

--- a/plugin/agents/workflow-manager.md
+++ b/plugin/agents/workflow-manager.md
@@ -4,6 +4,7 @@ description: Orchestrates multi-phase feature delivery across specialist agents.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
 maxTurns: 60
+color: purple
 ---
 
 You are the **workflow manager** for this project.

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -2,8 +2,21 @@ import type { BundleOptions, Harness } from "../../application/ports.ts";
 import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { skillFolderName } from "./skill_folder.ts";
+import { splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+
+// Cascade ignores Claude-only frontmatter fields (e.g. `color:`). Strip them
+// before emission so they don't eat into the 12k-char workflow cap.
+function stripCascadeIgnoredFields(content: string): string {
+  const split = splitFrontmatter(content);
+  if (!split) return content;
+  const cleaned = split.fmBody
+    .split("\n")
+    .filter((line) => !/^color\s*:/.test(line))
+    .join("\n");
+  return `---\n${cleaned}\n---\n${split.rest}`;
+}
 
 /**
  * Windsurf's per-workflow character cap. Cascade silently truncates at this
@@ -55,7 +68,7 @@ export class WindsurfHarness implements Harness {
       // agent-memory is Claude-only (folder convention); other harnesses skip.
       if (entry.category === "agent-memory") continue;
       out[destinationFor(entry)] = {
-        content: entry.content,
+        content: stripCascadeIgnoredFields(entry.content),
         executable: entry.executable,
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
         ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2938,6 +2938,7 @@ description: Product Owner and business guardian. Owns the product backlog, all 
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
 maxTurns: 30
+color: cyan
 ---
 
 You are the **Product Owner** for this project — the single source of truth
@@ -3236,6 +3237,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
+color: blue
 ---
 
 You are a **senior developer** on this project. Your sole mission is to
@@ -3311,6 +3313,7 @@ description: Coordinates parallel structural review agents (code, security, test
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 maxTurns: 30
+color: purple
 ---
 
 You are the **review coordinator**. Your only job is to run structural review
@@ -3367,6 +3370,7 @@ description: Reviews code quality, architecture, DRY/YAGNI, readability, and con
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
+color: yellow
 ---
 
 You are a **senior code reviewer**. Review ONLY the files provided. Do not
@@ -3422,6 +3426,7 @@ description: Reviews code for security issues — input validation, authz, secre
 model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 20
+color: red
 ---
 
 You are a **security auditor**. You operate in one of two modes depending
@@ -3551,6 +3556,7 @@ description: Reviews test coverage and quality for changed code. Spawned by the 
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
+color: yellow
 ---
 
 You are a **test reviewer**. Review ONLY the test files in the diff, cross-
@@ -3591,6 +3597,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
+color: green
 ---
 
 You are the **QA tester** for this project.
@@ -3648,6 +3655,7 @@ description: Orchestrates multi-phase feature delivery across specialist agents.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
 maxTurns: 60
+color: purple
 ---
 
 You are the **workflow manager** for this project.
@@ -3712,6 +3720,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
+color: orange
 ---
 
 You are the **DevOps / SRE** for this project. Your remit is everything
@@ -3833,6 +3842,7 @@ tools: Read, WebFetch, Grep, Glob
 permissionMode: default
 maxTurns: 10
 disable-model-invocation: false
+color: pink
 ---
 
 You are the **Specflow expert**. Your job is to explain how Specflow
@@ -4111,6 +4121,7 @@ model: sonnet
 tools: Read, Edit, Write, Glob, Grep
 maxTurns: 30
 disable-model-invocation: true
+color: pink
 ---
 
 You are a **UI/UX designer**. You own a single source of truth — the

--- a/templates/core/agents/code-reviewer.md
+++ b/templates/core/agents/code-reviewer.md
@@ -4,6 +4,7 @@ description: Reviews code quality, architecture, DRY/YAGNI, readability, and con
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
+color: yellow
 ---
 
 You are a **senior code reviewer**. Review ONLY the files provided. Do not

--- a/templates/core/agents/developer.md
+++ b/templates/core/agents/developer.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
+color: blue
 ---
 
 You are a **senior developer** on this project. Your sole mission is to

--- a/templates/core/agents/devops-sre.md
+++ b/templates/core/agents/devops-sre.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
+color: orange
 ---
 
 You are the **DevOps / SRE** for this project. Your remit is everything

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -4,6 +4,7 @@ description: Product Owner and business guardian. Owns the product backlog, all 
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
 maxTurns: 30
+color: cyan
 ---
 
 You are the **Product Owner** for this project — the single source of truth

--- a/templates/core/agents/qa-tester.md
+++ b/templates/core/agents/qa-tester.md
@@ -6,6 +6,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
+color: green
 ---
 
 You are the **QA tester** for this project.

--- a/templates/core/agents/review-coordinator.md
+++ b/templates/core/agents/review-coordinator.md
@@ -4,6 +4,7 @@ description: Coordinates parallel structural review agents (code, security, test
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 maxTurns: 30
+color: purple
 ---
 
 You are the **review coordinator**. Your only job is to run structural review

--- a/templates/core/agents/security-auditor.md
+++ b/templates/core/agents/security-auditor.md
@@ -4,6 +4,7 @@ description: Reviews code for security issues — input validation, authz, secre
 model: sonnet
 tools: Read, Grep, Glob, Bash
 maxTurns: 20
+color: red
 ---
 
 You are a **security auditor**. You operate in one of two modes depending

--- a/templates/core/agents/specflow-expert.md
+++ b/templates/core/agents/specflow-expert.md
@@ -13,6 +13,7 @@ tools: Read, WebFetch, Grep, Glob
 permissionMode: default
 maxTurns: 10
 disable-model-invocation: false
+color: pink
 ---
 
 You are the **Specflow expert**. Your job is to explain how Specflow

--- a/templates/core/agents/test-reviewer.md
+++ b/templates/core/agents/test-reviewer.md
@@ -4,6 +4,7 @@ description: Reviews test coverage and quality for changed code. Spawned by the 
 model: sonnet
 tools: Read, Grep, Glob
 maxTurns: 20
+color: yellow
 ---
 
 You are a **test reviewer**. Review ONLY the test files in the diff, cross-

--- a/templates/core/agents/ui-ux-designer.md
+++ b/templates/core/agents/ui-ux-designer.md
@@ -5,6 +5,7 @@ model: sonnet
 tools: Read, Edit, Write, Glob, Grep
 maxTurns: 30
 disable-model-invocation: true
+color: pink
 ---
 
 You are a **UI/UX designer**. You own a single source of truth — the

--- a/templates/core/agents/workflow-manager.md
+++ b/templates/core/agents/workflow-manager.md
@@ -4,6 +4,7 @@ description: Orchestrates multi-phase feature delivery across specialist agents.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
 maxTurns: 60
+color: purple
 ---
 
 You are the **workflow manager** for this project.


### PR DESCRIPTION
## Summary

- Add `color:` frontmatter to each of the 11 bundled agents so Claude Code can render them distinctly in the task list / transcript (`https://code.claude.com/docs/fr/sub-agents`). Same change mirrored in `plugin/agents/` (required by `plugin_sync_test.ts` byte-identity).
- Side-effect: Adding 12 chars to `specflow-expert.md` pushed the Windsurf-emitted workflow over the 12k Cascade cap. Drop `color:` (Claude-only field Cascade never reads) at Windsurf emission to free the budget back.

## Color mapping (8 valid Claude Code values)

| Family | Color | Agents |
| --- | --- | --- |
| Security | red | `security-auditor` |
| Builder | blue | `developer` |
| Validation | green | `qa-tester` |
| Reviewer | yellow | `code-reviewer`, `test-reviewer` |
| Orchestrator | purple | `review-coordinator`, `workflow-manager` |
| Infra | orange | `devops-sre` |
| Advisor | pink | `specflow-expert`, `ui-ux-designer` |
| Product | cyan | `product-owner` |

11 agents → 8 valid colors leaves three within-family doublons (reviewer / orchestrator / advisor). Non-Claude harnesses unaffected: Codex/Copilot/Gemini already rewrite or strip the frontmatter; Cursor/OpenCode/Antigravity pass verbatim and ignore unknown YAML keys.

## Test plan

- [x] `deno task test` — 594 passed (was failing on the Windsurf char-cap before the strip).
- [x] `deno task fmt && deno task lint` — clean.
- [x] Pre-commit hook (fmt-check + lint + bundle + typecheck) passed.
- [ ] Eyeball after merge: scaffold a fresh Claude project, dispatch a couple of agents, verify the rendered colors match the mapping above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)