### PR TITLE
feat(backlog): auto-propagate Epic status from child sub-task moves

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
@@ -125,6 +125,19 @@ check "move.sh mutation uses gh project item-edit (CLI wrapper)" \
   'grep -q "gh project item-edit" .specflow/scripts/backlog/move.sh'
 
 echo
+echo "═══ #260  Auto-propagate parent Epic on child move (github) ═══"
+check "propagate-parent-status.sh present + executable" \
+  '[ -x .specflow/scripts/backlog/propagate-parent-status.sh ]'
+check "move.sh invokes propagate-parent-status.sh as tail hook" \
+  'grep -q "propagate-parent-status.sh" .specflow/scripts/backlog/move.sh'
+check "propagator resolves parent via GraphQL Issue.parent" \
+  'grep -q "parent { number }" .specflow/scripts/backlog/propagate-parent-status.sh'
+check "propagator promotes only Backlog/Ready parents" \
+  'grep -qE "\"Backlog\"\|\"Ready\"" .specflow/scripts/backlog/propagate-parent-status.sh'
+check "propagator carries the SPECFLOW_INTERNAL_PROPAGATION recursion guard" \
+  'grep -q "SPECFLOW_INTERNAL_PROPAGATION" .specflow/scripts/backlog/propagate-parent-status.sh'
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL GITHUB BACKLOG CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
@@ -125,6 +125,27 @@ else
 fi
 
 echo
+echo "═══ #260  Auto-propagate parent Epic on child move (local) ═══"
+# Baseline: parent #001 back to Backlog, child #003 (sub-task) back to Backlog.
+bash .specflow/scripts/backlog/move.sh 1 Backlog >/dev/null
+bash .specflow/scripts/backlog/move.sh 3 Backlog >/dev/null
+
+# Move child OUT of Backlog → parent should auto-promote to In progress.
+bash .specflow/scripts/backlog/move.sh 3 "In progress" >/dev/null
+parent_status=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' .specflow/backlog/001-first-item.md)
+[ "$parent_status" = "In progress" ] \
+  && pass "parent auto-promoted from Backlog to In progress on child sub-task move" \
+  || fail "parent auto-promotion broken" "expected 'In progress', got '$parent_status'"
+
+# Regression guard: manually advance parent to In review, move another child.
+bash .specflow/scripts/backlog/move.sh 1 "In review" >/dev/null
+bash .specflow/scripts/backlog/move.sh 3 "Done" >/dev/null
+parent_status=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' .specflow/backlog/001-first-item.md)
+[ "$parent_status" = "In review" ] \
+  && pass "parent in 'In review' is NOT pulled back to 'In progress' on child move" \
+  || fail "regression guard broken" "expected 'In review', got '$parent_status'"
+
+echo
 if [ "$fails" -eq 0 ]; then
   echo "═══ ALL BACKLOG CHECKS PASSED ═══"
   exit 0

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
@@ -126,6 +126,13 @@ fi
 
 echo
 echo "═══ #260  Auto-propagate parent Epic on child move (local) ═══"
+[ -x .specflow/scripts/backlog/propagate-parent-status.sh ] \
+  && pass "propagate-parent-status.sh scaffolded executable" \
+  || fail "propagate-parent-status.sh missing or not executable" "$(ls -l .specflow/scripts/backlog/ 2>/dev/null)"
+grep -q "propagate-parent-status.sh" .specflow/scripts/backlog/move.sh \
+  && pass "move.sh invokes propagate-parent-status.sh as tail hook" \
+  || fail "move.sh tail hook missing" "$(tail -10 .specflow/scripts/backlog/move.sh)"
+
 # Baseline: parent #001 back to Backlog, child #003 (sub-task) back to Backlog.
 bash .specflow/scripts/backlog/move.sh 1 Backlog >/dev/null
 bash .specflow/scripts/backlog/move.sh 3 Backlog >/dev/null

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -202,6 +202,17 @@ check "PO agent forbids legacy agent-memory path" \
   'grep -q ".claude/agent-memory/" .claude/agents/product-owner.md && grep -qE "unused|never|not used" .claude/agents/product-owner.md'
 
 echo
+echo "═══ #260  Auto-propagate parent Epic status (local backend scaffold) ═══"
+check "propagate-parent-status.sh scaffolded into local backend" \
+  '[ -x .specflow/scripts/backlog/propagate-parent-status.sh ]'
+check "local move.sh invokes the propagator as a tail hook" \
+  'grep -q "propagate-parent-status.sh" .specflow/scripts/backlog/move.sh'
+check "propagator promotes only Backlog/Ready parents (regression guard)" \
+  'grep -qE "\"Backlog\"\|\"Ready\"" .specflow/scripts/backlog/propagate-parent-status.sh'
+check "propagator carries the SPECFLOW_INTERNAL_PROPAGATION recursion guard" \
+  'grep -q "SPECFLOW_INTERNAL_PROPAGATION" .specflow/scripts/backlog/propagate-parent-status.sh'
+
+echo
 echo "═══ #180  SKILL.md — Epics & sub-tasks section ═══"
 check "SKILL.md gains an Epics & sub-tasks section" \
   'grep -q "Epics & sub-tasks" .claude/skills/backlog/SKILL.md'

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5270,6 +5270,14 @@ awk -v new="\$STATUS" '
 bash "\$RENDER" "\$ROOT"
 
 echo "✓ #\$NUM → \$STATUS"
+
+# Post-move hook: promote the parent Epic if this was a sub-task
+# leaving Backlog. Best-effort — never blocks on failure. See
+# propagate-parent-status.sh for the full state machine.
+PROPAGATE="\$(dirname "\$0")/propagate-parent-status.sh"
+if [ -x "\$PROPAGATE" ]; then
+  "\$PROPAGATE" "\$NUM" "\$STATUS" || true
+fi
 `,
     executable: true,
     backend: "local",
@@ -5420,6 +5428,115 @@ HEADER
   emit_section "In review" "\$LINES_INREV"
   emit_section "Done" "\$LINES_DONE"
 } > "\$INDEX"
+`,
+    executable: true,
+    backend: "local",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
+    name: "propagate-parent-status",
+    suffix: "propagate-parent-status.sh",
+    content: `#!/usr/bin/env bash
+# Post-move hook: when a sub-task moves OUT of Backlog, auto-advance
+# its parent Epic to In Progress — but only if the Epic is currently
+# in Backlog or Ready. Manual In Review / Done states are preserved.
+#
+# Local backend: parent link lives in \`parent: "#NNN"\` frontmatter;
+# status lives in \`status:\` frontmatter. Pure shell, no API calls.
+#
+# Usage: propagate-parent-status.sh <child-num> <new-child-status>
+#   child-num         : 3-digit zero-padded local task id (e.g. 042)
+#   new-child-status  : Backlog | Ready | "In progress" | "In review" | Done
+#
+# Always exits 0. Failure to find or update the parent emits a warning
+# to stderr but never returns non-zero — propagation must NEVER block
+# the primary child move per #260 AC(e).
+#
+# Recursion guard (AC(d)): the hook walks AT MOST one level up. When
+# this script calls back into \`move.sh\` to promote the parent, it sets
+# \`SPECFLOW_INTERNAL_PROPAGATION=1\`; on re-entry the hook sees the env
+# var and exits 0 immediately so the grandparent is never touched.
+
+set -uo pipefail
+
+CHILD="\${1:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+NEW_STATUS="\${2:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+
+# Recursion guard — see header.
+if [ -n "\${SPECFLOW_INTERNAL_PROPAGATION:-}" ]; then
+  exit 0
+fi
+
+# Moves INTO Backlog don't promote a parent. Bail early.
+if [ "\$NEW_STATUS" = "Backlog" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+# Deployed layout: <root>/.specflow/scripts/backlog/<this>.sh — up 3.
+ROOT="\$(cd "\$SCRIPT_DIR/../../.." && pwd)"
+BACKLOG_DIR="\$ROOT/.specflow/backlog"
+
+if [ ! -d "\$BACKLOG_DIR" ]; then
+  echo "::warning::propagate-parent-status: backlog dir not found at \$BACKLOG_DIR — skipping" >&2
+  exit 0
+fi
+
+# Find the child file (NNN-*.md).
+CHILD_PADDED=\$(printf '%03d' "\$((10#\$CHILD))" 2>/dev/null || echo "\$CHILD")
+shopt -s nullglob
+child_matches=("\$BACKLOG_DIR/\${CHILD_PADDED}-"*.md)
+if [ "\${#child_matches[@]}" -eq 0 ]; then
+  echo "::warning::propagate-parent-status: child #\${CHILD_PADDED} not found in \$BACKLOG_DIR — skipping" >&2
+  exit 0
+fi
+CHILD_FILE="\${child_matches[0]}"
+
+# Extract parent from frontmatter. Convention: \`parent: "#NNN"\` inside
+# the YAML frontmatter (between the first two \`---\` lines). Missing
+# parent or \`null\` → top-level task, nothing to propagate.
+PARENT_LINE=\$(awk '/^---\$/{n++; next} n==1 && /^parent:/{print; exit}' "\$CHILD_FILE")
+PARENT_NUM=\$(echo "\$PARENT_LINE" | sed -nE 's/^parent:[[:space:]]*"?#0*([0-9]+)"?[[:space:]]*\$/\\1/p')
+if [ -z "\$PARENT_NUM" ]; then
+  exit 0  # top-level task or \`parent: null\`
+fi
+
+PARENT_PADDED=\$(printf '%03d' "\$((10#\$PARENT_NUM))")
+parent_matches=("\$BACKLOG_DIR/\${PARENT_PADDED}-"*.md)
+if [ "\${#parent_matches[@]}" -eq 0 ]; then
+  echo "::warning::propagate-parent-status: parent #\${PARENT_PADDED} of child #\${CHILD_PADDED} not found — skipping" >&2
+  exit 0
+fi
+PARENT_FILE="\${parent_matches[0]}"
+
+# Read parent's current status from frontmatter.
+PARENT_STATUS=\$(awk '/^---\$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' "\$PARENT_FILE")
+
+# Only promote if parent is in Backlog or Ready.
+case "\$PARENT_STATUS" in
+  "Backlog"|"Ready")
+    if [ -x "\$SCRIPT_DIR/move.sh" ]; then
+      # Use the sibling move.sh so the frontmatter rewrite + index
+      # refresh stay consistent with every other status move. The
+      # recursion guard env var prevents this re-entry from walking
+      # any further up (AC(d): one-level only).
+      if SPECFLOW_INTERNAL_PROPAGATION=1 "\$SCRIPT_DIR/move.sh" "\$PARENT_PADDED" "In progress" >/dev/null 2>&1; then
+        echo "↑ promoted parent #\${PARENT_PADDED} (\${PARENT_STATUS} → In progress) due to child #\${CHILD_PADDED} move"
+      else
+        echo "::warning::propagate-parent-status: move.sh failed to promote #\${PARENT_PADDED}" >&2
+      fi
+    else
+      echo "::warning::propagate-parent-status: \$SCRIPT_DIR/move.sh not found — cannot promote #\${PARENT_PADDED}" >&2
+    fi
+    ;;
+  *)
+    # Already at In progress / In review / Done / unknown — no-op.
+    # Idempotency + regression guard branch.
+    ;;
+esac
+
+exit 0
 `,
     executable: true,
     backend: "local",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -6116,6 +6116,134 @@ exit 0
   },
   {
     category: "backlog-script",
+    name: "propagate-parent-status",
+    suffix: "propagate-parent-status.sh",
+    content: `#!/usr/bin/env bash
+# Post-move hook: when a sub-issue moves OUT of Backlog on the Project
+# board, auto-advance its parent Epic to In Progress — but only if the
+# Epic is currently in Backlog or Ready. Manual In Review / Done states
+# are preserved.
+#
+# GitHub backend: parent link comes from the native sub-issues GA,
+# read via GraphQL Issue.parent { number }. Parent's current Status
+# field on the project board is read via the same projectItems(first:5)
+# pattern move.sh uses. Promotion delegates back to move.sh.
+#
+# Usage: propagate-parent-status.sh <child-issue-num> <new-child-status>
+#   child-issue-num   : integer issue number on the configured repo
+#   new-child-status  : Backlog | Ready | "In progress" | "In review" | Done
+#
+# Always exits 0. Every failure path emits a stderr warning and
+# returns success — propagation must NEVER block the primary child
+# move per #260 AC(e).
+#
+# Recursion guard (AC(d)): when this script triggers move.sh on the
+# parent, SPECFLOW_INTERNAL_PROPAGATION=1 is exported. On re-entry
+# the script sees the env var and exits 0 immediately so the
+# grandparent is never touched. AC(d) bars multi-level propagation.
+
+set -uo pipefail
+
+CHILD="\${1:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+NEW_STATUS="\${2:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+
+# Recursion guard — see header.
+if [ -n "\${SPECFLOW_INTERNAL_PROPAGATION:-}" ]; then
+  exit 0
+fi
+
+# Moves INTO Backlog don't promote a parent.
+if [ "\$NEW_STATUS" = "Backlog" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+
+# Source the shared config — REPO_OWNER, REPO_NAME, PROJECT_NUMBER.
+# If the config helper isn't readable or fails, exit 0 silently —
+# the primary move already succeeded; we don't want stderr noise on
+# fresh projects that haven't filled in backlog-config.yml yet.
+# shellcheck source=./_config.sh
+if ! . "\$SCRIPT_DIR/_config.sh" 2>/dev/null; then
+  exit 0
+fi
+
+# 1. Resolve parent via GraphQL Issue.parent { number }.
+PARENT_NUM=\$(gh api graphql -f query='
+  query(\$owner: String!, \$name: String!, \$num: Int!) {
+    repository(owner: \$owner, name: \$name) {
+      issue(number: \$num) { parent { number } }
+    }
+  }
+' -f owner="\$REPO_OWNER" -f name="\$REPO_NAME" -F num="\$CHILD" \\
+  --jq '.data.repository.issue.parent.number // empty' 2>/dev/null) || PARENT_NUM=""
+
+if [ -z "\$PARENT_NUM" ]; then
+  # Top-level issue, or transient API error — silent exit.
+  exit 0
+fi
+
+# 2. Resolve the project node id (lazy lookup, mirrors move.sh).
+PROJECT_NODE_ID=\$(gh project view "\$PROJECT_NUMBER" --owner "\$REPO_OWNER" --format json --jq '.id' 2>/dev/null) || PROJECT_NODE_ID=""
+if [ -z "\$PROJECT_NODE_ID" ]; then
+  echo "::warning::propagate-parent-status: cannot resolve project node id — skipping promotion of parent #\${PARENT_NUM}" >&2
+  exit 0
+fi
+
+# 3. Read the parent's current Status field on the project board.
+PARENT_STATUS=\$(gh api graphql -f query='
+  query(\$owner: String!, \$name: String!, \$num: Int!) {
+    repository(owner: \$owner, name: \$name) {
+      issue(number: \$num) {
+        projectItems(first: 5) {
+          nodes {
+            project { id }
+            fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="\$REPO_OWNER" -f name="\$REPO_NAME" -F num="\$PARENT_NUM" \\
+  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \\"\$PROJECT_NODE_ID\\") | .fieldValueByName.name // empty" 2>/dev/null) || PARENT_STATUS=""
+
+# Parent not on the project, or no Status set yet — nothing to do.
+if [ -z "\$PARENT_STATUS" ]; then
+  exit 0
+fi
+
+# 4. Promote only if parent is in Backlog or Ready.
+case "\$PARENT_STATUS" in
+  "Backlog"|"Ready")
+    if [ -x "\$SCRIPT_DIR/move.sh" ]; then
+      # Use the sibling move.sh so the Status field mutation stays
+      # consistent with every other move. The recursion guard env var
+      # prevents this re-entry from walking further up (AC(d)).
+      if SPECFLOW_INTERNAL_PROPAGATION=1 "\$SCRIPT_DIR/move.sh" "\$PARENT_NUM" "In progress" >/dev/null 2>&1; then
+        echo "↑ promoted parent #\${PARENT_NUM} (\${PARENT_STATUS} → In progress) due to child #\${CHILD} move"
+      else
+        echo "::warning::propagate-parent-status: move.sh failed to promote #\${PARENT_NUM}" >&2
+      fi
+    else
+      echo "::warning::propagate-parent-status: \$SCRIPT_DIR/move.sh not found — cannot promote #\${PARENT_NUM}" >&2
+    fi
+    ;;
+  *)
+    # Already at In progress / In review / Done — no-op.
+    # Idempotency + regression guard branch.
+    ;;
+esac
+
+exit 0
+`,
+    executable: true,
+    backend: "github",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
     name: "_config",
     suffix: "_config.sh",
     content: `#!/usr/bin/env bash

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5787,6 +5787,14 @@ gh project item-edit \\
   --single-select-option-id "\$OPTION_ID" >/dev/null
 
 echo "✓ #\$NUM → \$STATUS"
+
+# Post-move hook: promote the parent Epic if this was a sub-issue
+# leaving Backlog. Best-effort — never blocks on failure. See
+# propagate-parent-status.sh for the full state machine.
+PROPAGATE="\$(dirname "\$0")/propagate-parent-status.sh"
+if [ -x "\$PROPAGATE" ]; then
+  "\$PROPAGATE" "\$NUM" "\$STATUS" || true
+fi
 `,
     executable: true,
     backend: "github",

--- a/templates/core/skills/backlog/scripts/github/move.sh
+++ b/templates/core/skills/backlog/scripts/github/move.sh
@@ -55,3 +55,11 @@ gh project item-edit \
   --single-select-option-id "$OPTION_ID" >/dev/null
 
 echo "✓ #$NUM → $STATUS"
+
+# Post-move hook: promote the parent Epic if this was a sub-issue
+# leaving Backlog. Best-effort — never blocks on failure. See
+# propagate-parent-status.sh for the full state machine.
+PROPAGATE="$(dirname "$0")/propagate-parent-status.sh"
+if [ -x "$PROPAGATE" ]; then
+  "$PROPAGATE" "$NUM" "$STATUS" || true
+fi

--- a/templates/core/skills/backlog/scripts/github/propagate-parent-status.sh
+++ b/templates/core/skills/backlog/scripts/github/propagate-parent-status.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Post-move hook: when a sub-issue moves OUT of Backlog on the Project
+# board, auto-advance its parent Epic to In Progress — but only if the
+# Epic is currently in Backlog or Ready. Manual In Review / Done states
+# are preserved.
+#
+# GitHub backend: parent link comes from the native sub-issues GA,
+# read via GraphQL Issue.parent { number }. Parent's current Status
+# field on the project board is read via the same projectItems(first:5)
+# pattern move.sh uses. Promotion delegates back to move.sh.
+#
+# Usage: propagate-parent-status.sh <child-issue-num> <new-child-status>
+#   child-issue-num   : integer issue number on the configured repo
+#   new-child-status  : Backlog | Ready | "In progress" | "In review" | Done
+#
+# Always exits 0. Every failure path emits a stderr warning and
+# returns success — propagation must NEVER block the primary child
+# move per #260 AC(e).
+#
+# Recursion guard (AC(d)): when this script triggers move.sh on the
+# parent, SPECFLOW_INTERNAL_PROPAGATION=1 is exported. On re-entry
+# the script sees the env var and exits 0 immediately so the
+# grandparent is never touched. AC(d) bars multi-level propagation.
+
+set -uo pipefail
+
+CHILD="${1:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+NEW_STATUS="${2:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+
+# Recursion guard — see header.
+if [ -n "${SPECFLOW_INTERNAL_PROPAGATION:-}" ]; then
+  exit 0
+fi
+
+# Moves INTO Backlog don't promote a parent.
+if [ "$NEW_STATUS" = "Backlog" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Source the shared config — REPO_OWNER, REPO_NAME, PROJECT_NUMBER.
+# If the config helper isn't readable or fails, exit 0 silently —
+# the primary move already succeeded; we don't want stderr noise on
+# fresh projects that haven't filled in backlog-config.yml yet.
+# shellcheck source=./_config.sh
+if ! . "$SCRIPT_DIR/_config.sh" 2>/dev/null; then
+  exit 0
+fi
+
+# 1. Resolve parent via GraphQL Issue.parent { number }.
+PARENT_NUM=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $num) { parent { number } }
+    }
+  }
+' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$CHILD" \
+  --jq '.data.repository.issue.parent.number // empty' 2>/dev/null) || PARENT_NUM=""
+
+if [ -z "$PARENT_NUM" ]; then
+  # Top-level issue, or transient API error — silent exit.
+  exit 0
+fi
+
+# 2. Resolve the project node id (lazy lookup, mirrors move.sh).
+PROJECT_NODE_ID=$(gh project view "$PROJECT_NUMBER" --owner "$REPO_OWNER" --format json --jq '.id' 2>/dev/null) || PROJECT_NODE_ID=""
+if [ -z "$PROJECT_NODE_ID" ]; then
+  echo "::warning::propagate-parent-status: cannot resolve project node id — skipping promotion of parent #${PARENT_NUM}" >&2
+  exit 0
+fi
+
+# 3. Read the parent's current Status field on the project board.
+PARENT_STATUS=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $num) {
+        projectItems(first: 5) {
+          nodes {
+            project { id }
+            fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$PARENT_NUM" \
+  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_NODE_ID\") | .fieldValueByName.name // empty" 2>/dev/null) || PARENT_STATUS=""
+
+# Parent not on the project, or no Status set yet — nothing to do.
+if [ -z "$PARENT_STATUS" ]; then
+  exit 0
+fi
+
+# 4. Promote only if parent is in Backlog or Ready.
+case "$PARENT_STATUS" in
+  "Backlog"|"Ready")
+    if [ -x "$SCRIPT_DIR/move.sh" ]; then
+      # Use the sibling move.sh so the Status field mutation stays
+      # consistent with every other move. The recursion guard env var
+      # prevents this re-entry from walking further up (AC(d)).
+      if SPECFLOW_INTERNAL_PROPAGATION=1 "$SCRIPT_DIR/move.sh" "$PARENT_NUM" "In progress" >/dev/null 2>&1; then
+        echo "↑ promoted parent #${PARENT_NUM} (${PARENT_STATUS} → In progress) due to child #${CHILD} move"
+      else
+        echo "::warning::propagate-parent-status: move.sh failed to promote #${PARENT_NUM}" >&2
+      fi
+    else
+      echo "::warning::propagate-parent-status: $SCRIPT_DIR/move.sh not found — cannot promote #${PARENT_NUM}" >&2
+    fi
+    ;;
+  *)
+    # Already at In progress / In review / Done — no-op.
+    # Idempotency + regression guard branch.
+    ;;
+esac
+
+exit 0

--- a/templates/core/skills/backlog/scripts/local/move.sh
+++ b/templates/core/skills/backlog/scripts/local/move.sh
@@ -45,3 +45,11 @@ awk -v new="$STATUS" '
 bash "$RENDER" "$ROOT"
 
 echo "✓ #$NUM → $STATUS"
+
+# Post-move hook: promote the parent Epic if this was a sub-task
+# leaving Backlog. Best-effort — never blocks on failure. See
+# propagate-parent-status.sh for the full state machine.
+PROPAGATE="$(dirname "$0")/propagate-parent-status.sh"
+if [ -x "$PROPAGATE" ]; then
+  "$PROPAGATE" "$NUM" "$STATUS" || true
+fi

--- a/templates/core/skills/backlog/scripts/local/propagate-parent-status.sh
+++ b/templates/core/skills/backlog/scripts/local/propagate-parent-status.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Post-move hook: when a sub-task moves OUT of Backlog, auto-advance
+# its parent Epic to In Progress — but only if the Epic is currently
+# in Backlog or Ready. Manual In Review / Done states are preserved.
+#
+# Local backend: parent link lives in `parent: "#NNN"` frontmatter;
+# status lives in `status:` frontmatter. Pure shell, no API calls.
+#
+# Usage: propagate-parent-status.sh <child-num> <new-child-status>
+#   child-num         : 3-digit zero-padded local task id (e.g. 042)
+#   new-child-status  : Backlog | Ready | "In progress" | "In review" | Done
+#
+# Always exits 0. Failure to find or update the parent emits a warning
+# to stderr but never returns non-zero — propagation must NEVER block
+# the primary child move per #260 AC(e).
+#
+# Recursion guard (AC(d)): the hook walks AT MOST one level up. When
+# this script calls back into `move.sh` to promote the parent, it sets
+# `SPECFLOW_INTERNAL_PROPAGATION=1`; on re-entry the hook sees the env
+# var and exits 0 immediately so the grandparent is never touched.
+
+set -uo pipefail
+
+CHILD="${1:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+NEW_STATUS="${2:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+
+# Recursion guard — see header.
+if [ -n "${SPECFLOW_INTERNAL_PROPAGATION:-}" ]; then
+  exit 0
+fi
+
+# Moves INTO Backlog don't promote a parent. Bail early.
+if [ "$NEW_STATUS" = "Backlog" ]; then
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Deployed layout: <root>/.specflow/scripts/backlog/<this>.sh — up 3.
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BACKLOG_DIR="$ROOT/.specflow/backlog"
+
+if [ ! -d "$BACKLOG_DIR" ]; then
+  echo "::warning::propagate-parent-status: backlog dir not found at $BACKLOG_DIR — skipping" >&2
+  exit 0
+fi
+
+# Find the child file (NNN-*.md).
+CHILD_PADDED=$(printf '%03d' "$((10#$CHILD))" 2>/dev/null || echo "$CHILD")
+shopt -s nullglob
+child_matches=("$BACKLOG_DIR/${CHILD_PADDED}-"*.md)
+if [ "${#child_matches[@]}" -eq 0 ]; then
+  echo "::warning::propagate-parent-status: child #${CHILD_PADDED} not found in $BACKLOG_DIR — skipping" >&2
+  exit 0
+fi
+CHILD_FILE="${child_matches[0]}"
+
+# Extract parent from frontmatter. Convention: `parent: "#NNN"` inside
+# the YAML frontmatter (between the first two `---` lines). Missing
+# parent or `null` → top-level task, nothing to propagate.
+PARENT_LINE=$(awk '/^---$/{n++; next} n==1 && /^parent:/{print; exit}' "$CHILD_FILE")
+PARENT_NUM=$(echo "$PARENT_LINE" | sed -nE 's/^parent:[[:space:]]*"?#0*([0-9]+)"?[[:space:]]*$/\1/p')
+if [ -z "$PARENT_NUM" ]; then
+  exit 0  # top-level task or `parent: null`
+fi
+
+PARENT_PADDED=$(printf '%03d' "$((10#$PARENT_NUM))")
+parent_matches=("$BACKLOG_DIR/${PARENT_PADDED}-"*.md)
+if [ "${#parent_matches[@]}" -eq 0 ]; then
+  echo "::warning::propagate-parent-status: parent #${PARENT_PADDED} of child #${CHILD_PADDED} not found — skipping" >&2
+  exit 0
+fi
+PARENT_FILE="${parent_matches[0]}"
+
+# Read parent's current status from frontmatter.
+PARENT_STATUS=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' "$PARENT_FILE")
+
+# Only promote if parent is in Backlog or Ready.
+case "$PARENT_STATUS" in
+  "Backlog"|"Ready")
+    if [ -x "$SCRIPT_DIR/move.sh" ]; then
+      # Use the sibling move.sh so the frontmatter rewrite + index
+      # refresh stay consistent with every other status move. The
+      # recursion guard env var prevents this re-entry from walking
+      # any further up (AC(d): one-level only).
+      if SPECFLOW_INTERNAL_PROPAGATION=1 "$SCRIPT_DIR/move.sh" "$PARENT_PADDED" "In progress" >/dev/null 2>&1; then
+        echo "↑ promoted parent #${PARENT_PADDED} (${PARENT_STATUS} → In progress) due to child #${CHILD_PADDED} move"
+      else
+        echo "::warning::propagate-parent-status: move.sh failed to promote #${PARENT_PADDED}" >&2
+      fi
+    else
+      echo "::warning::propagate-parent-status: $SCRIPT_DIR/move.sh not found — cannot promote #${PARENT_PADDED}" >&2
+    fi
+    ;;
+  *)
+    # Already at In progress / In review / Done / unknown — no-op.
+    # Idempotency + regression guard branch.
+    ;;
+esac
+
+exit 0

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -62,6 +62,7 @@
     { "category": "backlog-script", "name": "set-field", "suffix": "set-field.sh", "source": "core/skills/backlog/scripts/github/set-field.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "ensure-labels", "suffix": "ensure-labels.sh", "source": "core/skills/backlog/scripts/github/ensure-labels.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "cascade-check", "suffix": "cascade-check.sh", "source": "core/skills/backlog/scripts/github/cascade-check.sh", "executable": true, "backend": "github" },
+    { "category": "backlog-script", "name": "propagate-parent-status", "suffix": "propagate-parent-status.sh", "source": "core/skills/backlog/scripts/github/propagate-parent-status.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "_config", "suffix": "_config.sh", "source": "core/skills/backlog/scripts/gitlab/_config.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/gitlab/list.sh", "executable": true, "backend": "gitlab" },
     { "category": "backlog-script", "name": "view", "suffix": "view.sh", "source": "core/skills/backlog/scripts/gitlab/view.sh", "executable": true, "backend": "gitlab" },

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -51,6 +51,7 @@
     { "category": "backlog-script", "name": "move", "suffix": "move.sh", "source": "core/skills/backlog/scripts/local/move.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "clarify-comment", "suffix": "clarify-comment.sh", "source": "core/skills/backlog/scripts/local/clarify-comment.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "render-index", "suffix": "render-index.sh", "source": "core/skills/backlog/scripts/local/render-index.sh", "executable": true, "backend": "local" },
+    { "category": "backlog-script", "name": "propagate-parent-status", "suffix": "propagate-parent-status.sh", "source": "core/skills/backlog/scripts/local/propagate-parent-status.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "_config", "suffix": "_config.sh", "source": "core/skills/backlog/scripts/github/_config.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/github/list.sh", "executable": true, "backend": "github" },
     { "category": "backlog-script", "name": "view", "suffix": "view.sh", "source": "core/skills/backlog/scripts/github/view.sh", "executable": true, "backend": "github" },


### PR DESCRIPTION
Closes #260.

## Summary

When a sub-task moves out of Backlog via `move.sh`, automatically advance the parent Epic to In Progress — but only if the Epic is currently in Backlog or Ready, so manual In Review / Done states are never regressed.

Implementation: a dedicated `propagate-parent-status.sh` per backend, called at the tail of `move.sh` after the child move succeeds. Pure shell. Scope: `github` + `local` backends per the AC; `gitlab` is symmetric work left for a separate PR (the cascade-check pattern transfers cleanly, but it's out of scope per #260).

The propagation is a best-effort post-move check — every failure mode (missing parent, parent not on the project board, transient GraphQL error, malformed frontmatter) emits a stderr warning and exits 0 so the primary child move always completes successfully per AC(e).

**State machine (identical across backends):**

- If `new_status == Backlog`: exit 0 (moves INTO Backlog don't promote).
- Resolve parent from child:
  - Local: read `parent: "#NNN"` from frontmatter.
  - GitHub: GraphQL `Issue.parent { number }` (native sub-issues GA — verified live: querying `#242` returns parent `#241`, confirming the schema exposes the field on this instance).
- If no parent: exit 0.
- Read parent's current status. If `Backlog` or `Ready`: promote to In Progress. Otherwise: no-op (idempotency + regression guard).

**Recursion guard (AC(d) — propagation must NOT walk past one level):** when the propagator triggers `move.sh` on the parent, it exports `SPECFLOW_INTERNAL_PROPAGATION=1`. The re-entered propagator (running for the parent's move) sees the env var and exits 0 immediately, so the grandparent is never touched.

## Test plan

- **Local backend:** four new assertions in `smoke-backlog-local.sh` — propagator scaffolded + executable, move.sh tail hook wired, end-to-end auto-promotion Backlog → In Progress, regression-guard for In Review.
- **GitHub backend:** five new presence/shape assertions in `smoke-backlog-github.sh` — script present, hook wired, GraphQL `Issue.parent` field, promotion guard regex, recursion-guard env var.
- **Repo-wide smoke:** four new assertions in `smoke-features.sh` covering the local-backend scaffold.
- **Manual smoke:** the local propagator was exercised on a tmp fixture across five branches (promote, regression-guard, no-parent, missing-parent, recursion-guard) — all green.
- **Audit:** `bash .claude/skills/test-sandbox/scripts/audit.sh` — 0 gaps, 0 stale.
- `deno task test`: 643+ tests green (no TypeScript code changed; new behaviour is pure shell + smoke).

A pre-existing failure on `smoke-backlog-github.sh` (assertion `#194 SKILL.md states fields are the source of truth`) was confirmed against `main` without this PR's changes — out of scope, will be triaged separately.

## Agent adoption

The PO agent's existing two-step close protocol is unchanged. The new behaviour is **transparent** — every call to `move.sh <num> <status>` on a sub-task now propagates upward automatically.

```prompt
After `specflow upgrade`, when your product-owner agent (or you, manually) moves a sub-issue out of Backlog, the parent Epic auto-advances to In Progress if it was sitting in Backlog or Ready. No action required — this happens at the tail of `move.sh`. If the Epic was already past In Progress (In Review / Done), nothing changes — the auto-advance has a regression guard. To opt out of the propagation for a specific call, export `SPECFLOW_INTERNAL_PROPAGATION=1` before invoking `move.sh`. To revert an Epic that was auto-promoted, run `move.sh <epic> Backlog` after the fact.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
