### PR TITLE
feat(backlog): mandatory grooming classification — Size, Priority, Issue Type, label

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -76,8 +76,9 @@ They never run `add.sh`, `move.sh`, `clarify-comment.sh`, or `gh issue
 You are typically dispatched with one of:
 
 - **"Add an issue for X"** — title (and optional body) provided. Decide
-  if the title is good as-is or needs sharpening, then `add.sh`. Return
-  the URL.
+  if the title is good as-is or needs sharpening, then `add.sh`. Then
+  **classify it** — Size + Priority + Issue Type + label — per
+  "Mandatory classification" below, in the same dispatch. Return the URL.
 - **"Clarify #N"** or **"process all current Backlog items"** — read the
   item, follow links, draft the body, decide the path (clarify
   autonomously / ask via comment / recommend archive).
@@ -169,12 +170,16 @@ For each mutation:
 
    Then:
    - `gh issue edit <num> --repo mkrlabs/specflow --body "<new body>"`
+   - **Classify it** — Size + Priority + Issue Type + label — per
+     "Mandatory classification" below. Not optional; do it before the
+     status move.
    - `.claude/skills/backlog/scripts/move.sh <num> Ready`
 
 6. **Final report.** When your dispatch ends, return a concise summary
    table with one row per item handled: number, title, action taken
    (`created` / `promoted` / `commented` / `moved-<status>` /
-   `closed-<reason>` / `recommended-archive`), and a one-line
+   `closed-<reason>` / `recommended-archive`), the classification
+   assigned (Size / Priority / Issue Type / label), and a one-line
    rationale. No walls of text.
 
    **When the dispatch was a "next" / "survey" / "what's next" call**
@@ -192,31 +197,52 @@ For each mutation:
    single-mutation dispatches (`add`, `move`, `close`) — there's no
    downstream phase to clean up for.
 
-## Sizing and priority — fields are the source of truth
+## Mandatory classification — every created or clarified item
 
-Project #4 has native single-select fields `Priority` (P0..P3) and
-`Size` (XS..XL). When you size or prioritise an item, write the value
-to the field via the helper below — **NEVER also apply a `priority:*`
-/ `size:*` label on an item that already has the native field**. The
-two are not peer signals; the label exists only as a fallback when the
-field cannot accept the value. Anything else is the dual-signal drift
-that prompted #194.
+Classifying an item is **part of grooming, not optional polish**. Every
+issue you create or clarify MUST exit with all four axes set before your
+final report. This is a **gate**: an unclassified item is not done.
+
+1. **Size** — `set-field.sh <num> Size <XS|S|M|L|XL>`.
+2. **Priority** — `set-field.sh <num> Priority <P0|P1|P2|P3>` (land the
+   value with the prioritisation framework — see your memory).
+3. **Issue Type** — `set-field.sh <num> IssueType <Task|Bug|Feature>`.
+   `Feature` = new capability; `Bug` = defect / regression; `Task` =
+   chore, docs, tooling, or pure refactor.
+4. **Label** — at least one, from the repo's available set (see your
+   `github-labels` memory — only the default GitHub labels exist).
+   `enhancement` for features, `bug` for defects, `documentation` for
+   docs-only work.
+
+Project #4 carries native single-select fields `Priority` (P0..P3) and
+`Size` (XS..XL); the `mkrlabs` org carries native Issue Types. The
+`set-field.sh` helper writes all three. **NEVER also apply a
+`priority:*` / `size:*` / `type:*` label on an item that already has the
+native field or type** — the two are not peer signals; the label is a
+fallback only. That dual-signal drift is what #194 fixed.
 
 ```
-set-field.sh <issue> Priority P1     # writes the field
+set-field.sh <issue> Priority P1      # writes the native field
 set-field.sh <issue> Size M
+set-field.sh <issue> IssueType Feature
 ```
 
 Helper at `.claude/skills/backlog/scripts/set-field.sh`. Exit codes:
-- `0` → field updated, no label needed (the only happy path).
-- `10` → no such field on Project #4 (shouldn't happen — but if it
-  does, fall back to `priority:*` / `size:*` labels and surface the
-  drift in the report).
-- `11` → field present but option missing on Project #4. Add the
-  option to the field (Project settings → field → "+" Add option, or
-  the `updateProjectV2Field` GraphQL mutation) and re-run rather than
-  silently falling back to a label.
-- `12` → issue not on Project #4. Resolve the attachment first.
+- `0` → field / type set, no label needed (the only happy path).
+- `10` → no such field / type on the project / org → fall back to the
+  matching label and surface the drift in the report.
+- `11` → field / type present but the value is unrecognised. For
+  Priority/Size, add the option to the field (Project settings → field
+  → "+" Add option, or the `updateProjectV2Field` mutation) and re-run;
+  for IssueType, you passed something other than Task/Bug/Feature — fix
+  the call.
+- `12` → issue not on Project #4 / not in the repo. Resolve the
+  attachment first.
+
+If any of the four axes cannot be persisted (auth, rate-limit, scope),
+the item does **not** silently ship under-classified — surface it under
+a `⚠ classification incomplete` line in your final report. A silent
+skip is a contract violation.
 
 The legacy `priority:*` / `size:*` labels were swept off the open
 issues by `.claude/skills/backlog/scripts/migrate-labels-to-fields.sh`

--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -17,3 +17,4 @@ treatment is now part of normal conventions).
 - [GitHub labels](github-labels.md) — only the 9 default GitHub labels exist; do not use ux/docs/friction slugs
 - [Plugin distribution](plugin-distribution.md) — install command, slash-command namespace, 21 assets, 3 install paths, upgrade migration, check --project gap warn
 - [Size and priority — native fields are source of truth](size-priority-labels.md) — Priority/Size are native Project fields; labels are strict fallback only; Project #4 option IDs pinned post #194 (PR #196); re-fetch IDs after any updateProjectV2Field call
+- [Issue Type classification](issue-type-classification.md) — gh issue edit --type unsupported; use GraphQL updateIssue; mkrlabs type IDs pinned; mandatory checklist: Size + Priority + IssueType + label + Ready before final report

--- a/.claude/agents/product-owner/memory/MEMORY.md
+++ b/.claude/agents/product-owner/memory/MEMORY.md
@@ -17,4 +17,5 @@ treatment is now part of normal conventions).
 - [GitHub labels](github-labels.md) — only the 9 default GitHub labels exist; do not use ux/docs/friction slugs
 - [Plugin distribution](plugin-distribution.md) — install command, slash-command namespace, 21 assets, 3 install paths, upgrade migration, check --project gap warn
 - [Size and priority — native fields are source of truth](size-priority-labels.md) — Priority/Size are native Project fields; labels are strict fallback only; Project #4 option IDs pinned post #194 (PR #196); re-fetch IDs after any updateProjectV2Field call
-- [Issue Type classification](issue-type-classification.md) — gh issue edit --type unsupported; use GraphQL updateIssue; mkrlabs type IDs pinned; mandatory checklist: Size + Priority + IssueType + label + Ready before final report
+- [Issue Type classification](issue-type-classification.md) — set native Task/Bug/Feature via `set-field.sh <num> IssueType <…>` (REST PATCH under the hood); mandatory checklist: Size + Priority + IssueType + label + Ready before final report
+- [Prefer REST over GraphQL](rest-over-graphql.md) — GraphQL burns the shared quota far faster and exhausts independently; use raw `gh api graphql` only when no REST/CLI/MCP path exists

--- a/.claude/agents/product-owner/memory/issue-type-classification.md
+++ b/.claude/agents/product-owner/memory/issue-type-classification.md
@@ -1,6 +1,6 @@
 ---
 name: issue-type-classification
-description: How to set native GitHub Issue Types (Task/Bug/Feature) on mkrlabs/specflow issues — gh issue edit --type is not supported; use GraphQL updateIssue mutation
+description: How to set native GitHub Issue Types (Task/Bug/Feature) on mkrlabs/specflow issues — use set-field.sh, which PATCHes the REST issues API
 type: reference
 ---
 
@@ -11,29 +11,19 @@ Setting Issue Type is mandatory on every created or clarified issue, alongside S
 ## Mechanism
 
 **Use `set-field.sh <num> IssueType <Task|Bug|Feature>`** — as of epic #241 the
-helper wraps the whole flow (resolves the org type ID, resolves the issue node
-ID, runs the mutation). Same exit-code contract as Priority/Size: `0` ok,
-`10` org has no such type, `11` value unrecognised, `12` issue not found.
+helper handles it in one call. Same exit-code contract as Priority/Size:
+`0` ok, `10` repo/org has no such native type, `11` value unrecognised,
+`12` issue not found.
 
-Under the hood it runs the `updateIssue` GraphQL mutation, since
-`gh issue edit --type` is not supported in the pinned CLI version:
+Under the hood it does a single REST PATCH (`gh issue edit --type` is not in
+the pinned CLI version). REST takes the type **name** directly — no org/issue
+node-ID resolution, ~1 quota point vs the GraphQL `updateIssue` path:
 
 ```bash
-gh api graphql -f query='
-mutation($issueId: ID!, $issueTypeId: ID!) {
-  updateIssue(input: {id: $issueId, issueTypeId: $issueTypeId}) {
-    issue { number issueType { name } }
-  }
-}' -f issueId="<node-id>" -f issueTypeId="<type-node-id>"
+gh api -X PATCH repos/mkrlabs/specflow/issues/<N> -f type=Feature --jq '.type.name'
+# read the current type:
+gh api repos/mkrlabs/specflow/issues/<N> --jq '.type.name'
 ```
-
-## mkrlabs org issue type IDs (verified 2026-05-14)
-
-| Type    | ID                    |
-|---------|-----------------------|
-| Task    | `IT_kwDOBv46cs4BE7za` |
-| Bug     | `IT_kwDOBv46cs4BE7zd` |
-| Feature | `IT_kwDOBv46cs4BE7ze` |
 
 ## Classification heuristics
 

--- a/.claude/agents/product-owner/memory/issue-type-classification.md
+++ b/.claude/agents/product-owner/memory/issue-type-classification.md
@@ -1,0 +1,52 @@
+---
+name: issue-type-classification
+description: How to set native GitHub Issue Types (Task/Bug/Feature) on mkrlabs/specflow issues — gh issue edit --type is not supported; use GraphQL updateIssue mutation
+type: reference
+---
+
+## Contract
+
+Setting Issue Type is mandatory on every created or clarified issue, alongside Size, Priority, and a label.
+
+## Mechanism
+
+**Use `set-field.sh <num> IssueType <Task|Bug|Feature>`** — as of epic #241 the
+helper wraps the whole flow (resolves the org type ID, resolves the issue node
+ID, runs the mutation). Same exit-code contract as Priority/Size: `0` ok,
+`10` org has no such type, `11` value unrecognised, `12` issue not found.
+
+Under the hood it runs the `updateIssue` GraphQL mutation, since
+`gh issue edit --type` is not supported in the pinned CLI version:
+
+```bash
+gh api graphql -f query='
+mutation($issueId: ID!, $issueTypeId: ID!) {
+  updateIssue(input: {id: $issueId, issueTypeId: $issueTypeId}) {
+    issue { number issueType { name } }
+  }
+}' -f issueId="<node-id>" -f issueTypeId="<type-node-id>"
+```
+
+## mkrlabs org issue type IDs (verified 2026-05-14)
+
+| Type    | ID                    |
+|---------|-----------------------|
+| Task    | `IT_kwDOBv46cs4BE7za` |
+| Bug     | `IT_kwDOBv46cs4BE7zd` |
+| Feature | `IT_kwDOBv46cs4BE7ze` |
+
+## Classification heuristics
+
+- **Feature** — new capability, new behavior, agent evolution, new command/flag.
+- **Task** — internal work, docs-only, refactors, sync/bundle steps, test verification.
+- **Bug** — unexpected behavior, regression, incorrect output.
+
+## Mandatory classification checklist (every create or clarify)
+
+1. `set-field.sh <num> Size <XS|S|M|L|XL>`
+2. `set-field.sh <num> Priority <P0|P1|P2|P3>`
+3. `set-field.sh <num> IssueType <Task|Bug|Feature>`
+4. `gh issue edit --add-label <label>` (from: bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix)
+5. `move.sh <num> Ready` (only after body has ## Why / ## AC / ## Out of scope)
+
+All five steps before final report. No exceptions.

--- a/.claude/agents/product-owner/memory/rest-over-graphql.md
+++ b/.claude/agents/product-owner/memory/rest-over-graphql.md
@@ -1,0 +1,28 @@
+---
+name: rest-over-graphql
+description: Always prefer the REST API over raw GraphQL — GraphQL burns the shared quota far faster and exhausts independently of REST
+type: feedback
+---
+
+Always reach for REST (`gh api <path>` / `gh issue` / `gh project` CLI / `mcp__github__*`
+tools) before raw `gh api graphql`. Use raw GraphQL **only** when no REST/CLI/MCP path
+exists for that operation.
+
+**Why:** GraphQL and REST share the same 5,000-points/hour authenticated quota, but a
+GraphQL call is scored by query complexity and costs many times more than the REST
+equivalent — and the two buckets drain independently, so GraphQL can hit `0/5000` while
+REST still has thousands left. On 2026-05-14, a session's GraphQL bucket was fully
+exhausted by backlog dispatches while REST sat at ~4000 remaining; that blocked PR
+creation and field mutations until the hourly reset. The `set-field.sh` IssueType path
+was deliberately built on a single REST `PATCH .../issues/N -f type=…` call instead of
+the 3-call GraphQL `updateIssue` flow for exactly this reason.
+
+**How to apply:**
+- Reads → `gh issue view/list`, `gh api repos/…`, or `mcp__github__*` REST tools.
+- Issue Type → `set-field.sh <num> IssueType <…>` (REST PATCH under the hood).
+- Priority/Size → `set-field.sh` (`gh project item-edit`, the thin CLI wrapper).
+- Raw `gh api graphql` is the last resort — e.g. `updateProjectV2ItemFieldValue` and
+  the targeted project-item-ID lookup, which genuinely have no REST equivalent. Keep
+  those queries as small as possible.
+- This reinforces the agent prompt's "Tool preference order: CLI → MCP → GraphQL" — REST
+  always wins ties.

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -40,6 +40,7 @@ gh project view 4 --owner mkrlabs --format json | jq '.id'
 .claude/skills/backlog/scripts/add.sh "<title>" [body] [labels-csv]   # creates issue + attaches to project
 .claude/skills/backlog/scripts/move.sh <issue-number> <Status>        # Status = Backlog|Ready|"In progress"|"In review"|Done
 .claude/skills/backlog/scripts/clarify-comment.sh <issue> "<comment>" # leave a question on the issue
+.claude/skills/backlog/scripts/set-field.sh <issue> <Priority|Size|IssueType> <value>  # set native classification — see "Classification" below
 ```
 
 For closing or editing, just use `gh` directly — no wrapper needed:
@@ -60,9 +61,22 @@ Order of preference for any new backlog tool: `gh issue` / `gh project item-edit
 
 - **Titles** — short imperative phrases ("Add docx skill", not "I want to add a docx skill"). Lowercase OK; no leading emoji.
 - **Bodies** — once clarified, follow `## Why` / `## Acceptance criteria` / `## Out of scope` / optional `## Notes`. Keep it tight: half a page beats a vague essay.
-- **Labels** — optional. Project #4 has no priority field; Status carries the workflow state.
+- **Labels** — at least one classifying label per item, from the default GitHub label set. See "Classification" below.
 - **Drafts** (project items with no underlying issue) are not used. Every task is a real issue.
 - **Closing** — close the issue, don't just move to Done. The repo's issue history is the audit trail.
+
+## Classification — mandatory on every item
+
+Every issue the PO creates or clarifies MUST exit with all four axes set — this is a gate, not polish:
+
+| Axis | How | Values |
+| --- | --- | --- |
+| Size | `set-field.sh <num> Size <value>` | `XS` `S` `M` `L` `XL` |
+| Priority | `set-field.sh <num> Priority <value>` | `P0` `P1` `P2` `P3` |
+| Issue Type | `set-field.sh <num> IssueType <value>` | `Task` `Bug` `Feature` |
+| Label | `gh issue edit <num> --add-label <label>` | default GitHub label set only |
+
+`Priority` / `Size` are native Project #4 single-select fields; `Issue Type` is a native `mkrlabs`-org concept. `set-field.sh` writes all three — **never** also apply a `priority:*` / `size:*` / `type:*` label on an item that already carries the native field or type. `set-field.sh` exit codes: `0` ok · `10` field/type absent (fall back to a label) · `11` value unrecognised · `12` issue not on the project / repo.
 
 ## When NOT to use this skill
 

--- a/.claude/skills/backlog/scripts/set-field.sh
+++ b/.claude/skills/backlog/scripts/set-field.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Set a native Project V2 single-select field value (Priority or Size) on an
-# issue on Specflow's own Project #4. Hardcoded mirror of the templated helper
+# Set a native classification value on an issue on Specflow's own Project #4:
+# the Project V2 single-select fields Priority / Size, or the org-level native
+# Issue Type (Task / Bug / Feature). Hardcoded mirror of the templated helper
 # at templates/core/skills/backlog/scripts/github/set-field.sh.
 #
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
@@ -8,21 +9,27 @@
 # considered as a replacement but would paginate through 200+ items just to
 # find one (~12x slower). The bulky multi-issue case is in `list.sh`.
 #
-# The actual field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only
-# — `gh project item-edit` is the CLI wrapper, used below.
+# The Project V2 field mutation (`updateProjectV2ItemFieldValue`) is
+# GraphQL-only — `gh project item-edit` is the CLI wrapper, used below.
+# The Issue Type mutation (`updateIssue` with `issueTypeId`) is also
+# GraphQL-only; `gh issue edit --type` is not available in the pinned gh
+# version, so the raw mutation is used.
 #
-# Usage: set-field.sh <issue-number> <Priority|Size> <value>
+# Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
+#   Priority  → P0 | P1 | P2 | P3
+#   Size      → XS | S | M | L | XL
+#   IssueType → Task | Bug | Feature
 #
 # Exit codes:
-#   0   field updated
-#   10  no such field on the project (caller should fall back to a label)
-#   11  field exists but has no option matching <value> (caller should fall back to a label)
-#   12  issue is not on Project #4
+#   0   field / type updated
+#   10  no such field / type on the project / org (caller should fall back to a label)
+#   11  field / type present but the value is unrecognised (caller should fall back to a label)
+#   12  issue is not on Project #4 / not in the repo
 #   1   usage / unexpected error
 set -euo pipefail
 
 if [ "$#" -lt 3 ]; then
-  echo 'usage: set-field.sh <issue-number> <Priority|Size> <value>' >&2
+  echo 'usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>' >&2
   exit 1
 fi
 ISSUE="$1"
@@ -30,6 +37,53 @@ FIELD_NAME="$2"
 VALUE="$3"
 
 PROJECT_ID="PVT_kwDOBv46cs4BV4Gz"
+
+# Issue Type is an org-level native concept, not a Project V2 field — it has
+# its own mutation path and exits before the Priority/Size project-field code.
+case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
+  issuetype | type)
+    case "$VALUE" in
+      Task | Bug | Feature) ;;
+      *)
+        echo "unknown IssueType value '$VALUE' (Task|Bug|Feature)" >&2
+        exit 11
+        ;;
+    esac
+    # Resolve the org issue-type ID dynamically — IDs are org-scoped and
+    # stable, but a query keeps the script correct if the org is ever
+    # reconfigured.
+    TYPE_ID=$(gh api graphql -f query='
+      query($owner: String!) {
+        organization(login: $owner) {
+          issueTypes(first: 20) { nodes { id name } }
+        }
+      }' -f owner="mkrlabs" \
+      | jq -r --arg v "$VALUE" '.data.organization.issueTypes.nodes[]? | select(.name == $v) | .id')
+    if [ -z "$TYPE_ID" ] || [ "$TYPE_ID" = "null" ]; then
+      echo "org 'mkrlabs' has no issue type '$VALUE' — fall back to a label" >&2
+      exit 10
+    fi
+    ISSUE_NODE_ID=$(gh api graphql -f query='
+      query($num: Int!) {
+        repository(owner:"mkrlabs", name:"specflow") {
+          issue(number: $num) { id }
+        }
+      }' -F num="$ISSUE" \
+      | jq -r '.data.repository.issue.id')
+    if [ -z "$ISSUE_NODE_ID" ] || [ "$ISSUE_NODE_ID" = "null" ]; then
+      echo "issue #$ISSUE not found in mkrlabs/specflow" >&2
+      exit 12
+    fi
+    gh api graphql -f query='
+      mutation($id: ID!, $typeId: ID!) {
+        updateIssue(input: { id: $id, issueTypeId: $typeId }) {
+          issue { issueType { name } }
+        }
+      }' -f id="$ISSUE_NODE_ID" -f typeId="$TYPE_ID" >/dev/null
+    echo "✓ #$ISSUE IssueType → $VALUE"
+    exit 0
+    ;;
+esac
 
 case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
   priority)
@@ -62,7 +116,7 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
     esac
     ;;
   *)
-    echo "error: unsupported field '$FIELD_NAME' (Priority|Size)" >&2
+    echo "error: unsupported field '$FIELD_NAME' (Priority|Size|IssueType)" >&2
     exit 1
     ;;
 esac

--- a/.claude/skills/backlog/scripts/set-field.sh
+++ b/.claude/skills/backlog/scripts/set-field.sh
@@ -11,9 +11,9 @@
 #
 # The Project V2 field mutation (`updateProjectV2ItemFieldValue`) is
 # GraphQL-only — `gh project item-edit` is the CLI wrapper, used below.
-# The Issue Type mutation (`updateIssue` with `issueTypeId`) is also
-# GraphQL-only; `gh issue edit --type` is not available in the pinned gh
-# version, so the raw mutation is used.
+# The Issue Type is set via the REST issues API (`PATCH .../issues/N` with
+# `type`) — a single call that takes the type name directly, cheaper than
+# the GraphQL `updateIssue` path and with no node-ID resolution.
 #
 # Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
 #   Priority  → P0 | P1 | P2 | P3
@@ -49,38 +49,27 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
         exit 11
         ;;
     esac
-    # Resolve the org issue-type ID dynamically — IDs are org-scoped and
-    # stable, but a query keeps the script correct if the org is ever
-    # reconfigured.
-    TYPE_ID=$(gh api graphql -f query='
-      query($owner: String!) {
-        organization(login: $owner) {
-          issueTypes(first: 20) { nodes { id name } }
-        }
-      }' -f owner="mkrlabs" \
-      | jq -r --arg v "$VALUE" '.data.organization.issueTypes.nodes[]? | select(.name == $v) | .id')
-    if [ -z "$TYPE_ID" ] || [ "$TYPE_ID" = "null" ]; then
-      echo "org 'mkrlabs' has no issue type '$VALUE' — fall back to a label" >&2
-      exit 10
+    # Single REST PATCH — takes the type name directly. A 422 means the
+    # repo/org has no such native type (fall back to a label); a 404 means
+    # the issue doesn't exist.
+    if ! RESULT=$(gh api -X PATCH "repos/mkrlabs/specflow/issues/$ISSUE" \
+      -f type="$VALUE" --jq '.type.name' 2>&1); then
+      case "$RESULT" in
+        *"Validation Failed"* | *422*)
+          echo "repo has no native issue type '$VALUE' — fall back to a label" >&2
+          exit 10
+          ;;
+        *"Not Found"* | *404*)
+          echo "issue #$ISSUE not found in mkrlabs/specflow" >&2
+          exit 12
+          ;;
+        *)
+          echo "set IssueType failed: $RESULT" >&2
+          exit 1
+          ;;
+      esac
     fi
-    ISSUE_NODE_ID=$(gh api graphql -f query='
-      query($num: Int!) {
-        repository(owner:"mkrlabs", name:"specflow") {
-          issue(number: $num) { id }
-        }
-      }' -F num="$ISSUE" \
-      | jq -r '.data.repository.issue.id')
-    if [ -z "$ISSUE_NODE_ID" ] || [ "$ISSUE_NODE_ID" = "null" ]; then
-      echo "issue #$ISSUE not found in mkrlabs/specflow" >&2
-      exit 12
-    fi
-    gh api graphql -f query='
-      mutation($id: ID!, $typeId: ID!) {
-        updateIssue(input: { id: $id, issueTypeId: $typeId }) {
-          issue { issueType { name } }
-        }
-      }' -f id="$ISSUE_NODE_ID" -f typeId="$TYPE_ID" >/dev/null
-    echo "✓ #$ISSUE IssueType → $VALUE"
+    echo "✓ #$ISSUE IssueType → $RESULT"
     exit 0
     ;;
 esac

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -439,15 +439,19 @@ repo. Idempotent; never edits or deletes existing labels. The GitHub default `bu
 but never re-created. The full reference lives in `.specflow/LABELS.md` next to the install —
 including a guidance note for local backend users on tagging via task-file frontmatter.
 
-**Priority and Size — native fields are the source of truth.** When a GitHub project ships native
-`Priority` and/or `Size` single-select fields on Project V2, the bundled
-`.specflow/scripts/backlog/set-field.sh` writes the value to the field — and the PO **never** also
-applies a `priority:*` / `size:*` label on the same item. Labels are reserved as a strict fallback
-for projects whose board has no such field; they are not a peer signal. `set-field.sh` exit codes
-tell the caller which path applies: `0` = field updated, `10` = field absent (fall back to label),
-`11` = field present but option missing (add the option, then re-run; only fall back to a label if
-you can't add it), `12` = issue not on the project. `detect-fields.sh` (run once per groom) emits
-the field/option IDs into env vars for case-insensitive matching.
+**Mandatory classification — every groomed item is sized, prioritised, typed, and labelled.** The PO
+classifies every item it creates or clarifies along four axes — Size, Priority, Issue Type (`Task` /
+`Bug` / `Feature`), and at least one label — before the item is done; classification is a gate, not
+optional polish. On a GitHub project with native `Priority` / `Size` single-select fields and native
+Issue Types, the bundled
+`.specflow/scripts/backlog/set-field.sh <issue> <Priority|Size|IssueType> <value>` writes each to
+its native field or type — and the PO **never** also applies a `priority:*` / `size:*` / `type:*`
+label on an item that already carries the native value. Labels are a strict fallback for projects or
+orgs without the native field/type; they are not a peer signal. `set-field.sh` exit codes tell the
+caller which path applies: `0` = set, `10` = field/type absent (fall back to label), `11` = value
+unrecognised, `12` = issue not on the project / not in the repo. `detect-fields.sh` (run once per
+groom) emits the field/option IDs into env vars for case-insensitive matching. On GitLab the four
+axes are scoped labels via `glab`; on the local Markdown backend they live in task-file frontmatter.
 
 **Epics & sub-tasks.** Big work that needs decomposition lives as a parent **epic** with one or more
 **sub-tasks**. The link mechanism differs per backend, but the contract is the same: parents cannot

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -27,37 +27,41 @@ missing or empty, flag it to the user — the project is under-documented.
 4. **Business briefs** — provide context to other agents before they build.
 5. **Priority justification** — explain every priority change.
 
-## Mandatory sizing + priority contract (GitHub / GitLab backends)
+## Mandatory classification contract — every created or clarified item
 
-Every backlog item you touch MUST exit with both a size
-(`XS`..`XL`) and a priority (`P0`..`P3`) persisted. **Gate**, not polish.
+Classifying an item is part of grooming, not optional polish. Every
+backlog item you touch MUST exit with **all four axes** persisted before
+your final report — a **gate**, not polish:
 
-**GitHub — fields are the source of truth; labels are a STRICT
-fallback.** When the project has native single-select fields `Priority`
-and/or `Size`, write the value to the field and **NEVER** also apply
-a `priority:*` / `size:*` label on the same item — that's the dual-
-signal drift `set-field.sh` exists to prevent. Labels are reserved for
-projects whose board has no such field. Bundled scripts at
-`.specflow/scripts/backlog/`:
+1. **Size** — `XS`..`XL`
+2. **Priority** — `P0`..`P3`
+3. **Issue Type** — `Task` (chore / docs / tooling / refactor), `Bug`
+   (defect / regression), or `Feature` (new capability)
+4. **Label** — at least one classifying label (`enhancement`, `bug`,
+   `documentation`, …)
 
-- `detect-fields.sh` — env lines with field/option IDs (case-insensitive
-  match). Run once per groom run.
-- `set-field.sh <issue> <Priority|Size> <value>` — exit codes:
-  - `0` → wrote field, no label (preferred path).
-  - `10` → field absent on this project → apply matching label.
-  - `11` → field present but option missing → apply matching label.
-  - `12` → not on project → surface under `⚠ size / priority missing`.
+Persistence depends on the backend:
 
-If the fallback label is missing, `gh label create` / `glab label
-create` it (colors in the groom phase template), then `gh issue edit
---add-label` / `glab issue update --label`. Persistence failures
-(auth, rate-limit) MUST land under `⚠ size / priority missing` —
-silent skip is a contract violation. Full routing + migration details
-in `/specflow groom`'s phase template.
+- **GitHub** — when the project has native `Priority` / `Size` fields
+  and the org has native Issue Types, write through `set-field.sh
+  <issue> <Priority|Size|IssueType> <value>` and **NEVER** also apply a
+  `priority:*` / `size:*` / `type:*` label on the same item (the
+  dual-signal drift the helper exists to prevent). Exit codes: `0` wrote
+  field/type · `10` field/type absent · `11` value unrecognised · `12`
+  issue not on project/repo. On `10`/`11`, fall back to the matching
+  label (`gh label create` it first if missing). Run `detect-fields.sh`
+  once per groom to discover field/option IDs.
+- **GitLab** — no `set-field.sh`; all four axes are scoped labels via
+  `glab` (`priority::P1`, `size::M`, `type::feature`, plus a plain
+  label). Create scoped labels on first use if absent.
+- **Local Markdown** — classification lives in the task file's
+  frontmatter: `priority:` and `complexity:` (size) are already
+  mandatory schema keys; record the Issue Type in `category:`
+  (`feature` / `bug` / `task`). No labels.
 
-**GitLab** has no `set-field.sh` analogue yet; falls straight to
-scoped labels via `glab`. **Local Markdown** uses frontmatter
-(`priority:` / `complexity:` keys) instead of fields or labels.
+Persistence failures on any backend (auth, rate-limit, missing scope)
+MUST land under `⚠ classification incomplete` in your report — a silent
+skip is a contract violation.
 
 ## Backlog backend
 
@@ -101,17 +105,14 @@ created: YYYY-MM-DD
 ---
 ```
 
-`parent: "#NNN"` is the local-Markdown sub-task convention (since Markdown
-backlogs have no native parent/child link). It is **grep-friendly** — running
-`grep -l 'parent: "#042"' .specflow/backlog/*.md` lists every child of epic
-042. An issue with `parent: null` (or no `parent:` key) is either a top-level
-task or itself an epic.
+`parent: "#NNN"` is the local-Markdown sub-task convention — grep-friendly
+(`grep -l 'parent: "#042"' .specflow/backlog/*.md` lists every child of
+#042). A missing or `null` `parent:` means a top-level task or an epic.
 
 ## Epic concept
 
-An **epic** is a backlog item that owns one or more **sub-tasks**. The PO must
-be able to create them, reference them as a unit, and close the parent only
-when every child is closed.
+An **epic** owns one or more **sub-tasks**: the PO creates them, tracks them
+as a unit, and closes the parent only when every child is closed.
 
 ### Creating sub-tasks (all backends)
 
@@ -142,13 +143,12 @@ Fails fast (exit 3) if the parent doesn't exist.
   --reason {completed|not_planned}`. Skipping the move leaves the item
   stuck in `In progress` / `In review` indefinitely. Local Markdown is
   one step (flip `status: done` in frontmatter).
-- **Board hygiene sweep**: when asked to "clean the board" / "sweep stale
-  items", list every column via `gh project item-list <N> --owner <owner>
-  --format json` (the wrappers filter to `states:OPEN` and miss closed
-  items still attached). For items in `In progress` / `In review` whose
-  issue is `CLOSED`, or `OPEN` with a merged PR linked → `move.sh <num>
-  Done`. Mirror for `Done` items whose issue is REOPENED. Idempotent;
-  safe after every release or via `/loop 1d`.
+- **Board hygiene sweep**: on "clean the board" / "sweep stale items",
+  list every column via `gh project item-list <N> --owner <owner>
+  --format json` (the wrappers filter to `states:OPEN`, missing closed
+  items). Items in `In progress` / `In review` that are `CLOSED` (or
+  `OPEN` with a merged PR) → `move.sh <num> Done`; mirror `Done` items
+  REOPENED. Idempotent; safe after every release.
 
 ### Epic detection heuristic
 
@@ -203,17 +203,15 @@ Total > 7 → critical, 5–7 → high, 3–5 → medium, < 3 → low.
 
 ### `/backlog` or `/backlog list`
 
-Display the current backlog overview. On the local backend, render
-`.specflow/backlog.md` (or recompose it from the task files if the index
-drifted). On GitHub, list issues in the configured repo, grouped by priority
-label / project status.
+Display the backlog overview. Local: render `.specflow/backlog.md`
+(recompose from the task files if the index drifted). GitHub: list issues
+in the configured repo, grouped by priority / project status.
 
 ### `/backlog next`
 
-Recommend the top 3 tasks. For each: business justification, domain context,
-workflow recommendation (spec vs direct), quick-win indicator (≤3 pts), and
-the exact command to start. Skip sub-tasks whose parent epic is not yet
-ready.
+Recommend the top 3 tasks. For each: business justification, domain
+context, workflow recommendation (spec vs direct), quick-win indicator
+(≤3 pts), exact start command. Skip sub-tasks whose parent epic isn't ready.
 
 ### `/backlog add <title>`
 
@@ -225,15 +223,15 @@ request as a sub-task ("add X as a child of #042" / "subtask of the auth
 epic"), set the parent link as soon as the child exists (frontmatter
 `parent: "#042"` locally, sub-issue API call on GitHub).
 
-All persisted backlog artifacts MUST be written in English:
+Every created task MUST exit fully classified — Size, Priority, Issue
+Type, and at least one label — per the "Mandatory classification
+contract" above. Classification is part of the same dispatch, not a
+follow-up.
 
-- task titles
-- frontmatter values
-- task descriptions, scope, notes, acceptance criteria
-- backlog index entries
-- GitHub issue titles and bodies
-
-You may reply in chat in the user's conversation language.
+All persisted backlog artifacts — titles, frontmatter values, descriptions,
+scope, notes, acceptance criteria, index entries, GitHub issue titles and
+bodies — MUST be written in English. You may reply in chat in the user's
+conversation language.
 
 ### `/backlog update <id>`
 
@@ -254,20 +252,20 @@ number of open epics with at least one open child.
 
 Full grooming session — review priorities, re-estimate, flag blockers, audit
 epic / sub-task hygiene (orphaned children, parents that should be closed,
-sub-tasks that escaped a closed epic).
+sub-tasks that escaped a closed epic). Any item still missing a Size,
+Priority, Issue Type, or label gets classified on the spot — the
+"Mandatory classification contract" applies retroactively during a groom.
 
 ### `/backlog brief <id>`
 
 Generate a PO business brief for a developer: feature purpose, business
-rules, user stories, gotchas, acceptance criteria. If the task is part of an
-epic, include a one-line summary of the parent and the sibling sub-tasks for
-context.
+rules, user stories, gotchas, acceptance criteria. If the task is in an
+epic, add a one-line summary of the parent and sibling sub-tasks.
 
 ### `/backlog epic <id>`
 
-Show an epic with all its sub-tasks (status, complexity, who's working on
-what). Useful before estimating overall epic completion or when reporting
-progress to stakeholders.
+Show an epic with all its sub-tasks (status, complexity, owner). Useful
+before estimating epic completion or reporting progress.
 
 ## Rules
 
@@ -279,10 +277,5 @@ progress to stakeholders.
 - Respect epic semantics — never close a parent while children remain open.
 - Write in user's conversation language in chat, but always write persisted
   artifacts in English.
-
-## Compatibility note
-
-Epic / sub-task awareness is available from this version of the scaffolded
-PO onward. Older projects that pre-date this template will not have the
-`parent:` frontmatter key on existing tasks; that's fine — the PO treats a
-missing key as `parent: null`.
+- Projects pre-dating the epic feature have no `parent:` key on old tasks —
+  that's fine; a missing key is treated as `parent: null`.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2961,37 +2961,41 @@ missing or empty, flag it to the user — the project is under-documented.
 4. **Business briefs** — provide context to other agents before they build.
 5. **Priority justification** — explain every priority change.
 
-## Mandatory sizing + priority contract (GitHub / GitLab backends)
+## Mandatory classification contract — every created or clarified item
 
-Every backlog item you touch MUST exit with both a size
-(\`XS\`..\`XL\`) and a priority (\`P0\`..\`P3\`) persisted. **Gate**, not polish.
+Classifying an item is part of grooming, not optional polish. Every
+backlog item you touch MUST exit with **all four axes** persisted before
+your final report — a **gate**, not polish:
 
-**GitHub — fields are the source of truth; labels are a STRICT
-fallback.** When the project has native single-select fields \`Priority\`
-and/or \`Size\`, write the value to the field and **NEVER** also apply
-a \`priority:*\` / \`size:*\` label on the same item — that's the dual-
-signal drift \`set-field.sh\` exists to prevent. Labels are reserved for
-projects whose board has no such field. Bundled scripts at
-\`.specflow/scripts/backlog/\`:
+1. **Size** — \`XS\`..\`XL\`
+2. **Priority** — \`P0\`..\`P3\`
+3. **Issue Type** — \`Task\` (chore / docs / tooling / refactor), \`Bug\`
+   (defect / regression), or \`Feature\` (new capability)
+4. **Label** — at least one classifying label (\`enhancement\`, \`bug\`,
+   \`documentation\`, …)
 
-- \`detect-fields.sh\` — env lines with field/option IDs (case-insensitive
-  match). Run once per groom run.
-- \`set-field.sh <issue> <Priority|Size> <value>\` — exit codes:
-  - \`0\` → wrote field, no label (preferred path).
-  - \`10\` → field absent on this project → apply matching label.
-  - \`11\` → field present but option missing → apply matching label.
-  - \`12\` → not on project → surface under \`⚠ size / priority missing\`.
+Persistence depends on the backend:
 
-If the fallback label is missing, \`gh label create\` / \`glab label
-create\` it (colors in the groom phase template), then \`gh issue edit
---add-label\` / \`glab issue update --label\`. Persistence failures
-(auth, rate-limit) MUST land under \`⚠ size / priority missing\` —
-silent skip is a contract violation. Full routing + migration details
-in \`/specflow groom\`'s phase template.
+- **GitHub** — when the project has native \`Priority\` / \`Size\` fields
+  and the org has native Issue Types, write through \`set-field.sh
+  <issue> <Priority|Size|IssueType> <value>\` and **NEVER** also apply a
+  \`priority:*\` / \`size:*\` / \`type:*\` label on the same item (the
+  dual-signal drift the helper exists to prevent). Exit codes: \`0\` wrote
+  field/type · \`10\` field/type absent · \`11\` value unrecognised · \`12\`
+  issue not on project/repo. On \`10\`/\`11\`, fall back to the matching
+  label (\`gh label create\` it first if missing). Run \`detect-fields.sh\`
+  once per groom to discover field/option IDs.
+- **GitLab** — no \`set-field.sh\`; all four axes are scoped labels via
+  \`glab\` (\`priority::P1\`, \`size::M\`, \`type::feature\`, plus a plain
+  label). Create scoped labels on first use if absent.
+- **Local Markdown** — classification lives in the task file's
+  frontmatter: \`priority:\` and \`complexity:\` (size) are already
+  mandatory schema keys; record the Issue Type in \`category:\`
+  (\`feature\` / \`bug\` / \`task\`). No labels.
 
-**GitLab** has no \`set-field.sh\` analogue yet; falls straight to
-scoped labels via \`glab\`. **Local Markdown** uses frontmatter
-(\`priority:\` / \`complexity:\` keys) instead of fields or labels.
+Persistence failures on any backend (auth, rate-limit, missing scope)
+MUST land under \`⚠ classification incomplete\` in your report — a silent
+skip is a contract violation.
 
 ## Backlog backend
 
@@ -3035,17 +3039,14 @@ created: YYYY-MM-DD
 ---
 \`\`\`
 
-\`parent: "#NNN"\` is the local-Markdown sub-task convention (since Markdown
-backlogs have no native parent/child link). It is **grep-friendly** — running
-\`grep -l 'parent: "#042"' .specflow/backlog/*.md\` lists every child of epic
-042. An issue with \`parent: null\` (or no \`parent:\` key) is either a top-level
-task or itself an epic.
+\`parent: "#NNN"\` is the local-Markdown sub-task convention — grep-friendly
+(\`grep -l 'parent: "#042"' .specflow/backlog/*.md\` lists every child of
+#042). A missing or \`null\` \`parent:\` means a top-level task or an epic.
 
 ## Epic concept
 
-An **epic** is a backlog item that owns one or more **sub-tasks**. The PO must
-be able to create them, reference them as a unit, and close the parent only
-when every child is closed.
+An **epic** owns one or more **sub-tasks**: the PO creates them, tracks them
+as a unit, and closes the parent only when every child is closed.
 
 ### Creating sub-tasks (all backends)
 
@@ -3076,13 +3077,12 @@ Fails fast (exit 3) if the parent doesn't exist.
   --reason {completed|not_planned}\`. Skipping the move leaves the item
   stuck in \`In progress\` / \`In review\` indefinitely. Local Markdown is
   one step (flip \`status: done\` in frontmatter).
-- **Board hygiene sweep**: when asked to "clean the board" / "sweep stale
-  items", list every column via \`gh project item-list <N> --owner <owner>
-  --format json\` (the wrappers filter to \`states:OPEN\` and miss closed
-  items still attached). For items in \`In progress\` / \`In review\` whose
-  issue is \`CLOSED\`, or \`OPEN\` with a merged PR linked → \`move.sh <num>
-  Done\`. Mirror for \`Done\` items whose issue is REOPENED. Idempotent;
-  safe after every release or via \`/loop 1d\`.
+- **Board hygiene sweep**: on "clean the board" / "sweep stale items",
+  list every column via \`gh project item-list <N> --owner <owner>
+  --format json\` (the wrappers filter to \`states:OPEN\`, missing closed
+  items). Items in \`In progress\` / \`In review\` that are \`CLOSED\` (or
+  \`OPEN\` with a merged PR) → \`move.sh <num> Done\`; mirror \`Done\` items
+  REOPENED. Idempotent; safe after every release.
 
 ### Epic detection heuristic
 
@@ -3137,17 +3137,15 @@ Total > 7 → critical, 5–7 → high, 3–5 → medium, < 3 → low.
 
 ### \`/backlog\` or \`/backlog list\`
 
-Display the current backlog overview. On the local backend, render
-\`.specflow/backlog.md\` (or recompose it from the task files if the index
-drifted). On GitHub, list issues in the configured repo, grouped by priority
-label / project status.
+Display the backlog overview. Local: render \`.specflow/backlog.md\`
+(recompose from the task files if the index drifted). GitHub: list issues
+in the configured repo, grouped by priority / project status.
 
 ### \`/backlog next\`
 
-Recommend the top 3 tasks. For each: business justification, domain context,
-workflow recommendation (spec vs direct), quick-win indicator (≤3 pts), and
-the exact command to start. Skip sub-tasks whose parent epic is not yet
-ready.
+Recommend the top 3 tasks. For each: business justification, domain
+context, workflow recommendation (spec vs direct), quick-win indicator
+(≤3 pts), exact start command. Skip sub-tasks whose parent epic isn't ready.
 
 ### \`/backlog add <title>\`
 
@@ -3159,15 +3157,15 @@ request as a sub-task ("add X as a child of #042" / "subtask of the auth
 epic"), set the parent link as soon as the child exists (frontmatter
 \`parent: "#042"\` locally, sub-issue API call on GitHub).
 
-All persisted backlog artifacts MUST be written in English:
+Every created task MUST exit fully classified — Size, Priority, Issue
+Type, and at least one label — per the "Mandatory classification
+contract" above. Classification is part of the same dispatch, not a
+follow-up.
 
-- task titles
-- frontmatter values
-- task descriptions, scope, notes, acceptance criteria
-- backlog index entries
-- GitHub issue titles and bodies
-
-You may reply in chat in the user's conversation language.
+All persisted backlog artifacts — titles, frontmatter values, descriptions,
+scope, notes, acceptance criteria, index entries, GitHub issue titles and
+bodies — MUST be written in English. You may reply in chat in the user's
+conversation language.
 
 ### \`/backlog update <id>\`
 
@@ -3188,20 +3186,20 @@ number of open epics with at least one open child.
 
 Full grooming session — review priorities, re-estimate, flag blockers, audit
 epic / sub-task hygiene (orphaned children, parents that should be closed,
-sub-tasks that escaped a closed epic).
+sub-tasks that escaped a closed epic). Any item still missing a Size,
+Priority, Issue Type, or label gets classified on the spot — the
+"Mandatory classification contract" applies retroactively during a groom.
 
 ### \`/backlog brief <id>\`
 
 Generate a PO business brief for a developer: feature purpose, business
-rules, user stories, gotchas, acceptance criteria. If the task is part of an
-epic, include a one-line summary of the parent and the sibling sub-tasks for
-context.
+rules, user stories, gotchas, acceptance criteria. If the task is in an
+epic, add a one-line summary of the parent and sibling sub-tasks.
 
 ### \`/backlog epic <id>\`
 
-Show an epic with all its sub-tasks (status, complexity, who's working on
-what). Useful before estimating overall epic completion or when reporting
-progress to stakeholders.
+Show an epic with all its sub-tasks (status, complexity, owner). Useful
+before estimating epic completion or reporting progress.
 
 ## Rules
 
@@ -3213,13 +3211,8 @@ progress to stakeholders.
 - Respect epic semantics — never close a parent while children remain open.
 - Write in user's conversation language in chat, but always write persisted
   artifacts in English.
-
-## Compatibility note
-
-Epic / sub-task awareness is available from this version of the scaffolded
-PO onward. Older projects that pre-date this template will not have the
-\`parent:\` frontmatter key on existing tasks; that's fine — the PO treats a
-missing key as \`parent: null\`.
+- Projects pre-dating the epic feature have no \`parent:\` key on old tasks —
+  that's fine; a missing key is treated as \`parent: null\`.
 `,
     executable: false,
     backend: null,
@@ -4823,7 +4816,7 @@ project\` calls and read configuration from \`backlog-config.yml\`.
 .specflow/scripts/backlog/move.sh <number> <Status>   # sets Project Status field
 .specflow/scripts/backlog/clarify-comment.sh <num> "<question>"
 .specflow/scripts/backlog/detect-fields.sh                                 # discover native Priority/Size single-select fields → env lines
-.specflow/scripts/backlog/set-field.sh <num> <Priority|Size> <value>       # set the native Project V2 field; exit codes 10/11/12 signal label fallback
+.specflow/scripts/backlog/set-field.sh <num> <Priority|Size|IssueType> <value>  # set the native Project V2 field / org Issue Type; exit codes 10/11/12 signal label fallback
 .specflow/scripts/backlog/ensure-labels.sh                                 # idempotently bootstrap the 7 Specflow semantic labels (security/refactor/docs/tech-debt/dx/performance/dependency)
 \`\`\`
 
@@ -4851,18 +4844,20 @@ Specflow change — the skill is path-aware.
 - **Closing** — close the issue (don't just move to Done). The repo's
   issue history is the audit trail.
 - **Drafts** are not used. Every task is a real issue.
-- **Priority / Size — fields are the source of truth.** When the
-  project has native single-select \`Priority\` and/or \`Size\` fields,
-  always write through \`set-field.sh\` and **NEVER also apply a
-  matching \`priority:*\` / \`size:*\` label on the same item** — that
-  dual-signal drift is exactly what the helper exists to prevent.
-  Labels are reserved as a strict fallback for projects whose board
-  has no such field. Non-zero exit codes tell the caller which
-  fallback applies: \`10\` = field absent on the project (use the
-  label), \`11\` = field present but the value option is missing
-  (add the option to the field, then re-run; only fall back to a
-  label if you can't add the option), \`12\` = issue not on the
-  project.
+- **Classification is mandatory — every created or clarified item
+  exits with Size, Priority, Issue Type, and at least one label.**
+  \`Priority\` / \`Size\` are native Project V2 single-select fields;
+  \`Issue Type\` (\`Task\` / \`Bug\` / \`Feature\`) is a native org-level
+  concept. Write all three through \`set-field.sh\` and **NEVER also
+  apply a matching \`priority:*\` / \`size:*\` / \`type:*\` label on an item
+  that already carries the native field or type** — that dual-signal
+  drift is exactly what the helper exists to prevent. Labels are
+  reserved as a strict fallback for projects / orgs without the native
+  field or type. Non-zero exit codes tell the caller which fallback
+  applies: \`10\` = field / type absent (use the label), \`11\` = present
+  but the value is unrecognised (for Priority/Size, add the option to
+  the field then re-run; for Issue Type, fix the call), \`12\` = issue
+  not on the project / not in the repo.
 
 ### Prerequisites
 
@@ -5688,23 +5683,32 @@ echo "PROJECT_NODE_ID=\$(gh project view "\$PROJECT_NUMBER" --owner "\$REPO_OWNE
     name: "set-field",
     suffix: "set-field.sh",
     content: `#!/usr/bin/env bash
-# Set a native Project V2 single-select field value (Priority or Size) on an issue.
+# Set a native classification value on an issue: the Project V2 single-select
+# fields Priority / Size, or the org-level native Issue Type (Task / Bug /
+# Feature).
 #
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
-# projectItems(first:5)) — negligible quota cost (~2 points). The actual
+# projectItems(first:5)) — negligible quota cost (~2 points). The Project V2
 # field mutation (\`updateProjectV2ItemFieldValue\`) is GraphQL-only —
-# \`gh project item-edit\` is the CLI wrapper, used below.
+# \`gh project item-edit\` is the CLI wrapper, used below. The Issue Type
+# mutation (\`updateIssue\` with \`issueTypeId\`) is also GraphQL-only and is
+# called raw, since \`gh issue edit --type\` is not available everywhere.
 #
-# Usage: set-field.sh <issue-number> <Priority|Size> <value>
+# Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
 #   Examples:
 #     set-field.sh 42 Priority P1
 #     set-field.sh 42 Size M
+#     set-field.sh 42 IssueType Feature
+#
+# Issue Types are an org-level GitHub feature. On user-owned repos (no org)
+# the org query returns nothing and the script exits 10 so the caller falls
+# back to a \`type:*\` label.
 #
 # Exit codes:
-#   0   field updated
-#   10  no such field on the project (caller should fall back to a label)
-#   11  field exists but has no option matching <value> (caller should fall back to a label)
-#   12  issue is not on the project
+#   0   field / type updated
+#   10  no such field / type on the project / org (caller should fall back to a label)
+#   11  field / type present but the value is unrecognised (caller should fall back to a label)
+#   12  issue is not on the project / not in the repo
 #   1   usage / unexpected error
 set -euo pipefail
 
@@ -5712,7 +5716,7 @@ set -euo pipefail
 . "\$(dirname "\$0")/_config.sh"
 
 if [ "\$#" -lt 3 ]; then
-  echo 'usage: set-field.sh <issue-number> <Priority|Size> <value>' >&2
+  echo 'usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>' >&2
   exit 1
 fi
 NUM="\$1"
@@ -5721,11 +5725,56 @@ VALUE="\$3"
 
 # Normalize field name to one of the canonical labels we support.
 FIELD_LOWER=\$(echo "\$FIELD_NAME" | tr '[:upper:]' '[:lower:]')
+
+# Issue Type is an org-level native concept, not a Project V2 field — it has
+# its own mutation path and exits before the Priority/Size project-field code.
+if [ "\$FIELD_LOWER" = "issuetype" ] || [ "\$FIELD_LOWER" = "type" ]; then
+  case "\$VALUE" in
+    Task | Bug | Feature) ;;
+    *)
+      echo "unknown IssueType value '\$VALUE' (Task|Bug|Feature)" >&2
+      exit 11
+      ;;
+  esac
+  # Resolve the org issue-type ID dynamically — IDs are org-scoped and worth
+  # nothing hard-coded in a template.
+  TYPE_ID=\$(gh api graphql -f query='
+    query(\$owner: String!) {
+      organization(login: \$owner) {
+        issueTypes(first: 20) { nodes { id name } }
+      }
+    }' -f owner="\$REPO_OWNER" \\
+    | jq -r --arg v "\$VALUE" '.data.organization.issueTypes.nodes[]? | select(.name == \$v) | .id')
+  if [ -z "\$TYPE_ID" ] || [ "\$TYPE_ID" = "null" ]; then
+    echo "owner '\$REPO_OWNER' has no native issue type '\$VALUE' — fall back to a label" >&2
+    exit 10
+  fi
+  ISSUE_NODE_ID=\$(gh api graphql -f query='
+    query(\$owner: String!, \$name: String!, \$num: Int!) {
+      repository(owner: \$owner, name: \$name) {
+        issue(number: \$num) { id }
+      }
+    }' -f owner="\$REPO_OWNER" -f name="\$REPO_NAME" -F num="\$NUM" \\
+    | jq -r '.data.repository.issue.id')
+  if [ -z "\$ISSUE_NODE_ID" ] || [ "\$ISSUE_NODE_ID" = "null" ]; then
+    echo "issue #\$NUM not found in \$REPO_OWNER/\$REPO_NAME" >&2
+    exit 12
+  fi
+  gh api graphql -f query='
+    mutation(\$id: ID!, \$typeId: ID!) {
+      updateIssue(input: { id: \$id, issueTypeId: \$typeId }) {
+        issue { issueType { name } }
+      }
+    }' -f id="\$ISSUE_NODE_ID" -f typeId="\$TYPE_ID" >/dev/null
+  echo "✓ #\$NUM IssueType → \$VALUE"
+  exit 0
+fi
+
 case "\$FIELD_LOWER" in
   priority) PREFIX="PRIORITY" CANONICAL="Priority" ;;
   size)     PREFIX="SIZE"     CANONICAL="Size" ;;
   *)
-    echo "error: unsupported field '\$FIELD_NAME' (Priority|Size)" >&2
+    echo "error: unsupported field '\$FIELD_NAME' (Priority|Size|IssueType)" >&2
     exit 1
     ;;
 esac

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5690,9 +5690,10 @@ echo "PROJECT_NODE_ID=\$(gh project view "\$PROJECT_NUMBER" --owner "\$REPO_OWNE
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
 # projectItems(first:5)) — negligible quota cost (~2 points). The Project V2
 # field mutation (\`updateProjectV2ItemFieldValue\`) is GraphQL-only —
-# \`gh project item-edit\` is the CLI wrapper, used below. The Issue Type
-# mutation (\`updateIssue\` with \`issueTypeId\`) is also GraphQL-only and is
-# called raw, since \`gh issue edit --type\` is not available everywhere.
+# \`gh project item-edit\` is the CLI wrapper, used below. The Issue Type is
+# set via the REST issues API (\`PATCH .../issues/N\` with \`type\`) — a single
+# call that takes the type name directly, cheaper than the GraphQL
+# \`updateIssue\` path and with no node-ID resolution.
 #
 # Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
 #   Examples:
@@ -5736,37 +5737,27 @@ if [ "\$FIELD_LOWER" = "issuetype" ] || [ "\$FIELD_LOWER" = "type" ]; then
       exit 11
       ;;
   esac
-  # Resolve the org issue-type ID dynamically — IDs are org-scoped and worth
-  # nothing hard-coded in a template.
-  TYPE_ID=\$(gh api graphql -f query='
-    query(\$owner: String!) {
-      organization(login: \$owner) {
-        issueTypes(first: 20) { nodes { id name } }
-      }
-    }' -f owner="\$REPO_OWNER" \\
-    | jq -r --arg v "\$VALUE" '.data.organization.issueTypes.nodes[]? | select(.name == \$v) | .id')
-  if [ -z "\$TYPE_ID" ] || [ "\$TYPE_ID" = "null" ]; then
-    echo "owner '\$REPO_OWNER' has no native issue type '\$VALUE' — fall back to a label" >&2
-    exit 10
+  # Single REST PATCH — takes the type name directly. A 422 means the
+  # repo/org has no such native type (fall back to a label); a 404 means
+  # the issue doesn't exist.
+  if ! RESULT=\$(gh api -X PATCH "repos/\$REPO_OWNER/\$REPO_NAME/issues/\$NUM" \\
+    -f type="\$VALUE" --jq '.type.name' 2>&1); then
+    case "\$RESULT" in
+      *"Validation Failed"* | *422*)
+        echo "\$REPO_OWNER/\$REPO_NAME has no native issue type '\$VALUE' — fall back to a label" >&2
+        exit 10
+        ;;
+      *"Not Found"* | *404*)
+        echo "issue #\$NUM not found in \$REPO_OWNER/\$REPO_NAME" >&2
+        exit 12
+        ;;
+      *)
+        echo "set IssueType failed: \$RESULT" >&2
+        exit 1
+        ;;
+    esac
   fi
-  ISSUE_NODE_ID=\$(gh api graphql -f query='
-    query(\$owner: String!, \$name: String!, \$num: Int!) {
-      repository(owner: \$owner, name: \$name) {
-        issue(number: \$num) { id }
-      }
-    }' -f owner="\$REPO_OWNER" -f name="\$REPO_NAME" -F num="\$NUM" \\
-    | jq -r '.data.repository.issue.id')
-  if [ -z "\$ISSUE_NODE_ID" ] || [ "\$ISSUE_NODE_ID" = "null" ]; then
-    echo "issue #\$NUM not found in \$REPO_OWNER/\$REPO_NAME" >&2
-    exit 12
-  fi
-  gh api graphql -f query='
-    mutation(\$id: ID!, \$typeId: ID!) {
-      updateIssue(input: { id: \$id, issueTypeId: \$typeId }) {
-        issue { issueType { name } }
-      }
-    }' -f id="\$ISSUE_NODE_ID" -f typeId="\$TYPE_ID" >/dev/null
-  echo "✓ #\$NUM IssueType → \$VALUE"
+  echo "✓ #\$NUM IssueType → \$RESULT"
   exit 0
 fi
 

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -27,37 +27,41 @@ missing or empty, flag it to the user — the project is under-documented.
 4. **Business briefs** — provide context to other agents before they build.
 5. **Priority justification** — explain every priority change.
 
-## Mandatory sizing + priority contract (GitHub / GitLab backends)
+## Mandatory classification contract — every created or clarified item
 
-Every backlog item you touch MUST exit with both a size
-(`XS`..`XL`) and a priority (`P0`..`P3`) persisted. **Gate**, not polish.
+Classifying an item is part of grooming, not optional polish. Every
+backlog item you touch MUST exit with **all four axes** persisted before
+your final report — a **gate**, not polish:
 
-**GitHub — fields are the source of truth; labels are a STRICT
-fallback.** When the project has native single-select fields `Priority`
-and/or `Size`, write the value to the field and **NEVER** also apply
-a `priority:*` / `size:*` label on the same item — that's the dual-
-signal drift `set-field.sh` exists to prevent. Labels are reserved for
-projects whose board has no such field. Bundled scripts at
-`.specflow/scripts/backlog/`:
+1. **Size** — `XS`..`XL`
+2. **Priority** — `P0`..`P3`
+3. **Issue Type** — `Task` (chore / docs / tooling / refactor), `Bug`
+   (defect / regression), or `Feature` (new capability)
+4. **Label** — at least one classifying label (`enhancement`, `bug`,
+   `documentation`, …)
 
-- `detect-fields.sh` — env lines with field/option IDs (case-insensitive
-  match). Run once per groom run.
-- `set-field.sh <issue> <Priority|Size> <value>` — exit codes:
-  - `0` → wrote field, no label (preferred path).
-  - `10` → field absent on this project → apply matching label.
-  - `11` → field present but option missing → apply matching label.
-  - `12` → not on project → surface under `⚠ size / priority missing`.
+Persistence depends on the backend:
 
-If the fallback label is missing, `gh label create` / `glab label
-create` it (colors in the groom phase template), then `gh issue edit
---add-label` / `glab issue update --label`. Persistence failures
-(auth, rate-limit) MUST land under `⚠ size / priority missing` —
-silent skip is a contract violation. Full routing + migration details
-in `/specflow groom`'s phase template.
+- **GitHub** — when the project has native `Priority` / `Size` fields
+  and the org has native Issue Types, write through `set-field.sh
+  <issue> <Priority|Size|IssueType> <value>` and **NEVER** also apply a
+  `priority:*` / `size:*` / `type:*` label on the same item (the
+  dual-signal drift the helper exists to prevent). Exit codes: `0` wrote
+  field/type · `10` field/type absent · `11` value unrecognised · `12`
+  issue not on project/repo. On `10`/`11`, fall back to the matching
+  label (`gh label create` it first if missing). Run `detect-fields.sh`
+  once per groom to discover field/option IDs.
+- **GitLab** — no `set-field.sh`; all four axes are scoped labels via
+  `glab` (`priority::P1`, `size::M`, `type::feature`, plus a plain
+  label). Create scoped labels on first use if absent.
+- **Local Markdown** — classification lives in the task file's
+  frontmatter: `priority:` and `complexity:` (size) are already
+  mandatory schema keys; record the Issue Type in `category:`
+  (`feature` / `bug` / `task`). No labels.
 
-**GitLab** has no `set-field.sh` analogue yet; falls straight to
-scoped labels via `glab`. **Local Markdown** uses frontmatter
-(`priority:` / `complexity:` keys) instead of fields or labels.
+Persistence failures on any backend (auth, rate-limit, missing scope)
+MUST land under `⚠ classification incomplete` in your report — a silent
+skip is a contract violation.
 
 ## Backlog backend
 
@@ -101,17 +105,14 @@ created: YYYY-MM-DD
 ---
 ```
 
-`parent: "#NNN"` is the local-Markdown sub-task convention (since Markdown
-backlogs have no native parent/child link). It is **grep-friendly** — running
-`grep -l 'parent: "#042"' .specflow/backlog/*.md` lists every child of epic
-042. An issue with `parent: null` (or no `parent:` key) is either a top-level
-task or itself an epic.
+`parent: "#NNN"` is the local-Markdown sub-task convention — grep-friendly
+(`grep -l 'parent: "#042"' .specflow/backlog/*.md` lists every child of
+#042). A missing or `null` `parent:` means a top-level task or an epic.
 
 ## Epic concept
 
-An **epic** is a backlog item that owns one or more **sub-tasks**. The PO must
-be able to create them, reference them as a unit, and close the parent only
-when every child is closed.
+An **epic** owns one or more **sub-tasks**: the PO creates them, tracks them
+as a unit, and closes the parent only when every child is closed.
 
 ### Creating sub-tasks (all backends)
 
@@ -142,13 +143,12 @@ Fails fast (exit 3) if the parent doesn't exist.
   --reason {completed|not_planned}`. Skipping the move leaves the item
   stuck in `In progress` / `In review` indefinitely. Local Markdown is
   one step (flip `status: done` in frontmatter).
-- **Board hygiene sweep**: when asked to "clean the board" / "sweep stale
-  items", list every column via `gh project item-list <N> --owner <owner>
-  --format json` (the wrappers filter to `states:OPEN` and miss closed
-  items still attached). For items in `In progress` / `In review` whose
-  issue is `CLOSED`, or `OPEN` with a merged PR linked → `move.sh <num>
-  Done`. Mirror for `Done` items whose issue is REOPENED. Idempotent;
-  safe after every release or via `/loop 1d`.
+- **Board hygiene sweep**: on "clean the board" / "sweep stale items",
+  list every column via `gh project item-list <N> --owner <owner>
+  --format json` (the wrappers filter to `states:OPEN`, missing closed
+  items). Items in `In progress` / `In review` that are `CLOSED` (or
+  `OPEN` with a merged PR) → `move.sh <num> Done`; mirror `Done` items
+  REOPENED. Idempotent; safe after every release.
 
 ### Epic detection heuristic
 
@@ -203,17 +203,15 @@ Total > 7 → critical, 5–7 → high, 3–5 → medium, < 3 → low.
 
 ### `/backlog` or `/backlog list`
 
-Display the current backlog overview. On the local backend, render
-`.specflow/backlog.md` (or recompose it from the task files if the index
-drifted). On GitHub, list issues in the configured repo, grouped by priority
-label / project status.
+Display the backlog overview. Local: render `.specflow/backlog.md`
+(recompose from the task files if the index drifted). GitHub: list issues
+in the configured repo, grouped by priority / project status.
 
 ### `/backlog next`
 
-Recommend the top 3 tasks. For each: business justification, domain context,
-workflow recommendation (spec vs direct), quick-win indicator (≤3 pts), and
-the exact command to start. Skip sub-tasks whose parent epic is not yet
-ready.
+Recommend the top 3 tasks. For each: business justification, domain
+context, workflow recommendation (spec vs direct), quick-win indicator
+(≤3 pts), exact start command. Skip sub-tasks whose parent epic isn't ready.
 
 ### `/backlog add <title>`
 
@@ -225,15 +223,15 @@ request as a sub-task ("add X as a child of #042" / "subtask of the auth
 epic"), set the parent link as soon as the child exists (frontmatter
 `parent: "#042"` locally, sub-issue API call on GitHub).
 
-All persisted backlog artifacts MUST be written in English:
+Every created task MUST exit fully classified — Size, Priority, Issue
+Type, and at least one label — per the "Mandatory classification
+contract" above. Classification is part of the same dispatch, not a
+follow-up.
 
-- task titles
-- frontmatter values
-- task descriptions, scope, notes, acceptance criteria
-- backlog index entries
-- GitHub issue titles and bodies
-
-You may reply in chat in the user's conversation language.
+All persisted backlog artifacts — titles, frontmatter values, descriptions,
+scope, notes, acceptance criteria, index entries, GitHub issue titles and
+bodies — MUST be written in English. You may reply in chat in the user's
+conversation language.
 
 ### `/backlog update <id>`
 
@@ -254,20 +252,20 @@ number of open epics with at least one open child.
 
 Full grooming session — review priorities, re-estimate, flag blockers, audit
 epic / sub-task hygiene (orphaned children, parents that should be closed,
-sub-tasks that escaped a closed epic).
+sub-tasks that escaped a closed epic). Any item still missing a Size,
+Priority, Issue Type, or label gets classified on the spot — the
+"Mandatory classification contract" applies retroactively during a groom.
 
 ### `/backlog brief <id>`
 
 Generate a PO business brief for a developer: feature purpose, business
-rules, user stories, gotchas, acceptance criteria. If the task is part of an
-epic, include a one-line summary of the parent and the sibling sub-tasks for
-context.
+rules, user stories, gotchas, acceptance criteria. If the task is in an
+epic, add a one-line summary of the parent and sibling sub-tasks.
 
 ### `/backlog epic <id>`
 
-Show an epic with all its sub-tasks (status, complexity, who's working on
-what). Useful before estimating overall epic completion or when reporting
-progress to stakeholders.
+Show an epic with all its sub-tasks (status, complexity, owner). Useful
+before estimating epic completion or reporting progress.
 
 ## Rules
 
@@ -279,10 +277,5 @@ progress to stakeholders.
 - Respect epic semantics — never close a parent while children remain open.
 - Write in user's conversation language in chat, but always write persisted
   artifacts in English.
-
-## Compatibility note
-
-Epic / sub-task awareness is available from this version of the scaffolded
-PO onward. Older projects that pre-date this template will not have the
-`parent:` frontmatter key on existing tasks; that's fine — the PO treats a
-missing key as `parent: null`.
+- Projects pre-dating the epic feature have no `parent:` key on old tasks —
+  that's fine; a missing key is treated as `parent: null`.

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -128,7 +128,7 @@ project` calls and read configuration from `backlog-config.yml`.
 .specflow/scripts/backlog/move.sh <number> <Status>   # sets Project Status field
 .specflow/scripts/backlog/clarify-comment.sh <num> "<question>"
 .specflow/scripts/backlog/detect-fields.sh                                 # discover native Priority/Size single-select fields → env lines
-.specflow/scripts/backlog/set-field.sh <num> <Priority|Size> <value>       # set the native Project V2 field; exit codes 10/11/12 signal label fallback
+.specflow/scripts/backlog/set-field.sh <num> <Priority|Size|IssueType> <value>  # set the native Project V2 field / org Issue Type; exit codes 10/11/12 signal label fallback
 .specflow/scripts/backlog/ensure-labels.sh                                 # idempotently bootstrap the 7 Specflow semantic labels (security/refactor/docs/tech-debt/dx/performance/dependency)
 ```
 
@@ -156,18 +156,20 @@ Specflow change — the skill is path-aware.
 - **Closing** — close the issue (don't just move to Done). The repo's
   issue history is the audit trail.
 - **Drafts** are not used. Every task is a real issue.
-- **Priority / Size — fields are the source of truth.** When the
-  project has native single-select `Priority` and/or `Size` fields,
-  always write through `set-field.sh` and **NEVER also apply a
-  matching `priority:*` / `size:*` label on the same item** — that
-  dual-signal drift is exactly what the helper exists to prevent.
-  Labels are reserved as a strict fallback for projects whose board
-  has no such field. Non-zero exit codes tell the caller which
-  fallback applies: `10` = field absent on the project (use the
-  label), `11` = field present but the value option is missing
-  (add the option to the field, then re-run; only fall back to a
-  label if you can't add the option), `12` = issue not on the
-  project.
+- **Classification is mandatory — every created or clarified item
+  exits with Size, Priority, Issue Type, and at least one label.**
+  `Priority` / `Size` are native Project V2 single-select fields;
+  `Issue Type` (`Task` / `Bug` / `Feature`) is a native org-level
+  concept. Write all three through `set-field.sh` and **NEVER also
+  apply a matching `priority:*` / `size:*` / `type:*` label on an item
+  that already carries the native field or type** — that dual-signal
+  drift is exactly what the helper exists to prevent. Labels are
+  reserved as a strict fallback for projects / orgs without the native
+  field or type. Non-zero exit codes tell the caller which fallback
+  applies: `10` = field / type absent (use the label), `11` = present
+  but the value is unrecognised (for Priority/Size, add the option to
+  the field then re-run; for Issue Type, fix the call), `12` = issue
+  not on the project / not in the repo.
 
 ### Prerequisites
 

--- a/templates/core/skills/backlog/scripts/github/set-field.sh
+++ b/templates/core/skills/backlog/scripts/github/set-field.sh
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
-# Set a native Project V2 single-select field value (Priority or Size) on an issue.
+# Set a native classification value on an issue: the Project V2 single-select
+# fields Priority / Size, or the org-level native Issue Type (Task / Bug /
+# Feature).
 #
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
-# projectItems(first:5)) — negligible quota cost (~2 points). The actual
+# projectItems(first:5)) — negligible quota cost (~2 points). The Project V2
 # field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only —
-# `gh project item-edit` is the CLI wrapper, used below.
+# `gh project item-edit` is the CLI wrapper, used below. The Issue Type
+# mutation (`updateIssue` with `issueTypeId`) is also GraphQL-only and is
+# called raw, since `gh issue edit --type` is not available everywhere.
 #
-# Usage: set-field.sh <issue-number> <Priority|Size> <value>
+# Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
 #   Examples:
 #     set-field.sh 42 Priority P1
 #     set-field.sh 42 Size M
+#     set-field.sh 42 IssueType Feature
+#
+# Issue Types are an org-level GitHub feature. On user-owned repos (no org)
+# the org query returns nothing and the script exits 10 so the caller falls
+# back to a `type:*` label.
 #
 # Exit codes:
-#   0   field updated
-#   10  no such field on the project (caller should fall back to a label)
-#   11  field exists but has no option matching <value> (caller should fall back to a label)
-#   12  issue is not on the project
+#   0   field / type updated
+#   10  no such field / type on the project / org (caller should fall back to a label)
+#   11  field / type present but the value is unrecognised (caller should fall back to a label)
+#   12  issue is not on the project / not in the repo
 #   1   usage / unexpected error
 set -euo pipefail
 
@@ -23,7 +32,7 @@ set -euo pipefail
 . "$(dirname "$0")/_config.sh"
 
 if [ "$#" -lt 3 ]; then
-  echo 'usage: set-field.sh <issue-number> <Priority|Size> <value>' >&2
+  echo 'usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>' >&2
   exit 1
 fi
 NUM="$1"
@@ -32,11 +41,56 @@ VALUE="$3"
 
 # Normalize field name to one of the canonical labels we support.
 FIELD_LOWER=$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')
+
+# Issue Type is an org-level native concept, not a Project V2 field — it has
+# its own mutation path and exits before the Priority/Size project-field code.
+if [ "$FIELD_LOWER" = "issuetype" ] || [ "$FIELD_LOWER" = "type" ]; then
+  case "$VALUE" in
+    Task | Bug | Feature) ;;
+    *)
+      echo "unknown IssueType value '$VALUE' (Task|Bug|Feature)" >&2
+      exit 11
+      ;;
+  esac
+  # Resolve the org issue-type ID dynamically — IDs are org-scoped and worth
+  # nothing hard-coded in a template.
+  TYPE_ID=$(gh api graphql -f query='
+    query($owner: String!) {
+      organization(login: $owner) {
+        issueTypes(first: 20) { nodes { id name } }
+      }
+    }' -f owner="$REPO_OWNER" \
+    | jq -r --arg v "$VALUE" '.data.organization.issueTypes.nodes[]? | select(.name == $v) | .id')
+  if [ -z "$TYPE_ID" ] || [ "$TYPE_ID" = "null" ]; then
+    echo "owner '$REPO_OWNER' has no native issue type '$VALUE' — fall back to a label" >&2
+    exit 10
+  fi
+  ISSUE_NODE_ID=$(gh api graphql -f query='
+    query($owner: String!, $name: String!, $num: Int!) {
+      repository(owner: $owner, name: $name) {
+        issue(number: $num) { id }
+      }
+    }' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$NUM" \
+    | jq -r '.data.repository.issue.id')
+  if [ -z "$ISSUE_NODE_ID" ] || [ "$ISSUE_NODE_ID" = "null" ]; then
+    echo "issue #$NUM not found in $REPO_OWNER/$REPO_NAME" >&2
+    exit 12
+  fi
+  gh api graphql -f query='
+    mutation($id: ID!, $typeId: ID!) {
+      updateIssue(input: { id: $id, issueTypeId: $typeId }) {
+        issue { issueType { name } }
+      }
+    }' -f id="$ISSUE_NODE_ID" -f typeId="$TYPE_ID" >/dev/null
+  echo "✓ #$NUM IssueType → $VALUE"
+  exit 0
+fi
+
 case "$FIELD_LOWER" in
   priority) PREFIX="PRIORITY" CANONICAL="Priority" ;;
   size)     PREFIX="SIZE"     CANONICAL="Size" ;;
   *)
-    echo "error: unsupported field '$FIELD_NAME' (Priority|Size)" >&2
+    echo "error: unsupported field '$FIELD_NAME' (Priority|Size|IssueType)" >&2
     exit 1
     ;;
 esac

--- a/templates/core/skills/backlog/scripts/github/set-field.sh
+++ b/templates/core/skills/backlog/scripts/github/set-field.sh
@@ -6,9 +6,10 @@
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
 # projectItems(first:5)) — negligible quota cost (~2 points). The Project V2
 # field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only —
-# `gh project item-edit` is the CLI wrapper, used below. The Issue Type
-# mutation (`updateIssue` with `issueTypeId`) is also GraphQL-only and is
-# called raw, since `gh issue edit --type` is not available everywhere.
+# `gh project item-edit` is the CLI wrapper, used below. The Issue Type is
+# set via the REST issues API (`PATCH .../issues/N` with `type`) — a single
+# call that takes the type name directly, cheaper than the GraphQL
+# `updateIssue` path and with no node-ID resolution.
 #
 # Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
 #   Examples:
@@ -52,37 +53,27 @@ if [ "$FIELD_LOWER" = "issuetype" ] || [ "$FIELD_LOWER" = "type" ]; then
       exit 11
       ;;
   esac
-  # Resolve the org issue-type ID dynamically — IDs are org-scoped and worth
-  # nothing hard-coded in a template.
-  TYPE_ID=$(gh api graphql -f query='
-    query($owner: String!) {
-      organization(login: $owner) {
-        issueTypes(first: 20) { nodes { id name } }
-      }
-    }' -f owner="$REPO_OWNER" \
-    | jq -r --arg v "$VALUE" '.data.organization.issueTypes.nodes[]? | select(.name == $v) | .id')
-  if [ -z "$TYPE_ID" ] || [ "$TYPE_ID" = "null" ]; then
-    echo "owner '$REPO_OWNER' has no native issue type '$VALUE' — fall back to a label" >&2
-    exit 10
+  # Single REST PATCH — takes the type name directly. A 422 means the
+  # repo/org has no such native type (fall back to a label); a 404 means
+  # the issue doesn't exist.
+  if ! RESULT=$(gh api -X PATCH "repos/$REPO_OWNER/$REPO_NAME/issues/$NUM" \
+    -f type="$VALUE" --jq '.type.name' 2>&1); then
+    case "$RESULT" in
+      *"Validation Failed"* | *422*)
+        echo "$REPO_OWNER/$REPO_NAME has no native issue type '$VALUE' — fall back to a label" >&2
+        exit 10
+        ;;
+      *"Not Found"* | *404*)
+        echo "issue #$NUM not found in $REPO_OWNER/$REPO_NAME" >&2
+        exit 12
+        ;;
+      *)
+        echo "set IssueType failed: $RESULT" >&2
+        exit 1
+        ;;
+    esac
   fi
-  ISSUE_NODE_ID=$(gh api graphql -f query='
-    query($owner: String!, $name: String!, $num: Int!) {
-      repository(owner: $owner, name: $name) {
-        issue(number: $num) { id }
-      }
-    }' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$NUM" \
-    | jq -r '.data.repository.issue.id')
-  if [ -z "$ISSUE_NODE_ID" ] || [ "$ISSUE_NODE_ID" = "null" ]; then
-    echo "issue #$NUM not found in $REPO_OWNER/$REPO_NAME" >&2
-    exit 12
-  fi
-  gh api graphql -f query='
-    mutation($id: ID!, $typeId: ID!) {
-      updateIssue(input: { id: $id, issueTypeId: $typeId }) {
-        issue { issueType { name } }
-      }
-    }' -f id="$ISSUE_NODE_ID" -f typeId="$TYPE_ID" >/dev/null
-  echo "✓ #$NUM IssueType → $VALUE"
+  echo "✓ #$NUM IssueType → $RESULT"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Closes epic **#241** and sub-issues **#242**, **#243**, **#244**, **#245**.

Grooming an item without classifying it was half a job. The PO agent's `add` / `clarify-autonomously` workflows described Priority/Size *passively* and never gated on them — so items like #240 shipped to Ready with no Priority, no Size, no Issue Type, no label.

- **PO agent prompts** (`.claude/agents/product-owner.md`, `templates/core/agents/product-owner.md`, plugin mirror) — Size + Priority + Issue Type + label are now a **non-skippable step** in `add` and `clarify-autonomously`, surfaced in the final report. The bundled PO degrades by backend: native fields/types on GitHub, `priority::`/`size::`/`type::` scoped labels on GitLab, frontmatter on local Markdown.
- **`set-field.sh`** (in-repo + templated `github/` helper) — new `set-field.sh <issue> IssueType <Task|Bug|Feature>` path. Sets the native type via a **single REST `PATCH .../issues/N`** (takes the type name directly — no node-ID resolution, ~1 quota point vs the 3-call GraphQL `updateIssue` flow). Same `0/10/11/12` exit-code contract.
- **Backlog `SKILL.md`** (in-repo + templated) — documents the classification contract + IssueType capability; drops the stale "Project #4 has no priority field" line.
- **PO memory** — new `rest-over-graphql.md` (always prefer REST; GraphQL burns the shared quota faster and exhausts independently), and `issue-type-classification.md` refreshed to the REST mechanism.
- **Windsurf cap** — the bundled PO crossed the 12k-char Cascade workflow cap once the contract was added; tightened verbose pre-existing PO prose to fit (now ~11.9k as a workflow).

## Test plan

- [x] `deno task test` — 594 passed / 0 failed
- [x] `deno task fmt` + `deno task lint` clean
- [x] `bash -n` on both `set-field.sh` copies
- [x] Windsurf Cascade-cap test green (bundled PO back under 12k)
- [x] `deno task bundle` regenerated `src/templates_bundle.ts` (committed)
- [x] **Live `set-field.sh IssueType`** — verified end-to-end via REST against #241 (`Feature`) and #244 (`Task`); bad value exits 11; all five epic issues confirmed typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)