### PR TITLE
fix(release): grant pull-requests: read for gen-changelog PR body fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # `scripts/gen-changelog.ts` calls `gh pr view <num> --json body`
+      # to extract the `## Agent adoption` section from each feat: PR.
+      # Without `pull-requests: read`, those calls return empty and the
+      # release body silently ships without the `### Adoption guide`
+      # block (v1.6.0 was published this way — body was amended manually
+      # post-release).
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

`scripts/gen-changelog.ts` (added in v1.6.0) calls `gh pr view <num> --json body` to extract `## Agent adoption` sections from `feat:` PR bodies. The build job's permissions block only had `contents: write`, so the call silently returned empty and the v1.6.0 release body shipped without the `### Adoption guide` section. (Body was amended manually post-release to include it.)

This patch adds `pull-requests: read` so future releases authenticate the PR-body fetch correctly.

## Agent adoption

Internal CI fix — no project-side adoption needed. The change is to the Specflow repo's own release workflow, not the scaffolded templates.

```prompt
No project adoption required. This change only affects the release workflow inside the Specflow repo itself; downstream projects scaffolded by `specflow init` are not affected.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)