### PR TITLE
feat: tool-mapping reference docs per harness (#283)

### DIFF
--- a/templates/core/skills/using-specflow/references/claude-tools.md
+++ b/templates/core/skills/using-specflow/references/claude-tools.md
@@ -1,0 +1,51 @@
+# Claude Code — baseline tool reference
+
+Specflow skills are authored using **Claude Code tool names** as the lingua
+franca. This file documents the canonical Claude Code tool set that other
+harness adapters (`codex-tools.md`, `cursor-tools.md`, `gemini-tools.md`,
+`opencode-tools.md`, `copilot-tools.md`) translate.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/`. Re-implemented for
+> Specflow's harness coverage.
+
+## Canonical tool set
+
+| Tool | Purpose |
+|---|---|
+| `Read` | Read a file from disk; supports image / PDF / notebook formats. |
+| `Write` | Write or overwrite a file from scratch. |
+| `Edit` | Exact-string replace in a file (must Read first). |
+| `Bash` | Run a shell command in the project working directory. |
+| `Skill` | Invoke another skill by name (`Skill({skill: "<name>", args: "…"})`). |
+| `Task` | Dispatch a subagent for a delegated task (`Task({subagent_type: "general-purpose", description: "…", prompt: "…"})`). |
+| `TodoWrite` | Persist a checklist for multi-step work. |
+| `WebSearch` | Search the web for current information. |
+| `WebFetch` | Fetch a URL and process it with a prompt. |
+| `Grep` / `Glob` | Search file contents or file paths. |
+
+## Conventions used by Specflow skills
+
+- **File paths** are always absolute, except inside markdown documentation
+  where project-relative paths read better.
+- **Subagents** spawned via `Task` receive precisely the context they need —
+  never the controller's full history. See the
+  [`subagent-driven-development`](../../subagent-driven-development/SKILL.md)
+  skill for the dispatch pattern.
+- **Skills** invoked via `Skill` are listed in the harness-provided
+  "available skills" registry; only use names that appear there.
+- **Slash commands** the user types (`/specflow plan`, `/backlog …`) are
+  resolved by the harness to a skill invocation — Specflow itself never
+  registers raw commands outside the skill layer.
+
+## When this file is the wrong reference
+
+You are on Claude Code only. If you are running in:
+- Codex CLI / App → see `codex-tools.md`
+- Cursor → see `cursor-tools.md`
+- Gemini CLI → see `gemini-tools.md`
+- OpenCode → see `opencode-tools.md`
+- GitHub Copilot CLI → see `copilot-tools.md`
+
+The `using-specflow` bootstrap skill auto-detects the running harness and
+loads the right reference at session start.

--- a/templates/core/skills/using-specflow/references/codex-tools.md
+++ b/templates/core/skills/using-specflow/references/codex-tools.md
@@ -1,0 +1,60 @@
+# Codex CLI / Codex App — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps every Claude Code tool to its Codex equivalent so a skill that says
+`Use Task to dispatch a subagent` reads correctly when Specflow runs
+inside Codex.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/codex-tools.md`.
+> Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | Codex | Notes |
+|---|---|---|
+| `Read` | `read_file` | Same argument shape (`path`). |
+| `Write` | `write_file` | Same shape; pass `content`. |
+| `Edit` | `apply_patch` | Codex uses a unified-diff style patch tool; the Edit semantic (old_string → new_string) maps to a one-hunk patch. |
+| `Bash` | `shell` | Same shape; Codex's `shell` runs in the workspace cwd. |
+| `Skill` | `skill` | Codex exposes a native `skill` tool — pass the skill name and args. |
+| `Task` | `spawn_agent` / `wait_agent` / `close_agent` | Three-step protocol: spawn, wait for completion, close. Wrap in a helper if you dispatch frequently. |
+| `TodoWrite` | `update_plan` | Codex's planner exposes a structured update API; pass the full updated plan, not deltas. |
+| `WebSearch` | `web.search` | Available only if the user has enabled web tools. |
+| `WebFetch` | `web.fetch` | Same. |
+| `Grep` | `shell` invoking `grep` / `rg` | No native grep tool — shell out. |
+| `Glob` | `shell` invoking `find` / `fd` | No native glob tool — shell out. |
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on Codex, expand to:
+
+```
+id = spawn_agent(agent_type="code-reviewer", prompt="<full prompt>")
+result = wait_agent(id, timeout=900)
+close_agent(id)
+```
+
+If the wait times out, decide whether to retry or to surface the partial
+result to the user.
+
+## Idiom differences worth noting
+
+- **Plan updates** are heavyweight on Codex — `update_plan` rewrites the
+  full plan each call. Don't call it per-step; call it at task boundaries.
+- **`apply_patch`** rejects malformed patches more strictly than Claude
+  Code's `Edit`. Always confirm a Read of the target file before patching.
+- **Subagent timeout** defaults vary; pass `timeout=` explicitly for any
+  dispatch you expect to take > 5 minutes.
+
+## Manifest pointer
+
+For the Codex marketplace adapter (`.codex-plugin/plugin.json`), the
+canonical install entry is:
+
+```
+/plugins  → search "specflow" → install
+```
+
+(Once Specflow ships to the Codex marketplace; see issue #277.)

--- a/templates/core/skills/using-specflow/references/copilot-tools.md
+++ b/templates/core/skills/using-specflow/references/copilot-tools.md
@@ -1,0 +1,80 @@
+# GitHub Copilot CLI — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its GitHub Copilot CLI equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/copilot-tools.md`.
+> Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | Copilot CLI | Notes |
+|---|---|---|
+| `Read` | `read` | Same shape. |
+| `Write` | `write` | Same. |
+| `Edit` | `edit` | Same. |
+| `Bash` | `bash` | Same. |
+| `Skill` | `skill` | Native — invokes a registered plugin skill. |
+| `Task` | `task` with `agent_type` parameter | Copilot's task tool takes `agent_type` to select a subagent (similar to Claude Code's `subagent_type`). |
+| `TodoWrite` | `sql` with built-in `todos` table | Copilot exposes a SQLite-backed durable state via the `sql` tool; the `todos` table is its checklist primitive. |
+| `WebSearch` | `web_search` | Same. |
+| `WebFetch` | `web_fetch` | Same. |
+| `Grep` | `grep` | Same. |
+| `Glob` | `glob` | Same. |
+
+## Plugin marketplace
+
+Copilot CLI distributes plugins through a **marketplace repository** — a
+separate GitHub repo registered with `copilot plugin marketplace add`.
+The Specflow marketplace (see issue #281) lives at
+`mkrlabs/specflow-marketplace` (planned) and registers Specflow as
+`specflow@specflow-marketplace`.
+
+Install flow for end users:
+
+```bash
+copilot plugin marketplace add mkrlabs/specflow-marketplace
+copilot plugin install specflow@specflow-marketplace
+```
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on Copilot CLI, expand to:
+
+```
+task({
+  agent_type: "code-reviewer",
+  description: "Review changes against the plan",
+  prompt: "<full prompt>"
+})
+```
+
+The agent runs in an isolated context and returns when complete. The
+calling skill gets the subagent's final report as the tool's return
+value.
+
+## Idiom differences worth noting
+
+- **`sql` for state.** Copilot's `TodoWrite` equivalent is a structured
+  database insert/update. Skill prose that says "track this in a TODO
+  list" needs the adapter to translate to a `sql` insert into the
+  `todos` table. The `using-specflow` bootstrap skill explains the
+  schema.
+- **No `WebFetch` slug.** Copilot uses `web_fetch` (snake_case) where
+  Claude Code uses `WebFetch` (PascalCase). The mapping is the only
+  difference — the semantics are identical.
+- **SessionStart hook.** Copilot's hook system uses
+  `{"additionalContext": "..."}` as the injection format (SDK standard).
+  The Specflow Copilot SessionStart hook (see #282) reads the
+  `using-specflow` bootstrap skill and emits this shape at session
+  boot.
+
+## Auto-activation
+
+Copilot honors the same `description:` frontmatter contract as Claude
+Code and Cursor — when the user's prompt matches phrases in a skill's
+`description:` field, Copilot invokes the skill. The SessionStart hook
+(once #282 lands) ensures `using-specflow` is loaded so the agent knows
+which Specflow skill to pick for which user phrasing.

--- a/templates/core/skills/using-specflow/references/cursor-tools.md
+++ b/templates/core/skills/using-specflow/references/cursor-tools.md
@@ -1,0 +1,53 @@
+# Cursor — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its Cursor Agent equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/`. Re-implemented for
+> Specflow.
+
+## Tool mapping
+
+| Claude Code | Cursor Agent | Notes |
+|---|---|---|
+| `Read` | `read_file` | Cursor's read tool returns the file with line numbers. |
+| `Write` | `edit_file` (full overwrite) | Cursor uses one `edit_file` tool for both create and edit; pass the full new content. |
+| `Edit` | `edit_file` (partial) | Same tool, pass a precise edit specification. |
+| `Bash` | `run_terminal_cmd` | Same shape; pass `command` + `is_background`. |
+| `Skill` | `Skill` | Cursor's Agent plugin format exposes a native `Skill` tool with the same shape as Claude Code. |
+| `Task` | `Task` via Agent plugin | Cursor supports subagent dispatch when the plugin declares `agents` in its manifest. |
+| `TodoWrite` | `todo_write` | Cursor's todo tool, semantically equivalent. |
+| `WebSearch` | `web_search` | Same. |
+| `WebFetch` | `web_search` + manual read | Cursor doesn't expose a separate URL-fetch tool; use `web_search` then `read_file` on the result if it's local. |
+| `Grep` / `Glob` | `grep_search` / `file_search` | Cursor exposes both natively with similar arguments. |
+
+## Idiom differences worth noting
+
+- **`edit_file` is unified.** Cursor doesn't distinguish `Write` (create
+  new) from `Edit` (modify existing); the same tool does both based on
+  whether the path exists. Skill authors should still write "create" or
+  "modify" in prose for clarity to other harnesses.
+- **Hooks live in `hooks-cursor.json`**, not `hooks.json`. Cursor uses
+  `snake_case` field names (`session_start`, `pre_tool_use`) where
+  Claude Code uses `camelCase` (`SessionStart`, `PreToolUse`). The
+  Specflow Cursor adapter handles the translation; skill content stays
+  uniform.
+- **Plugin manifest** uses `.cursor-plugin/plugin.json` with keys
+  `{skills, agents, commands, hooks}` (see issue #278 for the adapter).
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` works
+on Cursor identically to Claude Code, **provided the plugin's
+`.cursor-plugin/plugin.json` declares `agents: "./agents/"`**. Without
+that declaration, Cursor's Agent doesn't see the subagent definitions
+and the dispatch falls back to inline execution.
+
+## Auto-activation
+
+Cursor honors the same `description:` frontmatter contract as Claude
+Code — when the user's prompt matches phrases in a skill's `description:`
+field, Cursor invokes the skill automatically. The `SessionStart` hook
+(via `hooks-cursor.json`) injects the `using-specflow` bootstrap skill
+to make Specflow skill-aware on every turn.

--- a/templates/core/skills/using-specflow/references/gemini-tools.md
+++ b/templates/core/skills/using-specflow/references/gemini-tools.md
@@ -1,0 +1,69 @@
+# Gemini CLI — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its Gemini CLI equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/gemini-tools.md`.
+> Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | Gemini CLI | Notes |
+|---|---|---|
+| `Read` | `read_file` | Same argument shape. |
+| `Write` | `write_file` | Same. |
+| `Edit` | `replace` | Gemini's edit tool is named `replace`; pass `file_path`, `old_string`, `new_string`. |
+| `Bash` | `run_shell_command` | Same shape; pass `command`. |
+| `Skill` | `activate_skill` | Gemini's skill-invocation tool. |
+| `Task` | `@generalist` subagent | Gemini uses `@`-mention syntax for subagent dispatch. The `@generalist` agent is the catch-all equivalent of Claude Code's `general-purpose`. |
+| `TodoWrite` | `save_memory` for persistence; `todo` for in-session checklists | Gemini's persistent state model is split into ephemeral todos and durable memory. Pick the right one for context. |
+| `WebSearch` | `google_web_search` | Native — same shape. |
+| `WebFetch` | `web_fetch` | Same. |
+| `Grep` | `search_file_content` | Native grep equivalent. |
+| `Glob` | `glob` | Native. |
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on Gemini, expand to:
+
+```
+@generalist Please review the following code change against the plan:
+[paste full prompt content]
+```
+
+The `@`-mention triggers a fresh subagent context; pass the entire prompt
+as the message body. Wait for the subagent's response in the same chat
+stream — there is no separate `wait_agent` call.
+
+## Extension manifest
+
+Gemini CLI consumes plugins as **extensions**, not as Claude-style
+plugins. The Specflow extension manifest (see issue #279) lives at the
+repo root:
+
+```json
+{
+  "name": "specflow",
+  "description": "...",
+  "version": "1.x.x",
+  "contextFileName": "GEMINI.md"
+}
+```
+
+The `contextFileName` points at a `GEMINI.md` file that Gemini loads at
+session start (parallel to `CLAUDE.md` for Claude Code). The
+`using-specflow` bootstrap skill references this file from inside Gemini.
+
+## Idiom differences worth noting
+
+- **No persistent plan tool.** Gemini lacks a direct `TodoWrite`
+  equivalent for ephemeral plans; skill prose should describe the plan
+  in markdown and let the LLM maintain it in context, or use
+  `save_memory` for plans that must survive a session boundary.
+- **Subagents share the chat.** Unlike Claude Code's isolated `Task`
+  context, `@generalist` runs in the same conversation thread. Be
+  explicit about what context the subagent should attend to.
+- **Install command**: `gemini extensions install https://github.com/mkrlabs/specflow`
+  (once the extension manifest ships — issue #279).

--- a/templates/core/skills/using-specflow/references/opencode-tools.md
+++ b/templates/core/skills/using-specflow/references/opencode-tools.md
@@ -1,0 +1,90 @@
+# OpenCode — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its OpenCode equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `.opencode/plugins/superpowers.js` adapter and inline tool
+> mappings. Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | OpenCode | Notes |
+|---|---|---|
+| `Read` | `read` | OpenCode's read tool. |
+| `Write` | `write` | Same. |
+| `Edit` | `edit` | Same. |
+| `Bash` | `bash` | Same shape. |
+| `Skill` | `skill` | OpenCode exposes a native skill-invocation tool, lowercase. |
+| `Task` | `@`-mention subagent | OpenCode uses `@<agent-name>` syntax to dispatch subagents declared by the plugin. |
+| `TodoWrite` | `todowrite` | Lowercase variant. |
+| `WebSearch` | `websearch` | Lowercase. |
+| `WebFetch` | `webfetch` | Lowercase. |
+| `Grep` | `grep` | Same. |
+| `Glob` | `glob` | Same. |
+
+## Plugin shape — JavaScript adapter
+
+OpenCode plugins ship as JavaScript files (not JSON manifests). The
+Specflow adapter (see issue #280) lives at
+`.opencode/plugins/specflow.js` and registers itself via OpenCode's
+plugin loader:
+
+```javascript
+// Pseudo-shape based on superpowers' adapter pattern.
+module.exports = function specflow(config) {
+  const skillsDir = path.join(__dirname, "../../skills");
+  config.skills = config.skills || {};
+  config.skills.paths = config.skills.paths || [];
+  if (!config.skills.paths.includes(skillsDir)) {
+    config.skills.paths.push(skillsDir);
+  }
+  // Hook the SessionStart event to inject the using-specflow bootstrap.
+  config.experimental = config.experimental || {};
+  config.experimental.chat = config.experimental.chat || {};
+  config.experimental.chat.messages = config.experimental.chat.messages || {};
+  // ...
+};
+```
+
+Concrete implementation lands in #280.
+
+## Install instructions
+
+Add to the user's `opencode.json`:
+
+```json
+{
+  "plugin": [
+    "specflow@git+https://github.com/mkrlabs/specflow.git"
+  ]
+}
+```
+
+OpenCode fetches the repo, runs the adapter at session start, and the
+Specflow skills register themselves.
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on OpenCode, expand to:
+
+```
+@code-reviewer Please review the following code change against the plan:
+[paste full prompt content]
+```
+
+The `@`-mention triggers the subagent declared in the plugin's `agents/`
+directory. Wait for the response in the same chat thread.
+
+## Idiom differences worth noting
+
+- **No JSON manifest.** OpenCode's plugin system is code-driven, not
+  declarative. The adapter has to perform skill registration imperatively
+  in its function body.
+- **Skills resolved by path.** OpenCode reads `config.skills.paths` and
+  walks each directory for `SKILL.md` files. Specflow's skills live under
+  the plugin repo's `skills/` directory and are auto-discovered.
+- **Lowercase tool names** throughout. Skill prose that says "use the
+  Bash tool" still works because OpenCode's LLM understands the mapping,
+  but the actual tool name in JSON tool-use blocks is `bash`.


### PR DESCRIPTION
Closes #283. First foundation item of Epic #270 (multi-harness parity with obra/superpowers).

## Agent adoption

Specflow skills are authored using **Claude Code tool names** as the lingua franca. Future harness adapters (Codex #277, Cursor #278, Gemini #279, OpenCode #280, Copilot CLI #281) and the SessionStart bootstrap skill #282 need a canonical reference mapping every tool to its per-harness equivalent — otherwise skills authored for Claude Code break silently on other harnesses.

Six markdown files added at `templates/core/skills/using-specflow/references/`:

- `claude-tools.md` — baseline (Read/Write/Edit/Bash/Skill/Task/TodoWrite/WebSearch/WebFetch/Grep/Glob)
- `codex-tools.md` — Codex CLI / App (spawn_agent / update_plan / apply_patch)
- `cursor-tools.md` — Cursor Agent (edit_file unified, hooks-cursor.json snake_case)
- `gemini-tools.md` — Gemini CLI (activate_skill, @generalist, save_memory)
- `opencode-tools.md` — OpenCode (JS adapter, lowercase tool names)
- `copilot-tools.md` — Copilot CLI (sql/todos table, marketplace flow)

Each ~50-80 lines: tool mapping table + subagent-dispatch pattern example + idiom notes + cross-references to upcoming adapter issues.

```prompt
After `specflow upgrade`, these reference files sit in your project's skill tree at `.claude/skills/using-specflow/references/` (once #282 lands and bundles them). The future `using-specflow` bootstrap skill will load the right reference for your harness at session start — you don't read these manually unless you're authoring a new skill and want to know which tool name to use for which harness.
```

## Files

- `templates/core/skills/using-specflow/references/{claude,codex,cursor,gemini,opencode,copilot}-tools.md` — 6 new files. No `SKILL.md` neighbor yet (lands in #282). No manifest entry yet (lands in #282).

## Out of scope

- The `using-specflow` SKILL.md itself — lands in #282.
- Manifest entries to bundle these references into user projects — lands in #282.
- Antigravity / Windsurf tool-mapping — those use the binary-scaffold path, not the plugin path; out of scope per Epic #270.

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `skills/using-superpowers/references/`. Each file footer cites the upstream; re-implemented for Specflow's harness coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)