### PR TITLE
feat(agents): mandate in-code documentation in developer agent constitution

### DIFF
--- a/plugin/agents/developer.md
+++ b/plugin/agents/developer.md
@@ -32,6 +32,14 @@ architecture.
 5. **Respect the project constitution** — if unsure, re-read it.
 6. **Run validation before handing off** — at minimum type-check and the tests
    relevant to your change.
+7. **In-code documentation** — for every function, method, or class that
+   encodes business logic, a domain rule, or a non-obvious design decision,
+   write a doc-comment in the idiomatic format for the language (JSDoc for
+   JS/TS, docstrings for Python, KDoc for Kotlin, PHPDoc for PHP, `///` for
+   Rust/Swift, etc.) — infer the convention from the files already in the
+   project. Focus on *why* the code exists or why this approach was chosen,
+   not *what* it does. Pure CRUD, simple getters, and self-evident utilities
+   do not need doc-comments.
 
 ## Protocol
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3256,6 +3256,14 @@ architecture.
 5. **Respect the project constitution** — if unsure, re-read it.
 6. **Run validation before handing off** — at minimum type-check and the tests
    relevant to your change.
+7. **In-code documentation** — for every function, method, or class that
+   encodes business logic, a domain rule, or a non-obvious design decision,
+   write a doc-comment in the idiomatic format for the language (JSDoc for
+   JS/TS, docstrings for Python, KDoc for Kotlin, PHPDoc for PHP, \`///\` for
+   Rust/Swift, etc.) — infer the convention from the files already in the
+   project. Focus on *why* the code exists or why this approach was chosen,
+   not *what* it does. Pure CRUD, simple getters, and self-evident utilities
+   do not need doc-comments.
 
 ## Protocol
 

--- a/templates/core/agents/developer.md
+++ b/templates/core/agents/developer.md
@@ -32,6 +32,14 @@ architecture.
 5. **Respect the project constitution** — if unsure, re-read it.
 6. **Run validation before handing off** — at minimum type-check and the tests
    relevant to your change.
+7. **In-code documentation** — for every function, method, or class that
+   encodes business logic, a domain rule, or a non-obvious design decision,
+   write a doc-comment in the idiomatic format for the language (JSDoc for
+   JS/TS, docstrings for Python, KDoc for Kotlin, PHPDoc for PHP, `///` for
+   Rust/Swift, etc.) — infer the convention from the files already in the
+   project. Focus on *why* the code exists or why this approach was chosen,
+   not *what* it does. Pure CRUD, simple getters, and self-evident utilities
+   do not need doc-comments.
 
 ## Protocol
 


### PR DESCRIPTION
## Summary
- Adds Non-negotiable rule 7 to the bundled `developer` agent constitution: write idiomatic doc-comments (JSDoc/docstrings/KDoc/PHPDoc/`///`/etc.) on functions, methods, and classes that encode business logic, a domain rule, or a non-obvious design decision — focused on *why*, with the convention inferred from the project's existing files.
- Mirrors the change byte-identically to `plugin/agents/developer.md` (enforced by `plugin_sync_test.ts`) and regenerates `src/templates_bundle.ts` so every `specflow init` scaffolds it across all 8 harnesses.

## Design notes
- Resolves the open architectural question in #240: the language/framework guidance lives **inline** in the agent constitution (option a), not as a separate reference file or skill. Every other behavioural rule and bundled agent encodes its heuristics inline; a separate artifact would add a manifest entry, bundle category, startup-read wiring, and sync-test pair for three sentences of guidance.
- No frontmatter change — pure Markdown prose, so no 8-harness compatibility risk.

## Test plan
- [x] `deno task test` — 594 passed, 0 failed (incl. `plugin_sync_test.ts`)
- [x] `deno task bundle` regenerated `src/templates_bundle.ts`
- [x] pre-commit hook (fmt + lint + bundle + check) green

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)