### PR TITLE
feat: bundled writing-plans skill (#271)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -79,6 +79,21 @@ check "specflow-review auto-invoke alias present" \
   '[ -f .claude/skills/specflow-review/SKILL.md ]'
 
 echo
+echo "═══ #271  writing-plans skill (Epic #270 / A1) ═══"
+check "writing-plans skill scaffolded" \
+  '[ -f .claude/skills/writing-plans/SKILL.md ]'
+check "writing-plans frontmatter declares name: writing-plans" \
+  'head -5 .claude/skills/writing-plans/SKILL.md | grep -q "name: writing-plans"'
+check "writing-plans description targets plan-related trigger phrases" \
+  'head -10 .claude/skills/writing-plans/SKILL.md | grep -q "plan this"'
+check "writing-plans save path documented as docs/specflow/plans/" \
+  'grep -q "docs/specflow/plans" .claude/skills/writing-plans/SKILL.md'
+check "writing-plans enforces zero-placeholder discipline" \
+  'grep -qF "No placeholders" .claude/skills/writing-plans/SKILL.md'
+check "writing-plans credits obra/superpowers attribution" \
+  'grep -q "obra/superpowers" .claude/skills/writing-plans/SKILL.md'
+
+echo
 echo "═══ #75  loop.md + groom phase ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
 check "groom phase doc present" \

--- a/plugin/skills/writing-plans/SKILL.md
+++ b/plugin/skills/writing-plans/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: writing-plans
+description: Use when the user wants to plan a feature, an issue, a refactor, or any multi-step engineering task before touching code. Trigger phrases include "plan this", "write a plan", "give me an implementation plan", "plan how to fix #N", "design the implementation for X". Produces a single executable plan file with bite-sized TDD-style tasks and zero placeholders.
+---
+
+# Writing Plans
+
+Turn a feature request, an issue URL, or a free-form requirement into a
+**single executable plan file** that a developer (you, a subagent, or
+another human) can follow step-by-step without re-reading the spec.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow
+> with `docs/specflow/plans/` as the canonical save path and explicit
+> handoff to Specflow's `subagent-driven-development` / `executing-plans`
+> skills (issues #272 and #274).
+
+## When to use this skill
+
+Use when:
+
+- The user pastes a GitHub issue URL and says "plan this"
+- The user describes a feature and says "write a plan"
+- You hit a non-trivial change mid-task and need to step back before
+  coding
+- A `/specflow groom` pass surfaces a Ready item that needs design before
+  implementation
+
+Do **not** use when:
+
+- The change is genuinely trivial (one-line typo, single-config bump) —
+  just do it
+- The user explicitly asked for the spec-kit flow (`/specflow specify` →
+  `/specflow plan` produces design artefacts: research.md, data-model.md,
+  contracts/, quickstart.md — that's a different beast for greenfield
+  features with formal specs)
+
+## Announce at start
+
+> "I'm using the writing-plans skill to create the implementation plan."
+
+## Save plans to
+
+`docs/specflow/plans/YYYY-MM-DD-<feature-name>.md`
+
+User preference overrides this default (some teams prefer `.specflow/plans/`
+or `docs/plans/` — honor what they ask for). The date prefix gives plans
+a natural chronological order in the directory listing.
+
+## Scope check before writing
+
+If the spec covers multiple independent subsystems — e.g. "add OAuth
+**and** rewrite the billing engine **and** migrate to PostgreSQL" — STOP
+and propose breaking it into separate plans. Each plan should produce
+working, testable software on its own. A 3-subsystem plan is a backlog
+Epic, not a single plan.
+
+## File Structure section
+
+Before defining tasks, the plan must include a **File Structure** section
+that maps out which files will be created or modified. This is where
+decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each
+  file should have one clear responsibility.
+- Prefer smaller, focused files over large ones that do too much. You
+  reason best about code you can hold in context at once.
+- Files that change together should live together. Split by
+  responsibility, not by technical layer.
+- In existing Specflow code, follow established patterns. The hexagonal
+  layout (`src/domain/`, `src/application/`, `src/infrastructure/`,
+  `src/cli/`) is the house style — don't unilaterally restructure.
+
+The File Structure table informs task decomposition. Each task should
+produce self-contained changes that make sense independently.
+
+## Bite-sized task granularity
+
+**Each step is one action (2–5 minutes):**
+
+- "Write the failing test" — one step
+- "Run it to make sure it fails" — one step
+- "Implement the minimal code to make the test pass" — one step
+- "Run the tests and make sure they pass" — one step
+- "Commit" — one step
+
+A step that says "implement the feature" is too big. Break it down.
+
+## Plan document header
+
+Every plan **MUST** start with this header:
+
+````markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `specflow:subagent-driven-development` (recommended; #272 once shipped)
+> or `specflow:executing-plans` (#274 once shipped) to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2–3 sentences about approach — what changes, what stays]
+
+**Tech Stack:** [Deno + TypeScript, specific Specflow modules touched]
+
+> Issue: [URL if applicable]
+
+---
+````
+
+## Task structure
+
+Each task lists its files, then walks through TDD-style steps with
+**complete code blocks**. Example:
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+
+- Create: `src/exact/path/to/file.ts`
+- Modify: `src/exact/path/to/existing.ts:123-145`
+- Test: `tests/exact/path/to/test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+Deno.test("specific behaviour", () => {
+  const result = myFunction(input);
+  assertEquals(result, expected);
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+deno test tests/path/to/test.ts
+```
+
+Expected: FAIL with `myFunction is not defined`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```typescript
+export function myFunction(input: Input): Output {
+  return expected;
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+deno test tests/path/to/test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/to/test.ts src/path/to/file.ts
+git commit -m "feat(domain): add myFunction"
+```
+````
+
+## No placeholders — these are plan failures
+
+Every step must contain the actual content an engineer needs. **Never**
+write:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without showing the actual test code)
+- "Similar to Task N" (repeat the code — the reader may be reading tasks
+  out of order)
+- Steps that describe what to do without showing how (code blocks are
+  required for code steps)
+- References to types, functions, or methods not defined in any task
+
+If a step would have a placeholder, you don't understand the change well
+enough yet — back up, research, then write the step with real content.
+
+## Self-review
+
+After writing the complete plan, look at it with fresh eyes. **Run this
+checklist yourself — it is not a subagent dispatch.**
+
+1. **Spec coverage** — skim each requirement in the spec / issue. Can
+   you point to a task that implements it? List any gaps. If a
+   requirement has no task, add the task.
+
+2. **Placeholder scan** — search the plan for red flags from the
+   "No placeholders" list above. Fix every one.
+
+3. **Type consistency** — do the types, method signatures, and property
+   names you used in later tasks match what you defined in earlier
+   tasks? A function called `clearLayers()` in Task 3 but
+   `clearFullLayers()` in Task 7 is a bug.
+
+4. **Specflow conventions** — do file paths follow the hexagonal
+   layout? Do you respect the byte-identity plugin-sync contract
+   (`templates/core/...` plus `plugin/...` twin) for any new template
+   files? Are manifest entries added if you scaffold new files?
+
+5. **Smoke / audit** — if you touched any scaffolded skill or script,
+   does the plan include a step to update
+   `.claude/skills/test-sandbox/scripts/smoke-*.sh` and re-run
+   `audit.sh`?
+
+Fix issues inline. No need to re-review — just fix and move on.
+
+## Execution handoff
+
+After saving the plan, offer the user a choice of execution strategy:
+
+> "Plan complete and saved to `docs/specflow/plans/<filename>.md`. Two
+> execution options:
+>
+> 1. **Subagent-Driven** (recommended) — I dispatch a fresh subagent per
+>    task with two-stage review (spec compliance + code quality). Catches
+>    bugs early.
+> 2. **Inline Execution** — Execute tasks in this session with
+>    checkpoints. Faster for simple plans.
+>
+> Which approach?"
+
+**If subagent-driven chosen:**
+
+- **REQUIRED SUB-SKILL:** Use `specflow:subagent-driven-development`
+  (issue #272 once shipped — otherwise fall back to dispatching
+  Specflow's `developer` agent per task with manual two-stage review)
+- Fresh subagent per task + spec compliance + code quality review loop
+
+**If inline chosen:**
+
+- **REQUIRED SUB-SKILL:** Use `specflow:executing-plans` (issue #274
+  once shipped — otherwise execute tasks in-session with manual
+  checkpoint pauses)
+- Batch execution with explicit checkpoints
+
+## Key principles
+
+- **Exact file paths** always — `src/domain/x.ts:42`, not "the x module"
+- **Complete code** in every step — if a step changes code, show the code
+- **Exact commands** with expected output — `deno test path/to/file.ts`,
+  not "run the tests"
+- **DRY** — don't repeat boilerplate across tasks, but **do** repeat code
+  if a reader might jump straight to that task
+- **YAGNI** — don't plan capabilities the issue didn't ask for
+- **TDD** — every code-producing task starts with a failing test
+- **Frequent commits** — one commit per logical step, not per task
+
+## Out of scope
+
+This skill writes **plans**, not code. It hands off execution to
+`subagent-driven-development` or `executing-plans` (or to the user, if
+they prefer to drive manually). It does not:
+
+- Run tests itself
+- Open branches or PRs
+- Mutate the backlog (the `product-owner` agent owns those mutations)
+- Trigger releases (that's `/release` / `devops-sre`)
+
+## Integration with `/specflow plan`
+
+This skill is **distinct from** the `/specflow plan` phase of the
+spec-kit pipeline. The spec-kit `/specflow plan` produces design
+artefacts (research.md, data-model.md, contracts/, quickstart.md) for
+greenfield features starting from a `spec.md`. This `writing-plans`
+skill produces a **single executable plan file** for issue-driven or
+ad-hoc work where the spec-kit ceremony would be overkill.
+
+A user can use both:
+
+- `/specflow specify` → `/specflow plan` for a new multi-month feature
+  with formal contracts
+- `writing-plans` (auto-invoked) for "plan how to fix this backlog issue"
+
+Specflow ships both because real teams have both flows.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3140,6 +3140,295 @@ Do not duplicate the review procedure here — it lives in \`phases/review.md\` 
     skipIfExists: false,
   },
   {
+    category: "skill",
+    name: "writing-plans",
+    suffix: null,
+    content: `---
+name: writing-plans
+description: Use when the user wants to plan a feature, an issue, a refactor, or any multi-step engineering task before touching code. Trigger phrases include "plan this", "write a plan", "give me an implementation plan", "plan how to fix #N", "design the implementation for X". Produces a single executable plan file with bite-sized TDD-style tasks and zero placeholders.
+---
+
+# Writing Plans
+
+Turn a feature request, an issue URL, or a free-form requirement into a
+**single executable plan file** that a developer (you, a subagent, or
+another human) can follow step-by-step without re-reading the spec.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/writing-plans/SKILL.md\`. Re-implemented for Specflow
+> with \`docs/specflow/plans/\` as the canonical save path and explicit
+> handoff to Specflow's \`subagent-driven-development\` / \`executing-plans\`
+> skills (issues #272 and #274).
+
+## When to use this skill
+
+Use when:
+
+- The user pastes a GitHub issue URL and says "plan this"
+- The user describes a feature and says "write a plan"
+- You hit a non-trivial change mid-task and need to step back before
+  coding
+- A \`/specflow groom\` pass surfaces a Ready item that needs design before
+  implementation
+
+Do **not** use when:
+
+- The change is genuinely trivial (one-line typo, single-config bump) —
+  just do it
+- The user explicitly asked for the spec-kit flow (\`/specflow specify\` →
+  \`/specflow plan\` produces design artefacts: research.md, data-model.md,
+  contracts/, quickstart.md — that's a different beast for greenfield
+  features with formal specs)
+
+## Announce at start
+
+> "I'm using the writing-plans skill to create the implementation plan."
+
+## Save plans to
+
+\`docs/specflow/plans/YYYY-MM-DD-<feature-name>.md\`
+
+User preference overrides this default (some teams prefer \`.specflow/plans/\`
+or \`docs/plans/\` — honor what they ask for). The date prefix gives plans
+a natural chronological order in the directory listing.
+
+## Scope check before writing
+
+If the spec covers multiple independent subsystems — e.g. "add OAuth
+**and** rewrite the billing engine **and** migrate to PostgreSQL" — STOP
+and propose breaking it into separate plans. Each plan should produce
+working, testable software on its own. A 3-subsystem plan is a backlog
+Epic, not a single plan.
+
+## File Structure section
+
+Before defining tasks, the plan must include a **File Structure** section
+that maps out which files will be created or modified. This is where
+decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each
+  file should have one clear responsibility.
+- Prefer smaller, focused files over large ones that do too much. You
+  reason best about code you can hold in context at once.
+- Files that change together should live together. Split by
+  responsibility, not by technical layer.
+- In existing Specflow code, follow established patterns. The hexagonal
+  layout (\`src/domain/\`, \`src/application/\`, \`src/infrastructure/\`,
+  \`src/cli/\`) is the house style — don't unilaterally restructure.
+
+The File Structure table informs task decomposition. Each task should
+produce self-contained changes that make sense independently.
+
+## Bite-sized task granularity
+
+**Each step is one action (2–5 minutes):**
+
+- "Write the failing test" — one step
+- "Run it to make sure it fails" — one step
+- "Implement the minimal code to make the test pass" — one step
+- "Run the tests and make sure they pass" — one step
+- "Commit" — one step
+
+A step that says "implement the feature" is too big. Break it down.
+
+## Plan document header
+
+Every plan **MUST** start with this header:
+
+\`\`\`\`markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> \`specflow:subagent-driven-development\` (recommended; #272 once shipped)
+> or \`specflow:executing-plans\` (#274 once shipped) to implement this
+> plan task-by-task. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2–3 sentences about approach — what changes, what stays]
+
+**Tech Stack:** [Deno + TypeScript, specific Specflow modules touched]
+
+> Issue: [URL if applicable]
+
+---
+\`\`\`\`
+
+## Task structure
+
+Each task lists its files, then walks through TDD-style steps with
+**complete code blocks**. Example:
+
+\`\`\`\`markdown
+### Task N: [Component Name]
+
+**Files:**
+
+- Create: \`src/exact/path/to/file.ts\`
+- Modify: \`src/exact/path/to/existing.ts:123-145\`
+- Test: \`tests/exact/path/to/test.ts\`
+
+- [ ] **Step 1: Write the failing test**
+
+\`\`\`typescript
+Deno.test("specific behaviour", () => {
+  const result = myFunction(input);
+  assertEquals(result, expected);
+});
+\`\`\`
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+\`\`\`bash
+deno test tests/path/to/test.ts
+\`\`\`
+
+Expected: FAIL with \`myFunction is not defined\`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+\`\`\`typescript
+export function myFunction(input: Input): Output {
+  return expected;
+}
+\`\`\`
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+\`\`\`bash
+deno test tests/path/to/test.ts
+\`\`\`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+\`\`\`bash
+git add tests/path/to/test.ts src/path/to/file.ts
+git commit -m "feat(domain): add myFunction"
+\`\`\`
+\`\`\`\`
+
+## No placeholders — these are plan failures
+
+Every step must contain the actual content an engineer needs. **Never**
+write:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without showing the actual test code)
+- "Similar to Task N" (repeat the code — the reader may be reading tasks
+  out of order)
+- Steps that describe what to do without showing how (code blocks are
+  required for code steps)
+- References to types, functions, or methods not defined in any task
+
+If a step would have a placeholder, you don't understand the change well
+enough yet — back up, research, then write the step with real content.
+
+## Self-review
+
+After writing the complete plan, look at it with fresh eyes. **Run this
+checklist yourself — it is not a subagent dispatch.**
+
+1. **Spec coverage** — skim each requirement in the spec / issue. Can
+   you point to a task that implements it? List any gaps. If a
+   requirement has no task, add the task.
+
+2. **Placeholder scan** — search the plan for red flags from the
+   "No placeholders" list above. Fix every one.
+
+3. **Type consistency** — do the types, method signatures, and property
+   names you used in later tasks match what you defined in earlier
+   tasks? A function called \`clearLayers()\` in Task 3 but
+   \`clearFullLayers()\` in Task 7 is a bug.
+
+4. **Specflow conventions** — do file paths follow the hexagonal
+   layout? Do you respect the byte-identity plugin-sync contract
+   (\`templates/core/...\` plus \`plugin/...\` twin) for any new template
+   files? Are manifest entries added if you scaffold new files?
+
+5. **Smoke / audit** — if you touched any scaffolded skill or script,
+   does the plan include a step to update
+   \`.claude/skills/test-sandbox/scripts/smoke-*.sh\` and re-run
+   \`audit.sh\`?
+
+Fix issues inline. No need to re-review — just fix and move on.
+
+## Execution handoff
+
+After saving the plan, offer the user a choice of execution strategy:
+
+> "Plan complete and saved to \`docs/specflow/plans/<filename>.md\`. Two
+> execution options:
+>
+> 1. **Subagent-Driven** (recommended) — I dispatch a fresh subagent per
+>    task with two-stage review (spec compliance + code quality). Catches
+>    bugs early.
+> 2. **Inline Execution** — Execute tasks in this session with
+>    checkpoints. Faster for simple plans.
+>
+> Which approach?"
+
+**If subagent-driven chosen:**
+
+- **REQUIRED SUB-SKILL:** Use \`specflow:subagent-driven-development\`
+  (issue #272 once shipped — otherwise fall back to dispatching
+  Specflow's \`developer\` agent per task with manual two-stage review)
+- Fresh subagent per task + spec compliance + code quality review loop
+
+**If inline chosen:**
+
+- **REQUIRED SUB-SKILL:** Use \`specflow:executing-plans\` (issue #274
+  once shipped — otherwise execute tasks in-session with manual
+  checkpoint pauses)
+- Batch execution with explicit checkpoints
+
+## Key principles
+
+- **Exact file paths** always — \`src/domain/x.ts:42\`, not "the x module"
+- **Complete code** in every step — if a step changes code, show the code
+- **Exact commands** with expected output — \`deno test path/to/file.ts\`,
+  not "run the tests"
+- **DRY** — don't repeat boilerplate across tasks, but **do** repeat code
+  if a reader might jump straight to that task
+- **YAGNI** — don't plan capabilities the issue didn't ask for
+- **TDD** — every code-producing task starts with a failing test
+- **Frequent commits** — one commit per logical step, not per task
+
+## Out of scope
+
+This skill writes **plans**, not code. It hands off execution to
+\`subagent-driven-development\` or \`executing-plans\` (or to the user, if
+they prefer to drive manually). It does not:
+
+- Run tests itself
+- Open branches or PRs
+- Mutate the backlog (the \`product-owner\` agent owns those mutations)
+- Trigger releases (that's \`/release\` / \`devops-sre\`)
+
+## Integration with \`/specflow plan\`
+
+This skill is **distinct from** the \`/specflow plan\` phase of the
+spec-kit pipeline. The spec-kit \`/specflow plan\` produces design
+artefacts (research.md, data-model.md, contracts/, quickstart.md) for
+greenfield features starting from a \`spec.md\`. This \`writing-plans\`
+skill produces a **single executable plan file** for issue-driven or
+ad-hoc work where the spec-kit ceremony would be overkill.
+
+A user can use both:
+
+- \`/specflow specify\` → \`/specflow plan\` for a new multi-month feature
+  with formal contracts
+- \`writing-plans\` (auto-invoked) for "plan how to fix this backlog issue"
+
+Specflow ships both because real teams have both flows.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
     category: "backlog-cmd",
     name: "backlog",
     suffix: null,

--- a/templates/core/skills/writing-plans/SKILL.md
+++ b/templates/core/skills/writing-plans/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: writing-plans
+description: Use when the user wants to plan a feature, an issue, a refactor, or any multi-step engineering task before touching code. Trigger phrases include "plan this", "write a plan", "give me an implementation plan", "plan how to fix #N", "design the implementation for X". Produces a single executable plan file with bite-sized TDD-style tasks and zero placeholders.
+---
+
+# Writing Plans
+
+Turn a feature request, an issue URL, or a free-form requirement into a
+**single executable plan file** that a developer (you, a subagent, or
+another human) can follow step-by-step without re-reading the spec.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow
+> with `docs/specflow/plans/` as the canonical save path and explicit
+> handoff to Specflow's `subagent-driven-development` / `executing-plans`
+> skills (issues #272 and #274).
+
+## When to use this skill
+
+Use when:
+
+- The user pastes a GitHub issue URL and says "plan this"
+- The user describes a feature and says "write a plan"
+- You hit a non-trivial change mid-task and need to step back before
+  coding
+- A `/specflow groom` pass surfaces a Ready item that needs design before
+  implementation
+
+Do **not** use when:
+
+- The change is genuinely trivial (one-line typo, single-config bump) —
+  just do it
+- The user explicitly asked for the spec-kit flow (`/specflow specify` →
+  `/specflow plan` produces design artefacts: research.md, data-model.md,
+  contracts/, quickstart.md — that's a different beast for greenfield
+  features with formal specs)
+
+## Announce at start
+
+> "I'm using the writing-plans skill to create the implementation plan."
+
+## Save plans to
+
+`docs/specflow/plans/YYYY-MM-DD-<feature-name>.md`
+
+User preference overrides this default (some teams prefer `.specflow/plans/`
+or `docs/plans/` — honor what they ask for). The date prefix gives plans
+a natural chronological order in the directory listing.
+
+## Scope check before writing
+
+If the spec covers multiple independent subsystems — e.g. "add OAuth
+**and** rewrite the billing engine **and** migrate to PostgreSQL" — STOP
+and propose breaking it into separate plans. Each plan should produce
+working, testable software on its own. A 3-subsystem plan is a backlog
+Epic, not a single plan.
+
+## File Structure section
+
+Before defining tasks, the plan must include a **File Structure** section
+that maps out which files will be created or modified. This is where
+decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each
+  file should have one clear responsibility.
+- Prefer smaller, focused files over large ones that do too much. You
+  reason best about code you can hold in context at once.
+- Files that change together should live together. Split by
+  responsibility, not by technical layer.
+- In existing Specflow code, follow established patterns. The hexagonal
+  layout (`src/domain/`, `src/application/`, `src/infrastructure/`,
+  `src/cli/`) is the house style — don't unilaterally restructure.
+
+The File Structure table informs task decomposition. Each task should
+produce self-contained changes that make sense independently.
+
+## Bite-sized task granularity
+
+**Each step is one action (2–5 minutes):**
+
+- "Write the failing test" — one step
+- "Run it to make sure it fails" — one step
+- "Implement the minimal code to make the test pass" — one step
+- "Run the tests and make sure they pass" — one step
+- "Commit" — one step
+
+A step that says "implement the feature" is too big. Break it down.
+
+## Plan document header
+
+Every plan **MUST** start with this header:
+
+````markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `specflow:subagent-driven-development` (recommended; #272 once shipped)
+> or `specflow:executing-plans` (#274 once shipped) to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2–3 sentences about approach — what changes, what stays]
+
+**Tech Stack:** [Deno + TypeScript, specific Specflow modules touched]
+
+> Issue: [URL if applicable]
+
+---
+````
+
+## Task structure
+
+Each task lists its files, then walks through TDD-style steps with
+**complete code blocks**. Example:
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+
+- Create: `src/exact/path/to/file.ts`
+- Modify: `src/exact/path/to/existing.ts:123-145`
+- Test: `tests/exact/path/to/test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+Deno.test("specific behaviour", () => {
+  const result = myFunction(input);
+  assertEquals(result, expected);
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+deno test tests/path/to/test.ts
+```
+
+Expected: FAIL with `myFunction is not defined`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```typescript
+export function myFunction(input: Input): Output {
+  return expected;
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+deno test tests/path/to/test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/to/test.ts src/path/to/file.ts
+git commit -m "feat(domain): add myFunction"
+```
+````
+
+## No placeholders — these are plan failures
+
+Every step must contain the actual content an engineer needs. **Never**
+write:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without showing the actual test code)
+- "Similar to Task N" (repeat the code — the reader may be reading tasks
+  out of order)
+- Steps that describe what to do without showing how (code blocks are
+  required for code steps)
+- References to types, functions, or methods not defined in any task
+
+If a step would have a placeholder, you don't understand the change well
+enough yet — back up, research, then write the step with real content.
+
+## Self-review
+
+After writing the complete plan, look at it with fresh eyes. **Run this
+checklist yourself — it is not a subagent dispatch.**
+
+1. **Spec coverage** — skim each requirement in the spec / issue. Can
+   you point to a task that implements it? List any gaps. If a
+   requirement has no task, add the task.
+
+2. **Placeholder scan** — search the plan for red flags from the
+   "No placeholders" list above. Fix every one.
+
+3. **Type consistency** — do the types, method signatures, and property
+   names you used in later tasks match what you defined in earlier
+   tasks? A function called `clearLayers()` in Task 3 but
+   `clearFullLayers()` in Task 7 is a bug.
+
+4. **Specflow conventions** — do file paths follow the hexagonal
+   layout? Do you respect the byte-identity plugin-sync contract
+   (`templates/core/...` plus `plugin/...` twin) for any new template
+   files? Are manifest entries added if you scaffold new files?
+
+5. **Smoke / audit** — if you touched any scaffolded skill or script,
+   does the plan include a step to update
+   `.claude/skills/test-sandbox/scripts/smoke-*.sh` and re-run
+   `audit.sh`?
+
+Fix issues inline. No need to re-review — just fix and move on.
+
+## Execution handoff
+
+After saving the plan, offer the user a choice of execution strategy:
+
+> "Plan complete and saved to `docs/specflow/plans/<filename>.md`. Two
+> execution options:
+>
+> 1. **Subagent-Driven** (recommended) — I dispatch a fresh subagent per
+>    task with two-stage review (spec compliance + code quality). Catches
+>    bugs early.
+> 2. **Inline Execution** — Execute tasks in this session with
+>    checkpoints. Faster for simple plans.
+>
+> Which approach?"
+
+**If subagent-driven chosen:**
+
+- **REQUIRED SUB-SKILL:** Use `specflow:subagent-driven-development`
+  (issue #272 once shipped — otherwise fall back to dispatching
+  Specflow's `developer` agent per task with manual two-stage review)
+- Fresh subagent per task + spec compliance + code quality review loop
+
+**If inline chosen:**
+
+- **REQUIRED SUB-SKILL:** Use `specflow:executing-plans` (issue #274
+  once shipped — otherwise execute tasks in-session with manual
+  checkpoint pauses)
+- Batch execution with explicit checkpoints
+
+## Key principles
+
+- **Exact file paths** always — `src/domain/x.ts:42`, not "the x module"
+- **Complete code** in every step — if a step changes code, show the code
+- **Exact commands** with expected output — `deno test path/to/file.ts`,
+  not "run the tests"
+- **DRY** — don't repeat boilerplate across tasks, but **do** repeat code
+  if a reader might jump straight to that task
+- **YAGNI** — don't plan capabilities the issue didn't ask for
+- **TDD** — every code-producing task starts with a failing test
+- **Frequent commits** — one commit per logical step, not per task
+
+## Out of scope
+
+This skill writes **plans**, not code. It hands off execution to
+`subagent-driven-development` or `executing-plans` (or to the user, if
+they prefer to drive manually). It does not:
+
+- Run tests itself
+- Open branches or PRs
+- Mutate the backlog (the `product-owner` agent owns those mutations)
+- Trigger releases (that's `/release` / `devops-sre`)
+
+## Integration with `/specflow plan`
+
+This skill is **distinct from** the `/specflow plan` phase of the
+spec-kit pipeline. The spec-kit `/specflow plan` produces design
+artefacts (research.md, data-model.md, contracts/, quickstart.md) for
+greenfield features starting from a `spec.md`. This `writing-plans`
+skill produces a **single executable plan file** for issue-driven or
+ad-hoc work where the spec-kit ceremony would be overkill.
+
+A user can use both:
+
+- `/specflow specify` → `/specflow plan` for a new multi-month feature
+  with formal contracts
+- `writing-plans` (auto-invoked) for "plan how to fix this backlog issue"
+
+Specflow ships both because real teams have both flows.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -23,6 +23,7 @@
     { "category": "phase-script", "name": "release-gitlab", "suffix": "release-gitlab.sh", "source": "core/skills/specflow/scripts/release-gitlab.sh", "executable": true },
     { "category": "phase-script", "name": "release-local", "suffix": "release-local.sh", "source": "core/skills/specflow/scripts/release-local.sh", "executable": true },
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
+    { "category": "skill", "name": "writing-plans", "source": "core/skills/writing-plans/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -87,11 +87,12 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     assertEquals(codexGoalMd.includes("/specflow groom"), true);
 
     // Top-level skill folders post-consolidation: specflow router +
-    // specflow-auto + specflow-review alias + specflow-backlog = 4.
+    // specflow-auto + specflow-review alias + specflow-backlog +
+    // writing-plans (Epic #270 / A1) = 5.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 4);
+    assertEquals(agentsSkillsCount, 5);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -84,11 +84,11 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
 
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review +
-    // backlog + 11 agents = 29.
+    // writing-plans (#271) + backlog + 11 agents = 30.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 29);
+    assertEquals(instructionsCount, 30);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -76,11 +76,11 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
 
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review alias +
-    // backlog + 11 agent workflows = 29.
+    // writing-plans (#271) + backlog + 11 agent workflows = 30.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 29);
+    assertEquals(workflowsCount, 30);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -47,6 +47,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow-review/SKILL.md",
     source: "templates/core/skills/specflow-review/SKILL.md",
   },
+  // writing-plans skill — Specflow's native equivalent of obra/superpowers
+  // writing-plans, used for issue-driven planning where the spec-kit
+  // /specflow plan ceremony would be overkill (Epic #270, A1 #271).
+  {
+    plugin: "plugin/skills/writing-plans/SKILL.md",
+    source: "templates/core/skills/writing-plans/SKILL.md",
+  },
   // Dual-copy agents: 10 sub-agent definitions, each landing as
   // `plugin/agents/<name>.md`. Claude Code resolves agents by file
   // basename in plugin scope; no namespacing needed for invocation


### PR DESCRIPTION
Closes #271. A1 (cornerstone) of Epic #270.

## Agent adoption

Specflow now ships a native `writing-plans` skill — auto-invoked on user prompts like "plan this", "write a plan for X", "give me an implementation plan". Produces a single executable plan file at `docs/specflow/plans/YYYY-MM-DD-<feature>.md` with bite-sized TDD-style tasks and zero-placeholder discipline.

Distinct from `/specflow plan` (the spec-kit greenfield flow that produces research/data-model/contracts/quickstart artefacts from a `spec.md`). The two coexist for the two different real flows:
- `/specflow specify → /specflow plan` for multi-month features with formal specs
- `writing-plans` (auto-invoked) for issue-driven or ad-hoc planning

```prompt
After `specflow upgrade`, paste a GitHub issue URL and say "plan this" — your harness will invoke the new writing-plans skill, which produces a single executable plan file under docs/specflow/plans/. The plan enforces bite-sized TDD steps (write failing test → run → implement → run → commit, 2-5 min/step) and zero placeholders (no "TODO: add validation" allowed). After the plan is written, you'll be offered two execution options: subagent-driven (fresh subagent per task with spec+code review, recommended) or inline (sequential with checkpoints). Both fall back to manual execution until issues #272 (subagent-driven-development skill) and #274 (executing-plans skill) ship — those are the next foundation items of Epic #270.
```

## Files

- `templates/core/skills/writing-plans/SKILL.md` — the skill itself, 9896 chars (~2100 chars headroom under Windsurf cap)
- `plugin/skills/writing-plans/SKILL.md` — byte-identical mirror for the plugin distribution
- `templates/manifest.json` — registers the new skill (86 → 87 core entries)
- `tests/plugin/plugin_sync_test.ts` — adds writing-plans to the byte-identity SYNC_PAIRS
- `.claude/skills/test-sandbox/scripts/smoke-features.sh` — 6 new static-grep assertions (scaffolded, frontmatter, trigger phrases, save path, no-placeholders enforcement, superpowers attribution)
- `tests/integration/init_{codex,copilot,windsurf}_test.ts` — scaffolded-file count bumped to account for the new skill

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow with `docs/specflow/plans/` as the canonical save path and explicit handoff to upcoming Specflow `subagent-driven-development` (#272) and `executing-plans` (#274) skills.

## Out of scope

- `subagent-driven-development` and `executing-plans` skills (issues #272 + #274 — the execution loop the plan hands off to). Until those ship, the handoff section of the new skill names them as future-required and falls back to manual execution.
- Modifying `/specflow plan` (the spec-kit phase) — the two skills coexist intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)