### PR TITLE
feat(specflow): first-class skill alias / overlay convention + list-skills phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,27 @@ coexist with project-local copies from `specflow init`.
 
 Most teams use both. See [the docs](https://specflow.makerlabs.dev) for the full boundary table.
 
+## Project-specific skill overlays
+
+Need to override an upstream Specflow skill in one project — e.g. a monorepo `tag-version` that has
+to `cd` into an inner repo first? SKILL.md frontmatter accepts two optional fields:
+
+```yaml
+---
+name: tag-version
+alias_of: specflow.tag-version
+overlays:
+  - when: before
+    path: ./scripts/cd-inner-repo.sh
+---
+```
+
+Run `/specflow list-skills` to see which aliases and overlays are active in your project. The
+Specflow binary scaffolds and ships the convention; the harness (Claude Code, Cursor, …) honours it
+at dispatch time. See `docs/llms.md` for the full contract and
+[`templates/core/skills/alias-example/SKILL.md`](templates/core/skills/alias-example/SKILL.md) for a
+copy-pasteable starting point.
+
 ## Upgrading an existing project
 
 When you update the `specflow` binary (via `specflow self-update` or Homebrew), the bundled

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -357,6 +357,37 @@ Some harnesses also ship harness-specific helper files alongside the core scaffo
   Codex's experimental one-shot long-horizon feature; enable via `goals = true` under `[features]`
   in `config.toml`).
 
+## Project-specific skill overlays
+
+Specflow's skill folders are plain markdown — anything you put under your harness's `skills/`
+directory (e.g. `.claude/skills/<name>/`, `.cursor/skills/<name>/`) is a skill, full stop. To make
+the common "override an upstream skill" pattern discoverable, Specflow recognises two optional
+fields in `SKILL.md` frontmatter:
+
+| Field                    | Meaning                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `alias_of: <skill-name>` | This skill is a thin wrapper that delegates to the named upstream skill. Dotted notation (e.g. `specflow.tag-version`) makes the distribution explicit. |
+| `overlays:`              | A list of pre/post hooks. Each entry carries `when: before \| after` and `path: ./scripts/<file>.sh` relative to the SKILL.md.                          |
+
+The Specflow binary itself **never resolves or dispatches** aliases / overlays — the harness (Claude
+Code, Cursor, Codex, …) is responsible for honouring the frontmatter at invocation time. Specflow's
+role is to standardise the contract.
+
+To see what's installed and which aliases / overlays are active:
+
+```bash
+/specflow list-skills
+```
+
+The phase walks your harness's skills directory, parses every SKILL.md frontmatter, and renders a
+`NAME · KIND · ALIAS OF · OVERLAYS · DESCRIPTION` table. Skills without `alias_of` show
+`KIND = skill`; aliases show `KIND = alias` and the target.
+
+A reference example lives at
+[`templates/core/skills/alias-example/SKILL.md`](https://github.com/mkrlabs/specflow/blob/main/templates/core/skills/alias-example/SKILL.md)
+in the Specflow source tree. It is **not** installed by `specflow init` — copy it manually when you
+want to introduce your first alias.
+
 ## What makes Specflow different from upstream Spec Kit
 
 Specflow is a fork of the official `specify` CLI with the following additions:

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -17,6 +17,7 @@ when_to_use: |
   - groom: "groom the backlog", "run a hygiene pass"
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
+  - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
 ---
 
 # Specflow router
@@ -58,11 +59,12 @@ when_to_use: |
 | `groom` | `phases/groom.md` | Backlog hygiene pass via the product-owner agent. |
 | `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
 | `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
+| `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay hooks. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
-`checklist`, `groom`, `tag-version`, `release-version`) are one-shot
-regardless of chain mode.
+`checklist`, `groom`, `tag-version`, `release-version`, `list-skills`)
+are one-shot regardless of chain mode.
 
 ## Routing
 
@@ -102,7 +104,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, and `list-skills` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/plugin/skills/specflow/phases/list-skills.md
+++ b/plugin/skills/specflow/phases/list-skills.md
@@ -1,0 +1,84 @@
+
+# /specflow list-skills
+
+A one-shot inspection phase. List every skill installed for this project,
+flag which ones are aliases of upstream skills, and surface their pre/post
+hook overlays. The point is to make the *shadowing* relationships visible —
+without this, you have to read each script to know that a local
+`tag-version/` actually delegates to `specflow.tag-version`.
+
+This phase is **read-only** — it never mutates files, never invokes other
+phases, and never auto-chains.
+
+## What this phase does
+
+1. **Locate the harness skills directory.** Try, in order:
+   - `.claude/skills/` (Claude Code)
+   - `.cursor/skills/` (Cursor)
+   - `.windsurf/skills/`, `.gemini/skills/`, `.opencode/skills/`,
+     `.agent/skills/` (other supported harnesses)
+   - Use whichever directory exists in the current working tree. If
+     none exist, report `no skills installed` and stop.
+
+2. **Enumerate skill folders.** Each immediate sub-directory containing
+   a `SKILL.md` file is one skill. Sub-directories without a `SKILL.md`
+   are ignored (they may be phase-doc folders, scripts, etc.).
+
+3. **Read each `SKILL.md` frontmatter.** The frontmatter is the
+   block between the first two `---` lines. Extract:
+   - `name:` — the skill's invocation name (required).
+   - `description:` — short blurb (required).
+   - `alias_of:` — when present, the skill is an alias that delegates
+     to the named upstream skill. Convention is dotted notation, e.g.
+     `alias_of: specflow.tag-version`.
+   - `overlays:` — when present, a list of pre/post hooks. Each item
+     carries `when: before | after` and `path: <relative-script>`.
+
+4. **Render a markdown table** with five columns in this order:
+
+   | Column | Source | Empty value |
+   |---|---|---|
+   | `NAME` | `name:` field, fallback to folder name | n/a (always present) |
+   | `KIND` | `alias` if `alias_of` is present, else `skill` | n/a |
+   | `ALIAS OF` | `alias_of:` value | `—` |
+   | `OVERLAYS` | comma-joined `<path> (<when>)` per overlay entry | `—` |
+   | `DESCRIPTION` | `description:` field, truncated to 60 chars + `…` | n/a |
+
+5. **Sort the rows** by NAME ascending. Render aliases and skills in the
+   same alphabetical list — the `KIND` column already disambiguates.
+
+6. **Stop after the table.** Do not chain into another phase. Do not
+   propose follow-up actions unless the user asks. This is an inspect
+   command.
+
+## Example output
+
+```
+SKILLS — 4 installed (.claude/skills/)
+
+| NAME           | KIND   | ALIAS OF              | OVERLAYS                 | DESCRIPTION                                     |
+|----------------|--------|-----------------------|--------------------------|-------------------------------------------------|
+| backlog        | skill  | —                     | —                        | GitHub Project #4 backed backlog with classific…|
+| release-version| alias  | specflow.release-vers…| poll-cloud-build.sh (befo| Monorepo wrapper: poll Cloud Build then delegat…|
+| specflow       | skill  | —                     | —                        | Specflow workflow router — entry point for the …|
+| tag-version    | alias  | specflow.tag-version  | quality-gate.sh (before) | Monorepo wrapper: cd into inner repo then deleg…|
+```
+
+## Failure modes
+
+- `SKILL.md` missing → skip the folder silently (it's not a skill).
+- Frontmatter unparseable → render the row with `KIND = error` and
+  leave the other columns blank; surface the file path in a
+  `## Parse errors` footnote so the user can fix it.
+- `alias_of` points at a skill not present in the table → keep the row
+  as-is; cycle detection and unresolved-target warnings are the
+  harness's job at *invocation* time, not at *listing* time (per #265
+  out-of-scope).
+
+## When NOT to use this phase
+
+- To **invoke** a skill — that's the skill's own slash command.
+- To **modify** the alias/overlay relationship — edit the SKILL.md
+  frontmatter directly.
+- To **detect cycles** in alias chains — that requires the harness to
+  resolve at dispatch time, which is out of scope for this phase.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11,8 +11,8 @@ export const CORE_BUNDLE: CoreBundle = [
     suffix: null,
     content: `---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version). \`/specflow\` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills). \`/specflow\` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -28,6 +28,7 @@ when_to_use: |
   - groom: "groom the backlog", "run a hygiene pass"
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
+  - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
 ---
 
 # Specflow router
@@ -69,11 +70,12 @@ when_to_use: |
 | \`groom\` | \`phases/groom.md\` | Backlog hygiene pass via the product-owner agent. |
 | \`tag-version\` | \`phases/tag-version.md\` | Bump + create an annotated git tag using the project's versioning scheme. |
 | \`release-version\` | \`phases/release-version.md\` | Generate categorized release notes for a tag (default: latest). |
+| \`list-skills\` | \`phases/list-skills.md\` | List installed skills, flagging aliases and overlay hooks. |
 
 Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
 \`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
-\`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`) are one-shot
-regardless of chain mode.
+\`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`)
+are one-shot regardless of chain mode.
 
 ## Routing
 
@@ -113,7 +115,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See \`phases/auto-chain.md\` for the
 chain mechanics.
 
-\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, and \`release-version\` are out-of-band utilities, not part of the linear flow.
+\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, and \`list-skills\` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2397,6 +2397,99 @@ above will pick up where the previous run stopped, or they can pass
     skipIfExists: false,
   },
   {
+    category: "phase",
+    name: "list-skills",
+    suffix: "list-skills.md",
+    content: `
+# /specflow list-skills
+
+A one-shot inspection phase. List every skill installed for this project,
+flag which ones are aliases of upstream skills, and surface their pre/post
+hook overlays. The point is to make the *shadowing* relationships visible —
+without this, you have to read each script to know that a local
+\`tag-version/\` actually delegates to \`specflow.tag-version\`.
+
+This phase is **read-only** — it never mutates files, never invokes other
+phases, and never auto-chains.
+
+## What this phase does
+
+1. **Locate the harness skills directory.** Try, in order:
+   - \`.claude/skills/\` (Claude Code)
+   - \`.cursor/skills/\` (Cursor)
+   - \`.windsurf/skills/\`, \`.gemini/skills/\`, \`.opencode/skills/\`,
+     \`.agent/skills/\` (other supported harnesses)
+   - Use whichever directory exists in the current working tree. If
+     none exist, report \`no skills installed\` and stop.
+
+2. **Enumerate skill folders.** Each immediate sub-directory containing
+   a \`SKILL.md\` file is one skill. Sub-directories without a \`SKILL.md\`
+   are ignored (they may be phase-doc folders, scripts, etc.).
+
+3. **Read each \`SKILL.md\` frontmatter.** The frontmatter is the
+   block between the first two \`---\` lines. Extract:
+   - \`name:\` — the skill's invocation name (required).
+   - \`description:\` — short blurb (required).
+   - \`alias_of:\` — when present, the skill is an alias that delegates
+     to the named upstream skill. Convention is dotted notation, e.g.
+     \`alias_of: specflow.tag-version\`.
+   - \`overlays:\` — when present, a list of pre/post hooks. Each item
+     carries \`when: before | after\` and \`path: <relative-script>\`.
+
+4. **Render a markdown table** with five columns in this order:
+
+   | Column | Source | Empty value |
+   |---|---|---|
+   | \`NAME\` | \`name:\` field, fallback to folder name | n/a (always present) |
+   | \`KIND\` | \`alias\` if \`alias_of\` is present, else \`skill\` | n/a |
+   | \`ALIAS OF\` | \`alias_of:\` value | \`—\` |
+   | \`OVERLAYS\` | comma-joined \`<path> (<when>)\` per overlay entry | \`—\` |
+   | \`DESCRIPTION\` | \`description:\` field, truncated to 60 chars + \`…\` | n/a |
+
+5. **Sort the rows** by NAME ascending. Render aliases and skills in the
+   same alphabetical list — the \`KIND\` column already disambiguates.
+
+6. **Stop after the table.** Do not chain into another phase. Do not
+   propose follow-up actions unless the user asks. This is an inspect
+   command.
+
+## Example output
+
+\`\`\`
+SKILLS — 4 installed (.claude/skills/)
+
+| NAME           | KIND   | ALIAS OF              | OVERLAYS                 | DESCRIPTION                                     |
+|----------------|--------|-----------------------|--------------------------|-------------------------------------------------|
+| backlog        | skill  | —                     | —                        | GitHub Project #4 backed backlog with classific…|
+| release-version| alias  | specflow.release-vers…| poll-cloud-build.sh (befo| Monorepo wrapper: poll Cloud Build then delegat…|
+| specflow       | skill  | —                     | —                        | Specflow workflow router — entry point for the …|
+| tag-version    | alias  | specflow.tag-version  | quality-gate.sh (before) | Monorepo wrapper: cd into inner repo then deleg…|
+\`\`\`
+
+## Failure modes
+
+- \`SKILL.md\` missing → skip the folder silently (it's not a skill).
+- Frontmatter unparseable → render the row with \`KIND = error\` and
+  leave the other columns blank; surface the file path in a
+  \`## Parse errors\` footnote so the user can fix it.
+- \`alias_of\` points at a skill not present in the table → keep the row
+  as-is; cycle detection and unresolved-target warnings are the
+  harness's job at *invocation* time, not at *listing* time (per #265
+  out-of-scope).
+
+## When NOT to use this phase
+
+- To **invoke** a skill — that's the skill's own slash command.
+- To **modify** the alias/overlay relationship — edit the SKILL.md
+  frontmatter directly.
+- To **detect cycles** in alias chains — that requires the harness to
+  resolve at dispatch time, which is out of scope for this phase.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
     category: "phase-script",
     name: "tag",
     suffix: "tag.sh",

--- a/templates/core/skills/alias-example/SKILL.md
+++ b/templates/core/skills/alias-example/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: alias-example
+description: Reference SKILL.md showing the `alias_of` + `overlays` frontmatter convention. Copy this folder to your project's harness skills dir (e.g. `.claude/skills/`) and edit. Specflow itself never installs this file — it lives in the Specflow repo as documentation.
+alias_of: specflow.tag-version
+overlays:
+  - when: before
+    path: ./scripts/quality-gate.sh
+  - when: after
+    path: ./scripts/notify-slack.sh
+---
+
+# alias-example
+
+This file demonstrates the two optional frontmatter fields that
+Specflow's `/specflow list-skills` phase recognises:
+
+- **`alias_of: <skill-name>`** — declares that this skill is a wrapper
+  around an upstream skill. Convention is dotted notation, with the
+  plugin or distribution name as the prefix (e.g.
+  `alias_of: specflow.tag-version`). The harness is responsible for
+  resolving the alias at invocation time; Specflow only records the
+  relationship.
+
+- **`overlays:`** — a list of pre/post hooks the harness should run
+  around the wrapped skill's body. Each entry carries:
+  - `when: before` or `when: after` — where the hook fires relative to
+    the wrapped skill.
+  - `path: ./scripts/<name>.sh` — script path relative to this
+    SKILL.md's folder.
+
+## Why a project would override an upstream skill
+
+A common pattern: a monorepo that uses Specflow at the root but needs a
+slightly different `tag-version` because tags live inside a sub-repo.
+Rather than fork the canonical `specflow.tag-version` script, the
+project ships a thin wrapper as `alias_of: specflow.tag-version` plus
+an overlay that runs `cd inner-repo` before delegating.
+
+The result is grep-able and self-documenting: anyone running
+`/specflow list-skills` sees the alias relationship and the overlay
+hooks in one table. No code archaeology needed.
+
+## What Specflow does with this file
+
+**Nothing at runtime.** This file lives in the Specflow source tree
+purely as documentation. It is intentionally absent from
+`templates/manifest.json`, so `specflow init` and `specflow upgrade`
+will never scaffold it into your project. To use the pattern:
+
+1. Copy this folder into your harness skills directory:
+   ```
+   cp -r templates/core/skills/alias-example .claude/skills/my-skill
+   ```
+2. Edit the frontmatter — at minimum change `name:`, `alias_of:`, and
+   the overlay paths.
+3. Write the actual delegate-and-hook logic in the body of the file
+   (or in the overlay scripts).
+4. Run `/specflow list-skills` to confirm the harness sees the new
+   alias and overlay.
+
+## Prior art
+
+- komence/komence-monorepo commits `5fbae6ea` and `39691ae3` —
+  manually-implemented Option 2 wrappers that this convention codifies.

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -17,6 +17,7 @@ when_to_use: |
   - groom: "groom the backlog", "run a hygiene pass"
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
+  - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
 ---
 
 # Specflow router
@@ -58,11 +59,12 @@ when_to_use: |
 | `groom` | `phases/groom.md` | Backlog hygiene pass via the product-owner agent. |
 | `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
 | `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
+| `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay hooks. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
-`checklist`, `groom`, `tag-version`, `release-version`) are one-shot
-regardless of chain mode.
+`checklist`, `groom`, `tag-version`, `release-version`, `list-skills`)
+are one-shot regardless of chain mode.
 
 ## Routing
 
@@ -102,7 +104,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, and `list-skills` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/templates/core/skills/specflow/phases/list-skills.md
+++ b/templates/core/skills/specflow/phases/list-skills.md
@@ -1,0 +1,84 @@
+
+# /specflow list-skills
+
+A one-shot inspection phase. List every skill installed for this project,
+flag which ones are aliases of upstream skills, and surface their pre/post
+hook overlays. The point is to make the *shadowing* relationships visible —
+without this, you have to read each script to know that a local
+`tag-version/` actually delegates to `specflow.tag-version`.
+
+This phase is **read-only** — it never mutates files, never invokes other
+phases, and never auto-chains.
+
+## What this phase does
+
+1. **Locate the harness skills directory.** Try, in order:
+   - `.claude/skills/` (Claude Code)
+   - `.cursor/skills/` (Cursor)
+   - `.windsurf/skills/`, `.gemini/skills/`, `.opencode/skills/`,
+     `.agent/skills/` (other supported harnesses)
+   - Use whichever directory exists in the current working tree. If
+     none exist, report `no skills installed` and stop.
+
+2. **Enumerate skill folders.** Each immediate sub-directory containing
+   a `SKILL.md` file is one skill. Sub-directories without a `SKILL.md`
+   are ignored (they may be phase-doc folders, scripts, etc.).
+
+3. **Read each `SKILL.md` frontmatter.** The frontmatter is the
+   block between the first two `---` lines. Extract:
+   - `name:` — the skill's invocation name (required).
+   - `description:` — short blurb (required).
+   - `alias_of:` — when present, the skill is an alias that delegates
+     to the named upstream skill. Convention is dotted notation, e.g.
+     `alias_of: specflow.tag-version`.
+   - `overlays:` — when present, a list of pre/post hooks. Each item
+     carries `when: before | after` and `path: <relative-script>`.
+
+4. **Render a markdown table** with five columns in this order:
+
+   | Column | Source | Empty value |
+   |---|---|---|
+   | `NAME` | `name:` field, fallback to folder name | n/a (always present) |
+   | `KIND` | `alias` if `alias_of` is present, else `skill` | n/a |
+   | `ALIAS OF` | `alias_of:` value | `—` |
+   | `OVERLAYS` | comma-joined `<path> (<when>)` per overlay entry | `—` |
+   | `DESCRIPTION` | `description:` field, truncated to 60 chars + `…` | n/a |
+
+5. **Sort the rows** by NAME ascending. Render aliases and skills in the
+   same alphabetical list — the `KIND` column already disambiguates.
+
+6. **Stop after the table.** Do not chain into another phase. Do not
+   propose follow-up actions unless the user asks. This is an inspect
+   command.
+
+## Example output
+
+```
+SKILLS — 4 installed (.claude/skills/)
+
+| NAME           | KIND   | ALIAS OF              | OVERLAYS                 | DESCRIPTION                                     |
+|----------------|--------|-----------------------|--------------------------|-------------------------------------------------|
+| backlog        | skill  | —                     | —                        | GitHub Project #4 backed backlog with classific…|
+| release-version| alias  | specflow.release-vers…| poll-cloud-build.sh (befo| Monorepo wrapper: poll Cloud Build then delegat…|
+| specflow       | skill  | —                     | —                        | Specflow workflow router — entry point for the …|
+| tag-version    | alias  | specflow.tag-version  | quality-gate.sh (before) | Monorepo wrapper: cd into inner repo then deleg…|
+```
+
+## Failure modes
+
+- `SKILL.md` missing → skip the folder silently (it's not a skill).
+- Frontmatter unparseable → render the row with `KIND = error` and
+  leave the other columns blank; surface the file path in a
+  `## Parse errors` footnote so the user can fix it.
+- `alias_of` points at a skill not present in the table → keep the row
+  as-is; cycle detection and unresolved-target warnings are the
+  harness's job at *invocation* time, not at *listing* time (per #265
+  out-of-scope).
+
+## When NOT to use this phase
+
+- To **invoke** a skill — that's the skill's own slash command.
+- To **modify** the alias/overlay relationship — edit the SKILL.md
+  frontmatter directly.
+- To **detect cycles** in alias chains — that requires the harness to
+  resolve at dispatch time, which is out of scope for this phase.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -16,6 +16,7 @@
     { "category": "phase", "name": "tag-version", "suffix": "tag-version.md", "source": "core/skills/specflow/phases/tag-version.md" },
     { "category": "phase", "name": "release-version", "suffix": "release-version.md", "source": "core/skills/specflow/phases/release-version.md" },
     { "category": "phase", "name": "auto-chain", "suffix": "auto-chain.md", "source": "core/skills/specflow/phases/auto-chain.md" },
+    { "category": "phase", "name": "list-skills", "suffix": "list-skills.md", "source": "core/skills/specflow/phases/list-skills.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,12 +82,13 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 14 phases (11 original + tag-version + release-version + auto-chain) +
-    // specflow-auto + specflow-review + backlog + 11 agents = 28.
+    // Router + 15 phases (11 original + tag-version + release-version +
+    // auto-chain + list-skills) + specflow-auto + specflow-review +
+    // backlog + 11 agents = 29.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 28);
+    assertEquals(instructionsCount, 29);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,12 +74,13 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 14 phases (11 original + tag-version + release-version + auto-chain) +
-    // specflow-auto + specflow-review alias + backlog + 11 agent workflows = 28.
+    // Router + 15 phases (11 original + tag-version + release-version +
+    // auto-chain + list-skills) + specflow-auto + specflow-review alias +
+    // backlog + 11 agent workflows = 29.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 28);
+    assertEquals(workflowsCount, 29);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -32,6 +32,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "groom",
     "tag-version",
     "release-version",
+    "list-skills",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,


### PR DESCRIPTION
Closes #265.

## Agent adoption

Specflow's SKILL.md frontmatter now recognises two optional fields — `alias_of: <skill-name>` and `overlays: [{when, path}]` — that let a project ship a thin wrapper around an upstream skill without forking it. The relationship is recorded in the frontmatter and rendered by a new `/specflow list-skills` phase as a pipe table (NAME · KIND · ALIAS OF · OVERLAYS · DESCRIPTION).

The Specflow binary itself does NOT dispatch aliases or run overlays — the harness (Claude Code, Cursor, …) honours the frontmatter at invocation time. Specflow's contribution is the convention + the inspector phase.

## Files

- `templates/core/skills/specflow/phases/list-skills.md` + plugin twin — new phase doc.
- `templates/core/skills/specflow/SKILL.md` + plugin twin — router updated (Phase index, argument-hint, when_to_use, non-chainable classification).
- `templates/manifest.json` — registers the phase entry (85 → 86 core entries).
- `tests/plugin/plugin_sync_test.ts` — adds `list-skills` to the byte-identity contract.
- `tests/integration/init_{copilot,windsurf}_test.ts` — phase-count assertion bumps 28 → 29.
- `templates/core/skills/alias-example/SKILL.md` — reference example (NOT in manifest, NOT scaffolded — documentation only).
- `docs/llms.md` + `README.md` — new "Project-specific skill overlays" sections.

## Out of scope (intentionally)

- Alias-cycle detection in the binary (harness concern).
- Fallback behaviour when an `alias_of` target is missing (harness concern).
- A `specflow check --skills` subcommand (the `list-skills` phase covers the UX without binary changes).

## Prior art

komence/komence-monorepo commits `5fbae6ea` and `39691ae3` — Option-2 manual wrappers this convention codifies.

```prompt
After `specflow upgrade`, you can introduce a project-specific alias by copying templates/core/skills/alias-example/SKILL.md from the Specflow repo into your .claude/skills/<name>/ directory, editing the alias_of: and overlays: frontmatter to match your needs, and re-running /specflow list-skills to confirm the harness sees it.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)