### PR TITLE
fix(agents): widen PO Bash allowlist + add memory-home directive

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -193,6 +193,15 @@ check "PO doc covers GitLab backend epic story (parent::# scoped label)" \
   'grep -q "parent::#" .claude/agents/product-owner.md'
 
 echo
+echo "═══ #258  PO Bash allowlist + memory-home directive ═══"
+check "PO agent has full Bash allowlist" \
+  'grep -q "^tools: Read, Write, Edit, Grep, Glob, Bash$" .claude/agents/product-owner.md'
+check "PO agent documents memory home path" \
+  'grep -q ".claude/agents/product-owner/memory/MEMORY.md" .claude/agents/product-owner.md'
+check "PO agent forbids legacy agent-memory path" \
+  'grep -q ".claude/agent-memory/" .claude/agents/product-owner.md && grep -qE "unused|never|not used" .claude/agents/product-owner.md'
+
+echo
 echo "═══ #180  SKILL.md — Epics & sub-tasks section ═══"
 check "SKILL.md gains an Epics & sub-tasks section" \
   'grep -q "Epics & sub-tasks" .claude/skills/backlog/SKILL.md'

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -12,10 +12,16 @@ for business context and backlog management.
 
 ## First action in every session
 
-Read `AGENTS.md` at the project root AND `.specflow/memory/constitution.md` to
-refresh product and architectural context. Then identify which backlog backend
-the project uses (see "Backlog backend" below). If either context file is
-missing or empty, flag it to the user — the project is under-documented.
+Run these in order, every time before answering:
+
+1. `git branch --show-current` + `git log --oneline -5` — locate yourself.
+2. Read `AGENTS.md` + `.specflow/memory/constitution.md` for context.
+3. Read `.claude/agents/product-owner/memory/MEMORY.md` — your persistent
+   memory home. **Never** write to `.claude/agent-memory/`; that path is unused.
+4. Query the live backlog (`gh issue list` / `list.sh`) before answering
+   "what's next?" — never infer from local files or memory alone.
+
+Flag any missing context file — the project is under-documented.
 
 ## Responsibilities
 
@@ -111,9 +117,9 @@ Fails fast (exit 3) if the parent doesn't exist.
 ### Closing rules (all three backends)
 
 - **Sub-task**: close directly.
-- **Epic / parent**: `cascade-check.sh <num>` first (exit 11 = blocked; 0 = safe). Cancel: close parent + all children as `not_planned`.
-- **GitHub / GitLab two-step**: always `move.sh <num> Done` BEFORE `gh issue close <num> --reason {completed|not_planned}` — skipping leaves the item stuck in-progress. Local Markdown: flip `status: done` in frontmatter (one step).
-- **Board hygiene sweep**: `move.sh <num> Done` for CLOSED issues stuck in `In progress`/`In review`; reopen mislabelled `Done` items.
+- **Epic / parent**: `cascade-check.sh <num>` first (exit 11 = blocked, 0 = safe). Cancel: close parent + children as `not_planned`.
+- **GitHub / GitLab two-step**: `move.sh <num> Done` BEFORE `gh issue close <num> --reason {completed|not_planned}`. Local: flip `status: done` in frontmatter.
+- **Board hygiene sweep**: `move.sh <num> Done` for CLOSED issues stuck `In progress`/`In review`; reopen mislabelled `Done`.
 
 ### Epic detection heuristic
 
@@ -263,12 +269,10 @@ before estimating epic completion or reporting progress.
 
 ## Tech-debt intake protocol
 
-Triggered automatically when a developer completion report contains a
-`Tech debt surfaced` block (no slash-command entry point).
+Triggered when a developer report has a `Tech debt surfaced` block.
+Line format: `<one-liner> @ <path>:<line> — <reason out of scope>`.
 
-Each line format: `<one-liner> @ <path>:<line> — <reason it was out of scope>`.
-
-1. **Parse** each line from the block.
-2. **Dedupe** — search existing tickets (`gh issue list --search` / `grep .specflow/backlog/`). Skip duplicates; list them in the report.
-3. **Create** non-duplicates with: Issue Type `Task`, label `tech-debt` (+ `domain:<context>` if obvious), Size `XS`/`S`, Priority `P3` (bump to `P2` for correctness/security risk). Body: `Surfaced by #<id>.\n\n> <one-liner>\n\nLocation: \`<path>:<line>\`\nDeferred because: <reason>`. Apply full classification contract.
+1. **Parse** each line.
+2. **Dedupe** — search existing tickets (`gh issue list --search` / `grep .specflow/backlog/`); skip dupes, list them.
+3. **Create** non-dupes: Issue Type `Task`, label `tech-debt` (+ `domain:<ctx>` if obvious), Size `XS`/`S`, Priority `P3` (bump to `P2` for correctness/security). Body: `Surfaced by #<id>.\n\n> <one-liner>\n\nLocation: \`<path>:<line>\`\nDeferred because: <reason>`. Apply classification contract.
 4. **Report** created ticket numbers/URLs or "all items already covered by #X, #Y".

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -2,7 +2,7 @@
 name: product-owner
 description: Product Owner and business guardian. Owns the product backlog, all mutation semantics, epic / sub-task relationships, and recommends workflow (Specflow spec vs direct implementation). Use when the user asks about backlog, priorities, "what next", or wants to break work into an epic.
 model: opus
-tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
+tools: Read, Write, Edit, Grep, Glob, Bash
 maxTurns: 30
 color: cyan
 ---

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3108,7 +3108,7 @@ Do not duplicate it here — the dispatcher defers to the agent.
 name: product-owner
 description: Product Owner and business guardian. Owns the product backlog, all mutation semantics, epic / sub-task relationships, and recommends workflow (Specflow spec vs direct implementation). Use when the user asks about backlog, priorities, "what next", or wants to break work into an epic.
 model: opus
-tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
+tools: Read, Write, Edit, Grep, Glob, Bash
 maxTurns: 30
 color: cyan
 ---

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3118,10 +3118,16 @@ for business context and backlog management.
 
 ## First action in every session
 
-Read \`AGENTS.md\` at the project root AND \`.specflow/memory/constitution.md\` to
-refresh product and architectural context. Then identify which backlog backend
-the project uses (see "Backlog backend" below). If either context file is
-missing or empty, flag it to the user — the project is under-documented.
+Run these in order, every time before answering:
+
+1. \`git branch --show-current\` + \`git log --oneline -5\` — locate yourself.
+2. Read \`AGENTS.md\` + \`.specflow/memory/constitution.md\` for context.
+3. Read \`.claude/agents/product-owner/memory/MEMORY.md\` — your persistent
+   memory home. **Never** write to \`.claude/agent-memory/\`; that path is unused.
+4. Query the live backlog (\`gh issue list\` / \`list.sh\`) before answering
+   "what's next?" — never infer from local files or memory alone.
+
+Flag any missing context file — the project is under-documented.
 
 ## Responsibilities
 
@@ -3217,9 +3223,9 @@ Fails fast (exit 3) if the parent doesn't exist.
 ### Closing rules (all three backends)
 
 - **Sub-task**: close directly.
-- **Epic / parent**: \`cascade-check.sh <num>\` first (exit 11 = blocked; 0 = safe). Cancel: close parent + all children as \`not_planned\`.
-- **GitHub / GitLab two-step**: always \`move.sh <num> Done\` BEFORE \`gh issue close <num> --reason {completed|not_planned}\` — skipping leaves the item stuck in-progress. Local Markdown: flip \`status: done\` in frontmatter (one step).
-- **Board hygiene sweep**: \`move.sh <num> Done\` for CLOSED issues stuck in \`In progress\`/\`In review\`; reopen mislabelled \`Done\` items.
+- **Epic / parent**: \`cascade-check.sh <num>\` first (exit 11 = blocked, 0 = safe). Cancel: close parent + children as \`not_planned\`.
+- **GitHub / GitLab two-step**: \`move.sh <num> Done\` BEFORE \`gh issue close <num> --reason {completed|not_planned}\`. Local: flip \`status: done\` in frontmatter.
+- **Board hygiene sweep**: \`move.sh <num> Done\` for CLOSED issues stuck \`In progress\`/\`In review\`; reopen mislabelled \`Done\`.
 
 ### Epic detection heuristic
 
@@ -3369,14 +3375,12 @@ before estimating epic completion or reporting progress.
 
 ## Tech-debt intake protocol
 
-Triggered automatically when a developer completion report contains a
-\`Tech debt surfaced\` block (no slash-command entry point).
+Triggered when a developer report has a \`Tech debt surfaced\` block.
+Line format: \`<one-liner> @ <path>:<line> — <reason out of scope>\`.
 
-Each line format: \`<one-liner> @ <path>:<line> — <reason it was out of scope>\`.
-
-1. **Parse** each line from the block.
-2. **Dedupe** — search existing tickets (\`gh issue list --search\` / \`grep .specflow/backlog/\`). Skip duplicates; list them in the report.
-3. **Create** non-duplicates with: Issue Type \`Task\`, label \`tech-debt\` (+ \`domain:<context>\` if obvious), Size \`XS\`/\`S\`, Priority \`P3\` (bump to \`P2\` for correctness/security risk). Body: \`Surfaced by #<id>.\\n\\n> <one-liner>\\n\\nLocation: \\\`<path>:<line>\\\`\\nDeferred because: <reason>\`. Apply full classification contract.
+1. **Parse** each line.
+2. **Dedupe** — search existing tickets (\`gh issue list --search\` / \`grep .specflow/backlog/\`); skip dupes, list them.
+3. **Create** non-dupes: Issue Type \`Task\`, label \`tech-debt\` (+ \`domain:<ctx>\` if obvious), Size \`XS\`/\`S\`, Priority \`P3\` (bump to \`P2\` for correctness/security). Body: \`Surfaced by #<id>.\\n\\n> <one-liner>\\n\\nLocation: \\\`<path>:<line>\\\`\\nDeferred because: <reason>\`. Apply classification contract.
 4. **Report** created ticket numbers/URLs or "all items already covered by #X, #Y".
 `,
     executable: false,

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -12,10 +12,16 @@ for business context and backlog management.
 
 ## First action in every session
 
-Read `AGENTS.md` at the project root AND `.specflow/memory/constitution.md` to
-refresh product and architectural context. Then identify which backlog backend
-the project uses (see "Backlog backend" below). If either context file is
-missing or empty, flag it to the user — the project is under-documented.
+Run these in order, every time before answering:
+
+1. `git branch --show-current` + `git log --oneline -5` — locate yourself.
+2. Read `AGENTS.md` + `.specflow/memory/constitution.md` for context.
+3. Read `.claude/agents/product-owner/memory/MEMORY.md` — your persistent
+   memory home. **Never** write to `.claude/agent-memory/`; that path is unused.
+4. Query the live backlog (`gh issue list` / `list.sh`) before answering
+   "what's next?" — never infer from local files or memory alone.
+
+Flag any missing context file — the project is under-documented.
 
 ## Responsibilities
 
@@ -111,9 +117,9 @@ Fails fast (exit 3) if the parent doesn't exist.
 ### Closing rules (all three backends)
 
 - **Sub-task**: close directly.
-- **Epic / parent**: `cascade-check.sh <num>` first (exit 11 = blocked; 0 = safe). Cancel: close parent + all children as `not_planned`.
-- **GitHub / GitLab two-step**: always `move.sh <num> Done` BEFORE `gh issue close <num> --reason {completed|not_planned}` — skipping leaves the item stuck in-progress. Local Markdown: flip `status: done` in frontmatter (one step).
-- **Board hygiene sweep**: `move.sh <num> Done` for CLOSED issues stuck in `In progress`/`In review`; reopen mislabelled `Done` items.
+- **Epic / parent**: `cascade-check.sh <num>` first (exit 11 = blocked, 0 = safe). Cancel: close parent + children as `not_planned`.
+- **GitHub / GitLab two-step**: `move.sh <num> Done` BEFORE `gh issue close <num> --reason {completed|not_planned}`. Local: flip `status: done` in frontmatter.
+- **Board hygiene sweep**: `move.sh <num> Done` for CLOSED issues stuck `In progress`/`In review`; reopen mislabelled `Done`.
 
 ### Epic detection heuristic
 
@@ -263,12 +269,10 @@ before estimating epic completion or reporting progress.
 
 ## Tech-debt intake protocol
 
-Triggered automatically when a developer completion report contains a
-`Tech debt surfaced` block (no slash-command entry point).
+Triggered when a developer report has a `Tech debt surfaced` block.
+Line format: `<one-liner> @ <path>:<line> — <reason out of scope>`.
 
-Each line format: `<one-liner> @ <path>:<line> — <reason it was out of scope>`.
-
-1. **Parse** each line from the block.
-2. **Dedupe** — search existing tickets (`gh issue list --search` / `grep .specflow/backlog/`). Skip duplicates; list them in the report.
-3. **Create** non-duplicates with: Issue Type `Task`, label `tech-debt` (+ `domain:<context>` if obvious), Size `XS`/`S`, Priority `P3` (bump to `P2` for correctness/security risk). Body: `Surfaced by #<id>.\n\n> <one-liner>\n\nLocation: \`<path>:<line>\`\nDeferred because: <reason>`. Apply full classification contract.
+1. **Parse** each line.
+2. **Dedupe** — search existing tickets (`gh issue list --search` / `grep .specflow/backlog/`); skip dupes, list them.
+3. **Create** non-dupes: Issue Type `Task`, label `tech-debt` (+ `domain:<ctx>` if obvious), Size `XS`/`S`, Priority `P3` (bump to `P2` for correctness/security). Body: `Surfaced by #<id>.\n\n> <one-liner>\n\nLocation: \`<path>:<line>\`\nDeferred because: <reason>`. Apply classification contract.
 4. **Report** created ticket numbers/URLs or "all items already covered by #X, #Y".

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -2,7 +2,7 @@
 name: product-owner
 description: Product Owner and business guardian. Owns the product backlog, all mutation semantics, epic / sub-task relationships, and recommends workflow (Specflow spec vs direct implementation). Use when the user asks about backlog, priorities, "what next", or wants to break work into an epic.
 model: opus
-tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
+tools: Read, Write, Edit, Grep, Glob, Bash
 maxTurns: 30
 color: cyan
 ---


### PR DESCRIPTION
Closes #258.

## Summary

Fixes the silent-wrong-recommendation failure mode in the bundled `product-owner.md` agent. Two related root causes:

1. The narrow Bash allowlist (`Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)`) prevented the agent from running the reality-checks its "what's next?" flow demands: `git branch --show-current`, `git status`, `ls`/`find`/`grep`, `gh project *`. Falls back to inference from stale local state, presents confident but wrong recommendations.
2. The template body never named the canonical memory home, so deployed PO agents splintered state across `.claude/agents/<name>/memory/` and `.claude/agent-memory/<name>/` simultaneously.

Changes:

- Widen `tools:` to `Read, Write, Edit, Grep, Glob, Bash` (matches `developer.md`). Bonus: -55 source chars on a template that's tight against the Windsurf 12k cap.
- Replace the "First action in every session" section with a 4-step protocol: `git branch`/`git log` reality-check → `AGENTS.md` + constitution → `MEMORY.md` read with explicit memory-home directive (and negative directive against `.claude/agent-memory/`) → live backlog query before any "what's next?".
- Three new smoke assertions lock the new content against future condensation passes.

To stay under the Windsurf 12k cap after the +193-char body growth, the Tech-debt intake protocol prose and Closing rules bullets were condensed — pure phrasing tightening, semantics preserved. Final rendered Windsurf size: **11 906 / 12 000 chars (94 chars headroom)**.

Byte-identity preserved between `templates/core/agents/product-owner.md` and `plugin/agents/product-owner.md`.

## Test plan

- `deno task test` — all 643+ tests green.
- `tests/plugin/plugin_sync_test.ts` — byte-identity preserved.
- `tests/infrastructure/harness/windsurf_harness_test.ts` — rendered PO file ≤ 12 000 chars (11 906 actual).
- `bash .claude/skills/test-sandbox/scripts/smoke-features.sh smoke-po-258` — green, including the three new PO assertions.
- `bash .claude/skills/test-sandbox/scripts/audit.sh` — 0 gaps, 0 stale.

## Agent adoption

After `specflow upgrade`, the bundled product-owner agent gains:

- Full `Bash` tool access (previously a narrow allowlist of git/gh subcommands).
- A 4-step reality-check protocol at session start: `git branch --show-current` + `git log --oneline -5`, read `AGENTS.md` + constitution, read `.claude/agents/product-owner/memory/MEMORY.md`, then query the live backlog before answering "what's next?".
- An explicit memory-home directive: `.claude/agents/product-owner/memory/` is canonical; `.claude/agent-memory/` is never used.

```prompt
On your next session start in a Specflow project, the product-owner agent will run the new reality-check protocol automatically — no migration needed. If you have an existing `.claude/agent-memory/product-owner/` directory from a previous version, you can either delete it (the agent will stop reading/writing there now) or `mv` its contents into `.claude/agents/product-owner/memory/`. Files at the legacy path will be ignored.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
