### PR TITLE
feat(detection): smarter SemVer detection at `specflow init`

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -245,12 +245,21 @@ when stdin is a TTY, and falls back to a numeric prompt — or the defaults — 
   number is just a release identifier. No major/minor/patch guesswork; the letter suffix handles
   same-day re-tags.
 
-Specflow detects whether the project looks like a library (`package.json` `exports` /
-`pyproject.toml` `[project]` / `Cargo.toml` `[lib]` / `composer.json` `type=library`) and
-pre-selects a sensible default — the user can always override at the picker. The choice is persisted
-by **rewriting the scaffolded skill** itself (the unchosen scheme's blocks are stripped at scaffold
-time), so the on-disk `.specflow/scripts/release/tag.sh` only contains the chosen scheme's logic. To
-switch schemes later, re-run `specflow init` and pick the other option.
+Specflow pre-selects a sensible default by scanning the project for SemVer signals:
+
+- **Library publishing markers** — `package.json` `exports`, `pyproject.toml` `[project]` /
+  `[tool.poetry]`, `Cargo.toml` `[lib]`, `composer.json` `type=library`.
+- **Semver-shaped git tags** — any local tag matching `v?MAJOR.MINOR.PATCH` (with optional
+  pre-release / build suffix), e.g. `v1.2.3`, `1.0.0-rc.1`, `v2.0.0+build.5`. Date-shaped tags like
+  `v25.5.16a` are explicitly excluded so brownfield repos already on date scheme don't get
+  mis-suggested.
+- **CHANGELOG.md** — Keep-a-Changelog style headers (`## [1.2.0]`, `## v1.2.0`, `## 1.2.0`).
+
+Any one signal flips the suggestion to SemVer. When zero signals are found, Specflow suggests
+date-based. The user can always override at the picker. The choice is persisted by **rewriting the
+scaffolded skill** itself (the unchosen scheme's blocks are stripped at scaffold time), so the
+on-disk `.specflow/scripts/release/tag.sh` only contains the chosen scheme's logic. To switch
+schemes later, re-run `specflow init` and pick the other option.
 
 Pass `--scheme semver|date` to bypass the picker in non-TTY mode.
 

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -105,6 +105,12 @@ function detectSchemeSuggestion(targetDir: string): VersionScheme {
         return null;
       }
     },
+    listTags() {
+      // Stub: filled in by the follow-up commit that wires `git tag -l`
+      // into the detection. Keeping the port contract satisfied here so
+      // the rename commit type-checks on its own.
+      return [];
+    },
   });
   return result.suggestedScheme;
 }

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -106,10 +106,26 @@ function detectSchemeSuggestion(targetDir: string): VersionScheme {
       }
     },
     listTags() {
-      // Stub: filled in by the follow-up commit that wires `git tag -l`
-      // into the detection. Keeping the port contract satisfied here so
-      // the rename commit type-checks on its own.
-      return [];
+      // `git tag -l` is the cheapest read: a few KB of stdout for the
+      // largest repos, no network. If anything fails (no git binary, no
+      // .git dir, command errors), return an empty list — the detector
+      // treats absence as "no signal", not a failure.
+      try {
+        const out = new Deno.Command("git", {
+          args: ["tag", "-l"],
+          cwd: targetDir,
+          stdout: "piped",
+          stderr: "null",
+        }).outputSync();
+        if (!out.success) return [];
+        return new TextDecoder()
+          .decode(out.stdout)
+          .split("\n")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+      } catch {
+        return [];
+      }
     },
   });
   return result.suggestedScheme;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -25,6 +25,11 @@ ${bold("Flags (for init):")}
   --backlog-url <url> Kanban / project URL (e.g. https://github.com/orgs/<org>/projects/<N>)
                       Required for github/gitlab in non-interactive mode; pre-fills .specflow/backlog-config.yml
   --backlog-repo <r>  GitHub repo override <owner>/<name>; falls back to "git remote get-url origin"
+  --scheme <name>     Versioning scheme for the release scripts: semver | date
+                      Auto-detected from library markers (package.json exports, pyproject.toml,
+                      Cargo.toml [lib], composer.json type=library), semver-shaped git tags
+                      (v1.2.3), or a CHANGELOG.md with Keep-a-Changelog headers. Falls back to
+                      "date" when no signal is found.
 
 ${bold("Flags (for upgrade):")}
   --dry-run           Show the plan without writing

--- a/src/domain/project_detection.ts
+++ b/src/domain/project_detection.ts
@@ -1,18 +1,25 @@
 import type { VersionScheme } from "./installed_lock.ts";
 
 /**
- * Tiny synchronous filesystem facade — just what `detectVersionScheme`
- * needs. Implementations: a `Deno.statSync` / `Deno.readTextFileSync`
- * adapter in production, a fake map in tests.
+ * Tiny synchronous project-state facade — just what `detectVersionScheme`
+ * needs. Implementations: a `Deno.statSync` / `Deno.readTextFileSync` +
+ * `git tag -l` adapter in production, a fake map in tests.
  *
  * Synchronous on purpose: the detection runs once at init time, the
- * total work is reading a handful of small manifest files, and
- * threading async through every helper just to satisfy Deno globals
- * here would muddy the domain port.
+ * total work is reading a handful of small manifest files plus one
+ * `git tag` invocation, and threading async through every helper just
+ * to satisfy Deno globals here would muddy the domain port.
  */
-export type FsSnapshot = {
+export type ProjectSnapshot = {
   exists(rel: string): boolean;
   readText(rel: string): string | null;
+  /**
+   * Returns the list of local git tag names (`git tag -l` output, one
+   * per line, no `refs/tags/` prefix). Returns `[]` when the project is
+   * not a git repo, `git` is unavailable, or the subprocess fails — the
+   * caller treats absence as "no signal", not as an error.
+   */
+  listTags(): readonly string[];
 };
 
 export type DetectionResult = {
@@ -33,14 +40,14 @@ export type DetectionResult = {
  * The user always sees the suggestion as a pre-selected default they
  * can override — this is a UX shortcut, not a contract.
  */
-export function detectVersionScheme(fs: FsSnapshot): DetectionResult {
+export function detectVersionScheme(snap: ProjectSnapshot): DetectionResult {
   const evidence: string[] = [];
 
   // npm: a `package.json` with an `exports` or `main` field is a
   // strong library signal. A bare `package.json` (Vite app, Next app,
   // Express service) typically has neither.
-  if (fs.exists("package.json")) {
-    const raw = fs.readText("package.json");
+  if (snap.exists("package.json")) {
+    const raw = snap.readText("package.json");
     if (raw !== null) {
       try {
         const pkg = JSON.parse(raw) as Record<string, unknown>;
@@ -61,8 +68,8 @@ export function detectVersionScheme(fs: FsSnapshot): DetectionResult {
   }
 
   // Python: `pyproject.toml` with `[project]` or `[tool.poetry]` block.
-  if (fs.exists("pyproject.toml")) {
-    const raw = fs.readText("pyproject.toml");
+  if (snap.exists("pyproject.toml")) {
+    const raw = snap.readText("pyproject.toml");
     if (raw !== null) {
       if (/^\s*\[project\]\s*$/m.test(raw)) {
         evidence.push("pyproject.toml [project] block");
@@ -73,8 +80,8 @@ export function detectVersionScheme(fs: FsSnapshot): DetectionResult {
   }
 
   // Rust: `Cargo.toml` with `[lib]`. Apps have `[[bin]]` instead.
-  if (fs.exists("Cargo.toml")) {
-    const raw = fs.readText("Cargo.toml");
+  if (snap.exists("Cargo.toml")) {
+    const raw = snap.readText("Cargo.toml");
     if (raw !== null) {
       if (/^\s*\[lib\]\s*$/m.test(raw)) {
         evidence.push("Cargo.toml [lib] section");
@@ -83,8 +90,8 @@ export function detectVersionScheme(fs: FsSnapshot): DetectionResult {
   }
 
   // PHP: `composer.json` with `"type": "library"`.
-  if (fs.exists("composer.json")) {
-    const raw = fs.readText("composer.json");
+  if (snap.exists("composer.json")) {
+    const raw = snap.readText("composer.json");
     if (raw !== null) {
       try {
         const pkg = JSON.parse(raw) as Record<string, unknown>;

--- a/src/domain/project_detection.ts
+++ b/src/domain/project_detection.ts
@@ -104,6 +104,31 @@ export function detectVersionScheme(snap: ProjectSnapshot): DetectionResult {
     }
   }
 
+  // Git tags: a repo that has already shipped one or more semver-shaped
+  // tags is the strongest possible "this team uses SemVer" signal. We
+  // intentionally exclude Specflow's own date-tag shape (`vYY.M.Da`,
+  // identifiable by the trailing lowercase letter) so brownfield repos
+  // that adopted Specflow earlier with date-tags don't get mis-suggested.
+  //
+  // Accepted shapes (case-insensitive, optional `v` prefix):
+  //   v?MAJOR.MINOR.PATCH                      v1.2.3
+  //   v?MAJOR.MINOR.PATCH-<pre-release>         v1.2.3-rc.1
+  //   v?MAJOR.MINOR.PATCH+<build>               v1.2.3+build.5
+  //
+  // Rejected (treated as not-semver):
+  //   anything with a trailing letter        v25.5.16a, v1.2.3foo
+  //   anything missing the third component   v1.2, v1
+  //   anything with a fourth component       v1.2.3.4
+  const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]+)?$/;
+  const semverTags = snap.listTags().filter((t) => SEMVER_TAG_RE.test(t));
+  if (semverTags.length > 0) {
+    evidence.push(
+      semverTags.length === 1
+        ? `git tag ${semverTags[0]}`
+        : `${semverTags.length} semver-shaped git tags (e.g. ${semverTags[0]})`,
+    );
+  }
+
   // Ruby: any `*.gemspec` at the repo root is a library marker.
   // The FS snapshot doesn't enumerate; the caller passes a `*.gemspec`
   // hint as a synthetic path. Implementation: convention — caller probes

--- a/src/domain/project_detection.ts
+++ b/src/domain/project_detection.ts
@@ -129,6 +129,21 @@ export function detectVersionScheme(snap: ProjectSnapshot): DetectionResult {
     );
   }
 
+  // CHANGELOG.md with Keep-a-Changelog style version headers — another
+  // hard signal that the team thinks in terms of MAJOR.MINOR.PATCH
+  // releases. We accept both bracketed (`## [1.2.0]`) and bare
+  // (`## v1.2.0` / `## 1.2.0`) header forms; date-suffix shapes are
+  // rejected via the same trailing-letter guard as git tags.
+  if (snap.exists("CHANGELOG.md")) {
+    const raw = snap.readText("CHANGELOG.md");
+    if (raw !== null) {
+      const SEMVER_HEADING_RE = /^##\s+\[?v?\d+\.\d+\.\d+(?:[+-][0-9A-Za-z.-]+)?\]?\b/m;
+      if (SEMVER_HEADING_RE.test(raw)) {
+        evidence.push("CHANGELOG.md semver headings");
+      }
+    }
+  }
+
   // Ruby: any `*.gemspec` at the repo root is a library marker.
   // The FS snapshot doesn't enumerate; the caller passes a `*.gemspec`
   // hint as a synthetic path. Implementation: convention — caller probes

--- a/tests/domain/project_detection_test.ts
+++ b/tests/domain/project_detection_test.ts
@@ -99,3 +99,42 @@ Deno.test("detectVersionScheme collects multiple evidence lines when several mar
   assertEquals(r.suggestedScheme, "semver");
   assertEquals(r.evidence.length, 2);
 });
+
+Deno.test("detectVersionScheme suggests semver when a v-prefixed semver git tag exists", () => {
+  const r = detectVersionScheme(fakeSnapshot({}, ["v1.2.3"]));
+  assertEquals(r.suggestedScheme, "semver");
+  assertEquals(r.evidence.length, 1);
+});
+
+Deno.test("detectVersionScheme suggests semver when a bare semver git tag exists", () => {
+  const r = detectVersionScheme(fakeSnapshot({}, ["1.0.0"]));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme suggests semver for semver tags with pre-release / build suffix", () => {
+  const r = detectVersionScheme(fakeSnapshot({}, ["v1.2.3-rc.1", "v1.2.3+build.5"]));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme ignores Specflow-style date tags (letter-suffix shape)", () => {
+  // vYY.M.Da — Specflow's own date scheme. Shape-overlapping with
+  // semver MAJOR.MINOR.PATCH but disambiguated by the trailing letter.
+  const r = detectVersionScheme(fakeSnapshot({}, ["v25.5.16a", "v26.1.3b"]));
+  assertEquals(r.suggestedScheme, "date");
+  assertEquals(r.evidence, []);
+});
+
+Deno.test("detectVersionScheme ignores non-version tags", () => {
+  const r = detectVersionScheme(fakeSnapshot({}, ["release-1", "draft", "wip"]));
+  assertEquals(r.suggestedScheme, "date");
+});
+
+Deno.test("detectVersionScheme stacks evidence: lib marker + semver tags", () => {
+  const r = detectVersionScheme(fakeSnapshot(
+    { "package.json": JSON.stringify({ exports: { ".": "./i.js" } }) },
+    ["v0.1.0", "v0.2.0"],
+  ));
+  assertEquals(r.suggestedScheme, "semver");
+  // Both signals recorded for transparency.
+  assertEquals(r.evidence.length >= 2, true);
+});

--- a/tests/domain/project_detection_test.ts
+++ b/tests/domain/project_detection_test.ts
@@ -1,7 +1,10 @@
 import { assertEquals } from "@std/assert";
-import { detectVersionScheme, type FsSnapshot } from "../../src/domain/project_detection.ts";
+import { detectVersionScheme, type ProjectSnapshot } from "../../src/domain/project_detection.ts";
 
-function fakeFs(files: Record<string, string>): FsSnapshot {
+function fakeSnapshot(
+  files: Record<string, string>,
+  tags: readonly string[] = [],
+): ProjectSnapshot {
   return {
     exists(rel) {
       return Object.prototype.hasOwnProperty.call(files, rel);
@@ -9,17 +12,20 @@ function fakeFs(files: Record<string, string>): FsSnapshot {
     readText(rel) {
       return Object.prototype.hasOwnProperty.call(files, rel) ? files[rel] : null;
     },
+    listTags() {
+      return tags;
+    },
   };
 }
 
 Deno.test("detectVersionScheme defaults to date when no library markers exist", () => {
-  const r = detectVersionScheme(fakeFs({}));
+  const r = detectVersionScheme(fakeSnapshot({}));
   assertEquals(r.suggestedScheme, "date");
   assertEquals(r.evidence, []);
 });
 
 Deno.test("detectVersionScheme suggests semver when package.json has exports", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "package.json": JSON.stringify({
       name: "my-lib",
       exports: { ".": "./index.js" },
@@ -32,7 +38,7 @@ Deno.test("detectVersionScheme suggests semver when package.json has exports", (
 Deno.test("detectVersionScheme does NOT suggest semver for a private app package.json", () => {
   // Private app projects (Vite, Next, Express) typically have neither
   // `exports`, `publishConfig`, nor `private: false`.
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "package.json": JSON.stringify({
       name: "my-app",
       private: true,
@@ -43,42 +49,42 @@ Deno.test("detectVersionScheme does NOT suggest semver for a private app package
 });
 
 Deno.test("detectVersionScheme suggests semver when pyproject.toml has [project]", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "pyproject.toml": '[project]\nname = "my-pkg"\n',
   }));
   assertEquals(r.suggestedScheme, "semver");
 });
 
 Deno.test("detectVersionScheme suggests semver when pyproject.toml has [tool.poetry]", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "pyproject.toml": '[tool.poetry]\nname = "my-pkg"\n',
   }));
   assertEquals(r.suggestedScheme, "semver");
 });
 
 Deno.test("detectVersionScheme suggests semver when Cargo.toml has [lib]", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "Cargo.toml": '[package]\nname = "foo"\n\n[lib]\nname = "foo"\n',
   }));
   assertEquals(r.suggestedScheme, "semver");
 });
 
 Deno.test("detectVersionScheme stays at date when Cargo.toml is bin-only", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "Cargo.toml": '[package]\nname = "foo"\n\n[[bin]]\nname = "foo"\n',
   }));
   assertEquals(r.suggestedScheme, "date");
 });
 
 Deno.test("detectVersionScheme suggests semver when composer.json type=library", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "composer.json": JSON.stringify({ name: "foo/bar", type: "library" }),
   }));
   assertEquals(r.suggestedScheme, "semver");
 });
 
 Deno.test("detectVersionScheme ignores malformed JSON gracefully", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "package.json": "{ this is not valid JSON",
   }));
   // No library marker extractable → date default, no evidence added.
@@ -86,7 +92,7 @@ Deno.test("detectVersionScheme ignores malformed JSON gracefully", () => {
 });
 
 Deno.test("detectVersionScheme collects multiple evidence lines when several markers exist", () => {
-  const r = detectVersionScheme(fakeFs({
+  const r = detectVersionScheme(fakeSnapshot({
     "package.json": JSON.stringify({ exports: { ".": "./index.js" } }),
     "pyproject.toml": '[project]\nname = "foo"\n',
   }));

--- a/tests/domain/project_detection_test.ts
+++ b/tests/domain/project_detection_test.ts
@@ -138,3 +138,36 @@ Deno.test("detectVersionScheme stacks evidence: lib marker + semver tags", () =>
   // Both signals recorded for transparency.
   assertEquals(r.evidence.length >= 2, true);
 });
+
+Deno.test("detectVersionScheme suggests semver when CHANGELOG.md has Keep-a-Changelog headers", () => {
+  const changelog = [
+    "# Changelog",
+    "",
+    "## [Unreleased]",
+    "",
+    "## [1.2.0] - 2026-01-15",
+    "### Added",
+    "- thing",
+    "",
+    "## [1.1.0] - 2025-12-01",
+  ].join("\n");
+  const r = detectVersionScheme(fakeSnapshot({ "CHANGELOG.md": changelog }));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme suggests semver for plain `## v1.2.0` headers", () => {
+  const changelog = "# Changelog\n\n## v1.2.0\n\n## v1.1.0\n";
+  const r = detectVersionScheme(fakeSnapshot({ "CHANGELOG.md": changelog }));
+  assertEquals(r.suggestedScheme, "semver");
+});
+
+Deno.test("detectVersionScheme ignores CHANGELOG.md with no semver headings", () => {
+  const changelog = "# Changelog\n\n## [Unreleased]\n\n## Recent changes\n";
+  const r = detectVersionScheme(fakeSnapshot({ "CHANGELOG.md": changelog }));
+  assertEquals(r.suggestedScheme, "date");
+});
+
+Deno.test("detectVersionScheme tolerates a missing CHANGELOG.md", () => {
+  const r = detectVersionScheme(fakeSnapshot({}));
+  assertEquals(r.suggestedScheme, "date");
+});


### PR DESCRIPTION
Closes #257.

## Summary

`specflow init` already had the full versioning-scheme machinery — `--scheme=date|semver` flag, interactive picker after harness+backlog selection, persistence to `.specflow/installed.lock`, upgrade-preserve, conditional bundle filtering. The brownfield experience that triggered #257 was a **detection bias**: a SaaS project using SemVer (private `package.json`, no `exports`, no `[lib]`, no `type:library`) got `date` suggested because the heuristic only looked for library publishing markers.

This PR adds two new SemVer evidence sources to `detectVersionScheme()` so the suggestion catches SaaS-with-SemVer projects too:

1. **Semver-shaped git tags** (`v1.2.3`, `1.0.0-rc.1`, `v2.0.0+build.5`) — strongest signal, since tags reflect what the team actually ships. Specflow's own date-tag shape `vYY.M.Da` is explicitly excluded via the trailing-letter guard, so brownfield Specflow repos already on date scheme don't get mis-suggested.
2. **`CHANGELOG.md` with Keep-a-Changelog headers** (`## [1.2.0]`, `## v1.2.0`, `## 1.2.0`) — second-strongest signal, same date-shape exclusion.

The detection now layers three independent signals (library markers, git tags, CHANGELOG). Any one of them flips the suggestion to `semver`. Zero signals → `date` default preserved (Kevin's explicit call — no behavioural change for projects with no SemVer footprint).

Mechanical changes along the way:

- Renamed the domain port `FsSnapshot` → `ProjectSnapshot` (it now carries non-FS data) and added `listTags(): readonly string[]`. One production consumer, one test file — confined rename.
- Wired `git tag -l` via `Deno.Command.outputSync()` in the init handler's snapshot adapter. Wrapped in try/catch — any failure (no git, no `.git`, non-zero exit) returns `[]`, treated as "no signal".
- Added the missing `--scheme` doc to `specflow --help` (it was undocumented at the CLI level despite being supported for ~all of v1.x) and expanded `docs/llms.md`'s 'Pick a versioning scheme' section to list every detection signal.

## Test plan

- **Unit tests**: 10 new cases in `tests/domain/project_detection_test.ts` — git-tag positive (v-prefix, bare, pre-release/build), git-tag negative (date-suffix, non-version), CHANGELOG.md positive (Keep-a-Changelog, plain `## v1.2.0`), CHANGELOG.md negative (no semver headings, missing file), stacked evidence. 633 → 643 green.
- **Smoke**: ran `specflow init --here --ai claude --backlog local` against a SaaS-shaped fixture (`private: true` package.json + git tags `v1.0.0` / `v1.1.0` / `v1.2.0`). Picker showed `SemVer (v1.2.3) — best for libraries / SDKs with external consumers (default)`. Lockfile recorded `version_scheme: semver`.
- **Negative smoke**: same fixture without semver tags → picker shows `Date-based … (default)`, lockfile records `version_scheme: date`. Back-compat preserved.
- **Smoke-coverage audit**: 0 gaps, 0 stale assertions.

## Agent adoption

`specflow init` now suggests `semver` (instead of falling through to `date`) when it finds **either**:

- semver-shaped git tags in the repo (`v1.2.3`, `1.0.0-rc.1`, `v2.0.0+build.5`), or
- a `CHANGELOG.md` containing Keep-a-Changelog style headings (`## [1.2.0]`, `## v1.2.0`).

Existing library-marker detection (`package.json` exports, `pyproject.toml [project]`, …) is preserved. Projects with **zero** evidence still get `date` suggested, matching prior behavior.

No CLI flag rename. The `--scheme=date|semver` override still works the same way.

```prompt
After upgrading Specflow, if you ran `specflow init` on a brownfield SemVer project and got `version_scheme: date` in your `.specflow/installed.lock`, you can either re-run with `specflow init --here --force --scheme=semver` (overwrites release scripts in place) or just edit `.specflow/installed.lock` and change `version_scheme: date` to `version_scheme: semver`, then run `specflow upgrade` to regenerate the affected scripts. New projects pick up the smarter detection automatically — no action needed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
