### PR TITLE
chore(release-prep): close list-skills smoke gap + commit session artefacts

### DIFF
--- a/.claude/agents/architect/memory/MEMORY.md
+++ b/.claude/agents/architect/memory/MEMORY.md
@@ -17,3 +17,4 @@ obsolete once they are encoded in `AGENTS.md`).
 - [Router skill consolidation](router-skill-consolidation.md) — decisions for collapsing 11 specflow-* phase skills into a single /specflow router + phases/ subdirectory
 - [Auto-chain disable-model-invocation fix](auto-chain-disable-model-invocation.md) — lift the flag from the router to unblock Skill-tool chaining by specflow-auto
 - [Specflow-auto merge into router](specflow-auto-merge-into-router.md) — decisions for collapsing /specflow-auto chain logic into the /specflow router with --manual opt-out; deprecation alias + removal plan
+- [SKILL.md frontmatter schema](skill-frontmatter-schema.md) — pass-through guarantee for new optional fields; no TypeScript changes needed for alias_of/overlays

--- a/.claude/agents/architect/memory/skill-frontmatter-schema.md
+++ b/.claude/agents/architect/memory/skill-frontmatter-schema.md
@@ -1,0 +1,44 @@
+---
+name: skill-frontmatter-schema
+description: SKILL.md frontmatter fields used today + pass-through guarantee for issue #265 (alias_of / overlays)
+type: reference
+---
+
+## Current SKILL.md frontmatter fields (as of v1.3.1)
+
+Known fields used across the four bundled skills:
+
+| Field | Type | Where used |
+|---|---|---|
+| `name` | string | All four skills |
+| `description` | string | All four skills |
+| `argument-hint` | string | specflow router, backlog |
+| `when_to_use` | block-scalar string | specflow router, specflow-review |
+
+No typed schema exists in the TypeScript source. There is NO domain type,
+no Zod validation, no application-layer parser for SKILL.md frontmatter.
+
+## Bundler pass-through guarantee
+
+`scripts/bundle-templates.ts` reads SKILL.md as raw text via `Deno.readTextFile`
+and embeds it verbatim as a template-literal string in `src/templates_bundle.ts`.
+The bundler never parses YAML frontmatter — it only embeds the entire file content.
+
+The only frontmatter manipulation at deploy time is in
+`src/infrastructure/harness/skill_folder.ts::ensureSkillFrontmatter()` which
+injects `name:` and `description:` when absent (for Cursor/Codex registries).
+It does NOT strip unknown fields — it does a regex presence check for those two
+keys only, leaving all other frontmatter lines untouched.
+
+**Conclusion:** Adding `alias_of` and `overlays` as optional frontmatter fields
+requires ZERO bundler changes and ZERO TypeScript type changes. The fields flow
+through the entire pipeline unchanged. The harness only consumes what it knows
+about.
+
+## Plugin sync contract for new phase docs
+
+`tests/plugin/plugin_sync_test.ts` maintains a hardcoded `SYNC_PAIRS` array.
+Any NEW file added under `templates/core/skills/specflow/` that also needs a
+plugin twin under `plugin/skills/specflow/` MUST have a corresponding row added
+to `SYNC_PAIRS`, otherwise the test won't catch drift. New phase docs REQUIRE
+both the template file AND the plugin copy AND a SYNC_PAIRS row.

--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -58,7 +58,7 @@ check ".claude/commands/specflow.md present (slash-command shim, post-F3)" \
   '[ -f .claude/commands/specflow.md ]'
 check "router .claude/skills/specflow/SKILL.md present" \
   '[ -f .claude/skills/specflow/SKILL.md ]'
-for phase in specify constitution clarify plan tasks analyze implement merge review checklist groom tag-version release-version; do
+for phase in specify constitution clarify plan tasks analyze implement merge review checklist groom tag-version release-version list-skills; do
   check ".claude/skills/specflow/phases/$phase.md present" \
     "[ -f .claude/skills/specflow/phases/$phase.md ]"
 done
@@ -69,6 +69,8 @@ check "phase doc tag-version.md scaffolded (epic #226)" \
   '[ -f .claude/skills/specflow/phases/tag-version.md ]'
 check "phase doc release-version.md scaffolded (epic #226)" \
   '[ -f .claude/skills/specflow/phases/release-version.md ]'
+check "phase doc list-skills.md scaffolded (#265)" \
+  '[ -f .claude/skills/specflow/phases/list-skills.md ]'
 check "name: specflow on the router SKILL.md" \
   'head -3 .claude/skills/specflow/SKILL.md | grep -q "name: specflow"'
 check "disable-model-invocation NOT set on the router (Skill-tool chaining must work)" \

--- a/docs/superpowers/plans/2026-05-16-auto-propagate-epic-status.md
+++ b/docs/superpowers/plans/2026-05-16-auto-propagate-epic-status.md
@@ -1,0 +1,1058 @@
+# Auto-propagate Epic Status from Child Sub-task Moves Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a sub-task is moved out of Backlog via `move.sh`, automatically advance its parent
+Epic to In Progress — but only if the Epic is currently in Backlog or Ready, so manual In Review /
+Done states are never regressed.
+
+**Architecture:** A dedicated `propagate-parent-status.sh` helper per backend, called at the tail of
+`move.sh` after the child move succeeds. The helper resolves the child's parent, reads the parent's
+current status, and conditionally promotes it. Failures inside the propagation (missing parent, API
+error) emit a warning to stderr and exit 0 — propagation is a best-effort post-move check, never
+blocking the primary mutation. Scope: `github` + `local` backends only; `gitlab` is symmetric but
+out of scope per #260's AC.
+
+**Tech Stack:** Bash 4+ · `gh` CLI (REST + GraphQL) · `jq` · `awk` · Deno 2.x for TypeScript helper
+tests · existing parent-link helpers at `tests/helpers/parent_link.ts`.
+
+---
+
+## Context
+
+#260 reports that Epics on the Project board stay in Backlog while their sub-tasks advance — making
+it impossible to tell at a glance whether an Epic is genuinely idle or actively being worked on. The
+fix auto-advances the Epic's Status field the moment a child sub-task leaves Backlog.
+
+The codebase already has all the parent-link plumbing this needs:
+
+- **GitHub backend** — `add.sh --parent` uses
+  `POST /repos/{owner}/{repo}/issues/{parent}/sub_issues` (canonical native sub-issues API).
+  `cascade-check.sh` reads children via `GET .../sub_issues`. **What's missing** is the _reverse_
+  lookup (child → parent). The GitHub native sub-issues GA exposes `Issue.parent { number }` via
+  GraphQL; the plan uses that.
+- **Local backend** — `add.sh --parent` writes `parent: "#NNN"` into frontmatter.
+  `tests/helpers/parent_link.ts` already provides `extractParent()` / `findChildren()` helpers; the
+  new propagation reuses the same regex shape with a pure-shell parser (no Deno dependency in the
+  bundled script).
+
+The propagation logic is a tiny state machine:
+
+```
+post-move-hook(child_num, new_status):
+  if new_status == "Backlog":            return  # moving INTO Backlog can't trigger propagation
+  parent_num = resolve_parent(child_num)
+  if parent_num is null:                  return  # not a sub-task, top-level
+  parent_status = read_status(parent_num)
+  if parent_status in ("Backlog", "Ready"):
+      move(parent_num, "In progress")     # promote
+  # else: no-op — idempotent (already at or past In progress) + regression guard
+```
+
+Both backends implement the same machine; the resolve / read / move primitives differ. No new domain
+types, no new ports, no Specflow CLI changes — pure template-script work mirrored to the plugin.
+
+## File Structure
+
+- **Modify**: `templates/core/skills/backlog/scripts/github/move.sh` (~57 lines) — append a tail
+  call to `propagate-parent-status.sh` after the child move succeeds.
+- **Create**: `templates/core/skills/backlog/scripts/github/propagate-parent-status.sh` — the
+  GitHub-backend propagation logic.
+- **Modify**: `templates/core/skills/backlog/scripts/local/move.sh` (~47 lines) — same tail-call
+  pattern.
+- **Create**: `templates/core/skills/backlog/scripts/local/propagate-parent-status.sh` — the
+  local-backend propagation logic.
+- **Modify**: `.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh` — add assertions
+  covering propagation behaviour.
+- **Modify**: `.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh` — same, for local
+  backend.
+- **Modify**: `.claude/skills/test-sandbox/scripts/smoke-features.sh` — add a `#260` section
+  asserting the propagator script exists in both bundled trees.
+- **No code changes** in `src/`. No new TypeScript. No new tests in `tests/` (the existing smoke
+  layer is the right place — these are shell scripts, exercised end-to-end).
+
+The two new propagator scripts are byte-mirrored into the plugin tree by the existing bundle
+pipeline. No manual plugin sync needed because these scripts live under
+`templates/core/skills/backlog/scripts/<backend>/` which the plugin does not mirror directly —
+they're consumed at scaffold time by `specflow init` and emitted into the user's project. Verify
+with the plugin_sync_test after each task; if it complains, add the pair to `SYNC_PAIRS` (unlikely
+given the existing pattern).
+
+---
+
+## Tasks
+
+### Task 1: Local backend — `propagate-parent-status.sh` (new script + smoke)
+
+**Files:**
+
+- Create: `templates/core/skills/backlog/scripts/local/propagate-parent-status.sh`
+- Verify: `.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh` (will extend in Task 2)
+
+The local backend is the simpler case: parent link lives in `parent: "#NNN"` frontmatter, and status
+is a frontmatter field. Pure shell — no API calls. Build this first.
+
+- [ ] **Step 1: Create the script with the propagation machine**
+
+```bash
+cat > templates/core/skills/backlog/scripts/local/propagate-parent-status.sh <<'EOF'
+#!/usr/bin/env bash
+# Post-move hook: when a sub-task moves OUT of Backlog, auto-advance
+# its parent Epic to In Progress — but only if the Epic is currently
+# in Backlog or Ready. Manual In Review / Done states are preserved.
+#
+# Local backend: parent link lives in `parent: "#NNN"` frontmatter;
+# status lives in `status:` frontmatter. Pure shell, no API calls.
+#
+# Usage: propagate-parent-status.sh <child-num> <new-child-status>
+#   child-num         : 3-digit zero-padded local task id (e.g. 042)
+#   new-child-status  : Backlog | Ready | "In progress" | "In review" | Done
+#
+# Exits 0 on success OR any non-fatal condition (no parent, parent
+# missing, parent already past In Progress). Failure to find or
+# update the parent emits a warning to stderr but never returns
+# non-zero — propagation must not block the primary child move.
+
+set -euo pipefail
+
+CHILD="${1:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+NEW_STATUS="${2:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+
+# Moves INTO Backlog don't promote a parent. Bail early.
+if [ "$NEW_STATUS" = "Backlog" ]; then
+  exit 0
+fi
+
+# Locate the project root + backlog dir relative to this script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Layout: <root>/.specflow/scripts/backlog/<this>.sh — go up 3.
+ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+BACKLOG_DIR="$ROOT/.specflow/backlog"
+
+if [ ! -d "$BACKLOG_DIR" ]; then
+  echo "::warning::propagate-parent-status: backlog dir not found at $BACKLOG_DIR — skipping" >&2
+  exit 0
+fi
+
+# Find the child file (NNN-*.md).
+CHILD_PADDED=$(printf '%03d' "$((10#$CHILD))")
+CHILD_FILE=$(find "$BACKLOG_DIR" -maxdepth 1 -name "${CHILD_PADDED}-*.md" -print -quit)
+if [ -z "$CHILD_FILE" ]; then
+  echo "::warning::propagate-parent-status: child #${CHILD_PADDED} not found in $BACKLOG_DIR — skipping" >&2
+  exit 0
+fi
+
+# Extract parent from frontmatter. Convention: `parent: "#NNN"` inside
+# the YAML frontmatter (between the first two `---` lines). Missing
+# parent or `null` → top-level task, nothing to propagate.
+PARENT_LINE=$(awk '/^---$/{n++; next} n==1 && /^parent:/{print; exit}' "$CHILD_FILE")
+PARENT_NUM=$(echo "$PARENT_LINE" | sed -nE 's/^parent:[[:space:]]*"?#0*([0-9]+)"?[[:space:]]*$/\1/p')
+if [ -z "$PARENT_NUM" ]; then
+  exit 0  # not a sub-task
+fi
+
+PARENT_PADDED=$(printf '%03d' "$((10#$PARENT_NUM))")
+PARENT_FILE=$(find "$BACKLOG_DIR" -maxdepth 1 -name "${PARENT_PADDED}-*.md" -print -quit)
+if [ -z "$PARENT_FILE" ]; then
+  echo "::warning::propagate-parent-status: parent #${PARENT_PADDED} of child #${CHILD_PADDED} not found — skipping" >&2
+  exit 0
+fi
+
+# Read parent's current status from frontmatter.
+PARENT_STATUS=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' "$PARENT_FILE")
+
+# Only promote if parent is in Backlog or Ready.
+case "$PARENT_STATUS" in
+  "Backlog"|"Ready")
+    # Rewrite the parent's status to "In progress" in-place.
+    # Pattern mirrors local/move.sh's awk approach for consistency.
+    TMP=$(mktemp)
+    awk -v new="In progress" 'BEGIN{n=0; updated=0}
+      /^---$/ {n++; print; next}
+      n==1 && /^status:/ && !updated {print "status: " new; updated=1; next}
+      {print}
+    ' "$PARENT_FILE" > "$TMP" && mv "$TMP" "$PARENT_FILE"
+    echo "↑ promoted parent #${PARENT_PADDED} (${PARENT_STATUS} → In progress) due to child #${CHILD_PADDED} move"
+    # Refresh the index so the move is visible at /backlog list.
+    if [ -x "$SCRIPT_DIR/render-index.sh" ]; then
+      "$SCRIPT_DIR/render-index.sh" >/dev/null 2>&1 || true
+    fi
+    ;;
+  *)
+    # Already at In progress / In review / Done, or unknown — no-op.
+    # This is the idempotency + regression guard branch.
+    ;;
+esac
+
+exit 0
+EOF
+chmod +x templates/core/skills/backlog/scripts/local/propagate-parent-status.sh
+```
+
+- [ ] **Step 2: Verify the script syntax**
+
+```bash
+bash -n templates/core/skills/backlog/scripts/local/propagate-parent-status.sh && echo "syntax ok"
+```
+
+Expected: prints `syntax ok`.
+
+- [ ] **Step 3: Smoke-test the script manually**
+
+Build a tiny fixture in /tmp and exercise every branch:
+
+```bash
+SMOKE=$(mktemp -d)
+mkdir -p "$SMOKE/.specflow/backlog" "$SMOKE/.specflow/scripts/backlog"
+
+# Position the script at the path it expects (3 levels above the script dir)
+cp templates/core/skills/backlog/scripts/local/propagate-parent-status.sh \
+   "$SMOKE/.specflow/scripts/backlog/"
+
+# Fixture: parent #001 in Backlog, child #002 with parent: "#001"
+cat > "$SMOKE/.specflow/backlog/001-parent.md" <<EOM
+---
+id: 001
+title: Parent Epic
+status: Backlog
+parent: null
+---
+Epic body.
+EOM
+
+cat > "$SMOKE/.specflow/backlog/002-child.md" <<EOM
+---
+id: 002
+title: Child sub-task
+status: In progress
+parent: "#001"
+---
+Child body.
+EOM
+
+# Run the propagator
+"$SMOKE/.specflow/scripts/backlog/propagate-parent-status.sh" 002 "In progress"
+
+# Verify parent moved from Backlog → In progress
+grep '^status:' "$SMOKE/.specflow/backlog/001-parent.md"
+```
+
+Expected output: `↑ promoted parent #001 (Backlog → In progress) due to child #002 move` then
+`status: In progress`.
+
+- [ ] **Step 4: Smoke-test the regression-guard branch**
+
+Reset the parent to `Done` and verify the propagator leaves it alone:
+
+```bash
+sed -i.bak 's/^status: .*/status: Done/' "$SMOKE/.specflow/backlog/001-parent.md"
+"$SMOKE/.specflow/scripts/backlog/propagate-parent-status.sh" 002 "In review"
+grep '^status:' "$SMOKE/.specflow/backlog/001-parent.md"
+```
+
+Expected: `status: Done` (unchanged). No `↑ promoted` line printed.
+
+- [ ] **Step 5: Smoke-test the no-parent branch**
+
+Remove the parent link and verify silent exit 0:
+
+```bash
+sed -i.bak 's/parent: "#001"/parent: null/' "$SMOKE/.specflow/backlog/002-child.md"
+"$SMOKE/.specflow/scripts/backlog/propagate-parent-status.sh" 002 "Done" && echo "exit ok"
+```
+
+Expected: prints `exit ok` (no output from the propagator).
+
+- [ ] **Step 6: Smoke-test the missing-parent branch (warning + non-zero never)**
+
+Add a parent link to a non-existent parent and verify warning + exit 0:
+
+```bash
+sed -i.bak 's/parent: null/parent: "#999"/' "$SMOKE/.specflow/backlog/002-child.md"
+"$SMOKE/.specflow/scripts/backlog/propagate-parent-status.sh" 002 "Done" 2>&1 | grep -q "parent #999.*not found"
+echo "exit code: $?"
+```
+
+Expected: prints `exit code: 0` and the warning text matches.
+
+- [ ] **Step 7: Cleanup the fixture**
+
+```bash
+rm -rf "$SMOKE"
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add templates/core/skills/backlog/scripts/local/propagate-parent-status.sh
+git commit -m "feat(backlog/local): add propagate-parent-status.sh post-move hook
+
+When a sub-task moves out of Backlog (to In Progress, In Review, or
+Done), this script reads the parent link from frontmatter, reads the
+parent's current status, and promotes the parent to In Progress
+IF it is currently in Backlog or Ready. Otherwise no-ops — both an
+idempotency guard (parent already advancing) and a regression guard
+(parent manually in In Review / Done is never pulled back).
+
+Pure shell, no API calls — the parent link is grep-friendly
+frontmatter (parent: \"#NNN\") and the status is a sibling field.
+Failure modes (no parent, missing parent file, malformed frontmatter)
+emit warnings to stderr and exit 0 — propagation must NEVER block
+the primary child move per #260 AC(e).
+
+Wiring into move.sh lands in a follow-up commit.
+
+Refs #260."
+```
+
+---
+
+### Task 2: Local backend — wire the propagator into `move.sh` + smoke assertions
+
+**Files:**
+
+- Modify: `templates/core/skills/backlog/scripts/local/move.sh` (~47 lines)
+- Modify: `.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh`
+
+- [ ] **Step 1: Read the current `move.sh`**
+
+```bash
+cat templates/core/skills/backlog/scripts/local/move.sh
+```
+
+Identify the line where the frontmatter rewrite + `render-index.sh` call completes successfully —
+that's where the propagator hook lands.
+
+- [ ] **Step 2: Append the propagator call at the tail of `move.sh`**
+
+Locate the section near the end (after the `render-index.sh` invocation and the final success
+message) and add:
+
+```bash
+# Post-move hook: promote the parent Epic if this was a sub-task
+# leaving Backlog. Best-effort — never blocks on failure. See
+# propagate-parent-status.sh for the full state machine.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$SCRIPT_DIR/propagate-parent-status.sh" ]; then
+  "$SCRIPT_DIR/propagate-parent-status.sh" "$NUM" "$NEW_STATUS" || true
+fi
+```
+
+The variable names `NUM` and `NEW_STATUS` must match what `move.sh` already uses for the child
+number and new status. If they differ, adapt — `cat move.sh` and check the actual variable names
+(read the `${1:?...}` lines at the top of the script).
+
+- [ ] **Step 3: Verify the syntax**
+
+```bash
+bash -n templates/core/skills/backlog/scripts/local/move.sh && echo "syntax ok"
+```
+
+Expected: `syntax ok`.
+
+- [ ] **Step 4: Run the existing local backlog smoke**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh 2>&1 | tail -20
+```
+
+Expected: all existing assertions still pass. The smoke creates an init project, exercises add.sh /
+move.sh / cascade-check.sh — adding the propagator hook to move.sh must not break any existing
+behaviour (single-task moves without a parent simply no-op through the propagator).
+
+- [ ] **Step 5: Extend the local backlog smoke with propagation assertions**
+
+Open `.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh` and find the existing
+`## --parent` block (around lines 100-117). After the existing parent-link assertions, append:
+
+```bash
+echo
+echo "═══ #260  Auto-propagate parent Epic on child move (local) ═══"
+
+# Reset child #002 to Backlog and parent #001 to Backlog for a clean baseline.
+"$DIR/.specflow/scripts/backlog/move.sh" 002 Backlog >/dev/null
+"$DIR/.specflow/scripts/backlog/move.sh" 001 Backlog >/dev/null
+
+# Move child OUT of Backlog → parent should auto-promote.
+"$DIR/.specflow/scripts/backlog/move.sh" 002 "In progress" >/dev/null
+parent_status=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' "$DIR/.specflow/backlog/001-"*.md)
+[ "$parent_status" = "In progress" ] \
+  && pass "parent auto-promoted from Backlog to In progress on child sub-task move" \
+  || fail "parent expected 'In progress', got '$parent_status'"
+
+# Regression guard: manually move parent to In review, then move another child.
+"$DIR/.specflow/scripts/backlog/move.sh" 001 "In review" >/dev/null
+"$DIR/.specflow/scripts/backlog/move.sh" 002 "Done" >/dev/null
+parent_status=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' "$DIR/.specflow/backlog/001-"*.md)
+[ "$parent_status" = "In review" ] \
+  && pass "parent in 'In review' is NOT pulled back to 'In progress' on child move" \
+  || fail "parent regression guard broken: expected 'In review', got '$parent_status'"
+```
+
+The script's existing `pass` / `fail` helpers (defined at the top of the smoke script) are reused.
+
+- [ ] **Step 6: Run the extended smoke**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh 2>&1 | tail -15
+```
+
+Expected: all assertions pass, including the two new ones.
+
+- [ ] **Step 7: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: 643+ tests still green (no TypeScript code changed).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add templates/core/skills/backlog/scripts/local/move.sh \
+        .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
+git commit -m "feat(backlog/local): wire propagate-parent-status into move.sh
+
+After move.sh successfully updates a child task's frontmatter status
+and refreshes the local index, it now invokes the sibling
+propagate-parent-status.sh script with (child_num, new_status).
+The hook short-circuits to no-op if:
+  * the new status is Backlog (moves INTO Backlog don't promote);
+  * the task has no parent link (it's a top-level task);
+  * the parent file is missing (warning emitted to stderr);
+  * the parent is already at In Progress, In Review, or Done.
+
+Smoke coverage: two new assertions in smoke-backlog-local.sh —
+(1) parent auto-promotes Backlog → In Progress on first child move,
+(2) parent manually at In Review is never pulled back.
+
+Refs #260."
+```
+
+---
+
+### Task 3: GitHub backend — `propagate-parent-status.sh` (new script + manual smoke)
+
+**Files:**
+
+- Create: `templates/core/skills/backlog/scripts/github/propagate-parent-status.sh`
+
+The GitHub side does the same state machine but the primitives are API calls. The parent
+reverse-lookup uses GraphQL (the REST `GET /repos/.../issues/N` does not expose `parent.number`
+reliably across all schema versions; GraphQL `Issue.parent { number }` has been stable since the
+sub-issues GA).
+
+- [ ] **Step 1: Verify the GraphQL parent-lookup works against this repo's live state**
+
+Use any open Specflow issue with a parent to confirm the query shape. Pick a child issue number that
+you know has a parent (one of #241–#245 created in the classification epic — they were children of
+an epic). Run:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $num) {
+        number
+        parent {
+          number
+          state
+        }
+      }
+    }
+  }
+' -f owner=mkrlabs -f name=specflow -F num=241 --jq '.data.repository.issue.parent.number'
+```
+
+Expected: prints the parent issue number (a real integer) OR `null` if #241 turns out to be
+top-level. If the query errors out with "Field 'parent' doesn't exist on type 'Issue'", the GitHub
+instance is on a schema version that hasn't exposed sub-issues parent yet — STOP and surface this;
+the plan needs a different reverse-lookup strategy (label-based, like the GitLab backend uses).
+
+- [ ] **Step 2: Create the script with the propagation machine**
+
+```bash
+cat > templates/core/skills/backlog/scripts/github/propagate-parent-status.sh <<'EOF'
+#!/usr/bin/env bash
+# Post-move hook: when a sub-issue moves OUT of Backlog on the Project
+# board, auto-advance its parent Epic to In Progress — but only if the
+# Epic is currently in Backlog or Ready. Manual In Review / Done states
+# are preserved.
+#
+# GitHub backend: parent link comes from the native sub-issues GA,
+# read via GraphQL Issue.parent { number }. Parent's current Status
+# field on the project board is read via the same GraphQL projectItems
+# query move.sh uses. Promotion uses `gh project item-edit`.
+#
+# Usage: propagate-parent-status.sh <child-issue-num> <new-child-status>
+#   child-issue-num   : integer issue number on the configured repo
+#   new-child-status  : Backlog | Ready | "In progress" | "In review" | Done
+#
+# Always exits 0. Any failure to resolve or update the parent emits a
+# warning to stderr — propagation must NEVER block the primary child
+# move per #260 AC(e).
+
+set -uo pipefail
+
+CHILD="${1:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+NEW_STATUS="${2:?usage: propagate-parent-status.sh <child-num> <new-status>}"
+
+# Moves INTO Backlog don't promote a parent.
+if [ "$NEW_STATUS" = "Backlog" ]; then
+  exit 0
+fi
+
+# Resolve config: REPO_OWNER, REPO_NAME, PROJECT_NUMBER from the
+# bundled backlog-config.yml (same pattern as move.sh / add.sh).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_FILE="$(cd "$SCRIPT_DIR/../../../.." && pwd)/.specflow/backlog-config.yml"
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "::warning::propagate-parent-status: $CONFIG_FILE not found — skipping" >&2
+  exit 0
+fi
+
+# Minimal YAML extraction — same one-liner pattern move.sh uses.
+REPO_OWNER=$(awk '/^repo_owner:/{print $2; exit}' "$CONFIG_FILE" | tr -d '"')
+REPO_NAME=$(awk '/^repo_name:/{print $2; exit}' "$CONFIG_FILE" | tr -d '"')
+PROJECT_NUMBER=$(awk '/^project_number:/{print $2; exit}' "$CONFIG_FILE" | tr -d '"')
+
+if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ] || [ -z "$PROJECT_NUMBER" ]; then
+  echo "::warning::propagate-parent-status: backlog-config.yml is incomplete — skipping" >&2
+  exit 0
+fi
+
+# 1. Resolve parent via GraphQL Issue.parent { number }.
+PARENT_NUM=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $num) { parent { number } }
+    }
+  }
+' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$CHILD" \
+  --jq '.data.repository.issue.parent.number // empty' 2>/dev/null) || PARENT_NUM=""
+
+if [ -z "$PARENT_NUM" ]; then
+  # Top-level issue or transient API error — silent exit (the API
+  # error case is rare and would surface elsewhere anyway).
+  exit 0
+fi
+
+# 2. Resolve the parent's current Status field value on the project.
+#    Reuses move.sh's projectItems(first:5) targeted lookup pattern.
+PROJECT_NODE_ID=$(gh project view "$PROJECT_NUMBER" --owner "$REPO_OWNER" --format json --jq '.id' 2>/dev/null)
+if [ -z "$PROJECT_NODE_ID" ]; then
+  echo "::warning::propagate-parent-status: cannot resolve project node id — skipping" >&2
+  exit 0
+fi
+
+PARENT_STATUS=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
+      issue(number: $num) {
+        projectItems(first: 5) {
+          nodes {
+            project { id }
+            fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F num="$PARENT_NUM" \
+  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_NODE_ID\") | .fieldValueByName.name // empty" 2>/dev/null) || PARENT_STATUS=""
+
+# Parent not on the project, or no Status set yet — nothing to do.
+if [ -z "$PARENT_STATUS" ]; then
+  exit 0
+fi
+
+# 3. Promote only if parent is in Backlog or Ready.
+case "$PARENT_STATUS" in
+  "Backlog"|"Ready")
+    if [ -x "$SCRIPT_DIR/move.sh" ]; then
+      # Reuse move.sh — same script that exercised propagation; the
+      # recursive call lands at the propagator hook but PARENT_STATUS
+      # will then be "In progress", so it's a one-shot no-op walk.
+      "$SCRIPT_DIR/move.sh" "$PARENT_NUM" "In progress" >/dev/null 2>&1 \
+        && echo "↑ promoted parent #${PARENT_NUM} (${PARENT_STATUS} → In progress) due to child #${CHILD} move" \
+        || echo "::warning::propagate-parent-status: move.sh failed to promote #${PARENT_NUM}" >&2
+    else
+      echo "::warning::propagate-parent-status: $SCRIPT_DIR/move.sh not found — cannot promote #${PARENT_NUM}" >&2
+    fi
+    ;;
+  *)
+    # Already at In progress / In review / Done — no-op.
+    ;;
+esac
+
+exit 0
+EOF
+chmod +x templates/core/skills/backlog/scripts/github/propagate-parent-status.sh
+```
+
+- [ ] **Step 3: Verify syntax**
+
+```bash
+bash -n templates/core/skills/backlog/scripts/github/propagate-parent-status.sh && echo "syntax ok"
+```
+
+Expected: `syntax ok`.
+
+- [ ] **Step 4: Manual end-to-end smoke against the live Specflow project**
+
+This step exercises the real flow. Find a fresh issue / sub-issue pair on Project #4 (or create a
+throwaway one — but cleanup matters). Easier path: re-use the propagator against an existing child
+whose parent is already past Backlog (so the regression guard fires and the parent is not actually
+mutated):
+
+```bash
+# Pick child #245 (an already-closed sub-task whose parent #240 is Done).
+# Calling propagate against it should be a NO-OP (regression guard).
+.claude/skills/backlog/scripts/propagate-parent-status.sh 245 "In progress"
+```
+
+Wait — the propagator script is in `templates/core/...`, not yet deployed to `.claude/`. Skip this
+manual smoke; the **automated smoke in Task 4** will cover the GitHub backend behaviour with a
+sandboxed project.
+
+- [ ] **Step 5: Commit the script**
+
+```bash
+git add templates/core/skills/backlog/scripts/github/propagate-parent-status.sh
+git commit -m "feat(backlog/github): add propagate-parent-status.sh post-move hook
+
+GitHub-backend twin of the local-backend script: when a sub-issue
+moves out of Backlog on the Project board, look up the parent via
+GraphQL Issue.parent { number } (native sub-issues GA), read the
+parent's current Status from the project's Status field, and call
+move.sh on the parent if it is in Backlog or Ready.
+
+All API failures (missing config, parent not on project, transient
+GraphQL error) emit warnings to stderr and exit 0 — propagation
+must NEVER block the primary child move per #260 AC(e).
+
+Wiring into move.sh lands in a follow-up commit.
+
+Refs #260."
+```
+
+---
+
+### Task 4: GitHub backend — wire propagator into `move.sh` + smoke assertions
+
+**Files:**
+
+- Modify: `templates/core/skills/backlog/scripts/github/move.sh` (~57 lines)
+- Modify: `.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh`
+
+- [ ] **Step 1: Read the current `move.sh`**
+
+```bash
+cat templates/core/skills/backlog/scripts/github/move.sh
+```
+
+Identify the last successful action (typically the `gh project item-edit` invocation around line
+51-55). The hook lands immediately after it.
+
+- [ ] **Step 2: Append the propagator call**
+
+Insert at the tail (after the `gh project item-edit` succeeds and any closing log message):
+
+```bash
+# Post-move hook: promote the parent Epic if this was a sub-issue
+# leaving Backlog. Best-effort — never blocks on failure. See
+# propagate-parent-status.sh for the full state machine.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$SCRIPT_DIR/propagate-parent-status.sh" ]; then
+  "$SCRIPT_DIR/propagate-parent-status.sh" "$NUM" "$STATUS" || true
+fi
+```
+
+The variables `$NUM` and `$STATUS` (or whatever the script uses for child issue number and the new
+status string) must match the call sites already in `move.sh`. Run `cat move.sh` and confirm the
+actual variable names before pasting; if they're different, adapt accordingly.
+
+- [ ] **Step 3: Verify syntax**
+
+```bash
+bash -n templates/core/skills/backlog/scripts/github/move.sh && echo "syntax ok"
+```
+
+Expected: `syntax ok`.
+
+- [ ] **Step 4: Extend the GitHub backlog smoke**
+
+Open `.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh` and find the existing move.sh
+assertions section. After them, add a presence + integration check:
+
+```bash
+echo
+echo "═══ #260  Auto-propagate parent Epic on child move (github) ═══"
+
+check "propagate-parent-status.sh present in github backend" \
+  '[ -x .specflow/scripts/backlog/propagate-parent-status.sh ]'
+check "github move.sh invokes propagate-parent-status.sh as a tail hook" \
+  'grep -q "propagate-parent-status.sh" .specflow/scripts/backlog/move.sh'
+check "propagate-parent-status.sh resolves parent via GraphQL Issue.parent" \
+  'grep -q "Issue.parent\|parent { number }\|parent.number" .specflow/scripts/backlog/propagate-parent-status.sh'
+check "propagate-parent-status.sh promotes only Backlog/Ready parents" \
+  'grep -q "\"Backlog\"|\"Ready\"" .specflow/scripts/backlog/propagate-parent-status.sh'
+check "propagate-parent-status.sh exits 0 on every error path" \
+  'grep -c "exit 0" .specflow/scripts/backlog/propagate-parent-status.sh | awk "{exit (\$1>=3 ? 0 : 1)}"'
+```
+
+These are presence + shape assertions because exercising the real Projects v2 API in a smoke test
+requires a sandbox project and write permissions — out of scope for the smoke layer.
+
+- [ ] **Step 5: Run the GitHub backlog smoke**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/smoke-backlog-github.sh 2>&1 | tail -20
+```
+
+Expected: all assertions pass, including the five new presence/shape checks.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: 643+ tests still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/core/skills/backlog/scripts/github/move.sh \
+        .claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+git commit -m "feat(backlog/github): wire propagate-parent-status into move.sh
+
+After gh project item-edit successfully updates the child's Status
+field, move.sh now invokes the sibling propagate-parent-status.sh
+script with (child_issue_num, new_status). The hook:
+  * short-circuits to no-op if new_status == Backlog;
+  * resolves the parent via GraphQL Issue.parent { number };
+  * reads the parent's current Status from the project board;
+  * promotes the parent to In Progress only if it is in Backlog or
+    Ready — otherwise no-op (idempotency + regression guard).
+
+Smoke coverage: five new presence/shape assertions in
+smoke-backlog-github.sh covering script presence, the tail-hook
+wiring, the parent-resolution GraphQL field, the promotion guard,
+and the exit-0-on-every-error-path contract.
+
+Refs #260."
+```
+
+---
+
+### Task 5: Lock the cross-backend invariant in smoke-features.sh
+
+**Files:**
+
+- Modify: `.claude/skills/test-sandbox/scripts/smoke-features.sh`
+
+The repo-wide smoke-features.sh already has per-feature sections (#180 Epic, #258 PO Bash
+allowlist). Add a #260 section that asserts the new propagator scripts are scaffolded into a fresh
+init for both backends.
+
+- [ ] **Step 1: Find an appropriate insertion point**
+
+The current smoke-features.sh runs against a local backend by default (see the
+`init --backlog local` invocation at line 25). It can only assert on the LOCAL backend's files. Add
+the assertion in the same neighbourhood as the existing #258 section.
+
+- [ ] **Step 2: Add the new section**
+
+After the existing `═══ #258  PO Bash allowlist + memory-home directive ═══` block in
+`.claude/skills/test-sandbox/scripts/smoke-features.sh`, append:
+
+```bash
+echo
+echo "═══ #260  Auto-propagate parent Epic status (local) ═══"
+check "propagate-parent-status.sh scaffolded into local backend" \
+  '[ -x .specflow/scripts/backlog/propagate-parent-status.sh ]'
+check "local move.sh invokes the propagator as a tail hook" \
+  'grep -q "propagate-parent-status.sh" .specflow/scripts/backlog/move.sh'
+check "propagate-parent-status.sh promotes only Backlog/Ready parents" \
+  'grep -qE "\"Backlog\"\|\"Ready\"" .specflow/scripts/backlog/propagate-parent-status.sh'
+```
+
+The github-backend equivalents live in `smoke-backlog-github.sh` (Task 4); this section only locks
+the local-backend scaffold path.
+
+- [ ] **Step 3: Run smoke-features.sh**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/smoke-features.sh smoke-260 2>&1 | tail -10
+```
+
+Expected: `═══ ALL CHECKS PASSED ═══` with the three new lines printed.
+
+- [ ] **Step 4: Run the smoke-coverage audit**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/audit.sh 2>&1 | tail -5
+```
+
+Expected: `0 coverage gap(s)`, `0 stale assertion(s)`.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: 643+ tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/test-sandbox/scripts/smoke-features.sh
+git commit -m "test(smoke): lock #260 propagator scaffold + wiring (local)
+
+Three assertions on the repo-wide smoke runner:
+  1. propagate-parent-status.sh is scaffolded executable.
+  2. local move.sh invokes the propagator as a tail hook.
+  3. The promotion is guarded to Backlog/Ready parents only.
+
+The github-backend variants are covered in smoke-backlog-github.sh.
+
+Refs #260."
+```
+
+---
+
+### Task 6: PR + CI + merge + close #260
+
+**Files:** none — git/gh operations only.
+
+- [ ] **Step 1: Final sanity sweep**
+
+```bash
+git status --porcelain  # must be empty
+deno task test 2>&1 | tail -3
+bash .claude/skills/test-sandbox/scripts/audit.sh 2>&1 | tail -5
+```
+
+Expected: clean tree, 643+ tests green, 0 audit gaps.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/auto-propagate-epic-status
+```
+
+- [ ] **Step 3: Open the PR via REST (avoids GraphQL rate-limit risk)**
+
+Write the body to `/tmp/pr-260-body.md`:
+
+````markdown
+Closes #260.
+
+## Summary
+
+When a sub-task moves out of Backlog via `move.sh`, automatically advance the parent Epic to In
+Progress — but only if the Epic is in Backlog or Ready, so manual In Review / Done states are never
+regressed.
+
+Implementation: a dedicated `propagate-parent-status.sh` per backend, called at the tail of
+`move.sh` after the child move succeeds. Pure shell. Scope: `github` + `local` backends; `gitlab` is
+symmetric but out of scope per the AC.
+
+The propagation is a best-effort post-move check — every failure mode (missing parent, missing
+parent file, transient GraphQL error, malformed frontmatter) emits a stderr warning and exits 0 so
+the primary child move always completes successfully per AC(e).
+
+State machine (identical across backends):
+
+- If `new_status == Backlog`: exit 0 (moves INTO Backlog don't promote).
+- Resolve parent from child. If none: exit 0.
+- Read parent's current status. If `Backlog` or `Ready`: promote to In Progress. Otherwise: no-op
+  (idempotency + regression guard).
+
+## Test plan
+
+- Local backend: two new smoke assertions in `smoke-backlog-local.sh` exercising the propagation
+  end-to-end (parent Backlog → In Progress on child move; parent at In Review never pulled back).
+- GitHub backend: five new presence/shape assertions in `smoke-backlog-github.sh` (script present,
+  hook wired, GraphQL parent resolution, promotion guard, exit-0-on-error contract).
+- Repo-wide: three new assertions in `smoke-features.sh` locking the local-backend scaffold.
+- `deno task test`: 643+ tests green.
+- `.claude/skills/test-sandbox/scripts/audit.sh`: 0 gaps, 0 stale.
+
+## Agent adoption
+
+The PO agent's existing two-step close protocol is unchanged. The new behaviour is **transparent** —
+every call to `move.sh <num> <status>` on a sub-task now propagates upward automatically.
+
+```prompt
+After `specflow upgrade`, when your product-owner agent (or you, manually) moves a sub-issue out of Backlog, the parent Epic auto-advances to In Progress if it was sitting in Backlog or Ready. No action required from the agent or the user — this happens at the tail of `move.sh`. If an Epic was already past In Progress (In Review / Done), nothing changes — the auto-advance has a regression guard. To revert this behaviour for a specific move, you can run `move.sh <parent> Backlog` after the child move to put the parent back.
+```
+````
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+````
+Then create the PR:
+
+```bash
+jq -n --arg title "feat(backlog): auto-propagate Epic status from child sub-task moves" \
+      --rawfile body /tmp/pr-260-body.md \
+      '{title: $title, body: $body, head: "feat/auto-propagate-epic-status", base: "main"}' \
+  | gh api -X POST repos/mkrlabs/specflow/pulls --input - --jq '"#\(.number) \(.html_url)"'
+````
+
+Expected: prints `#NNN https://github.com/mkrlabs/specflow/pull/NNN`.
+
+- [ ] **Step 4: Watch CI to green**
+
+```bash
+SHA=$(git rev-parse HEAD)
+for i in 1 2 3 4 5 6 7; do
+  STATUS=$(gh api "repos/mkrlabs/specflow/commits/$SHA/check-runs" \
+    --jq '[.check_runs[] | select(.status != "completed")] | length' 2>/dev/null)
+  if [ "$STATUS" = "0" ]; then echo "all done at attempt $i"; break; fi
+  echo "attempt $i: $STATUS in-progress, sleeping 30s"
+  sleep 30
+done
+gh api "repos/mkrlabs/specflow/commits/$SHA/check-runs?per_page=30" \
+  --jq '[.check_runs[]] | sort_by(.started_at) | reverse | unique_by(.name) | .[] | "\(.name)\t\(.conclusion // "-")"'
+```
+
+Expected: every check `success`. If `docs-drift` fails — the PR touches
+`templates/core/skills/backlog/scripts/` which is a user-visible surface — but the change adds new
+scripts rather than modifying user-facing CLI behaviour, so apply the `docs:not-needed` label:
+
+```bash
+gh api -X POST repos/mkrlabs/specflow/issues/<PR>/labels -f "labels[]=docs:not-needed" --jq '.[].name'
+```
+
+Wait 15s for the workflow to re-run on the label event, then re-check.
+
+- [ ] **Step 5: Squash-merge via REST**
+
+```bash
+gh api -X PUT repos/mkrlabs/specflow/pulls/<PR>/merge -f merge_method=squash \
+  --jq '{merged, sha, message}'
+```
+
+Expected: `{"merged":true,...}`.
+
+- [ ] **Step 6: Dispatch the product-owner subagent to close #260**
+
+Dispatch prompt:
+
+```
+Close mkrlabs/specflow#260 with reason: completed. Reference the merged
+PR (<PR_NUMBER>, commit <SHA>) in the close comment. Brief summary:
+propagate-parent-status.sh added per backend (github + local), wired
+as a tail hook in move.sh; the parent Epic auto-promotes from Backlog
+or Ready to In Progress when any child sub-task leaves Backlog. Regression
+guard preserves manual In Review / Done parents. Failure paths exit 0
+so the primary child move is never blocked. Smoke coverage: local
+end-to-end (two new assertions), github presence/shape (five new
+assertions), repo-wide scaffold (three new assertions). Ships via
+specflow upgrade.
+
+Note for future: auto-Done propagation when all children reach Done is
+the natural follow-on — leaving the question open in #260's `## Notes`.
+PO can recommend opening a sibling issue once this lands.
+```
+
+Expected: PO closes #260, board moves to Done, comment posted.
+
+- [ ] **Step 7: Pull main locally**
+
+```bash
+git checkout main && git pull --ff-only
+```
+
+Expected: fast-forward to the squash-merge commit.
+
+---
+
+## Verification
+
+End-to-end after all tasks:
+
+1. **Unit tests**: `deno task test` — 643+ green (no TypeScript changes; new behaviour is pure
+   shell + smoke).
+2. **Local smoke**: `bash .claude/skills/test-sandbox/scripts/smoke-backlog-local.sh` — two new
+   propagation assertions green.
+3. **GitHub smoke**: `bash .claude/skills/test-sandbox/scripts/smoke-backlog-github.sh` — five new
+   presence/shape assertions green.
+4. **Repo-wide smoke**: `bash .claude/skills/test-sandbox/scripts/smoke-features.sh smoke-260` —
+   three new scaffold assertions green; full pass.
+5. **Smoke audit**: `bash .claude/skills/test-sandbox/scripts/audit.sh` — 0 gaps, 0 stale.
+6. **CI**: every check green on the PR; merged via REST.
+
+## Out of scope (do NOT do)
+
+- **Auto-Done propagation** when all children are Done (called out explicitly in #260's `## Notes`
+  as a follow-up axis; the open question "what's 'all children' with nested epics?" needs its own
+  design pass).
+- **Cross-repo Epic ↔ sub-task** relationships. Parent and children must live in the same repo for
+  this PR.
+- **Closing the Epic issue itself** when all children close — that stays manual.
+- **Multi-level propagation** — if an Epic is itself a child of a grandparent Epic, the grandparent
+  is not touched. AC(d) implicitly mandates one-level propagation only.
+- **GitLab backend** — symmetric work, but the AC says "both backends: `github` and `local`". A
+  follow-up PR can add `templates/core/skills/backlog/scripts/gitlab/propagate-parent-status.sh`
+  using the scoped-label parent-lookup pattern.
+- **Renaming** any existing script. Move.sh, cascade-check.sh, add.sh are untouched in behaviour —
+  only the tail of move.sh gains a hook call.
+- **Modifying the PO agent template**. The propagation is transparent; the PO's existing two-step
+  close protocol still applies.
+- **Tests against the live mkrlabs/specflow Project #4** — the github-backend smoke uses
+  presence/shape checks rather than exercising the real API, because mutating Project #4 from a
+  smoke run would pollute the live board.
+
+## Failure modes to watch for
+
+1. **GraphQL `Issue.parent` not exposed** — if Task 3 Step 1's GraphQL probe errors with
+   `Field 'parent' doesn't exist on type 'Issue'`, the GitHub instance is on an older schema.
+   Surface this and stop — the plan needs a label-based fallback (see how `gitlab/cascade-check.sh`
+   uses `parent::#NNN` scoped labels).
+2. **Variable naming mismatch in `move.sh`** — Task 2 Step 2 and Task 4 Step 2 assume specific
+   variable names (`$NUM`, `$NEW_STATUS` / `$STATUS`). The implementer MUST `cat move.sh` first and
+   adapt the hook call to whatever names the script actually uses at the call site.
+3. **Recursion guard** — the GitHub propagator calls `move.sh` on the parent, which calls the
+   propagator on the grandparent. AC(d) bars multi-level promotion; the script naturally handles
+   this because the grandparent's status will (after the first promotion) be `In progress` or
+   further, which falls into the no-op branch. **Verify by tracing**: parent at Backlog → promoted
+   to In Progress → propagator called on grandparent → grandparent at Backlog → promoted to In
+   Progress → propagator called on great-grandparent → ... This DOES walk all the way up. If
+   multi-level propagation is unwanted, add an environment-variable guard `SPECFLOW_PROPAGATE_DEPTH`
+   capped at 1. **Decision**: AC(d) says "Propagation beyond one level... grandparent is not
+   touched". Implement the guard.
+4. **Smoke-test order** — the local smoke's new assertions reset child #002 + parent #001 to Backlog
+   before exercising. If the prior add.sh smoke leaves them in a different state, the baseline might
+   not be Backlog. Run the baseline-reset moves explicitly even if they look redundant (they're
+   idempotent).
+5. **docs-drift check** — the PR touches `templates/core/skills/backlog/scripts/` which is a
+   user-visible surface. The change is behaviour-additive, not user-facing-CLI-changing. Apply the
+   `docs:not-needed` label per the precedent set on PR #261 (issue #258).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-16-auto-propagate-epic-status.md`. Two
+execution options:
+
+**1. Subagent-Driven (recommended for this plan)** — fresh subagent per task with two-stage review
+(spec compliance + code quality) between each task. Useful here because the multi-backend symmetry
+(Tasks 1-2 local ↔ Tasks 3-4 github) makes it easy to introduce subtle divergence — the reviewer
+catches drift before it lands.
+
+**2. Inline Execution** — drive all six tasks in this session. Faster, lower overhead. Appropriate
+given that the shell scripting is straightforward and the smoke layer catches behavioural
+regressions immediately.
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-16-po-bash-allowlist-and-memory-home.md
+++ b/docs/superpowers/plans/2026-05-16-po-bash-allowlist-and-memory-home.md
@@ -1,0 +1,573 @@
+# PO agent Bash allowlist + memory-home directive Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the silent-wrong-recommendation failure mode in the bundled `product-owner.md` agent
+template by widening its `tools:` frontmatter to full `Bash` and adding the missing first-action
+protocol (with explicit memory-home directive) so the agent always reality-checks before answering.
+
+**Architecture:** Pure template edit in `templates/core/agents/product-owner.md` with byte-identical
+mirror in `plugin/agents/product-owner.md`. The change reduces the `tools:` line from 97 chars to 42
+(freeing 55 chars), and replaces the existing "First action" section with an expanded version that
+folds in the new mandatory checks (`git branch --show-current`, `git log --oneline -5`, read
+`MEMORY.md`, query live backlog) **and** the memory-home directive. Net source growth ~ +67 chars,
+which fits comfortably in the current 64-char Windsurf headroom plus the 55 chars freed by the
+tools-line trim (post-render rendered size budget: 119 chars of headroom).
+
+**Tech Stack:** Deno 2.x · TypeScript · template bundle generated via `deno task bundle` ·
+byte-identity enforced by `tests/plugin/plugin_sync_test.ts` · Windsurf 12000-char cap enforced by
+`tests/infrastructure/harness/windsurf_harness_test.ts:123-133`.
+
+---
+
+## Context
+
+Issue #258 reports that the bundled `product-owner.md` agent ships with a narrow Bash allowlist
+(`Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)`) that prevents the agent from
+doing the basic reality-checks its core "what's next?" flow demands: `git branch --show-current`,
+`git status`, `ls`/`find`/`grep` to confirm whether a task is already implemented, and
+`gh project *` to read the live board. The agent silently falls back to inferring from local files +
+stale memory and produces confident-looking but wrong recommendations.
+
+A secondary defect: the template body does not tell the PO where its persistent memory lives. Today
+the scaffolded `.claude/agents/product-owner/memory/` directory exists, but nothing in the template
+instructs the agent that this — and only this — is the canonical memory home. As a result, deployed
+PO agents in the wild splinter state across `.claude/agent-memory/<name>/` and
+`.claude/agents/<name>/memory/` simultaneously.
+
+The fix is a single template file edit (mirrored to the plugin copy) and a handful of smoke
+assertions to lock the new content. `specflow upgrade` delivers it via the normal bundle path — no
+migration code needed.
+
+## File Structure
+
+- **Modify**: `templates/core/agents/product-owner.md` — the canonical agent template.
+- **Modify**: `plugin/agents/product-owner.md` — byte-identical mirror (enforced by
+  `tests/plugin/plugin_sync_test.ts:57`).
+- **Modify**: `.claude/skills/test-sandbox/scripts/smoke-features.sh` — add 3 new assertions to lock
+  the new directives.
+- **No code changes.** No new files. No new types.
+
+The template is currently **12 066 bytes** on disk; rendered through the Windsurf harness it
+produces **11 936 chars** (64 chars headroom under the 12 000 cap). The Windsurf harness strips the
+`color:` frontmatter line and does additional normalization that totals ~130 chars saved
+post-render. Net plan: tools-line trim frees 55 source chars; new "First action" content adds ~122
+source chars; net source growth ~67 chars; rendered headroom after the change projected at ~52 chars
+(still under cap).
+
+---
+
+## Tasks
+
+### Task 1: Widen `tools:` frontmatter to full Bash
+
+**Files:**
+
+- Modify: `templates/core/agents/product-owner.md:5`
+- Modify: `plugin/agents/product-owner.md:5`
+
+The current narrow allowlist forces the PO into silent failure when it needs `git status`,
+`git branch`, `ls`, `find`, `grep`, or `gh project *`. The cleanest fix — and the one the AC
+explicitly endorses ("full Bash, matching `developer.md`") — is the unrestricted `Bash` token. As a
+bonus this is **shorter** than the current line (42 vs 97 chars), freeing 55 chars for the new
+content in Task 2.
+
+- [ ] **Step 1: Edit the source template**
+
+Change line 5 of `templates/core/agents/product-owner.md` from:
+
+```yaml
+tools: Read, Write, Edit, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)
+```
+
+to:
+
+```yaml
+tools: Read, Write, Edit, Grep, Glob, Bash
+```
+
+- [ ] **Step 2: Mirror to the plugin copy**
+
+Same edit at line 5 of `plugin/agents/product-owner.md`. Faster path: copy the source file onto the
+plugin file verbatim after editing the source:
+
+```bash
+cp /Users/kevin/Sites/specflow/templates/core/agents/product-owner.md \
+   /Users/kevin/Sites/specflow/plugin/agents/product-owner.md
+diff /Users/kevin/Sites/specflow/templates/core/agents/product-owner.md \
+     /Users/kevin/Sites/specflow/plugin/agents/product-owner.md
+```
+
+Expected: `diff` produces zero output.
+
+- [ ] **Step 3: Verify the byte-identity test still passes**
+
+```bash
+deno test tests/plugin/plugin_sync_test.ts
+```
+
+Expected: `ok | 1 passed | 0 failed` (the SYNC_PAIRS row for `product-owner.md` reads both files and
+asserts byte equality).
+
+- [ ] **Step 4: Verify the Windsurf cap test still passes after rebundle**
+
+```bash
+deno task bundle && deno test tests/infrastructure/harness/windsurf_harness_test.ts --filter "Cascade cap"
+```
+
+Expected: `ok | 1 passed | 0 failed`. (The bundle step regenerates `src/templates_bundle.ts` from
+the modified template; the cap test then exercises the rendered Windsurf output.)
+
+- [ ] **Step 5: Run the full test suite — must be green**
+
+```bash
+deno task test
+```
+
+Expected: all 643+ tests pass. No new tests yet (they land in Task 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/core/agents/product-owner.md plugin/agents/product-owner.md
+git commit -m "fix(agents): widen product-owner Bash allowlist to full Bash
+
+The narrow allowlist (gh issue/api + git log/diff) prevented the PO
+agent from running the reality-checks its 'what's next?' flow needs:
+git branch --show-current, git status, ls/find/grep to verify a task
+is already implemented, gh project * to read the live board. The
+agent silently fell back to inference from stale local state and
+produced confident-looking but wrong recommendations.
+
+Matches the developer.md template's pattern. Bonus: -55 chars on a
+template that's tight against the Windsurf 12k cap.
+
+Refs #258."
+```
+
+---
+
+### Task 2: Expand "First action" section with memory-home + reality-checks
+
+**Files:**
+
+- Modify: `templates/core/agents/product-owner.md:13-18`
+- Modify: `plugin/agents/product-owner.md:13-18`
+
+The existing section is 6 lines covering only `AGENTS.md` + `constitution.md`. Replace it with a
+4-step protocol that adds (a) the git reality-checks, (b) the memory-home read with the negative
+directive about `.claude/agent-memory/`, and (c) the mandatory live-backlog query before any "what's
+next?" answer.
+
+- [ ] **Step 1: Edit the source template**
+
+Replace lines 13-18 of `templates/core/agents/product-owner.md`. The current text is:
+
+```markdown
+## First action in every session
+
+Read `AGENTS.md` at the project root AND `.specflow/memory/constitution.md` to refresh product and
+architectural context. Then identify which backlog backend the project uses (see "Backlog backend"
+below). If either context file is missing or empty, flag it to the user — the project is
+under-documented.
+```
+
+Replace with:
+
+```markdown
+## First action in every session
+
+Run these in order, every time before answering:
+
+1. `git branch --show-current` + `git log --oneline -5` — locate yourself.
+2. Read `AGENTS.md` + `.specflow/memory/constitution.md` for context.
+3. Read `.claude/agents/product-owner/memory/MEMORY.md` — your persistent memory home. **Never**
+   write to `.claude/agent-memory/`; that path is unused.
+4. Query the live backlog (`gh issue list` / `list.sh`) before answering "what's next?" — never
+   infer from local files or memory alone.
+
+Flag any missing context file — the project is under-documented.
+```
+
+- [ ] **Step 2: Mirror to the plugin copy**
+
+```bash
+cp /Users/kevin/Sites/specflow/templates/core/agents/product-owner.md \
+   /Users/kevin/Sites/specflow/plugin/agents/product-owner.md
+diff /Users/kevin/Sites/specflow/templates/core/agents/product-owner.md \
+     /Users/kevin/Sites/specflow/plugin/agents/product-owner.md
+```
+
+Expected: `diff` produces zero output.
+
+- [ ] **Step 3: Verify byte counts are within budget**
+
+```bash
+wc -c templates/core/agents/product-owner.md
+```
+
+Expected: ~12 133 bytes (source size after the edit; was 12 066, +67 net after Task 1 trim and Task
+2 expansion).
+
+```bash
+deno task bundle
+```
+
+Expected: `Bundled 83 core entries + 11 harness-specific → src/templates_bundle.ts`.
+
+- [ ] **Step 4: Verify the Windsurf cap test passes after rebundle**
+
+```bash
+deno test tests/infrastructure/harness/windsurf_harness_test.ts --filter "Cascade cap"
+```
+
+Expected: `ok | 1 passed | 0 failed`. The rendered output for
+`.windsurf/workflows/specflow-agent-product-owner.md` should be ≤ 12 000 chars (projected ~11 948,
+~52 chars headroom).
+
+If this step fails with `exceeds 12000 chars: <N>` (e.g. N=12 050), surface the failure and
+**stop**. The fallback trim target is the `### Closing rules (all three backends)` paragraph at
+lines 111-116 of the current template — the GitHub/GitLab two-step bullet is the densest and most
+condensable. Do **not** trim by editing the new section just added.
+
+- [ ] **Step 5: Verify the byte-identity test passes**
+
+```bash
+deno test tests/plugin/plugin_sync_test.ts
+```
+
+Expected: `ok | 1 passed | 0 failed`.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: all 643+ tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/core/agents/product-owner.md plugin/agents/product-owner.md
+git commit -m "feat(agents): add first-action protocol + memory-home directive to PO
+
+Expands the 'First action in every session' section with four
+mandatory reality-checks the PO must run before answering:
+
+1. git branch + git log to locate itself in the repo's history.
+2. AGENTS.md + constitution.md for product/arch context (unchanged).
+3. .claude/agents/product-owner/memory/MEMORY.md — explicitly named
+   as the persistent memory home, with a negative directive that
+   .claude/agent-memory/ is NOT used. This kills the splinter-state
+   bug where deployed PO agents wrote to both paths simultaneously.
+4. Live backlog query — never answer 'what's next?' from inference.
+
+Pairs with the previous commit that widened the tools allowlist so
+these checks can actually run. Net source +67 chars; rendered output
+stays under the Windsurf 12k cap.
+
+Refs #258."
+```
+
+---
+
+### Task 3: Add smoke assertions to lock the new content
+
+**Files:**
+
+- Modify: `.claude/skills/test-sandbox/scripts/smoke-features.sh` (after the existing three
+  product-owner assertions at lines 189, 191, 193)
+
+The smoke harness already asserts a few PO-specific strings on the scaffolded output. Add three new
+assertions to lock the new content so a future condensation pass can't quietly drop the new
+directives.
+
+- [ ] **Step 1: Locate the existing PO assertions**
+
+```bash
+grep -n "product-owner.md" .claude/skills/test-sandbox/scripts/smoke-features.sh
+```
+
+Expected: lines 189, 191, 193 — three existing `check` invocations grepping for
+`Epic detection heuristic`, `cascade-check.sh`, and `parent::#` respectively.
+
+- [ ] **Step 2: Add three new assertions immediately after line 193**
+
+Open `.claude/skills/test-sandbox/scripts/smoke-features.sh` and insert (after the existing
+`parent::#` assertion line):
+
+```bash
+check "PO agent has full Bash allowlist" \
+  'grep -q "^tools: Read, Write, Edit, Grep, Glob, Bash$" .claude/agents/product-owner.md'
+check "PO agent documents memory home path" \
+  'grep -q ".claude/agents/product-owner/memory/MEMORY.md" .claude/agents/product-owner.md'
+check "PO agent forbids legacy agent-memory path" \
+  'grep -q ".claude/agent-memory/" .claude/agents/product-owner.md && grep -q "unused\|never\|not used" .claude/agents/product-owner.md'
+```
+
+Match the existing formatting (two-space indent, line continuation style) so `deno fmt` / shellcheck
+stay quiet. Pattern: each `check` block is the description (string) followed by the grep predicate
+(string), exactly like the surrounding assertions.
+
+- [ ] **Step 3: Run the smoke suite locally**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/smoke-features.sh 2>&1 | tail -20
+```
+
+Expected: all checks pass, including the three new ones. The smoke script scaffolds a fresh init
+into a temp dir and runs the assertions against it; since Task 2 already landed in the template, the
+new assertions should green.
+
+- [ ] **Step 4: Run the smoke-coverage audit**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/audit.sh
+```
+
+Expected: `0 coverage gap(s)`, `0 stale assertion(s)`. The audit cross-references template surfaces
+against smoke assertions — adding three assertions for surfaces touched in Task 2 should not
+introduce gaps.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/test-sandbox/scripts/smoke-features.sh
+git commit -m "test(smoke): lock PO Bash allowlist + memory-home directives
+
+Three new assertions in smoke-features.sh covering the surfaces
+touched in the previous two commits:
+
+1. The tools: line is the exact full-Bash form (regression guard
+   against a future narrow-allowlist re-introduction).
+2. The agent body names .claude/agents/product-owner/memory/MEMORY.md
+   as the memory home.
+3. The agent body explicitly negates .claude/agent-memory/ as unused.
+
+Refs #258."
+```
+
+---
+
+### Task 4: End-to-end verification + open the PR
+
+**Files:** none — verification + git/gh actions only.
+
+- [ ] **Step 1: Verify the branch state is clean and tests pass**
+
+```bash
+git status --porcelain   # must be empty
+deno task test 2>&1 | tail -3
+```
+
+Expected: empty status; test suite green.
+
+- [ ] **Step 2: Verify the smoke-coverage audit is green**
+
+```bash
+bash .claude/skills/test-sandbox/scripts/audit.sh 2>&1 | tail -5
+```
+
+Expected: `0 coverage gap(s)`, `0 stale assertion(s)`.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin fix/po-bash-allowlist-and-memory-home
+```
+
+- [ ] **Step 4: Open the PR with the adoption block**
+
+Use the REST API (avoids GraphQL rate-limit issues) — write the body to `/tmp/pr-258-body.md` first:
+
+````markdown
+Closes #258.
+
+## Summary
+
+Fixes the silent-wrong-recommendation failure mode in the bundled `product-owner.md` agent. Two
+related root causes:
+
+1. The narrow Bash allowlist (`Bash(git log *), Bash(git diff *), Bash(gh issue *), Bash(gh api *)`)
+   prevented the agent from running the reality-checks its "what's next?" flow demands:
+   `git branch --show-current`, `git status`, `ls`/`find`/`grep`, `gh project *`. Falls back to
+   inference from stale local state, presents confident but wrong recommendations.
+2. The template body never named the canonical memory home, so deployed PO agents splintered state
+   across `.claude/agents/<name>/memory/` and `.claude/agent-memory/<name>/` simultaneously.
+
+Changes:
+
+- Widen `tools:` to `Read, Write, Edit, Grep, Glob, Bash` (matches `developer.md`). Bonus: -55
+  source chars on a template that's tight against the Windsurf 12k cap.
+- Replace the "First action in every session" section with a 4-step protocol: `git branch`/`git log`
+  reality-check → `AGENTS.md` + constitution → `MEMORY.md` read with explicit memory-home directive
+  (and negative directive against `.claude/agent-memory/`) → live backlog query before any "what's
+  next?".
+- Three new smoke assertions lock the new content against future condensation passes.
+
+Byte-identity preserved between `templates/core/agents/product-owner.md` and
+`plugin/agents/product-owner.md`. Windsurf cap test passes (rendered output well under 12 000
+chars).
+
+## Test plan
+
+- `deno task test` — all 643+ tests green.
+- `tests/plugin/plugin_sync_test.ts` — byte-identity preserved.
+- `tests/infrastructure/harness/windsurf_harness_test.ts` — rendered PO file ≤ 12 000 chars.
+- `bash .claude/skills/test-sandbox/scripts/smoke-features.sh` — green, including the three new PO
+  assertions.
+- `bash .claude/skills/test-sandbox/scripts/audit.sh` — 0 gaps, 0 stale.
+
+## Agent adoption
+
+After `specflow upgrade`, the bundled product-owner agent gains:
+
+- Full `Bash` tool access (previously a narrow allowlist of git/gh subcommands).
+- A 4-step reality-check protocol at session start: `git branch --show-current` +
+  `git log --oneline -5`, read `AGENTS.md` + constitution, read
+  `.claude/agents/product-owner/memory/MEMORY.md`, then query the live backlog before answering
+  "what's next?".
+- An explicit memory-home directive: `.claude/agents/product-owner/memory/` is canonical;
+  `.claude/agent-memory/` is never used.
+
+```prompt
+On your next session start in a Specflow project, the product-owner agent will run the new reality-check protocol automatically — no migration needed. If you have an existing `.claude/agent-memory/product-owner/` directory from before this upgrade, you can either delete it (the agent will stop reading/writing there now) or `mv` its contents into `.claude/agents/product-owner/memory/`. Files at the legacy path will be ignored.
+```
+````
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+````
+Then create the PR:
+
+```bash
+jq -n --arg title "fix(agents): widen PO Bash allowlist + add memory-home directive" \
+      --rawfile body /tmp/pr-258-body.md \
+      '{title: $title, body: $body, head: "fix/po-bash-allowlist-and-memory-home", base: "main"}' \
+  | gh api -X POST repos/mkrlabs/specflow/pulls --input - --jq '"#\(.number) \(.html_url)"'
+````
+
+Expected: prints `#NNN https://github.com/mkrlabs/specflow/pull/NNN`.
+
+- [ ] **Step 5: Watch CI to green**
+
+```bash
+SHA=$(git rev-parse HEAD)
+for i in 1 2 3 4 5 6; do
+  STATUS=$(gh api "repos/mkrlabs/specflow/commits/$SHA/check-runs" \
+    --jq '[.check_runs[] | select(.status != "completed")] | length' 2>/dev/null)
+  if [ "$STATUS" = "0" ]; then echo "all done at attempt $i"; break; fi
+  echo "attempt $i: $STATUS in-progress, sleeping 30s"
+  sleep 30
+done
+gh api "repos/mkrlabs/specflow/commits/$SHA/check-runs" \
+  --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion // "-")"'
+```
+
+Expected: every check completed with `success` (lint, lint-test, cross-smoke macos/ubuntu/windows,
+CodeQL, Analyze, docs-drift, comment-on-linked-issues).
+
+- [ ] **Step 6: Squash-merge via REST**
+
+```bash
+gh api -X PUT repos/mkrlabs/specflow/pulls/<NUMBER>/merge -f merge_method=squash \
+  --jq '{merged, sha, message}'
+```
+
+Expected: `{"merged":true,...}`.
+
+- [ ] **Step 7: Dispatch the product-owner subagent to close #258**
+
+Per Specflow's CLAUDE.md, all backlog mutations go through the PO agent. Dispatch it with this
+prompt:
+
+```
+Close mkrlabs/specflow#258 with reason: completed. Reference the merged
+PR (replace <PR> with the actual PR number returned in Step 4) in the
+close comment. Brief summary: tools allowlist widened to full Bash;
+First-action protocol expanded with git/MEMORY.md/backlog reality-checks
+and explicit memory-home directive; three smoke assertions lock the new
+content. Ships via specflow upgrade.
+```
+
+Expected: PO closes the issue, board moves to Done, close comment posted.
+
+- [ ] **Step 8: Pull main locally**
+
+```bash
+git checkout main && git pull --ff-only
+```
+
+Expected: fast-forward to the squash-merge commit.
+
+---
+
+## Verification
+
+End-to-end after all tasks:
+
+1. **Unit tests**: `deno task test` — must be 643+ green (no new unit tests; the smoke layer covers
+   the surface change).
+2. **Byte-identity**: `tests/plugin/plugin_sync_test.ts` green —
+   `templates/core/agents/product-owner.md` byte-identical to `plugin/agents/product-owner.md`.
+3. **Windsurf cap**: `tests/infrastructure/harness/windsurf_harness_test.ts --filter "Cascade cap"`
+   green — rendered PO file ≤ 12 000 chars.
+4. **Smoke**: `bash .claude/skills/test-sandbox/scripts/smoke-features.sh` — three new assertions
+   green (tools line, memory-home path, agent-memory negation).
+5. **Smoke audit**: `bash .claude/skills/test-sandbox/scripts/audit.sh` — 0 gaps, 0 stale.
+6. **Pre-commit hook**: every commit goes through `deno fmt --check`, `deno lint`,
+   `deno task bundle`, `deno check src/main.ts` — gates failure before push.
+
+## Out of scope (do NOT do)
+
+- Changing the tool allowlist of any other bundled agent (developer.md is already full-Bash;
+  architect.md, qa-tester.md, security-auditor.md, devops-sre.md all need separate analysis — out of
+  scope per #258).
+- Adding new memory entries to the PO agent's template-shipped MEMORY.md (the file stays empty; the
+  agent populates it).
+- Adding a "source-of-truth rule" GraphQL query (called out as a separate follow-up in #258's
+  `## Notes`).
+- Renaming or relocating the memory directory itself (`.claude/agents/<name>/memory/` is the
+  convention; this PR documents it, doesn't move it).
+- Adding a new PO command or modifying any existing `/backlog *` command body (the issue is strictly
+  about tools + memory home directive, not capabilities).
+- Updating docs at `docs/llms.md` or the public site — the change is internal to the agent template;
+  no user-facing CLI surface changed.
+
+## Failure modes to watch for
+
+1. **Plugin drift fails CI**: if Task 1 Step 2 (the `cp` mirror) is skipped or done wrong,
+   `plugin_sync_test.ts` fails with
+   `Plugin copy of plugin/agents/product-owner.md has drifted from templates/core/agents/product-owner.md`.
+   Fix: re-run the `cp` from source to plugin and recommit.
+2. **Windsurf cap overrun**: if Task 2 grows the template past the cap (unlikely given the projected
+   52-char headroom but possible if line wrapping bloats), `windsurf_harness_test.ts` fails with
+   `exceeds 12000 chars: <N>`. Fix: trim the `### Closing rules (all three backends)` paragraph at
+   lines 111-116, specifically the GitHub/GitLab two-step bullet — the densest in the file. Do
+   **not** trim the new "First action" content.
+3. **Smoke audit reports stale assertion**: if Task 3's grep patterns don't exactly match what Task
+   2 wrote (e.g. line-anchored regex `^tools: ...$` mismatching a YAML emitter that adds spaces),
+   the smoke test fails with `expected pattern not found`. Fix: adjust the grep pattern in
+   `smoke-features.sh` to match the actual emitted form —
+   `cat .claude/agents/product-owner.md | head -5` against a fresh init dump tells you the exact
+   form.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-16-po-bash-allowlist-and-memory-home.md`.
+Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task with two-stage review (spec
+compliance + code quality) between each task. Useful here because the Windsurf-cap headroom is tight
+enough that a sloppy edit could blow the budget — the reviewer step catches that before commit.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch with
+checkpoints. Faster, lower overhead. Appropriate given the 4-task scope and the
+verbose-but-mechanical nature of each task.
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-16-skill-aliases-overlays.md
+++ b/docs/superpowers/plans/2026-05-16-skill-aliases-overlays.md
@@ -1,0 +1,721 @@
+# Skill aliases & overlays Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a first-class, harness-agnostic convention for project-specific skill aliases
+(`alias_of`) and pre/post hooks (`overlays`) in SKILL.md frontmatter, plus a `/specflow list-skills`
+phase that renders an inspectable table of what's installed.
+
+**Architecture:** Pure convention — zero TypeScript / runtime changes. The Specflow binary already
+passes SKILL.md content byte-identically from `templates/core/` through the bundler to disk
+(verified in `scripts/bundle-templates.ts:64-72`). The new fields live in the YAML frontmatter; the
+bundler doesn't inspect them. Dispatch semantics (resolving an alias, running an overlay) stay in
+the harness (Claude Code, Cursor, …) — Specflow only scaffolds the contract. The `list-skills` phase
+is a markdown procedure the harness LLM executes by walking `.claude/skills/` (or equivalent) and
+reading frontmatter — same pattern as every other phase.
+
+**Tech Stack:** Deno 2 + TypeScript bundler · YAML frontmatter in SKILL.md · markdown phase docs
+read by the harness · `tests/plugin/plugin_sync_test.ts` byte-identity gate.
+
+> Issue: https://github.com/mkrlabs/specflow/issues/265
+
+---
+
+## Spec deviations (deliberate)
+
+The grooming-time AC text on #265 names the example path as
+`templates/core/skills/alias-example/SKILL.md` AND describes it as "NOT installed by default —
+documentation/starter only". Those two halves are mutually inconsistent: anything inside
+`templates/core/skills/` is, by convention, in the install path _only when listed in
+`templates/manifest.json`_. The plan takes the second half literally — the example file lives at
+`templates/core/skills/alias-example/SKILL.md` but is **not** added to `templates/manifest.json`, so
+`bundle-templates.ts` never bundles it, `init` / `upgrade` never scaffold it, and there is no plugin
+twin to keep in sync. Users browse / link to the file on GitHub for reference. This honours "NOT
+installed by default" cleanly.
+
+The AC says the `list-skills` table has the columns `NAME · KIND · ALIAS OF · OVERLAYS`. The plan
+keeps those four columns and adds a fifth — `DESCRIPTION` — because every existing SKILL.md already
+carries `description:` and surfacing it in the same table eliminates a second lookup for the user.
+This is additive; it doesn't change the AC contract.
+
+---
+
+## File Structure
+
+| File                                                   | Responsibility                                                                                                                                   | Action                       |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `templates/core/skills/specflow/phases/list-skills.md` | Procedure doc telling the harness LLM how to walk skills dirs, parse frontmatter, and render the alias/overlay table.                            | **Create**                   |
+| `plugin/skills/specflow/phases/list-skills.md`         | Byte-identical twin of the above, required for the plugin distribution path.                                                                     | **Create**                   |
+| `templates/core/skills/specflow/SKILL.md`              | Router skill — its Phase index, `argument-hint`, `when_to_use`, and non-chainable list are the source of truth that drives `/specflow` dispatch. | **Modify**                   |
+| `plugin/skills/specflow/SKILL.md`                      | Byte-identical twin of the router skill.                                                                                                         | **Modify**                   |
+| `templates/manifest.json`                              | Adds one entry registering the new phase in the install bundle.                                                                                  | **Modify**                   |
+| `src/templates_bundle.ts`                              | Generated file — refreshed by `deno task bundle` after the manifest changes.                                                                     | **Regen (do not hand-edit)** |
+| `tests/plugin/plugin_sync_test.ts`                     | Adds `"list-skills"` to the phases array so byte-identity drift is detected by CI.                                                               | **Modify**                   |
+| `templates/core/skills/alias-example/SKILL.md`         | Canonical example showing `alias_of` + `overlays` frontmatter syntax. Documentation only — **no** manifest entry, **no** plugin twin.            | **Create**                   |
+| `docs/llms.md`                                         | New `## Project-specific skill overlays` section documenting the convention.                                                                     | **Modify**                   |
+| `README.md`                                            | New `## Project-specific skill overlays` section linking back to `docs/llms.md`.                                                                 | **Modify**                   |
+
+---
+
+## Tasks
+
+### Task 1: Add the `list-skills` phase doc + manifest entry + plugin twin
+
+**Files:**
+
+- Create: `templates/core/skills/specflow/phases/list-skills.md`
+- Create: `plugin/skills/specflow/phases/list-skills.md`
+- Modify: `templates/manifest.json` (one new entry)
+- Modify: `tests/plugin/plugin_sync_test.ts` (one new array element)
+- Regen: `src/templates_bundle.ts` (via `deno task bundle`)
+
+- [ ] **Step 1: Write the failing plugin-sync test entry** — add `"list-skills"` to the phases array
+      in `tests/plugin/plugin_sync_test.ts` before either source or plugin file exists. This is the
+      TDD anchor; the test will fail with a missing-file error, confirming the contract works.
+
+Edit `tests/plugin/plugin_sync_test.ts:21-34`:
+
+```typescript
+...[
+  "specify",
+  "clarify",
+  "plan",
+  "tasks",
+  "analyze",
+  "implement",
+  "review",
+  "merge",
+  "constitution",
+  "checklist",
+  "groom",
+  "tag-version",
+  "release-version",
+  "list-skills",
+].map((name) => ({
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+deno test tests/plugin/plugin_sync_test.ts
+```
+
+Expected: a failure on the new pair, with `Deno.readTextFile` throwing `NotFound` (or similar) for
+`plugin/skills/specflow/phases/list-skills.md` and/or
+`templates/core/skills/specflow/phases/list-skills.md`.
+
+- [ ] **Step 3: Create the source phase doc**
+
+Create `templates/core/skills/specflow/phases/list-skills.md` with the following content:
+
+````markdown
+# /specflow list-skills
+
+A one-shot inspection phase. List every skill installed for this project, flag which ones are
+aliases of upstream skills, and surface their pre/post hook overlays. The point is to make the
+_shadowing_ relationships visible — without this, you have to read each script to know that a local
+`tag-version/` actually delegates to `specflow.tag-version`.
+
+This phase is **read-only** — it never mutates files, never invokes other phases, and never
+auto-chains.
+
+## What this phase does
+
+1. **Locate the harness skills directory.** Try, in order:
+   - `.claude/skills/` (Claude Code)
+   - `.cursor/skills/` (Cursor)
+   - `.windsurf/skills/`, `.gemini/skills/`, `.opencode/skills/`, `.agent/skills/` (other supported
+     harnesses)
+   - Use whichever directory exists in the current working tree. If none exist, report
+     `no skills installed` and stop.
+
+2. **Enumerate skill folders.** Each immediate sub-directory containing a `SKILL.md` file is one
+   skill. Sub-directories without a `SKILL.md` are ignored (they may be phase-doc folders, scripts,
+   etc.).
+
+3. **Read each `SKILL.md` frontmatter.** The frontmatter is the block between the first two `---`
+   lines. Extract:
+   - `name:` — the skill's invocation name (required).
+   - `description:` — short blurb (required).
+   - `alias_of:` — when present, the skill is an alias that delegates to the named upstream skill.
+     Convention is dotted notation, e.g. `alias_of: specflow.tag-version`.
+   - `overlays:` — when present, a list of pre/post hooks. Each item carries `when: before | after`
+     and `path: <relative-script>`.
+
+4. **Render a markdown table** with five columns in this order:
+
+   | Column        | Source                                            | Empty value          |
+   | ------------- | ------------------------------------------------- | -------------------- |
+   | `NAME`        | `name:` field, fallback to folder name            | n/a (always present) |
+   | `KIND`        | `alias` if `alias_of` is present, else `skill`    | n/a                  |
+   | `ALIAS OF`    | `alias_of:` value                                 | `—`                  |
+   | `OVERLAYS`    | comma-joined `<path> (<when>)` per overlay entry  | `—`                  |
+   | `DESCRIPTION` | `description:` field, truncated to 60 chars + `…` | n/a                  |
+
+5. **Sort the rows** by NAME ascending. Render aliases and skills in the same alphabetical list —
+   the `KIND` column already disambiguates.
+
+6. **Stop after the table.** Do not chain into another phase. Do not propose follow-up actions
+   unless the user asks. This is an inspect command.
+
+## Example output
+
+```
+SKILLS — 4 installed (.claude/skills/)
+
+| NAME           | KIND   | ALIAS OF              | OVERLAYS                 | DESCRIPTION                                     |
+|----------------|--------|-----------------------|--------------------------|-------------------------------------------------|
+| backlog        | skill  | —                     | —                        | GitHub Project #4 backed backlog with classific…|
+| release-version| alias  | specflow.release-vers…| poll-cloud-build.sh (befo| Monorepo wrapper: poll Cloud Build then delegat…|
+| specflow       | skill  | —                     | —                        | Specflow workflow router — entry point for the …|
+| tag-version    | alias  | specflow.tag-version  | quality-gate.sh (before) | Monorepo wrapper: cd into inner repo then deleg…|
+```
+
+## Failure modes
+
+- `SKILL.md` missing → skip the folder silently (it's not a skill).
+- Frontmatter unparseable → render the row with `KIND = error` and leave the other columns blank;
+  surface the file path in a `## Parse errors` footnote so the user can fix it.
+- `alias_of` points at a skill not present in the table → keep the row as-is; cycle detection and
+  unresolved-target warnings are the harness's job at _invocation_ time, not at _listing_ time (per
+  #265 out-of-scope).
+
+## When NOT to use this phase
+
+- To **invoke** a skill — that's the skill's own slash command.
+- To **modify** the alias/overlay relationship — edit the SKILL.md frontmatter directly.
+- To **detect cycles** in alias chains — that requires the harness to resolve at dispatch time,
+  which is out of scope for this phase.
+````
+
+- [ ] **Step 4: Register the new phase in the manifest**
+
+Edit `templates/manifest.json`. Find line 17 (the `release-version` phase entry) and add a new entry
+directly after `auto-chain` (line 18):
+
+```json
+{ "category": "phase", "name": "list-skills", "suffix": "list-skills.md", "source": "core/skills/specflow/phases/list-skills.md" },
+```
+
+The full ordered block for the phase category in `templates/manifest.json` will then read:
+
+```json
+{ "category": "phase", "name": "release-version", "suffix": "release-version.md", "source": "core/skills/specflow/phases/release-version.md" },
+{ "category": "phase", "name": "auto-chain", "suffix": "auto-chain.md", "source": "core/skills/specflow/phases/auto-chain.md" },
+{ "category": "phase", "name": "list-skills", "suffix": "list-skills.md", "source": "core/skills/specflow/phases/list-skills.md" },
+```
+
+- [ ] **Step 5: Regenerate the bundle**
+
+```bash
+deno task bundle
+```
+
+Expected stdout: `Bundled <N+1> core entries + <M> harness-specific → src/templates_bundle.ts` where
+N+1 reflects the new phase entry. The `assertAllSourcesPresent` check inside
+`scripts/bundle-templates.ts:46-62` confirms the file at
+`templates/core/skills/specflow/phases/list-skills.md` exists; if you skipped Step 3, this command
+will fail with `Missing template sources`.
+
+- [ ] **Step 6: Create the byte-identical plugin twin**
+
+```bash
+cp templates/core/skills/specflow/phases/list-skills.md plugin/skills/specflow/phases/list-skills.md
+```
+
+The plugin path is not pre-formatted by `deno fmt` (excluded in `deno.json`), so a verbatim copy is
+safe.
+
+- [ ] **Step 7: Run the plugin-sync test to confirm it now passes**
+
+```bash
+deno test tests/plugin/plugin_sync_test.ts
+```
+
+Expected: every pair passes, including the new `list-skills` pair.
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: all green. No other test references the phase list directly, so adding a new phase doesn't
+ripple.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add templates/core/skills/specflow/phases/list-skills.md \
+        plugin/skills/specflow/phases/list-skills.md \
+        templates/manifest.json \
+        src/templates_bundle.ts \
+        tests/plugin/plugin_sync_test.ts
+git commit -m "feat(specflow): add list-skills phase for alias/overlay inspection"
+```
+
+---
+
+### Task 2: Wire `list-skills` into the router SKILL.md
+
+**Files:**
+
+- Modify: `templates/core/skills/specflow/SKILL.md` (frontmatter + Phase index + non-chainable
+  list + Workflow overview)
+- Modify: `plugin/skills/specflow/SKILL.md` (byte-identical twin)
+
+- [ ] **Step 1: Extend the router's `argument-hint`** in `templates/core/skills/specflow/SKILL.md:4`
+
+Change from:
+
+```yaml
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version> [args]
+```
+
+To:
+
+```yaml
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
+```
+
+- [ ] **Step 2: Add a trigger phrase to `when_to_use`** in
+      `templates/core/skills/specflow/SKILL.md:5-19`
+
+After the `release-version:` line (line 19), add a new line:
+
+```yaml
+- list-skills: "list installed skills", "show skill aliases", "what overlays are active"
+```
+
+So the block reads:
+
+```yaml
+- release-version: "release", "publish a release", "create release notes"
+- list-skills: "list installed skills", "show skill aliases", "what overlays are active"
+```
+
+- [ ] **Step 3: Update the top-of-file router description** in
+      `templates/core/skills/specflow/SKILL.md:3`
+
+Change the parenthesised phase list in the `description:` line from:
+
+```
+(specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version)
+```
+
+To:
+
+```
+(specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills)
+```
+
+- [ ] **Step 4: Add the Phase index row** in `templates/core/skills/specflow/SKILL.md:46-60`
+
+After the `release-version` row (line 60), add:
+
+```markdown
+| `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay
+hooks. |
+```
+
+- [ ] **Step 5: Update the non-chainable phase list** in
+      `templates/core/skills/specflow/SKILL.md:62-65`
+
+Change from:
+
+```markdown
+Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`. The
+others (`merge`, `constitution`, `checklist`, `groom`, `tag-version`, `release-version`) are
+one-shot regardless of chain mode.
+```
+
+To:
+
+```markdown
+Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`. The
+others (`merge`, `constitution`, `checklist`, `groom`, `tag-version`, `release-version`,
+`list-skills`) are one-shot regardless of chain mode.
+```
+
+- [ ] **Step 6: Update the Workflow overview blurb** in
+      `templates/core/skills/specflow/SKILL.md:105`
+
+Change from:
+
+```markdown
+`constitution`, `checklist`, `groom`, `tag-version`, and `release-version` are out-of-band
+utilities, not part of the linear flow.
+```
+
+To:
+
+```markdown
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, and `list-skills` are
+out-of-band utilities, not part of the linear flow.
+```
+
+- [ ] **Step 7: Verify the file is still under the Windsurf 12000-char cap**
+
+```bash
+wc -c templates/core/skills/specflow/SKILL.md
+```
+
+Expected: well under 12000 (current is 6343; the diff adds roughly 500 chars). The Windsurf harness
+adapter at `src/infrastructure/harness/windsurf_harness.ts` will strip a few hundred chars at render
+time, so the rendered size will be slightly smaller than the source. The hard ceiling is enforced by
+`tests/infrastructure/harness/windsurf_harness_test.ts:123-133`.
+
+- [ ] **Step 8: Mirror to the plugin twin** byte-identically
+
+```bash
+cp templates/core/skills/specflow/SKILL.md plugin/skills/specflow/SKILL.md
+```
+
+- [ ] **Step 9: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: all green. The Windsurf cap test and the plugin-sync test both pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add templates/core/skills/specflow/SKILL.md plugin/skills/specflow/SKILL.md
+git commit -m "feat(specflow): wire list-skills into the router phase index"
+```
+
+---
+
+### Task 3: Add the `alias-example` documentation file
+
+**Files:**
+
+- Create: `templates/core/skills/alias-example/SKILL.md` (documentation only — NOT in manifest, NOT
+  bundled, NOT scaffolded)
+
+- [ ] **Step 1: Create the example SKILL.md**
+
+```bash
+mkdir -p templates/core/skills/alias-example
+```
+
+Create `templates/core/skills/alias-example/SKILL.md`:
+
+````markdown
+---
+name: alias-example
+description: Reference SKILL.md showing the `alias_of` + `overlays` frontmatter convention. Copy this folder to your project's harness skills dir (e.g. `.claude/skills/`) and edit. Specflow itself never installs this file — it lives in the Specflow repo as documentation.
+alias_of: specflow.tag-version
+overlays:
+  - when: before
+    path: ./scripts/quality-gate.sh
+  - when: after
+    path: ./scripts/notify-slack.sh
+---
+
+# alias-example
+
+This file demonstrates the two optional frontmatter fields that Specflow's `/specflow list-skills`
+phase recognises:
+
+- **`alias_of: <skill-name>`** — declares that this skill is a wrapper around an upstream skill.
+  Convention is dotted notation, with the plugin or distribution name as the prefix (e.g.
+  `alias_of: specflow.tag-version`). The harness is responsible for resolving the alias at
+  invocation time; Specflow only records the relationship.
+
+- **`overlays:`** — a list of pre/post hooks the harness should run around the wrapped skill's body.
+  Each entry carries:
+  - `when: before` or `when: after` — where the hook fires relative to the wrapped skill.
+  - `path: ./scripts/<name>.sh` — script path relative to this SKILL.md's folder.
+
+## Why a project would override an upstream skill
+
+A common pattern: a monorepo that uses Specflow at the root but needs a slightly different
+`tag-version` because tags live inside a sub-repo. Rather than fork the canonical
+`specflow.tag-version` script, the project ships a thin wrapper as `alias_of: specflow.tag-version`
+plus an overlay that runs `cd inner-repo` before delegating.
+
+The result is grep-able and self-documenting: anyone running `/specflow list-skills` sees the alias
+relationship and the overlay hooks in one table. No code archaeology needed.
+
+## What Specflow does with this file
+
+**Nothing at runtime.** This file lives in the Specflow source tree purely as documentation. It is
+intentionally absent from `templates/manifest.json`, so `specflow init` and `specflow upgrade` will
+never scaffold it into your project. To use the pattern:
+
+1. Copy this folder into your harness skills directory:
+   ```
+   cp -r templates/core/skills/alias-example .claude/skills/my-skill
+   ```
+2. Edit the frontmatter — at minimum change `name:`, `alias_of:`, and the overlay paths.
+3. Write the actual delegate-and-hook logic in the body of the file (or in the overlay scripts).
+4. Run `/specflow list-skills` to confirm the harness sees the new alias and overlay.
+
+## Prior art
+
+- komence/komence-monorepo commits `5fbae6ea` and `39691ae3` — manually-implemented Option 2
+  wrappers that this convention codifies.
+````
+
+- [ ] **Step 2: Confirm the file is NOT in the manifest**
+
+```bash
+jq '.core[] | select(.source | contains("alias-example"))' templates/manifest.json
+```
+
+Expected: no output (empty). If anything is printed, the file was accidentally registered — remove
+that entry before committing.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: all green. Untracked files under `templates/core/` are not scanned by any test
+(`assertAllSourcesPresent` only checks files referenced by the manifest, see
+`scripts/bundle-templates.ts:46-62`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/core/skills/alias-example/SKILL.md
+git commit -m "docs(skills): add alias-example reference SKILL.md"
+```
+
+---
+
+### Task 4: Document the convention in `docs/llms.md` and `README.md`
+
+**Files:**
+
+- Modify: `docs/llms.md` (insert new `## Project-specific skill overlays` section between
+  `## Available harnesses` and `## What makes Specflow different from upstream Spec Kit`)
+- Modify: `README.md` (insert new `## Project-specific skill overlays` section between
+  `## Claude Code plugin` and `## Upgrading an existing project`)
+
+- [ ] **Step 1: Add the section to `docs/llms.md`**
+
+Insert the following block before the `## What makes Specflow different from upstream Spec Kit`
+heading (currently at line 360). The new section becomes the last subsection under the
+harness-introduction region.
+
+````markdown
+## Project-specific skill overlays
+
+Specflow's skill folders are plain markdown — anything you put under your harness's `skills/`
+directory (e.g. `.claude/skills/<name>/`, `.cursor/skills/<name>/`) is a skill, full stop. To make
+the common "override an upstream skill" pattern discoverable, Specflow recognises two optional
+fields in `SKILL.md` frontmatter:
+
+| Field                    | Meaning                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `alias_of: <skill-name>` | This skill is a thin wrapper that delegates to the named upstream skill. Dotted notation (e.g. `specflow.tag-version`) makes the distribution explicit. |
+| `overlays:`              | A list of pre/post hooks. Each entry carries `when: before \| after` and `path: ./scripts/<file>.sh` relative to the SKILL.md.                          |
+
+The Specflow binary itself **never resolves or dispatches** aliases / overlays — the harness (Claude
+Code, Cursor, Codex, …) is responsible for honouring the frontmatter at invocation time. Specflow's
+role is to standardise the contract.
+
+To see what's installed and which aliases / overlays are active:
+
+```bash
+/specflow list-skills
+```
+````
+
+The phase walks your harness's skills directory, parses every SKILL.md frontmatter, and renders a
+`NAME · KIND · ALIAS OF · OVERLAYS ·
+DESCRIPTION` table. Skills without `alias_of` show
+`KIND = skill`; aliases show `KIND = alias` and the target.
+
+A reference example lives at
+[`templates/core/skills/alias-example/SKILL.md`](https://github.com/mkrlabs/specflow/blob/main/templates/core/skills/alias-example/SKILL.md)
+in the Specflow source tree. It is **not** installed by `specflow
+init` — copy it manually when you
+want to introduce your first alias.
+
+````
+- [ ] **Step 2: Add the section to `README.md`**
+
+Insert the following block before the `## Upgrading an existing project` heading (currently at line 87 of README.md):
+
+```markdown
+## Project-specific skill overlays
+
+Need to override an upstream Specflow skill in one project — e.g. a
+monorepo `tag-version` that has to `cd` into an inner repo first?
+SKILL.md frontmatter accepts two optional fields:
+
+```yaml
+---
+name: tag-version
+alias_of: specflow.tag-version
+overlays:
+  - when: before
+    path: ./scripts/cd-inner-repo.sh
+---
+````
+
+Run `/specflow list-skills` to see which aliases and overlays are active in your project. The
+Specflow binary scaffolds and ships the convention; the harness (Claude Code, Cursor, …) honours it
+at dispatch time. See `docs/llms.md` for the full contract and
+[`templates/core/skills/alias-example/SKILL.md`](templates/core/skills/alias-example/SKILL.md) for a
+copy-pasteable starting point.
+
+````
+- [ ] **Step 3: Run `deno fmt --check` on the markdown files**
+
+```bash
+deno fmt --check docs/llms.md README.md
+````
+
+If `deno fmt` complains about whitespace or list-indent, run `deno fmt
+docs/llms.md README.md` to
+fix in place, then re-stage.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+deno task test
+```
+
+Expected: all green. Documentation changes don't impact any test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/llms.md README.md
+git commit -m "docs: document alias_of + overlays SKILL.md convention"
+```
+
+---
+
+### Task 5: Branch, push, open PR, drive to merge
+
+**Files:** none — this is the integration task.
+
+- [ ] **Step 1: Check what's already committed**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: four `feat:` / `docs:` commits from Tasks 1-4. If the work landed directly on a fresh
+branch off `main`, this is the full history.
+
+- [ ] **Step 2: Branch (if working directly on main)**
+
+If `git rev-parse --abbrev-ref HEAD` returns `main`, switch to a feature branch:
+
+```bash
+git switch -c 265-skill-aliases-overlays
+```
+
+The four commits move with the branch (`git switch -c` carries uncommitted work, and committed work
+is already on this HEAD).
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push --set-upstream origin 265-skill-aliases-overlays
+```
+
+- [ ] **Step 4: Open the PR via REST (avoids GraphQL rate-limit)**
+
+````bash
+gh api -X POST repos/mkrlabs/specflow/pulls --input - <<'JSON'
+{
+  "title": "feat(specflow): first-class skill alias / overlay convention + list-skills phase",
+  "head": "265-skill-aliases-overlays",
+  "base": "main",
+  "body": "Closes #265.\n\n## Agent adoption\n\nSpecflow's SKILL.md frontmatter now recognises two optional fields — `alias_of: <skill-name>` and `overlays: [{when, path}]` — that let a project ship a thin wrapper around an upstream skill without forking it. The relationship is recorded in the frontmatter and rendered by a new `/specflow list-skills` phase as a pipe table (NAME · KIND · ALIAS OF · OVERLAYS · DESCRIPTION).\n\nThe Specflow binary itself does NOT dispatch aliases or run overlays — the harness (Claude Code, Cursor, …) honours the frontmatter at invocation time. Specflow's contribution is the convention + the inspector phase.\n\n## Files\n\n- `templates/core/skills/specflow/phases/list-skills.md` + plugin twin — new phase doc.\n- `templates/core/skills/specflow/SKILL.md` + plugin twin — router updated (Phase index, argument-hint, when_to_use, non-chainable classification).\n- `templates/manifest.json` — registers the phase entry.\n- `tests/plugin/plugin_sync_test.ts` — adds `list-skills` to the byte-identity contract.\n- `templates/core/skills/alias-example/SKILL.md` — reference example (NOT in manifest, NOT scaffolded — documentation only).\n- `docs/llms.md` + `README.md` — new \"Project-specific skill overlays\" sections.\n\n## Out of scope (intentionally)\n\n- Alias-cycle detection in the binary (harness concern).\n- Fallback behaviour when an `alias_of` target is missing (harness concern).\n- A `specflow check --skills` subcommand (the `list-skills` phase covers the UX without binary changes).\n\n## Prior art\n\nkomence/komence-monorepo commits `5fbae6ea` and `39691ae3` — Option-2 manual wrappers this convention codifies.\n\n```prompt\nAfter `specflow upgrade`, you can introduce a project-specific alias by copying templates/core/skills/alias-example/SKILL.md from the Specflow repo into your .claude/skills/<name>/ directory, editing the alias_of: and overlays: frontmatter to match your needs, and re-running /specflow list-skills to confirm the harness sees it.\n```\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+}
+JSON
+````
+
+Capture the returned PR URL.
+
+- [ ] **Step 5: Wait for CI, then merge via REST**
+
+```bash
+PR=$(gh api repos/mkrlabs/specflow/pulls --jq '.[] | select(.head.ref=="265-skill-aliases-overlays") | .number' | head -1)
+gh pr checks "$PR" --watch --interval 10 --repo mkrlabs/specflow
+```
+
+If `docs-check` fails because the CI heuristic doesn't recognise the doc updates as sufficient,
+apply the workaround label:
+
+```bash
+gh api -X POST "repos/mkrlabs/specflow/issues/$PR/labels" -f "labels[]=docs:not-needed"
+```
+
+Then merge once green:
+
+```bash
+gh api -X PUT "repos/mkrlabs/specflow/pulls/$PR/merge" -f merge_method=squash
+```
+
+- [ ] **Step 6: Close the issue via the PO subagent**
+
+Per CLAUDE.md, "Every backlog mutation goes through the `product-owner` subagent." Dispatch the PO
+with a brief instruction to close #265 with `reason: completed`, referencing the merged PR in the
+close comment. Do NOT call `gh issue close` from the main session.
+
+- [ ] **Step 7: Local cleanup**
+
+```bash
+git switch main
+git pull
+git branch -D 265-skill-aliases-overlays
+```
+
+---
+
+## Verification
+
+End-to-end after all tasks:
+
+1. **Test suite** — `deno task test` is green at every commit boundary (TDD anchor in Task 1 Step
+   1-2, full suite at every task's "Run tests" step).
+2. **Bundle integrity** — `deno task bundle` succeeds and `src/templates_bundle.ts` reflects the new
+   manifest entry. The `assertAllSourcesPresent` check confirms `list-skills.md` exists at the
+   manifested path.
+3. **Plugin sync** — `tests/plugin/plugin_sync_test.ts` passes with the new `list-skills` pair.
+   Adding a phase without its plugin twin breaks the test loudly.
+4. **Windsurf cap** — `tests/infrastructure/harness/windsurf_harness_test.ts` confirms the router
+   SKILL.md stays under 12000 rendered chars (current 6343 + ~500 added = ~6800, well clear of the
+   cap).
+5. **Pre-commit gates** — every commit hits `deno fmt --check`, `deno lint`, `deno task bundle`,
+   `deno check src/main.ts` (the pre-commit hook described in CLAUDE.md). Markdown lint surprises
+   get fixed inline with `deno fmt <file>`.
+6. **Mental smoke** — `/specflow list-skills` on a project with one alias produces a markdown table
+   with NAME, KIND=alias, ALIAS OF=<target>, OVERLAYS listed, DESCRIPTION truncated. No phase-doc
+   bug surfaces (the doc is markdown, executed by the harness LLM).
+
+## Out of scope (do NOT do)
+
+- **Adding YAML schema validation** for `alias_of` / `overlays` in TypeScript. There is no existing
+  SKILL.md schema in the codebase (architect confirmed: zero parsers, zero Zod, zero strip-unknowns
+  logic in `scripts/bundle-templates.ts:64-72`). Introducing one for two optional fields is a 10x
+  over-build.
+- **Wiring the `alias-example` into `templates/manifest.json`.** The example is deliberately
+  documentation-only — see "Spec deviations" at the top of this plan.
+- **Implementing alias cycle detection** anywhere in Specflow. Per #265 AC, that is the harness's
+  responsibility at dispatch time.
+- **Building a `specflow check --skills` CLI subcommand.** The `list-skills` phase achieves
+  equivalent UX without any binary changes; reserve a binary subcommand for a future ticket if the
+  phase proves insufficient.
+- **Auto-generating overlay scripts** during `specflow init`. Per #265 AC, out of scope.
+- **Renaming any existing phase or skill** to align with the new convention. The new fields are
+  purely additive.
+
+## PR adoption block
+
+The PR body in Task 5 Step 4 already includes the `## Agent adoption` section per
+`.github/pull_request_template.md`. No further work needed at PR time.


### PR DESCRIPTION
Pre-release tidy before tagging v1.7.0.

**Smoke gap** — the audit (.claude/skills/test-sandbox/scripts/audit.sh) flagged `templates/core/skills/specflow/phases/list-skills.md` (shipped in #266) as missing a smoke assertion. Added in two places:

- Phase-loop on L61 of smoke-features.sh gains `list-skills`
- Literal-name `check` below the release-version one so the audit's basename-substring grep can find it in the source

Re-running audit.sh after the fix: `0 coverage gap(s), 0 stale assertion(s)`.

**Session artefacts** — committing files that had been sitting dirty in the working tree because the release skill requires `git status --porcelain` to be empty before tagging:

- `.claude/agents/architect/memory/MEMORY.md` + new `skill-frontmatter-schema.md` — persisted findings from the architect's #265 investigation
- `docs/superpowers/plans/2026-05-16-{auto-propagate-epic-status,po-bash-allowlist-and-memory-home,skill-aliases-overlays}.md` — three plan files for the issues #258, #260, #265 that all landed today via PRs #259, #262, #266

No code behavior change. Direct enabler for the v1.7.0 release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)