### PR TITLE
fix(docs): use absolute path for llms.txt link on /docs/ page

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -11,7 +11,7 @@ harness (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot CLI, Windsurf, O
 Antigravity) is what reads the generated files and acts on them.
 
 This page is the canonical documentation. The same content is available as raw Markdown at
-[`/llms.txt`](./llms.txt) for LLM consumption — see [llmstxt.org](https://llmstxt.org/) for the
+[`/llms.txt`](/llms.txt) for LLM consumption — see [llmstxt.org](https://llmstxt.org/) for the
 convention.
 
 ## Install


### PR DESCRIPTION
## Why

The inline link in the opening paragraph of `docs/llms.md` used `./llms.txt`, which on a page hosted at `/docs/` resolves to `/docs/llms.txt` — a 404. The file is served at `/llms.txt` (no prefix), and the build script (`scripts/build-docs.ts`) explicitly forbids moving it.

## What

One-line change: `[`/llms.txt`](./llms.txt)` → `[`/llms.txt`](/llms.txt)`.

Root-relative paths resolve against the site root regardless of where the rendering page sits, so the link is now correct from any page (incl. the root and any future sub-paths).

## Verification

- `deno task docs:build` ✓ (62189 bytes, v1.4.0)
- All 4 `llms.txt` hrefs in `docs-dist/docs/index.html` are now absolute
- Footer link was already correct — untouched
- `deno task test` 594/0 ✓

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)