### PR TITLE
feat(specflow): /specflow auto-chains by default; /specflow-auto deprecated

### DIFF
--- a/.claude/agents/architect/memory/MEMORY.md
+++ b/.claude/agents/architect/memory/MEMORY.md
@@ -16,3 +16,4 @@ obsolete once they are encoded in `AGENTS.md`).
 - [Claude plugin backwards compat](claude-plugin-compat.md) — state table + detection method for v0.x inline agents when plugin is installed
 - [Router skill consolidation](router-skill-consolidation.md) — decisions for collapsing 11 specflow-* phase skills into a single /specflow router + phases/ subdirectory
 - [Auto-chain disable-model-invocation fix](auto-chain-disable-model-invocation.md) — lift the flag from the router to unblock Skill-tool chaining by specflow-auto
+- [Specflow-auto merge into router](specflow-auto-merge-into-router.md) — decisions for collapsing /specflow-auto chain logic into the /specflow router with --manual opt-out; deprecation alias + removal plan

--- a/.claude/agents/architect/memory/specflow-auto-merge-into-router.md
+++ b/.claude/agents/architect/memory/specflow-auto-merge-into-router.md
@@ -1,0 +1,60 @@
+---
+name: specflow-auto-merge-into-router
+description: Design decisions for merging specflow-auto chain logic into the /specflow router as the default, with --manual opt-out
+type: decision
+---
+
+**Rule: merge specflow-auto chain-control logic into `specflow/SKILL.md` (the router). Auto-chain becomes the default for `/specflow specify`. `--manual` flag suppresses it. `specflow-auto/SKILL.md` becomes a one-release deprecation alias, then is removed from manifest.json.**
+
+Why: two-skill structure is invisible to users who default to the shorter `/specflow specify`; agents recommend it without knowing they're missing the chain. The router already owns dispatch; chain semantics belong there.
+
+**How to apply — router SKILL.md changes:**
+- Add a pre-dispatch block in the router: parse `$ARGUMENTS` for `--manual` before extracting phase name. If `--manual` found, strip it and set chain-mode = false; default chain-mode = true.
+- After executing the phase file for `specify`, if chain-mode = true: proceed through the auto-chain logic (the STOP #1 clarification checkpoint, silent gates, STOP #2 merge checkpoint) inline in the router body or via a new `phases/auto-chain.md` include.
+- Mid-chain re-entry rule (artefact-detection default + `--continue` / `--once` overrides) moves into the router body for all non-specify phases.
+- `--manual` is parsed at router level, NOT passed through to phase files.
+
+**How to apply — specflow-auto/SKILL.md deprecation alias:**
+- Body becomes: "This skill is deprecated since vX.Y. `/specflow` auto-chains by default. Run `/specflow <phase> <args>` directly. For one-shot use: `/specflow specify --manual \"<description>\"`."
+- Do NOT use a Skill tool call from the alias body — it creates a dependency on the router for non-Claude harnesses that don't have the Skill tool. Plain prose redirect is sufficient (and the alias disappears in one release anyway).
+- Remove from manifest.json and plugin/skills/specflow-auto/ in the release AFTER the deprecation release.
+
+**Key implementation details confirmed from code search:**
+
+1. Char cap: No harness enforces a char limit on SKILL.md bodies (only agents have the 12k Windsurf check). Merged router body at ~8-9k chars is safe.
+
+2. `--manual` parsing location: MUST be at router level (SKILL.md), not inside phase files. Phase files receive `$ARGUMENTS` verbatim and treat it as feature description (specify.md) or artefact ID (plan.md etc). Stripping `--manual` before passing to the phase is the router's job.
+
+3. analyze.md "Run /specflow plan" suggestion: under the merged router, a user acting on that suggestion in a context where downstream artefacts are absent WILL trigger chain behavior. This is actually desirable — that's the correct default. Document it as intentional in the phase file suggestion text (change to "Run `/specflow plan --once`" if the user only wants to regenerate plan, or `/specflow plan` to chain from there).
+
+4. review.md line 84: currently says "hand back to /specflow-auto for STOP #2". After merge, change to "the router will present STOP #2 automatically" — the phrase "hand back to /specflow-auto" disappears.
+
+5. Upgrade plan behavior: specflow-auto/SKILL.md has NO skipIfExists. Upgrade overwrites vanilla copies, preserves customized copies. When it becomes a deprecation alias, existing users get the alias on next upgrade (correct). When it is removed from manifest.json entirely, upgrade_plan.ts emits a `remove` action for users whose disk copy matches the lock SHA, and `preserve` for users who customized it. No orphan-file risk.
+
+6. plugin_coverage.ts line 48 and line 94: must remove the specflow-auto entry from PLUGIN_COVERED_PATHS_CLAUDE and isPluginCoveredPath when the skill is removed. Keep it during the one-release deprecation window.
+
+7. smoke-features.sh lines 205-211: currently asserts specflow-auto/SKILL.md has "Mid-chain re-entry", "--continue", "--once". After the merge these assertions must be MOVED to test the router SKILL.md instead. The specflow-auto block gets a single new assertion: "specflow-auto SKILL.md body contains deprecation notice".
+
+**What is NOT needed:**
+- No new port, no new adapter, no infrastructure change. This is purely template content + manifest.json + plugin/ mirror + plugin_coverage.ts.
+- qa-tester/memory/MEMORY.md is an empty stub — no stale memories to fix.
+- Product-owner, developer, review-coordinator, workflow-manager agents: none mention specflow-auto. Only specflow-expert.md (line 217) and cursor's specify-rules.mdc (line 32) need updating.
+
+**Files requiring edits (exhaustive list):**
+- `templates/core/skills/specflow/SKILL.md` — inline chain-control + --manual flag handling
+- `templates/core/skills/specflow-auto/SKILL.md` — deprecation alias body
+- `templates/core/skills/specflow/phases/review.md` — remove "hand back to /specflow-auto" (line 84)
+- `templates/core/skills/specflow/phases/specify.md` — already reports "readiness for next phase"; no chain logic needed there (chain is driven by router after specify returns)
+- `templates/core/agents/specflow-expert.md` line 217 — update to "/specflow specify auto-chains by default; /specflow-auto is deprecated"
+- `templates/harness-specific/cursor/specify-rules.mdc` line 32 — remove /specflow-auto entry or mark deprecated
+- `plugin/skills/specflow/SKILL.md` — mirror of router SKILL.md (byte-identical)
+- `plugin/skills/specflow-auto/SKILL.md` — mirror of deprecation alias
+- `plugin/skills/specflow/phases/review.md` — mirror
+- `plugin/agents/specflow-expert.md` — mirror
+- `plugin/README.md` — update description of specflow-auto
+- `docs/llms.md` — rewrite auto-chain section (lines 358-413)
+- `.claude/skills/test-sandbox/scripts/smoke-features.sh` — move specflow-auto assertions to router, add deprecation notice assertion
+- `src/domain/plugin_coverage.ts` — keep specflow-auto during deprecation release, remove in next
+- `templates/manifest.json` — keep specflow-auto entry during deprecation release
+
+**Spec slug recommendation:** `docs/superpowers/specs/NNN-specflow-auto-merge.md`

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -242,6 +242,15 @@ check "implement.md halts BLOCKED when the Domain Model is absent" \
   'grep -q "awaiting:product-owner-domain-brief" .claude/skills/specflow/phases/implement.md'
 
 echo
+echo "═══ Phase-doc drift fixes — auto-chain default ═══"
+check "analyze.md re-run hint mentions --once for one-shot regen" \
+  'grep -q "Run /specflow plan --once to regenerate" .claude/skills/specflow/phases/analyze.md'
+check "review.md owns STOP #2 (no /specflow-auto handoff)" \
+  '! grep -q "hand back to \`/specflow-auto\`" .claude/skills/specflow/phases/review.md'
+check "review.md surfaces STOP #2 from phases/auto-chain.md" \
+  'grep -q "STOP #2 summary block defined in" .claude/skills/specflow/phases/review.md'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -202,6 +202,15 @@ check "SKILL.md describes the cascade-check close gate" \
   'grep -q "cascade-check.sh" .claude/skills/backlog/SKILL.md'
 
 echo
+echo "═══ #251  auto-chain — chain mechanics file present ═══"
+check "phases/auto-chain.md is bundled into the project" \
+  'test -f .claude/skills/specflow/phases/auto-chain.md'
+check "auto-chain.md documents STOP #1 and STOP #2" \
+  'grep -q "STOP #1" .claude/skills/specflow/phases/auto-chain.md && grep -q "STOP #2" .claude/skills/specflow/phases/auto-chain.md'
+check "auto-chain.md documents mid-chain re-entry" \
+  'grep -q "Mid-chain re-entry" .claude/skills/specflow/phases/auto-chain.md'
+
+echo
 echo "═══ #182  specflow-auto — mid-chain re-entry ═══"
 check "specflow-auto SKILL.md documents mid-chain re-entry" \
   'grep -q "Mid-chain re-entry" .claude/skills/specflow-auto/SKILL.md'

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -217,13 +217,11 @@ check "router SKILL.md no longer recommends /specflow-auto for end-to-end runs" 
   '! grep -q "use \`/specflow-auto specify" .claude/skills/specflow/SKILL.md'
 
 echo
-echo "═══ #182  specflow-auto — mid-chain re-entry ═══"
-check "specflow-auto SKILL.md documents mid-chain re-entry" \
-  'grep -q "Mid-chain re-entry" .claude/skills/specflow-auto/SKILL.md'
-check "specflow-auto SKILL.md describes the --continue flag" \
-  'grep -q -- "--continue" .claude/skills/specflow-auto/SKILL.md'
-check "specflow-auto SKILL.md describes the --once flag" \
-  'grep -q -- "--once" .claude/skills/specflow-auto/SKILL.md'
+echo "═══ #182  specflow-auto — deprecation alias ═══"
+check "specflow-auto SKILL.md carries the deprecation notice" \
+  'grep -q "DEPRECATED" .claude/skills/specflow-auto/SKILL.md'
+check "specflow-auto SKILL.md tells users to use /specflow instead" \
+  'grep -q "auto-chains by default" .claude/skills/specflow-auto/SKILL.md'
 
 echo
 echo "═══ #188  /specflow merge auto-closes the linked backlog issue ═══"

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -209,6 +209,12 @@ check "auto-chain.md documents STOP #1 and STOP #2" \
   'grep -q "STOP #1" .claude/skills/specflow/phases/auto-chain.md && grep -q "STOP #2" .claude/skills/specflow/phases/auto-chain.md'
 check "auto-chain.md documents mid-chain re-entry" \
   'grep -q "Mid-chain re-entry" .claude/skills/specflow/phases/auto-chain.md'
+check "router SKILL.md parses --manual flag" \
+  'grep -q -- "--manual" .claude/skills/specflow/SKILL.md'
+check "router SKILL.md routes to phases/auto-chain.md when chain mode is on" \
+  'grep -q "phases/auto-chain.md" .claude/skills/specflow/SKILL.md'
+check "router SKILL.md no longer recommends /specflow-auto for end-to-end runs" \
+  '! grep -q "use \`/specflow-auto specify" .claude/skills/specflow/SKILL.md'
 
 echo
 echo "═══ #182  specflow-auto — mid-chain re-entry ═══"

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -60,15 +60,15 @@ projects** without running `specflow init`, install the Claude Code plugin:
 ```
 
 The plugin ships the same 23 assets the binary scaffolds — the consolidated `specflow` router skill
-(with 11 phase docs), the `specflow-review` auto-invoke alias, the `specflow-auto` skill, and 9
-sub-agents — but at user scope, versioned, and auto-updated via `/plugin update`. Because the
-plugin's slash-commands are namespaced and the consolidated router itself is named `specflow`,
-you'll see a double-prefix at the call site:
+(with 11 phase docs, the `specflow-review` auto-invoke alias, and the deprecated `specflow-auto`
+skill), and 9 sub-agents — but at user scope, versioned, and auto-updated via `/plugin update`.
+Because the plugin's slash-commands are namespaced and the consolidated router itself is named
+`specflow`, you'll see a double-prefix at the call site:
 
 ```
 /specflow-plugin:specflow specify "<feature description>"
 /specflow-plugin:specflow plan
-/specflow-plugin:specflow-auto specify "<feature description>"
+/specflow-plugin:specflow specify "<feature description>"
 ```
 
 Slightly verbose, but unambiguous. If you scaffold project-local with `specflow init`, you get the
@@ -355,10 +355,10 @@ The generated `specify` skill chains `clarify → plan → tasks → analyze →
 in a single session. Upstream stops at every step and asks the human to invoke the next one.
 Specflow only stops twice: when clarification is genuinely required, and once before merging.
 
-The chain is invoked through the bundled `/specflow-auto` skill:
+The chain is invoked through the bundled `/specflow` skill:
 
 ```
-/specflow-auto specify "<feature description>"
+/specflow specify "<feature description>"
 ```
 
 Two checkpoints inside the chain:
@@ -391,26 +391,29 @@ with the merged commit range and `gh issue close --reason completed`. The board 
 To opt out of the chain entirely (run only `specify` and stop):
 
 ```
-/specflow-auto specify --manual "<feature description>"
+/specflow specify --manual "<feature description>"
 ```
 
 #### Mid-chain re-entry
 
-Any phase other than `specify` can also enter the chain when invoked through `/specflow-auto` —
-useful for two real workflows:
+Any phase other than `specify` can also enter the chain when invoked mid-flow — useful for two real
+workflows:
 
 - **Manual review between early phases** — read `spec.md` after `specify` lands, then
-  `/specflow-auto clarify N` resumes the chain through `plan → tasks → … → STOP #2`.
+  `/specflow clarify N` resumes the chain through `plan → tasks → … → STOP #2`.
 - **Context-budget recovery** — open a fresh session after compaction and run
-  `/specflow-auto implement N` to pick up the tail (`→ review → STOP #2`).
+  `/specflow implement N` to pick up the tail (`→ review → STOP #2`).
 
 The default is **context-aware**: if downstream artefacts under `.specflow/specs/<feature>/` are
 missing, the chain fires; if they exist, the invocation is treated as a single-phase re-run (so
 regenerating `plan.md` doesn't accidentally cascade through the rest). Two explicit overrides when
 the default guesses wrong:
 
-- `/specflow-auto <phase> N --continue` — force the chain regardless of artefact state.
-- `/specflow-auto <phase> N --once` — force one-shot regardless.
+- `/specflow <phase> N --continue` — force the chain regardless of artefact state.
+- `/specflow <phase> N --once` — force one-shot regardless.
+
+The `/specflow-auto` slash command is kept for one release as a deprecation alias and will be
+removed in the next major version.
 
 ### 2. `review` phase post-implement
 
@@ -559,8 +562,8 @@ marketplace:
 
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
 sub-agents — no binary, no `specflow init` required. The 24 plugin assets (the consolidated
-`specflow` router skill with 11 phase docs, the `specflow-review` auto-invoke alias, the
-`specflow-auto` skill, and 10 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist
+`specflow` router skill with 11 phase docs, the `specflow-review` auto-invoke alias, the deprecated
+`specflow-auto` alias, and 10 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist
 with project-local copies without collision.
 
 When both the plugin and the binary are in use, `specflow upgrade` detects the plugin and

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -60,7 +60,7 @@ projects** without running `specflow init`, install the Claude Code plugin:
 ```
 
 The plugin ships the same 23 assets the binary scaffolds — the consolidated `specflow` router skill
-(with 11 phase docs, the `specflow-review` auto-invoke alias, and the deprecated `specflow-auto`
+(with 14 phase docs, the `specflow-review` auto-invoke alias, and the deprecated `specflow-auto`
 skill), and 9 sub-agents — but at user scope, versioned, and auto-updated via `/plugin update`.
 Because the plugin's slash-commands are namespaced and the consolidated router itself is named
 `specflow`, you'll see a double-prefix at the call site:
@@ -562,7 +562,7 @@ marketplace:
 
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
 sub-agents — no binary, no `specflow init` required. The 24 plugin assets (the consolidated
-`specflow` router skill with 11 phase docs, the `specflow-review` auto-invoke alias, the deprecated
+`specflow` router skill with 14 phase docs, the `specflow-review` auto-invoke alias, the deprecated
 `specflow-auto` alias, and 10 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist
 with project-local copies without collision.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specflow-plugin",
-  "description": "Specflow's specflow-auto skill, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
+  "description": "Specflow's auto-chained spec-driven workflow, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
   "version": "1.4.0",
   "author": {
     "name": "MakerLabs"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,18 +1,19 @@
 # specflow-plugin — Claude Code plugin for Specflow
 
 This is the Claude Code plugin distribution of [Specflow](https://specflow.makerlabs.dev). It ships
-the same slash-commands, sub-agents, and the specflow-auto skill that the `specflow` binary
-scaffolds into projects — just as a user-scope plugin instead.
+the same slash-commands and sub-agents that the `specflow` binary scaffolds into projects — just as
+a user-scope plugin instead. `/specflow specify "<feature>"` auto-chains the full workflow by
+default; pass `--manual` to opt out.
 
 ## What's in here
 
-| Path                                                                                                                                        | Contents                                                              |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specflow-plugin`, lockstep with the binary version) |
-| `skills/specflow-auto/SKILL.md`                                                                                                             | Auto-chain skill — `/specflow-plugin:specflow-auto`                   |
-| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/specflow-plugin:specify`, etc.     |
-| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                      |
-| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specflow-plugin:groom`                                |
+| Path                                                                                                                                        | Contents                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specflow-plugin`, lockstep with the binary version)         |
+| `skills/specflow-auto/SKILL.md`                                                                                                             | Deprecated alias (removed in next major) — kept one release for muscle memory |
+| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specflow slash-commands — `/specflow-plugin:specify`, etc.             |
+| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                              |
+| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specflow-plugin:groom`                                        |
 
 The full plugin migration shipped in v0.12.x (issue
 [#73](https://github.com/mkrlabs/specflow/issues/73)). When the plugin is installed and the project
@@ -57,7 +58,7 @@ To test changes to the plugin without publishing:
 claude --plugin-dir /path/to/specflow/plugin
 ```
 
-Then invoke any plugin skill: `/specflow-plugin:specflow-auto specify "…"`.
+Then invoke any plugin skill: `/specflow-plugin:specflow specify "…"`.
 
 ## Versioning
 

--- a/plugin/agents/specflow-expert.md
+++ b/plugin/agents/specflow-expert.md
@@ -214,11 +214,11 @@ layout and frontmatter conventions.
 
 ### What makes Specflow different from upstream Spec Kit
 
-1. **Auto-chained pipeline** — `/specflow-auto` chains `clarify →
-   plan → tasks → analyze → implement → review → merge` in one
-   session. Upstream stops at every step and asks the human; Specflow
-   stops only when clarification is genuinely required and once
-   before the merge.
+1. **Auto-chained pipeline** — `/specflow specify "<feature>"` chains
+   `specify → clarify → plan → tasks → analyze → implement → review`
+   in one session, pausing only on real clarification and once before
+   merge. `/specflow-auto` is kept for one release as a deprecation
+   alias.
 
 2. **Dedicated `review` phase** — after `implement`, a `review` step
    checks architecture, error handling, test coverage, and quality

--- a/plugin/skills/specflow-auto/SKILL.md
+++ b/plugin/skills/specflow-auto/SKILL.md
@@ -1,131 +1,27 @@
 ---
 name: specflow-auto
-description: Auto-chain Specflow workflow — when the user runs /specflow-auto specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+description: DEPRECATED — /specflow now auto-chains by default since v1.5.0. This skill is kept as an alias for one release and will be removed in the next major version.
 ---
 
-# Specflow Auto-Chain
+# /specflow-auto is deprecated
 
-This skill turns the Specflow workflow into a single-command operation. When the
-user invokes `/specflow-auto specify "<feature description>"`, you MUST chain every
-Specflow phase in the same session without asking the user between phases,
-EXCEPT at the two checkpoints defined below.
+Auto-chain is now the default behavior of `/specflow`. Use:
 
-## Default flow
+- `/specflow specify "<feature>"` — runs the full chain automatically
+  (specify → clarify → plan → tasks → analyze → implement → review →
+  STOP #2 for merge confirmation).
+- `/specflow specify --manual "<feature>"` — runs `specify` only, no
+  chain.
+- `/specflow <phase> <args>` — mid-chain re-entry with artefact
+  detection (chain if downstream artefacts are absent, one-shot if
+  present). Override with `--once` (force one-shot) or `--continue`
+  (force chain).
 
-```
-specify → clarify → plan → tasks → analyze → implement → review → merge
-          ▲                                                        ▲
-          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
-```
+See `phases/auto-chain.md` (in the `specflow` skill) for the full chain
+mechanics, including STOP #1 (clarification checkpoint) and STOP #2
+(pre-merge confirmation).
 
-## Per-phase behavior
-
-After each phase completes successfully, immediately invoke the next phase via
-the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
-for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
-log is sufficient.
-
-## STOP #1 — Clarification checkpoint
-
-After `/specflow clarify` finishes:
-
-- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently
-  to `/specflow plan`.
-- If markers remain, present the top 3 questions to the user (per the
-  `/specflow clarify` format) and wait for answers. Once the spec is updated,
-  resume the chain automatically.
-
-## Silent gates
-
-These phases run without user interruption unless they fail hard or surface
-CRITICAL findings:
-
-- `/specflow plan` — generates plan + research + data-model + contracts + quickstart.
-- `/specflow tasks` — generates tasks.md.
-- `/specflow analyze` — cross-artifact consistency check. On LOW/MEDIUM findings,
-  log a summary and continue. On CRITICAL findings, stop and surface them.
-- `/specflow implement` — runs the developer → review-coordinator → qa-tester
-  pipeline. Has its own internal fix loop for review findings; do not intercept.
-- `/specflow review` — final quality scan.
-
-## STOP #2 — Pre-merge validation
-
-After `/specflow review` passes, ALWAYS stop and present a compact summary
-before invoking `/specflow merge`. The summary must include:
-
-- Feature name and branch
-- Files created / modified (count + key paths)
-- Tests added and full-suite status
-- Known deviations from tasks.md and rationale
-- Open risks / deferred items
-- One-line business outcome
-
-Then ask explicitly: "Ready to merge? (yes to run /specflow merge, no to stay on
-the branch)". Wait for explicit confirmation. On "yes", invoke
-`/specflow merge`. After merge, the chain ends.
-
-## Opt-out
-
-If the user invokes `/specflow-auto specify --manual "<description>"`, run
-`/specflow specify` only and stop. Do not auto-chain. Each subsequent phase must
-be invoked manually by the user.
-
-## Mid-chain re-entry
-
-When the user invokes any phase other than `specify` directly (e.g.
-`/specflow-auto plan 042`, `/specflow-auto implement 042`), apply this
-context-aware default:
-
-- **Downstream artefacts missing** → chain. The user is resuming an
-  interrupted flow (long session, fresh shell after compaction, manual
-  review between early phases). Continue through the remaining phases →
-  STOP #2 with the same checkpoints as the entry-point flow.
-- **Downstream artefacts present** → one-shot. The user is re-running a
-  single phase (regenerate `plan.md` after a tweak, re-analyse after a
-  spec edit). Do NOT cascade.
-
-"Downstream artefacts" means files under `.specflow/specs/<feature>/`
-produced by phases AFTER the one being invoked:
-
-| Invoked phase | Downstream artefacts to check |
-|---|---|
-| `clarify`   | `plan.md`, `tasks.md` |
-| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
-| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
-| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
-| `implement` | a merged PR, a `review.md`, or task completion past 50% |
-| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
-
-If any listed artefact is present, infer one-shot intent. If all are
-absent, chain.
-
-### Explicit overrides
-
-- `/specflow-auto <phase> N --continue` — force the chain regardless of
-  artefact state. Useful when you want to regenerate a phase AND cascade
-  downstream work afterwards (e.g. tweak `plan.md`, then re-run
-  `tasks → analyze → implement → review` from scratch).
-- `/specflow-auto <phase> N --once` — force one-shot regardless. Useful
-  when downstream artefacts haven't been generated yet but you only
-  want to run this single phase right now (e.g. inspect the spec
-  before authorising the rest of the chain).
-
-The flags are mutually exclusive; the explicit form always wins over
-the artefact-detection default.
-
-## Failure handling
-
-- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
-  surface the error, ask the user how to proceed. Do not silently retry.
-- Task-level blockers reported by the developer agent during `implement`: the
-  implement workflow has its own fix loop; do not intercept.
-- `clarify` producing more than 5 questions: present the top 3 per the
-  `/specflow clarify` quota; the rest can be asked later.
-
-## Context budget
-
-Long features (≥13 story points or ≥30 tasks) may exhaust context during
-`/specflow implement`. If compaction occurs mid-chain, inform the user and
-let them resume from a fresh session — the artefact-detection default in
-"Mid-chain re-entry" above will pick up where the previous run stopped, or
-they can pass `--continue` explicitly.
+This skill will be removed in the next major release. If you see this
+file in your project after running `specflow upgrade`, it means
+muscle-memory invocations of `/specflow-auto` keep working — but you
+should switch to the new entry point.

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -21,12 +21,25 @@ when_to_use: |
 
 # Specflow router
 
-`$ARGUMENTS` carries the user's input. Parse it as `<phase> [rest]`:
+`$ARGUMENTS` carries the user's input. Parse it as `[<flag>...] <phase> [rest]`:
 
-- The first token is the phase name.
-- Everything after the first whitespace is the argument string for that phase.
+1. **Chain mode parsing** — scan the tokens for at most one of
+   `--manual`, `--once`, `--continue`. They are mutually exclusive; if
+   more than one is present, report `error: --manual, --once, and --continue are mutually exclusive` and stop.
+   - `--manual` → CHAIN_MODE = `off`
+   - `--once`   → CHAIN_MODE = `once`
+   - `--continue` → CHAIN_MODE = `continue`
+   - none      → CHAIN_MODE = `auto` (the default)
 
-If `$ARGUMENTS` is empty, render the **Workflow overview** below and stop. Do not pick a phase yourself.
+   Strip the matched flag from the token list before going further.
+
+2. **Phase extraction** — the first remaining token is the phase name.
+   Everything after the first whitespace is the argument string for
+   that phase.
+
+3. **Empty arguments** — if no tokens remain after flag parsing (or
+   `$ARGUMENTS` was empty to start with), render the **Workflow overview**
+   below and stop. Do not pick a phase yourself.
 
 ## Phase index
 
@@ -46,13 +59,35 @@ If `$ARGUMENTS` is empty, render the **Workflow overview** below and stop. Do no
 | `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
 | `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
 
+Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
+`implement`, `review`. The others (`merge`, `constitution`,
+`checklist`, `groom`, `tag-version`, `release-version`) are one-shot
+regardless of chain mode.
+
 ## Routing
 
 1. **Read** the phase reference file (`phases/<phase>.md`) for the requested phase using the `Read` tool.
-2. **Substitute** the remainder of `$ARGUMENTS` for the phase's input.
+2. **Substitute** the stripped phase arguments for the phase's input.
 3. **Execute** the procedure in the reference file end-to-end.
+4. **Decide whether to chain** (see "Chain decision" below).
 
-Unknown phase → print the index above and stop.
+Unknown phase → print the phase index and stop.
+
+## Chain decision
+
+After the phase procedure completes successfully:
+
+- `CHAIN_MODE == off` (the user passed `--manual`) → stop. Report the
+  phase outcome and leave the next step to the user.
+- Phase is not in the chainable list (e.g. `constitution`, `checklist`,
+  `groom`, `tag-version`, `release-version`) → stop.
+- `CHAIN_MODE == once` → stop.
+- `CHAIN_MODE == continue` → read `phases/auto-chain.md` and chain
+  through the remaining phases regardless of downstream-artefact state.
+- `CHAIN_MODE == auto` (the default) → read `phases/auto-chain.md`. For
+  `specify`, the chain always continues. For any other chainable phase,
+  apply the artefact-detection table in that file — chain if downstream
+  artefacts are absent, one-shot if present.
 
 ## Workflow overview
 
@@ -62,34 +97,37 @@ specify → clarify → plan → tasks → analyze → implement → review → 
                                                           STOP for pre-merge validation
 ```
 
+Default behavior: `/specflow specify "..."` runs the entire chain in one
+session, pausing only at STOP #1 (if clarifications are needed) and
+STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
+chain mechanics.
+
 `constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
 ```
 /specflow specify "Add OAuth2 login"
-  → spec drafted in .specflow/specs/<NNN>-add-oauth2-login/spec.md
-
-/specflow clarify
-  → resolves any [NEEDS CLARIFICATION] markers
-
-/specflow plan
-  → research, data-model, contracts, quickstart written
-
-/specflow tasks
-  → tasks.md generated
-
-/specflow analyze
-  → cross-artifact consistency check
-
-/specflow implement
-  → developer → review-coordinator → qa-tester pipeline
-
-/specflow review
-  → final quality scan
-
-/specflow merge
-  → pre-merge validation + merge
+  → drafts the spec, then auto-chains:
+    → /specflow clarify  (STOP #1 only if [NEEDS CLARIFICATION] markers remain)
+    → /specflow plan
+    → /specflow tasks
+    → /specflow analyze
+    → /specflow implement
+    → /specflow review
+    → STOP #2 — summary + "Ready to merge?" confirmation
+    → /specflow merge  (on "yes")
 ```
 
-For an end-to-end run that auto-chains the silent gates, use `/specflow-auto specify "<feature>"`.
+To run a single phase only (no chain), pass `--manual`:
+
+```
+/specflow specify --manual "Add OAuth2 login"
+```
+
+To force or skip the chain mid-flow:
+
+```
+/specflow plan 042 --once       # regenerate plan.md only, do not cascade
+/specflow plan 042 --continue   # regenerate plan.md AND cascade tasks → review
+```

--- a/plugin/skills/specflow/phases/analyze.md
+++ b/plugin/skills/specflow/phases/analyze.md
@@ -187,7 +187,7 @@ At end of report, output a concise Next Actions block:
 
 - If CRITICAL issues exist: Recommend resolving before `/specflow implement`
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
-- Provide explicit command suggestions: e.g., "Run /specflow specify with refinement", "Run /specflow plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+- Provide explicit command suggestions: e.g., "Run /specflow specify --manual to refine the spec without re-cascading", "Run /specflow plan --once to regenerate the plan only, or /specflow plan to cascade through tasks → review", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
 ### 8. Offer Remediation
 

--- a/plugin/skills/specflow/phases/auto-chain.md
+++ b/plugin/skills/specflow/phases/auto-chain.md
@@ -1,0 +1,122 @@
+# Auto-chain control
+
+This file carries the chain mechanics that the `/specflow` router follows
+when chain mode is engaged. The router reads it after a chainable phase
+(`specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`)
+completes — unless `--manual` or `--once` was passed, or downstream
+artefacts indicate one-shot intent.
+
+## Default flow
+
+```
+specify → clarify → plan → tasks → analyze → implement → review → merge
+          ▲                                                        ▲
+          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+```
+
+## Per-phase behavior
+
+After each phase completes successfully, immediately invoke the next phase via
+the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
+for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
+log is sufficient.
+
+## STOP #1 — Clarification checkpoint
+
+After `/specflow clarify` finishes:
+
+- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently
+  to `/specflow plan`.
+- If markers remain, present the top 3 questions to the user (per the
+  `/specflow clarify` format) and wait for answers. Once the spec is updated,
+  resume the chain automatically.
+
+## Silent gates
+
+These phases run without user interruption unless they fail hard or surface
+CRITICAL findings:
+
+- `/specflow plan` — generates plan + research + data-model + contracts + quickstart.
+- `/specflow tasks` — generates tasks.md.
+- `/specflow analyze` — cross-artifact consistency check. On LOW/MEDIUM findings,
+  log a summary and continue. On CRITICAL findings, stop and surface them.
+- `/specflow implement` — runs the developer → review-coordinator → qa-tester
+  pipeline. Has its own internal fix loop for review findings; do not intercept.
+- `/specflow review` — final quality scan.
+
+## STOP #2 — Pre-merge validation
+
+After `/specflow review` passes, ALWAYS stop and present a compact summary
+before invoking `/specflow merge`. The summary must include:
+
+- Feature name and branch
+- Files created / modified (count + key paths)
+- Tests added and full-suite status
+- Known deviations from tasks.md and rationale
+- Open risks / deferred items
+- One-line business outcome
+
+Then ask explicitly: "Ready to merge? (yes to run /specflow merge, no to stay on
+the branch)". Wait for explicit confirmation. On "yes", invoke
+`/specflow merge`. After merge, the chain ends.
+
+## Mid-chain re-entry
+
+When the user invokes any phase other than `specify` directly (e.g.
+`/specflow plan 042`, `/specflow implement 042`), apply this
+context-aware default:
+
+- **Downstream artefacts missing** → chain. The user is resuming an
+  interrupted flow (long session, fresh shell after compaction, manual
+  review between early phases). Continue through the remaining phases →
+  STOP #2 with the same checkpoints as the entry-point flow.
+- **Downstream artefacts present** → one-shot. The user is re-running a
+  single phase (regenerate `plan.md` after a tweak, re-analyse after a
+  spec edit). Do NOT cascade.
+
+"Downstream artefacts" means files under `.specflow/specs/<feature>/`
+produced by phases AFTER the one being invoked:
+
+| Invoked phase | Downstream artefacts to check |
+|---|---|
+| `clarify`   | `plan.md`, `tasks.md` |
+| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
+| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
+| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
+| `implement` | a merged PR, a `review.md`, or task completion past 50% |
+| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
+
+If any listed artefact is present, infer one-shot intent. If all are
+absent, chain.
+
+### Explicit overrides
+
+The router-level flags `--continue` and `--once` override the
+artefact-detection default. They are mutually exclusive with each other
+and with `--manual`:
+
+- `--continue` — force the chain regardless of artefact state. Useful
+  when you want to regenerate a phase AND cascade downstream work
+  afterwards (e.g. tweak `plan.md`, then re-run `tasks → analyze →
+  implement → review` from scratch).
+- `--once` — force one-shot regardless. Useful when downstream
+  artefacts haven't been generated yet but you only want to run this
+  single phase right now (e.g. inspect the spec before authorising
+  the rest of the chain).
+
+## Failure handling
+
+- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
+  surface the error, ask the user how to proceed. Do not silently retry.
+- Task-level blockers reported by the developer agent during `implement`: the
+  implement workflow has its own fix loop; do not intercept.
+- `clarify` producing more than 5 questions: present the top 3 per the
+  `/specflow clarify` quota; the rest can be asked later.
+
+## Context budget
+
+Long features (≥13 story points or ≥30 tasks) may exhaust context during
+`/specflow implement`. If compaction occurs mid-chain, inform the user and
+let them resume from a fresh session — the artefact-detection default
+above will pick up where the previous run stopped, or they can pass
+`--continue` explicitly.

--- a/plugin/skills/specflow/phases/review.md
+++ b/plugin/skills/specflow/phases/review.md
@@ -81,5 +81,6 @@ Remaining findings (MEDIUM/LOW, non-blocking)
 Overall: PASS | FAIL
 ```
 
-If Overall = PASS, invoke `/specflow merge` (or hand back to `/specflow-auto`
-for STOP #2). If FAIL, stop and report to the user.
+If Overall = PASS, surface the STOP #2 summary block defined in
+`phases/auto-chain.md` and ask for merge confirmation, then invoke
+`/specflow merge` on "yes". If FAIL, stop and report to the user.

--- a/src/infrastructure/harness/skill_folder.ts
+++ b/src/infrastructure/harness/skill_folder.ts
@@ -13,7 +13,7 @@ export function skillFolderName(entry: CoreEntry): string {
     case "backlog-skill":
       // Skill names that already begin with "specflow" are emitted as-is
       // (the router itself is "specflow"; the auto-invoke alias is
-      // "specflow-review"; the auto-chainer is "specflow-auto"). Other
+      // "specflow-review"; "specflow-auto" is the deprecated alias). Other
       // skills (`backlog`, …) get the namespacing prefix to avoid
       // clashes inside a global skills registry.
       return entry.name === "specflow" || entry.name.startsWith("specflow-")

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -4257,11 +4257,11 @@ layout and frontmatter conventions.
 
 ### What makes Specflow different from upstream Spec Kit
 
-1. **Auto-chained pipeline** — \`/specflow-auto\` chains \`clarify →
-   plan → tasks → analyze → implement → review → merge\` in one
-   session. Upstream stops at every step and asks the human; Specflow
-   stops only when clarification is genuinely required and once
-   before the merge.
+1. **Auto-chained pipeline** — \`/specflow specify "<feature>"\` chains
+   \`specify → clarify → plan → tasks → analyze → implement → review\`
+   in one session, pausing only on real clarification and once before
+   merge. \`/specflow-auto\` is kept for one release as a deprecation
+   alias.
 
 2. **Dedicated \`review\` phase** — after \`implement\`, a \`review\` step
    checks architecture, error handling, test coverage, and quality

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -32,12 +32,25 @@ when_to_use: |
 
 # Specflow router
 
-\`\$ARGUMENTS\` carries the user's input. Parse it as \`<phase> [rest]\`:
+\`\$ARGUMENTS\` carries the user's input. Parse it as \`[<flag>...] <phase> [rest]\`:
 
-- The first token is the phase name.
-- Everything after the first whitespace is the argument string for that phase.
+1. **Chain mode parsing** — scan the tokens for at most one of
+   \`--manual\`, \`--once\`, \`--continue\`. They are mutually exclusive; if
+   more than one is present, report \`error: --manual, --once, and --continue are mutually exclusive\` and stop.
+   - \`--manual\` → CHAIN_MODE = \`off\`
+   - \`--once\`   → CHAIN_MODE = \`once\`
+   - \`--continue\` → CHAIN_MODE = \`continue\`
+   - none      → CHAIN_MODE = \`auto\` (the default)
 
-If \`\$ARGUMENTS\` is empty, render the **Workflow overview** below and stop. Do not pick a phase yourself.
+   Strip the matched flag from the token list before going further.
+
+2. **Phase extraction** — the first remaining token is the phase name.
+   Everything after the first whitespace is the argument string for
+   that phase.
+
+3. **Empty arguments** — if no tokens remain after flag parsing (or
+   \`\$ARGUMENTS\` was empty to start with), render the **Workflow overview**
+   below and stop. Do not pick a phase yourself.
 
 ## Phase index
 
@@ -57,13 +70,35 @@ If \`\$ARGUMENTS\` is empty, render the **Workflow overview** below and stop. Do
 | \`tag-version\` | \`phases/tag-version.md\` | Bump + create an annotated git tag using the project's versioning scheme. |
 | \`release-version\` | \`phases/release-version.md\` | Generate categorized release notes for a tag (default: latest). |
 
+Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
+\`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
+\`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`) are one-shot
+regardless of chain mode.
+
 ## Routing
 
 1. **Read** the phase reference file (\`phases/<phase>.md\`) for the requested phase using the \`Read\` tool.
-2. **Substitute** the remainder of \`\$ARGUMENTS\` for the phase's input.
+2. **Substitute** the stripped phase arguments for the phase's input.
 3. **Execute** the procedure in the reference file end-to-end.
+4. **Decide whether to chain** (see "Chain decision" below).
 
-Unknown phase → print the index above and stop.
+Unknown phase → print the phase index and stop.
+
+## Chain decision
+
+After the phase procedure completes successfully:
+
+- \`CHAIN_MODE == off\` (the user passed \`--manual\`) → stop. Report the
+  phase outcome and leave the next step to the user.
+- Phase is not in the chainable list (e.g. \`constitution\`, \`checklist\`,
+  \`groom\`, \`tag-version\`, \`release-version\`) → stop.
+- \`CHAIN_MODE == once\` → stop.
+- \`CHAIN_MODE == continue\` → read \`phases/auto-chain.md\` and chain
+  through the remaining phases regardless of downstream-artefact state.
+- \`CHAIN_MODE == auto\` (the default) → read \`phases/auto-chain.md\`. For
+  \`specify\`, the chain always continues. For any other chainable phase,
+  apply the artefact-detection table in that file — chain if downstream
+  artefacts are absent, one-shot if present.
 
 ## Workflow overview
 
@@ -73,37 +108,40 @@ specify → clarify → plan → tasks → analyze → implement → review → 
                                                           STOP for pre-merge validation
 \`\`\`
 
+Default behavior: \`/specflow specify "..."\` runs the entire chain in one
+session, pausing only at STOP #1 (if clarifications are needed) and
+STOP #2 (pre-merge confirmation). See \`phases/auto-chain.md\` for the
+chain mechanics.
+
 \`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, and \`release-version\` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
 \`\`\`
 /specflow specify "Add OAuth2 login"
-  → spec drafted in .specflow/specs/<NNN>-add-oauth2-login/spec.md
-
-/specflow clarify
-  → resolves any [NEEDS CLARIFICATION] markers
-
-/specflow plan
-  → research, data-model, contracts, quickstart written
-
-/specflow tasks
-  → tasks.md generated
-
-/specflow analyze
-  → cross-artifact consistency check
-
-/specflow implement
-  → developer → review-coordinator → qa-tester pipeline
-
-/specflow review
-  → final quality scan
-
-/specflow merge
-  → pre-merge validation + merge
+  → drafts the spec, then auto-chains:
+    → /specflow clarify  (STOP #1 only if [NEEDS CLARIFICATION] markers remain)
+    → /specflow plan
+    → /specflow tasks
+    → /specflow analyze
+    → /specflow implement
+    → /specflow review
+    → STOP #2 — summary + "Ready to merge?" confirmation
+    → /specflow merge  (on "yes")
 \`\`\`
 
-For an end-to-end run that auto-chains the silent gates, use \`/specflow-auto specify "<feature>"\`.
+To run a single phase only (no chain), pass \`--manual\`:
+
+\`\`\`
+/specflow specify --manual "Add OAuth2 login"
+\`\`\`
+
+To force or skip the chain mid-flow:
+
+\`\`\`
+/specflow plan 042 --once       # regenerate plan.md only, do not cascade
+/specflow plan 042 --continue   # regenerate plan.md AND cascade tasks → review
+\`\`\`
 `,
     executable: false,
     backend: null,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -1054,7 +1054,7 @@ At end of report, output a concise Next Actions block:
 
 - If CRITICAL issues exist: Recommend resolving before \`/specflow implement\`
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
-- Provide explicit command suggestions: e.g., "Run /specflow specify with refinement", "Run /specflow plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+- Provide explicit command suggestions: e.g., "Run /specflow specify --manual to refine the spec without re-cascading", "Run /specflow plan --once to regenerate the plan only, or /specflow plan to cascade through tasks → review", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
 ### 8. Offer Remediation
 
@@ -1408,8 +1408,9 @@ Remaining findings (MEDIUM/LOW, non-blocking)
 Overall: PASS | FAIL
 \`\`\`
 
-If Overall = PASS, invoke \`/specflow merge\` (or hand back to \`/specflow-auto\`
-for STOP #2). If FAIL, stop and report to the user.
+If Overall = PASS, surface the STOP #2 summary block defined in
+\`phases/auto-chain.md\` and ask for merge confirmation, then invoke
+\`/specflow merge\` on "yes". If FAIL, stop and report to the user.
 `,
     executable: false,
     backend: null,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2227,6 +2227,137 @@ The script emits the body verbatim. Do NOT:
     skipIfExists: false,
   },
   {
+    category: "phase",
+    name: "auto-chain",
+    suffix: "auto-chain.md",
+    content: `# Auto-chain control
+
+This file carries the chain mechanics that the \`/specflow\` router follows
+when chain mode is engaged. The router reads it after a chainable phase
+(\`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`, \`implement\`, \`review\`)
+completes — unless \`--manual\` or \`--once\` was passed, or downstream
+artefacts indicate one-shot intent.
+
+## Default flow
+
+\`\`\`
+specify → clarify → plan → tasks → analyze → implement → review → merge
+          ▲                                                        ▲
+          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+\`\`\`
+
+## Per-phase behavior
+
+After each phase completes successfully, immediately invoke the next phase via
+the \`Skill\` tool (or the platform equivalent). Do not emit a user-facing "ready
+for next step?" prompt. A one-line \`✓ <phase> complete — proceeding to <next>\`
+log is sufficient.
+
+## STOP #1 — Clarification checkpoint
+
+After \`/specflow clarify\` finishes:
+
+- If zero \`[NEEDS CLARIFICATION]\` markers remain in \`spec.md\`, continue silently
+  to \`/specflow plan\`.
+- If markers remain, present the top 3 questions to the user (per the
+  \`/specflow clarify\` format) and wait for answers. Once the spec is updated,
+  resume the chain automatically.
+
+## Silent gates
+
+These phases run without user interruption unless they fail hard or surface
+CRITICAL findings:
+
+- \`/specflow plan\` — generates plan + research + data-model + contracts + quickstart.
+- \`/specflow tasks\` — generates tasks.md.
+- \`/specflow analyze\` — cross-artifact consistency check. On LOW/MEDIUM findings,
+  log a summary and continue. On CRITICAL findings, stop and surface them.
+- \`/specflow implement\` — runs the developer → review-coordinator → qa-tester
+  pipeline. Has its own internal fix loop for review findings; do not intercept.
+- \`/specflow review\` — final quality scan.
+
+## STOP #2 — Pre-merge validation
+
+After \`/specflow review\` passes, ALWAYS stop and present a compact summary
+before invoking \`/specflow merge\`. The summary must include:
+
+- Feature name and branch
+- Files created / modified (count + key paths)
+- Tests added and full-suite status
+- Known deviations from tasks.md and rationale
+- Open risks / deferred items
+- One-line business outcome
+
+Then ask explicitly: "Ready to merge? (yes to run /specflow merge, no to stay on
+the branch)". Wait for explicit confirmation. On "yes", invoke
+\`/specflow merge\`. After merge, the chain ends.
+
+## Mid-chain re-entry
+
+When the user invokes any phase other than \`specify\` directly (e.g.
+\`/specflow plan 042\`, \`/specflow implement 042\`), apply this
+context-aware default:
+
+- **Downstream artefacts missing** → chain. The user is resuming an
+  interrupted flow (long session, fresh shell after compaction, manual
+  review between early phases). Continue through the remaining phases →
+  STOP #2 with the same checkpoints as the entry-point flow.
+- **Downstream artefacts present** → one-shot. The user is re-running a
+  single phase (regenerate \`plan.md\` after a tweak, re-analyse after a
+  spec edit). Do NOT cascade.
+
+"Downstream artefacts" means files under \`.specflow/specs/<feature>/\`
+produced by phases AFTER the one being invoked:
+
+| Invoked phase | Downstream artefacts to check |
+|---|---|
+| \`clarify\`   | \`plan.md\`, \`tasks.md\` |
+| \`plan\`      | \`tasks.md\`, \`data-model.md\`, \`contracts/\`, \`quickstart.md\` |
+| \`tasks\`     | \`tasks.md\` markings beyond the initial generation, or any task marked done |
+| \`analyze\`   | nothing (analyze is a read-only gate; treat as one-shot unless \`--continue\`) |
+| \`implement\` | a merged PR, a \`review.md\`, or task completion past 50% |
+| \`review\`    | nothing past review (chain-tail is just \`merge\`); treat as one-shot unless \`--continue\` |
+
+If any listed artefact is present, infer one-shot intent. If all are
+absent, chain.
+
+### Explicit overrides
+
+The router-level flags \`--continue\` and \`--once\` override the
+artefact-detection default. They are mutually exclusive with each other
+and with \`--manual\`:
+
+- \`--continue\` — force the chain regardless of artefact state. Useful
+  when you want to regenerate a phase AND cascade downstream work
+  afterwards (e.g. tweak \`plan.md\`, then re-run \`tasks → analyze →
+  implement → review\` from scratch).
+- \`--once\` — force one-shot regardless. Useful when downstream
+  artefacts haven't been generated yet but you only want to run this
+  single phase right now (e.g. inspect the spec before authorising
+  the rest of the chain).
+
+## Failure handling
+
+- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
+  surface the error, ask the user how to proceed. Do not silently retry.
+- Task-level blockers reported by the developer agent during \`implement\`: the
+  implement workflow has its own fix loop; do not intercept.
+- \`clarify\` producing more than 5 questions: present the top 3 per the
+  \`/specflow clarify\` quota; the rest can be asked later.
+
+## Context budget
+
+Long features (≥13 story points or ≥30 tasks) may exhaust context during
+\`/specflow implement\`. If compaction occurs mid-chain, inform the user and
+let them resume from a fresh session — the artefact-detection default
+above will pick up where the previous run stopped, or they can pass
+\`--continue\` explicitly.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
     category: "phase-script",
     name: "tag",
     suffix: "tag.sh",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -4769,135 +4769,31 @@ should survive across sessions and isn't captured elsewhere:
     suffix: null,
     content: `---
 name: specflow-auto
-description: Auto-chain Specflow workflow — when the user runs /specflow-auto specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+description: DEPRECATED — /specflow now auto-chains by default since v1.5.0. This skill is kept as an alias for one release and will be removed in the next major version.
 ---
 
-# Specflow Auto-Chain
+# /specflow-auto is deprecated
 
-This skill turns the Specflow workflow into a single-command operation. When the
-user invokes \`/specflow-auto specify "<feature description>"\`, you MUST chain every
-Specflow phase in the same session without asking the user between phases,
-EXCEPT at the two checkpoints defined below.
+Auto-chain is now the default behavior of \`/specflow\`. Use:
 
-## Default flow
+- \`/specflow specify "<feature>"\` — runs the full chain automatically
+  (specify → clarify → plan → tasks → analyze → implement → review →
+  STOP #2 for merge confirmation).
+- \`/specflow specify --manual "<feature>"\` — runs \`specify\` only, no
+  chain.
+- \`/specflow <phase> <args>\` — mid-chain re-entry with artefact
+  detection (chain if downstream artefacts are absent, one-shot if
+  present). Override with \`--once\` (force one-shot) or \`--continue\`
+  (force chain).
 
-\`\`\`
-specify → clarify → plan → tasks → analyze → implement → review → merge
-          ▲                                                        ▲
-          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
-\`\`\`
+See \`phases/auto-chain.md\` (in the \`specflow\` skill) for the full chain
+mechanics, including STOP #1 (clarification checkpoint) and STOP #2
+(pre-merge confirmation).
 
-## Per-phase behavior
-
-After each phase completes successfully, immediately invoke the next phase via
-the \`Skill\` tool (or the platform equivalent). Do not emit a user-facing "ready
-for next step?" prompt. A one-line \`✓ <phase> complete — proceeding to <next>\`
-log is sufficient.
-
-## STOP #1 — Clarification checkpoint
-
-After \`/specflow clarify\` finishes:
-
-- If zero \`[NEEDS CLARIFICATION]\` markers remain in \`spec.md\`, continue silently
-  to \`/specflow plan\`.
-- If markers remain, present the top 3 questions to the user (per the
-  \`/specflow clarify\` format) and wait for answers. Once the spec is updated,
-  resume the chain automatically.
-
-## Silent gates
-
-These phases run without user interruption unless they fail hard or surface
-CRITICAL findings:
-
-- \`/specflow plan\` — generates plan + research + data-model + contracts + quickstart.
-- \`/specflow tasks\` — generates tasks.md.
-- \`/specflow analyze\` — cross-artifact consistency check. On LOW/MEDIUM findings,
-  log a summary and continue. On CRITICAL findings, stop and surface them.
-- \`/specflow implement\` — runs the developer → review-coordinator → qa-tester
-  pipeline. Has its own internal fix loop for review findings; do not intercept.
-- \`/specflow review\` — final quality scan.
-
-## STOP #2 — Pre-merge validation
-
-After \`/specflow review\` passes, ALWAYS stop and present a compact summary
-before invoking \`/specflow merge\`. The summary must include:
-
-- Feature name and branch
-- Files created / modified (count + key paths)
-- Tests added and full-suite status
-- Known deviations from tasks.md and rationale
-- Open risks / deferred items
-- One-line business outcome
-
-Then ask explicitly: "Ready to merge? (yes to run /specflow merge, no to stay on
-the branch)". Wait for explicit confirmation. On "yes", invoke
-\`/specflow merge\`. After merge, the chain ends.
-
-## Opt-out
-
-If the user invokes \`/specflow-auto specify --manual "<description>"\`, run
-\`/specflow specify\` only and stop. Do not auto-chain. Each subsequent phase must
-be invoked manually by the user.
-
-## Mid-chain re-entry
-
-When the user invokes any phase other than \`specify\` directly (e.g.
-\`/specflow-auto plan 042\`, \`/specflow-auto implement 042\`), apply this
-context-aware default:
-
-- **Downstream artefacts missing** → chain. The user is resuming an
-  interrupted flow (long session, fresh shell after compaction, manual
-  review between early phases). Continue through the remaining phases →
-  STOP #2 with the same checkpoints as the entry-point flow.
-- **Downstream artefacts present** → one-shot. The user is re-running a
-  single phase (regenerate \`plan.md\` after a tweak, re-analyse after a
-  spec edit). Do NOT cascade.
-
-"Downstream artefacts" means files under \`.specflow/specs/<feature>/\`
-produced by phases AFTER the one being invoked:
-
-| Invoked phase | Downstream artefacts to check |
-|---|---|
-| \`clarify\`   | \`plan.md\`, \`tasks.md\` |
-| \`plan\`      | \`tasks.md\`, \`data-model.md\`, \`contracts/\`, \`quickstart.md\` |
-| \`tasks\`     | \`tasks.md\` markings beyond the initial generation, or any task marked done |
-| \`analyze\`   | nothing (analyze is a read-only gate; treat as one-shot unless \`--continue\`) |
-| \`implement\` | a merged PR, a \`review.md\`, or task completion past 50% |
-| \`review\`    | nothing past review (chain-tail is just \`merge\`); treat as one-shot unless \`--continue\` |
-
-If any listed artefact is present, infer one-shot intent. If all are
-absent, chain.
-
-### Explicit overrides
-
-- \`/specflow-auto <phase> N --continue\` — force the chain regardless of
-  artefact state. Useful when you want to regenerate a phase AND cascade
-  downstream work afterwards (e.g. tweak \`plan.md\`, then re-run
-  \`tasks → analyze → implement → review\` from scratch).
-- \`/specflow-auto <phase> N --once\` — force one-shot regardless. Useful
-  when downstream artefacts haven't been generated yet but you only
-  want to run this single phase right now (e.g. inspect the spec
-  before authorising the rest of the chain).
-
-The flags are mutually exclusive; the explicit form always wins over
-the artefact-detection default.
-
-## Failure handling
-
-- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
-  surface the error, ask the user how to proceed. Do not silently retry.
-- Task-level blockers reported by the developer agent during \`implement\`: the
-  implement workflow has its own fix loop; do not intercept.
-- \`clarify\` producing more than 5 questions: present the top 3 per the
-  \`/specflow clarify\` quota; the rest can be asked later.
-
-## Context budget
-
-Long features (≥13 story points or ≥30 tasks) may exhaust context during
-\`/specflow implement\`. If compaction occurs mid-chain, inform the user and
-let them resume from a fresh session — the artefact-detection default in
-"Mid-chain re-entry" above will pick up where the previous run stopped, or
-they can pass \`--continue\` explicitly.
+This skill will be removed in the next major release. If you see this
+file in your project after running \`specflow upgrade\`, it means
+muscle-memory invocations of \`/specflow-auto\` keep working — but you
+should switch to the new entry point.
 `,
     executable: false,
     backend: null,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -10032,7 +10032,7 @@ Invoke the **specflow** skill (at \`.claude/skills/specflow/SKILL.md\`) using th
 
 Empty \`\$ARGUMENTS\` → the skill prints the workflow overview and stops.
 
-This command is a thin slash-command shim so users can type \`/specflow specify "..."\` directly. The skill itself has \`disable-model-invocation: true\`; this command makes the explicit \`/\` form available alongside the \`specflow-review\` auto-invoke alias.
+This command is a thin slash-command shim so users can type \`/specflow specify "..."\` directly. The router auto-chains the rest of the workflow by default; pass \`--manual\` to opt out, or \`--once\` / \`--continue\` to override the mid-chain artefact-detection heuristic.
 `,
       executable: false,
     },
@@ -10497,7 +10497,7 @@ clarifications needed) STOP #2 (pre-merge validation)
 - \`/specflow review\` — architecture + quality gates
 - \`/specflow merge\` — merge the feature branch to main
 - \`/specflow-backlog\` — manage the product backlog (via the PO agent)
-- \`/specflow-auto\` — auto-chain dispatcher invoked by \`/specflow specify\`
+- \`/specflow-auto\` — deprecated alias of \`/specflow\`; will be removed in the next major release
 
 ## Agent roles (invocable manually as skills)
 

--- a/templates/core/agents/specflow-expert.md
+++ b/templates/core/agents/specflow-expert.md
@@ -214,11 +214,11 @@ layout and frontmatter conventions.
 
 ### What makes Specflow different from upstream Spec Kit
 
-1. **Auto-chained pipeline** — `/specflow-auto` chains `clarify →
-   plan → tasks → analyze → implement → review → merge` in one
-   session. Upstream stops at every step and asks the human; Specflow
-   stops only when clarification is genuinely required and once
-   before the merge.
+1. **Auto-chained pipeline** — `/specflow specify "<feature>"` chains
+   `specify → clarify → plan → tasks → analyze → implement → review`
+   in one session, pausing only on real clarification and once before
+   merge. `/specflow-auto` is kept for one release as a deprecation
+   alias.
 
 2. **Dedicated `review` phase** — after `implement`, a `review` step
    checks architecture, error handling, test coverage, and quality

--- a/templates/core/skills/specflow-auto/SKILL.md
+++ b/templates/core/skills/specflow-auto/SKILL.md
@@ -1,131 +1,27 @@
 ---
 name: specflow-auto
-description: Auto-chain Specflow workflow — when the user runs /specflow-auto specify, chain clarify → plan → tasks → analyze → implement → review → merge, stopping only for required clarifications and final pre-merge validation.
+description: DEPRECATED — /specflow now auto-chains by default since v1.5.0. This skill is kept as an alias for one release and will be removed in the next major version.
 ---
 
-# Specflow Auto-Chain
+# /specflow-auto is deprecated
 
-This skill turns the Specflow workflow into a single-command operation. When the
-user invokes `/specflow-auto specify "<feature description>"`, you MUST chain every
-Specflow phase in the same session without asking the user between phases,
-EXCEPT at the two checkpoints defined below.
+Auto-chain is now the default behavior of `/specflow`. Use:
 
-## Default flow
+- `/specflow specify "<feature>"` — runs the full chain automatically
+  (specify → clarify → plan → tasks → analyze → implement → review →
+  STOP #2 for merge confirmation).
+- `/specflow specify --manual "<feature>"` — runs `specify` only, no
+  chain.
+- `/specflow <phase> <args>` — mid-chain re-entry with artefact
+  detection (chain if downstream artefacts are absent, one-shot if
+  present). Override with `--once` (force one-shot) or `--continue`
+  (force chain).
 
-```
-specify → clarify → plan → tasks → analyze → implement → review → merge
-          ▲                                                        ▲
-          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
-```
+See `phases/auto-chain.md` (in the `specflow` skill) for the full chain
+mechanics, including STOP #1 (clarification checkpoint) and STOP #2
+(pre-merge confirmation).
 
-## Per-phase behavior
-
-After each phase completes successfully, immediately invoke the next phase via
-the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
-for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
-log is sufficient.
-
-## STOP #1 — Clarification checkpoint
-
-After `/specflow clarify` finishes:
-
-- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently
-  to `/specflow plan`.
-- If markers remain, present the top 3 questions to the user (per the
-  `/specflow clarify` format) and wait for answers. Once the spec is updated,
-  resume the chain automatically.
-
-## Silent gates
-
-These phases run without user interruption unless they fail hard or surface
-CRITICAL findings:
-
-- `/specflow plan` — generates plan + research + data-model + contracts + quickstart.
-- `/specflow tasks` — generates tasks.md.
-- `/specflow analyze` — cross-artifact consistency check. On LOW/MEDIUM findings,
-  log a summary and continue. On CRITICAL findings, stop and surface them.
-- `/specflow implement` — runs the developer → review-coordinator → qa-tester
-  pipeline. Has its own internal fix loop for review findings; do not intercept.
-- `/specflow review` — final quality scan.
-
-## STOP #2 — Pre-merge validation
-
-After `/specflow review` passes, ALWAYS stop and present a compact summary
-before invoking `/specflow merge`. The summary must include:
-
-- Feature name and branch
-- Files created / modified (count + key paths)
-- Tests added and full-suite status
-- Known deviations from tasks.md and rationale
-- Open risks / deferred items
-- One-line business outcome
-
-Then ask explicitly: "Ready to merge? (yes to run /specflow merge, no to stay on
-the branch)". Wait for explicit confirmation. On "yes", invoke
-`/specflow merge`. After merge, the chain ends.
-
-## Opt-out
-
-If the user invokes `/specflow-auto specify --manual "<description>"`, run
-`/specflow specify` only and stop. Do not auto-chain. Each subsequent phase must
-be invoked manually by the user.
-
-## Mid-chain re-entry
-
-When the user invokes any phase other than `specify` directly (e.g.
-`/specflow-auto plan 042`, `/specflow-auto implement 042`), apply this
-context-aware default:
-
-- **Downstream artefacts missing** → chain. The user is resuming an
-  interrupted flow (long session, fresh shell after compaction, manual
-  review between early phases). Continue through the remaining phases →
-  STOP #2 with the same checkpoints as the entry-point flow.
-- **Downstream artefacts present** → one-shot. The user is re-running a
-  single phase (regenerate `plan.md` after a tweak, re-analyse after a
-  spec edit). Do NOT cascade.
-
-"Downstream artefacts" means files under `.specflow/specs/<feature>/`
-produced by phases AFTER the one being invoked:
-
-| Invoked phase | Downstream artefacts to check |
-|---|---|
-| `clarify`   | `plan.md`, `tasks.md` |
-| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
-| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
-| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
-| `implement` | a merged PR, a `review.md`, or task completion past 50% |
-| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
-
-If any listed artefact is present, infer one-shot intent. If all are
-absent, chain.
-
-### Explicit overrides
-
-- `/specflow-auto <phase> N --continue` — force the chain regardless of
-  artefact state. Useful when you want to regenerate a phase AND cascade
-  downstream work afterwards (e.g. tweak `plan.md`, then re-run
-  `tasks → analyze → implement → review` from scratch).
-- `/specflow-auto <phase> N --once` — force one-shot regardless. Useful
-  when downstream artefacts haven't been generated yet but you only
-  want to run this single phase right now (e.g. inspect the spec
-  before authorising the rest of the chain).
-
-The flags are mutually exclusive; the explicit form always wins over
-the artefact-detection default.
-
-## Failure handling
-
-- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
-  surface the error, ask the user how to proceed. Do not silently retry.
-- Task-level blockers reported by the developer agent during `implement`: the
-  implement workflow has its own fix loop; do not intercept.
-- `clarify` producing more than 5 questions: present the top 3 per the
-  `/specflow clarify` quota; the rest can be asked later.
-
-## Context budget
-
-Long features (≥13 story points or ≥30 tasks) may exhaust context during
-`/specflow implement`. If compaction occurs mid-chain, inform the user and
-let them resume from a fresh session — the artefact-detection default in
-"Mid-chain re-entry" above will pick up where the previous run stopped, or
-they can pass `--continue` explicitly.
+This skill will be removed in the next major release. If you see this
+file in your project after running `specflow upgrade`, it means
+muscle-memory invocations of `/specflow-auto` keep working — but you
+should switch to the new entry point.

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -21,12 +21,25 @@ when_to_use: |
 
 # Specflow router
 
-`$ARGUMENTS` carries the user's input. Parse it as `<phase> [rest]`:
+`$ARGUMENTS` carries the user's input. Parse it as `[<flag>...] <phase> [rest]`:
 
-- The first token is the phase name.
-- Everything after the first whitespace is the argument string for that phase.
+1. **Chain mode parsing** — scan the tokens for at most one of
+   `--manual`, `--once`, `--continue`. They are mutually exclusive; if
+   more than one is present, report `error: --manual, --once, and --continue are mutually exclusive` and stop.
+   - `--manual` → CHAIN_MODE = `off`
+   - `--once`   → CHAIN_MODE = `once`
+   - `--continue` → CHAIN_MODE = `continue`
+   - none      → CHAIN_MODE = `auto` (the default)
 
-If `$ARGUMENTS` is empty, render the **Workflow overview** below and stop. Do not pick a phase yourself.
+   Strip the matched flag from the token list before going further.
+
+2. **Phase extraction** — the first remaining token is the phase name.
+   Everything after the first whitespace is the argument string for
+   that phase.
+
+3. **Empty arguments** — if no tokens remain after flag parsing (or
+   `$ARGUMENTS` was empty to start with), render the **Workflow overview**
+   below and stop. Do not pick a phase yourself.
 
 ## Phase index
 
@@ -46,13 +59,35 @@ If `$ARGUMENTS` is empty, render the **Workflow overview** below and stop. Do no
 | `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
 | `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
 
+Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
+`implement`, `review`. The others (`merge`, `constitution`,
+`checklist`, `groom`, `tag-version`, `release-version`) are one-shot
+regardless of chain mode.
+
 ## Routing
 
 1. **Read** the phase reference file (`phases/<phase>.md`) for the requested phase using the `Read` tool.
-2. **Substitute** the remainder of `$ARGUMENTS` for the phase's input.
+2. **Substitute** the stripped phase arguments for the phase's input.
 3. **Execute** the procedure in the reference file end-to-end.
+4. **Decide whether to chain** (see "Chain decision" below).
 
-Unknown phase → print the index above and stop.
+Unknown phase → print the phase index and stop.
+
+## Chain decision
+
+After the phase procedure completes successfully:
+
+- `CHAIN_MODE == off` (the user passed `--manual`) → stop. Report the
+  phase outcome and leave the next step to the user.
+- Phase is not in the chainable list (e.g. `constitution`, `checklist`,
+  `groom`, `tag-version`, `release-version`) → stop.
+- `CHAIN_MODE == once` → stop.
+- `CHAIN_MODE == continue` → read `phases/auto-chain.md` and chain
+  through the remaining phases regardless of downstream-artefact state.
+- `CHAIN_MODE == auto` (the default) → read `phases/auto-chain.md`. For
+  `specify`, the chain always continues. For any other chainable phase,
+  apply the artefact-detection table in that file — chain if downstream
+  artefacts are absent, one-shot if present.
 
 ## Workflow overview
 
@@ -62,34 +97,37 @@ specify → clarify → plan → tasks → analyze → implement → review → 
                                                           STOP for pre-merge validation
 ```
 
+Default behavior: `/specflow specify "..."` runs the entire chain in one
+session, pausing only at STOP #1 (if clarifications are needed) and
+STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
+chain mechanics.
+
 `constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
 ```
 /specflow specify "Add OAuth2 login"
-  → spec drafted in .specflow/specs/<NNN>-add-oauth2-login/spec.md
-
-/specflow clarify
-  → resolves any [NEEDS CLARIFICATION] markers
-
-/specflow plan
-  → research, data-model, contracts, quickstart written
-
-/specflow tasks
-  → tasks.md generated
-
-/specflow analyze
-  → cross-artifact consistency check
-
-/specflow implement
-  → developer → review-coordinator → qa-tester pipeline
-
-/specflow review
-  → final quality scan
-
-/specflow merge
-  → pre-merge validation + merge
+  → drafts the spec, then auto-chains:
+    → /specflow clarify  (STOP #1 only if [NEEDS CLARIFICATION] markers remain)
+    → /specflow plan
+    → /specflow tasks
+    → /specflow analyze
+    → /specflow implement
+    → /specflow review
+    → STOP #2 — summary + "Ready to merge?" confirmation
+    → /specflow merge  (on "yes")
 ```
 
-For an end-to-end run that auto-chains the silent gates, use `/specflow-auto specify "<feature>"`.
+To run a single phase only (no chain), pass `--manual`:
+
+```
+/specflow specify --manual "Add OAuth2 login"
+```
+
+To force or skip the chain mid-flow:
+
+```
+/specflow plan 042 --once       # regenerate plan.md only, do not cascade
+/specflow plan 042 --continue   # regenerate plan.md AND cascade tasks → review
+```

--- a/templates/core/skills/specflow/phases/analyze.md
+++ b/templates/core/skills/specflow/phases/analyze.md
@@ -187,7 +187,7 @@ At end of report, output a concise Next Actions block:
 
 - If CRITICAL issues exist: Recommend resolving before `/specflow implement`
 - If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
-- Provide explicit command suggestions: e.g., "Run /specflow specify with refinement", "Run /specflow plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+- Provide explicit command suggestions: e.g., "Run /specflow specify --manual to refine the spec without re-cascading", "Run /specflow plan --once to regenerate the plan only, or /specflow plan to cascade through tasks → review", "Manually edit tasks.md to add coverage for 'performance-metrics'"
 
 ### 8. Offer Remediation
 

--- a/templates/core/skills/specflow/phases/auto-chain.md
+++ b/templates/core/skills/specflow/phases/auto-chain.md
@@ -1,0 +1,122 @@
+# Auto-chain control
+
+This file carries the chain mechanics that the `/specflow` router follows
+when chain mode is engaged. The router reads it after a chainable phase
+(`specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`)
+completes — unless `--manual` or `--once` was passed, or downstream
+artefacts indicate one-shot intent.
+
+## Default flow
+
+```
+specify → clarify → plan → tasks → analyze → implement → review → merge
+          ▲                                                        ▲
+          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+```
+
+## Per-phase behavior
+
+After each phase completes successfully, immediately invoke the next phase via
+the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
+for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
+log is sufficient.
+
+## STOP #1 — Clarification checkpoint
+
+After `/specflow clarify` finishes:
+
+- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently
+  to `/specflow plan`.
+- If markers remain, present the top 3 questions to the user (per the
+  `/specflow clarify` format) and wait for answers. Once the spec is updated,
+  resume the chain automatically.
+
+## Silent gates
+
+These phases run without user interruption unless they fail hard or surface
+CRITICAL findings:
+
+- `/specflow plan` — generates plan + research + data-model + contracts + quickstart.
+- `/specflow tasks` — generates tasks.md.
+- `/specflow analyze` — cross-artifact consistency check. On LOW/MEDIUM findings,
+  log a summary and continue. On CRITICAL findings, stop and surface them.
+- `/specflow implement` — runs the developer → review-coordinator → qa-tester
+  pipeline. Has its own internal fix loop for review findings; do not intercept.
+- `/specflow review` — final quality scan.
+
+## STOP #2 — Pre-merge validation
+
+After `/specflow review` passes, ALWAYS stop and present a compact summary
+before invoking `/specflow merge`. The summary must include:
+
+- Feature name and branch
+- Files created / modified (count + key paths)
+- Tests added and full-suite status
+- Known deviations from tasks.md and rationale
+- Open risks / deferred items
+- One-line business outcome
+
+Then ask explicitly: "Ready to merge? (yes to run /specflow merge, no to stay on
+the branch)". Wait for explicit confirmation. On "yes", invoke
+`/specflow merge`. After merge, the chain ends.
+
+## Mid-chain re-entry
+
+When the user invokes any phase other than `specify` directly (e.g.
+`/specflow plan 042`, `/specflow implement 042`), apply this
+context-aware default:
+
+- **Downstream artefacts missing** → chain. The user is resuming an
+  interrupted flow (long session, fresh shell after compaction, manual
+  review between early phases). Continue through the remaining phases →
+  STOP #2 with the same checkpoints as the entry-point flow.
+- **Downstream artefacts present** → one-shot. The user is re-running a
+  single phase (regenerate `plan.md` after a tweak, re-analyse after a
+  spec edit). Do NOT cascade.
+
+"Downstream artefacts" means files under `.specflow/specs/<feature>/`
+produced by phases AFTER the one being invoked:
+
+| Invoked phase | Downstream artefacts to check |
+|---|---|
+| `clarify`   | `plan.md`, `tasks.md` |
+| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
+| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
+| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
+| `implement` | a merged PR, a `review.md`, or task completion past 50% |
+| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
+
+If any listed artefact is present, infer one-shot intent. If all are
+absent, chain.
+
+### Explicit overrides
+
+The router-level flags `--continue` and `--once` override the
+artefact-detection default. They are mutually exclusive with each other
+and with `--manual`:
+
+- `--continue` — force the chain regardless of artefact state. Useful
+  when you want to regenerate a phase AND cascade downstream work
+  afterwards (e.g. tweak `plan.md`, then re-run `tasks → analyze →
+  implement → review` from scratch).
+- `--once` — force one-shot regardless. Useful when downstream
+  artefacts haven't been generated yet but you only want to run this
+  single phase right now (e.g. inspect the spec before authorising
+  the rest of the chain).
+
+## Failure handling
+
+- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
+  surface the error, ask the user how to proceed. Do not silently retry.
+- Task-level blockers reported by the developer agent during `implement`: the
+  implement workflow has its own fix loop; do not intercept.
+- `clarify` producing more than 5 questions: present the top 3 per the
+  `/specflow clarify` quota; the rest can be asked later.
+
+## Context budget
+
+Long features (≥13 story points or ≥30 tasks) may exhaust context during
+`/specflow implement`. If compaction occurs mid-chain, inform the user and
+let them resume from a fresh session — the artefact-detection default
+above will pick up where the previous run stopped, or they can pass
+`--continue` explicitly.

--- a/templates/core/skills/specflow/phases/review.md
+++ b/templates/core/skills/specflow/phases/review.md
@@ -81,5 +81,6 @@ Remaining findings (MEDIUM/LOW, non-blocking)
 Overall: PASS | FAIL
 ```
 
-If Overall = PASS, invoke `/specflow merge` (or hand back to `/specflow-auto`
-for STOP #2). If FAIL, stop and report to the user.
+If Overall = PASS, surface the STOP #2 summary block defined in
+`phases/auto-chain.md` and ask for merge confirmation, then invoke
+`/specflow merge` on "yes". If FAIL, stop and report to the user.

--- a/templates/harness-specific/claude/commands/specflow.md
+++ b/templates/harness-specific/claude/commands/specflow.md
@@ -15,4 +15,4 @@ Invoke the **specflow** skill (at `.claude/skills/specflow/SKILL.md`) using the 
 
 Empty `$ARGUMENTS` → the skill prints the workflow overview and stops.
 
-This command is a thin slash-command shim so users can type `/specflow specify "..."` directly. The skill itself has `disable-model-invocation: true`; this command makes the explicit `/` form available alongside the `specflow-review` auto-invoke alias.
+This command is a thin slash-command shim so users can type `/specflow specify "..."` directly. The router auto-chains the rest of the workflow by default; pass `--manual` to opt out, or `--once` / `--continue` to override the mid-chain artefact-detection heuristic.

--- a/templates/harness-specific/cursor/specify-rules.mdc
+++ b/templates/harness-specific/cursor/specify-rules.mdc
@@ -29,7 +29,7 @@ clarifications needed) STOP #2 (pre-merge validation)
 - `/specflow review` — architecture + quality gates
 - `/specflow merge` — merge the feature branch to main
 - `/specflow-backlog` — manage the product backlog (via the PO agent)
-- `/specflow-auto` — auto-chain dispatcher invoked by `/specflow specify`
+- `/specflow-auto` — deprecated alias of `/specflow`; will be removed in the next major release
 
 ## Agent roles (invocable manually as skills)
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -15,6 +15,7 @@
     { "category": "phase", "name": "groom", "suffix": "groom.md", "source": "core/skills/specflow/phases/groom.md" },
     { "category": "phase", "name": "tag-version", "suffix": "tag-version.md", "source": "core/skills/specflow/phases/tag-version.md" },
     { "category": "phase", "name": "release-version", "suffix": "release-version.md", "source": "core/skills/specflow/phases/release-version.md" },
+    { "category": "phase", "name": "auto-chain", "suffix": "auto-chain.md", "source": "core/skills/specflow/phases/auto-chain.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,12 +82,12 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 13 phases (11 original + tag-version + release-version) +
-    // specflow-auto + specflow-review + backlog + 11 agents = 27.
+    // Router + 14 phases (11 original + tag-version + release-version + auto-chain) +
+    // specflow-auto + specflow-review + backlog + 11 agents = 28.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 27);
+    assertEquals(instructionsCount, 28);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,12 +74,12 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 13 phases (11 original + tag-version + release-version) +
-    // specflow-auto + specflow-review alias + backlog + 11 agent workflows = 27.
+    // Router + 14 phases (11 original + tag-version + release-version + auto-chain) +
+    // specflow-auto + specflow-review alias + backlog + 11 agent workflows = 28.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 27);
+    assertEquals(workflowsCount, 28);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);


### PR DESCRIPTION
## Why

Specflow ships two slash-skills today: `/specflow` (phase-by-phase) and `/specflow-auto` (auto-chain). End users and AI agents default to `/specflow specify` because it's the shorter name, then copy-paste every subsequent phase by hand. The auto-chain is hidden behind a noisier alias.

Recent in-the-wild evidence (Kevin's `/loop` screenshot): an agent suggested `/specflow specify "..."` expecting a manual phase-by-phase walk. This PR removes that footgun structurally.

## What

`/specflow specify` auto-chains the full workflow by default. The router owns flag parsing (`--manual`, `--once`, `--continue`) and reads a new `phases/auto-chain.md` to drive the chain.

| Invocation | Behavior |
|---|---|
| `/specflow specify "X"` | Full chain → STOP #2 (merge approval) |
| `/specflow specify --manual "X"` | Spec only, no chain |
| `/specflow plan 042` (mid-flow) | Artefact-detection: chain if downstream missing, one-shot otherwise |
| `/specflow plan 042 --once` | Force one-shot |
| `/specflow plan 042 --continue` | Force chain |
| `/specflow-auto <anything>` | Deprecation alias (one release), removed in next major |

## Architecture

- Router `SKILL.md` parses flags, dispatches to the phase, decides whether to chain.
- New `phases/auto-chain.md` carries chain mechanics (STOP #1, silent gates, STOP #2, mid-chain re-entry table, failure handling).
- `/specflow-auto/SKILL.md` rewritten as plain-prose redirect — no Skill-tool call, works on every harness.

## Drift fixes bundled

- `phases/review.md` — no longer hands STOP #2 to `/specflow-auto`; surfaces the summary block from `phases/auto-chain.md`.
- `phases/analyze.md` — re-run hint now distinguishes `--manual` / `--once` / cascade.
- `claude/commands/specflow.md` — dropped stale `disable-model-invocation: true` claim.
- `cursor/specify-rules.mdc` — `/specflow-auto` marked deprecated.
- `plugin/README.md` + `plugin/.claude-plugin/plugin.json` — marketing flipped.
- `docs/llms.md` — auto-chain section rewritten + 3 scattered demotions + phase-doc count drift (11 → 14, was already stale).
- `src/infrastructure/harness/skill_folder.ts` — comment refreshed.

## Verification

- **Architect validation:** completed 2026-05-16, captured in `docs/superpowers/specs/2026-05-16-specflow-auto-merge-design.md` and `.claude/agents/architect/memory/specflow-auto-merge-into-router.md`.
- **Subagent-driven execution:** 9 implementation tasks, 8 spec+quality reviews, 1 final cross-cutting review — all approved.
- `deno task test` → **594 passed / 0 failed**.
- Smoke audit → **0 coverage gaps / 0 stale assertions**. New smoke blocks: `#251 auto-chain — chain mechanics` (6 checks), `#182 specflow-auto — deprecation alias` (2 checks), `Phase-doc drift fixes` (3 checks).
- Mirror parity verified (templates/core ↔ plugin byte-identical for all touched files).
- Windsurf Cascade 12k char cap respected (one cap-driven wording compression on `specflow-expert.md` — both required signals preserved).

## Migration story

- `specflow upgrade` from 1.4.x: `/specflow-auto` users automatically get the deprecation prose on next upgrade. Their existing invocations keep working through this release.
- Next major release: drop `specflow-auto` from `templates/manifest.json` + `plugin_coverage.ts`; `upgrade_plan.ts` emits a clean `remove` for vanilla files.

## Release classification

**Minor.** Behavior change with backward compatibility preserved via the one-release deprecation alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
