### PR TITLE
fix(site): swap invisible Unicode copy glyph for inline SVG icon

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -70,7 +70,20 @@
 
           <div class="cta-row">
             <button type="button" class="btn btn-primary" data-copy-target="install-snippet">
-              <span class="btn-icon" aria-hidden="true">⎘</span>
+              <span class="btn-icon" aria-hidden="true"><svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect width="13" height="13" x="9" y="9" rx="2" ry="2" />
+                  <path
+                    d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                  />
+                </svg></span>
               <span class="btn-label">Copy install command</span>
             </button>
             <a class="btn btn-secondary" href="/docs/">Read the docs</a>
@@ -200,6 +213,17 @@
       // a separate script file would just be ceremony.
 
       // Copy-to-clipboard for the install snippet.
+      //
+      // Inline SVG icons (Lucide — MIT). Keeping them as JS string constants
+      // rather than DOM clones because we toggle them on success/failure and
+      // `innerHTML` swaps are simpler than two hidden <svg> siblings with
+      // class-based visibility. Both share the same viewBox and stroke recipe
+      // so the visual weight stays identical across the copy → check transition.
+      const ICON_COPY =
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="13" height="13" x="9" y="9" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+      const ICON_CHECK =
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
       document.addEventListener("click", (e) => {
         const btn = e.target.closest("[data-copy-target]");
         if (!btn) return;
@@ -210,11 +234,11 @@
         const icon = btn.querySelector(".btn-icon");
         const restore = () => {
           if (label) label.textContent = "Copy install command";
-          if (icon) icon.textContent = "⎘";
+          if (icon) icon.innerHTML = ICON_COPY;
         };
         navigator.clipboard.writeText(text).then(() => {
           if (label) label.textContent = "Copied";
-          if (icon) icon.textContent = "✓";
+          if (icon) icon.innerHTML = ICON_CHECK;
           setTimeout(restore, 1500);
         }).catch(() => {
           if (label) label.textContent = "Copy failed — select manually";

--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -467,8 +467,18 @@ main > section {
 }
 
 .btn-icon {
-  font-size: 14px;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Sized to match the 15px button label, with a touch of optical weight on
+     top. The icon is an inline SVG using `currentColor`, so it inherits the
+     button's foreground colour automatically (white on primary, brand on
+     ghost). */
+}
+
+.btn-icon svg {
+  width: 16px;
+  height: 16px;
 }
 
 /* ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

The hero "Copy install command" button on https://specflow.makerlabs.dev used `⎘` (U+2398 NEXT PAGE) at `font-size: 14px`. Most system fonts have no glyph for that codepoint, so the icon rendered as tofu / empty on every default macOS / Windows / Linux setup — the button shipped without a visible icon for ~everyone.

This PR replaces the Unicode char with an inline SVG copy icon (and a matching check icon for the post-copy success state), sized 16×16 to match the 15px button label.

**Why inline SVG, not an icon font:** the page uses exactly one glyph. Pulling in Lucide / Font Awesome / Phosphor adds a network round-trip plus FOUT (flash of unstyled text while the font downloads) for zero gain. The SVG uses `currentColor` so primary / secondary / ghost button variants all theme correctly with no extra CSS.

**Behavioural change:** the success-state icon swap in JS moves from `textContent = "✓"` to `innerHTML = ICON_CHECK` (the two SVG strings are hoisted to module-scope constants for readability). Same UX, same 1.5s restore timer.

## Agent adoption

No agent adoption needed — this is a pure docs-site fix. No CLI surface, no scaffolded files, no template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)