### PR TITLE
feat: bundled requesting-code-review skill (#273)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -94,6 +94,23 @@ check "writing-plans credits obra/superpowers attribution" \
   'grep -q "obra/superpowers" .claude/skills/writing-plans/SKILL.md'
 
 echo
+echo "═══ #273  requesting-code-review skill (Epic #270 / A3) ═══"
+check "requesting-code-review skill scaffolded" \
+  '[ -f .claude/skills/requesting-code-review/SKILL.md ]'
+check "requesting-code-review frontmatter declares name" \
+  'head -5 .claude/skills/requesting-code-review/SKILL.md | grep -q "name: requesting-code-review"'
+check "requesting-code-review description targets review-related triggers" \
+  'head -10 .claude/skills/requesting-code-review/SKILL.md | grep -q "review this"'
+check "requesting-code-review documents code-reviewer agent dispatch" \
+  'grep -q "subagent_type: code-reviewer\|subagent_type=\"code-reviewer\"" .claude/skills/requesting-code-review/SKILL.md'
+check "requesting-code-review embeds canonical reviewer prompt template" \
+  'grep -qF "Critical (Must Fix)" .claude/skills/requesting-code-review/SKILL.md'
+check "requesting-code-review documents two-stage review pattern" \
+  'grep -q "Two-stage review\|two-stage review" .claude/skills/requesting-code-review/SKILL.md'
+check "requesting-code-review credits obra/superpowers attribution" \
+  'grep -q "obra/superpowers" .claude/skills/requesting-code-review/SKILL.md'
+
+echo
 echo "═══ #75  loop.md + groom phase ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
 check "groom phase doc present" \

--- a/plugin/skills/requesting-code-review/SKILL.md
+++ b/plugin/skills/requesting-code-review/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: requesting-code-review
+description: Use when work is complete enough to need an independent eye — after each task in a subagent-driven plan, after a major feature, before merging to main. Trigger phrases include "review this", "request code review", "review the changes", "review my work", "check this before merge". Dispatches a fresh code-reviewer subagent with precise context and a canonical prompt template.
+---
+
+# Requesting Code Review
+
+Dispatch a code reviewer subagent to catch issues before they cascade.
+The reviewer gets precisely crafted context for evaluation — never your
+session's history. This keeps the reviewer focused on the work product,
+not your thought process, and preserves your own context for continued
+work.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/requesting-code-review/SKILL.md` + the
+> `code-reviewer.md` prompt template. Re-implemented for Specflow with
+> the prompt template inlined here (single file) and integrated with
+> Specflow's bundled `code-reviewer` agent.
+
+**Core principle:** Review early, review often.
+
+## When to request review
+
+**Mandatory:**
+
+- After each task in a subagent-driven plan (#272, once shipped)
+- After completing a major feature
+- Before merging to main
+
+**Optional but valuable:**
+
+- When stuck (fresh perspective)
+- Before refactoring (baseline check)
+- After fixing a complex bug
+
+## Specflow integration
+
+Specflow ships a bundled **`code-reviewer` agent**
+(`templates/core/agents/code-reviewer.md`) that this skill dispatches.
+The agent's system prompt covers Specflow conventions (hexagonal
+layers, byte-identity plugin-sync contract, smoke audit, Windsurf cap,
+backlog-script conventions, …). Use it instead of `general-purpose`
+when reviewing changes inside this repo.
+
+For changes that touch security surfaces, also dispatch
+`security-auditor` in parallel. For test-only diffs, `test-reviewer`
+is the right specialist.
+
+## How to request
+
+**Step 1: Get the git range to review.**
+
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main, or last task commit
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+For a subagent-driven task, BASE is the commit at the start of the task,
+HEAD is the current task's commit. For a whole feature, BASE is
+`origin/main` and HEAD is the branch tip.
+
+**Step 2: Dispatch the code-reviewer subagent** with the canonical
+prompt template (see below). Use the `Task` tool with
+`subagent_type: code-reviewer` and pass the four placeholders:
+`{DESCRIPTION}`, `{PLAN_OR_REQUIREMENTS}`, `{BASE_SHA}`, `{HEAD_SHA}`.
+
+**Step 3: Act on the feedback.**
+
+- Fix Critical issues immediately. Do not proceed.
+- Fix Important issues before moving to the next task.
+- Note Minor issues for a follow-up commit or a tidy-up later.
+- Push back if the reviewer is wrong — with code/tests/reasoning, not
+  just assertion.
+
+## The canonical reviewer prompt template
+
+Paste this verbatim into a `Task({subagent_type: "code-reviewer", ...})`
+dispatch, substituting the four placeholders. The format is mandatory —
+Specflow's two-stage review pattern (spec compliance, then code
+quality; see #272 once shipped) depends on the reviewer returning the
+exact sections below.
+
+````
+You are a Senior Code Reviewer with expertise in software architecture,
+design patterns, and best practices. Your job is to review completed
+work against its plan or requirements and identify issues before they
+cascade.
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Requirements / Plan
+
+{PLAN_OR_REQUIREMENTS}
+
+## Git Range to Review
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## What to Check
+
+**Plan alignment:**
+- Does the implementation match the plan / requirements?
+- Are deviations justified improvements, or problematic departures?
+- Is all planned functionality present?
+
+**Code quality:**
+- Clean separation of concerns?
+- Proper error handling?
+- Type safety where applicable?
+- DRY without premature abstraction?
+- Edge cases handled?
+
+**Architecture:**
+- Sound design decisions?
+- Reasonable scalability and performance?
+- Security concerns?
+- Integrates cleanly with surrounding code?
+
+**Testing:**
+- Tests verify real behavior, not mocks?
+- Edge cases covered?
+- Integration tests where they matter?
+- All tests passing?
+
+**Production readiness:**
+- Migration strategy if schema changed?
+- Backward compatibility considered?
+- Documentation complete?
+- No obvious bugs?
+
+## Calibration
+
+Categorize issues by actual severity. Not everything is Critical.
+Acknowledge what was done well before listing issues — accurate praise
+helps the implementer trust the rest of the feedback.
+
+If you find significant deviations from the plan, flag them specifically
+so the implementer can confirm whether the deviation was intentional.
+If you find issues with the plan itself rather than the implementation,
+say so.
+
+## Output Format
+
+### Strengths
+[What's well done? Be specific.]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (Should Fix)
+[Architecture problems, missing features, poor error handling, test gaps]
+
+#### Minor (Nice to Have)
+[Code style, optimization opportunities, documentation polish]
+
+For each issue:
+- File:line reference
+- What's wrong
+- Why it matters
+- How to fix (if not obvious)
+
+### Recommendations
+[Improvements for code quality, architecture, or process]
+
+### Assessment
+
+**Ready to merge?** [Yes | No | With fixes]
+
+**Reasoning:** [1-2 sentence technical assessment]
+
+## Critical Rules
+
+**DO:**
+- Categorize by actual severity
+- Be specific (file:line, not vague)
+- Explain WHY each issue matters
+- Acknowledge strengths
+- Give a clear verdict
+
+**DON'T:**
+- Say "looks good" without checking
+- Mark nitpicks as Critical
+- Give feedback on code you didn't actually read
+- Be vague ("improve error handling")
+- Avoid giving a clear verdict
+````
+
+## Two-stage review pattern (subagent-driven only)
+
+Specflow's `subagent-driven-development` skill (#272, once shipped)
+runs **two reviews per task**, in this order:
+
+1. **Spec-compliance review** — verifies the implementation matches the
+   plan task verbatim. Nothing more, nothing less. Catches scope creep
+   and missed requirements. Uses a different prompt template focused on
+   plan↔code alignment only.
+
+2. **Code-quality review** — runs only if spec compliance passes. Uses
+   the canonical template above. Catches architecture, testing, and
+   production-readiness gaps.
+
+The order matters: spec compliance is cheap and disqualifies "looks
+clean but builds the wrong thing" implementations. Don't run code
+quality first — you'll waste reviewer cycles on code that has to be
+rewritten anyway.
+
+For one-shot reviews (not subagent-driven), just use the code-quality
+template above. Skip the spec-compliance stage.
+
+## Example dispatch (Claude Code)
+
+```typescript
+Task({
+  subagent_type: "code-reviewer",
+  description: "Review writing-plans skill (#271)",
+  prompt: `<paste the template above with placeholders filled in>`
+});
+```
+
+## Example output
+
+```
+### Strengths
+- Clean separation between SKILL.md content and inline prompt template
+- Honest attribution to obra/superpowers MIT with re-implementation note
+- Trigger phrases in description are concrete and match likely user phrasing
+
+### Issues
+
+#### Important
+1. **Missing fallback when code-reviewer agent unavailable**
+   - File: SKILL.md:L42
+   - Issue: skill assumes `subagent_type: code-reviewer` exists; on harnesses where the agent isn't bundled, the dispatch will fail silently
+   - Fix: document the `general-purpose` fallback explicitly
+
+#### Minor
+1. **Trigger phrase "review this" is broad**
+   - File: SKILL.md:L4
+   - Issue: could over-trigger on conversational uses ("review this list with me")
+   - Impact: low — the user can disambiguate; not worth tightening
+
+### Recommendations
+- Consider linking from the developer agent doctrine to this skill once shipped
+
+### Assessment
+
+**Ready to merge: Yes**
+
+**Reasoning:** Solid first draft of the skill. The single Important item is a small note, not a defect. Minor items are taste calls.
+```
+
+## Red flags
+
+**Never:**
+
+- Skip review because "it's simple"
+- Ignore Critical issues
+- Proceed with unfixed Important issues
+- Argue with valid technical feedback
+
+**If the reviewer is wrong:**
+
+- Push back with technical reasoning
+- Show code/tests that prove it works
+- Request clarification
+
+## When NOT to use this skill
+
+- For the final pre-merge check on a feature branch — that's
+  `/specflow review`, which has broader scope (architecture, quality
+  gates, fmt/lint/typecheck/tests).
+- For security-specific concerns — dispatch `security-auditor` instead.
+- For test-quality concerns specifically — dispatch `test-reviewer`.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3429,6 +3429,298 @@ Specflow ships both because real teams have both flows.
     skipIfExists: false,
   },
   {
+    category: "skill",
+    name: "requesting-code-review",
+    suffix: null,
+    content: `---
+name: requesting-code-review
+description: Use when work is complete enough to need an independent eye — after each task in a subagent-driven plan, after a major feature, before merging to main. Trigger phrases include "review this", "request code review", "review the changes", "review my work", "check this before merge". Dispatches a fresh code-reviewer subagent with precise context and a canonical prompt template.
+---
+
+# Requesting Code Review
+
+Dispatch a code reviewer subagent to catch issues before they cascade.
+The reviewer gets precisely crafted context for evaluation — never your
+session's history. This keeps the reviewer focused on the work product,
+not your thought process, and preserves your own context for continued
+work.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/requesting-code-review/SKILL.md\` + the
+> \`code-reviewer.md\` prompt template. Re-implemented for Specflow with
+> the prompt template inlined here (single file) and integrated with
+> Specflow's bundled \`code-reviewer\` agent.
+
+**Core principle:** Review early, review often.
+
+## When to request review
+
+**Mandatory:**
+
+- After each task in a subagent-driven plan (#272, once shipped)
+- After completing a major feature
+- Before merging to main
+
+**Optional but valuable:**
+
+- When stuck (fresh perspective)
+- Before refactoring (baseline check)
+- After fixing a complex bug
+
+## Specflow integration
+
+Specflow ships a bundled **\`code-reviewer\` agent**
+(\`templates/core/agents/code-reviewer.md\`) that this skill dispatches.
+The agent's system prompt covers Specflow conventions (hexagonal
+layers, byte-identity plugin-sync contract, smoke audit, Windsurf cap,
+backlog-script conventions, …). Use it instead of \`general-purpose\`
+when reviewing changes inside this repo.
+
+For changes that touch security surfaces, also dispatch
+\`security-auditor\` in parallel. For test-only diffs, \`test-reviewer\`
+is the right specialist.
+
+## How to request
+
+**Step 1: Get the git range to review.**
+
+\`\`\`bash
+BASE_SHA=\$(git rev-parse HEAD~1)  # or origin/main, or last task commit
+HEAD_SHA=\$(git rev-parse HEAD)
+\`\`\`
+
+For a subagent-driven task, BASE is the commit at the start of the task,
+HEAD is the current task's commit. For a whole feature, BASE is
+\`origin/main\` and HEAD is the branch tip.
+
+**Step 2: Dispatch the code-reviewer subagent** with the canonical
+prompt template (see below). Use the \`Task\` tool with
+\`subagent_type: code-reviewer\` and pass the four placeholders:
+\`{DESCRIPTION}\`, \`{PLAN_OR_REQUIREMENTS}\`, \`{BASE_SHA}\`, \`{HEAD_SHA}\`.
+
+**Step 3: Act on the feedback.**
+
+- Fix Critical issues immediately. Do not proceed.
+- Fix Important issues before moving to the next task.
+- Note Minor issues for a follow-up commit or a tidy-up later.
+- Push back if the reviewer is wrong — with code/tests/reasoning, not
+  just assertion.
+
+## The canonical reviewer prompt template
+
+Paste this verbatim into a \`Task({subagent_type: "code-reviewer", ...})\`
+dispatch, substituting the four placeholders. The format is mandatory —
+Specflow's two-stage review pattern (spec compliance, then code
+quality; see #272 once shipped) depends on the reviewer returning the
+exact sections below.
+
+\`\`\`\`
+You are a Senior Code Reviewer with expertise in software architecture,
+design patterns, and best practices. Your job is to review completed
+work against its plan or requirements and identify issues before they
+cascade.
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Requirements / Plan
+
+{PLAN_OR_REQUIREMENTS}
+
+## Git Range to Review
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+\`\`\`bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+\`\`\`
+
+## What to Check
+
+**Plan alignment:**
+- Does the implementation match the plan / requirements?
+- Are deviations justified improvements, or problematic departures?
+- Is all planned functionality present?
+
+**Code quality:**
+- Clean separation of concerns?
+- Proper error handling?
+- Type safety where applicable?
+- DRY without premature abstraction?
+- Edge cases handled?
+
+**Architecture:**
+- Sound design decisions?
+- Reasonable scalability and performance?
+- Security concerns?
+- Integrates cleanly with surrounding code?
+
+**Testing:**
+- Tests verify real behavior, not mocks?
+- Edge cases covered?
+- Integration tests where they matter?
+- All tests passing?
+
+**Production readiness:**
+- Migration strategy if schema changed?
+- Backward compatibility considered?
+- Documentation complete?
+- No obvious bugs?
+
+## Calibration
+
+Categorize issues by actual severity. Not everything is Critical.
+Acknowledge what was done well before listing issues — accurate praise
+helps the implementer trust the rest of the feedback.
+
+If you find significant deviations from the plan, flag them specifically
+so the implementer can confirm whether the deviation was intentional.
+If you find issues with the plan itself rather than the implementation,
+say so.
+
+## Output Format
+
+### Strengths
+[What's well done? Be specific.]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (Should Fix)
+[Architecture problems, missing features, poor error handling, test gaps]
+
+#### Minor (Nice to Have)
+[Code style, optimization opportunities, documentation polish]
+
+For each issue:
+- File:line reference
+- What's wrong
+- Why it matters
+- How to fix (if not obvious)
+
+### Recommendations
+[Improvements for code quality, architecture, or process]
+
+### Assessment
+
+**Ready to merge?** [Yes | No | With fixes]
+
+**Reasoning:** [1-2 sentence technical assessment]
+
+## Critical Rules
+
+**DO:**
+- Categorize by actual severity
+- Be specific (file:line, not vague)
+- Explain WHY each issue matters
+- Acknowledge strengths
+- Give a clear verdict
+
+**DON'T:**
+- Say "looks good" without checking
+- Mark nitpicks as Critical
+- Give feedback on code you didn't actually read
+- Be vague ("improve error handling")
+- Avoid giving a clear verdict
+\`\`\`\`
+
+## Two-stage review pattern (subagent-driven only)
+
+Specflow's \`subagent-driven-development\` skill (#272, once shipped)
+runs **two reviews per task**, in this order:
+
+1. **Spec-compliance review** — verifies the implementation matches the
+   plan task verbatim. Nothing more, nothing less. Catches scope creep
+   and missed requirements. Uses a different prompt template focused on
+   plan↔code alignment only.
+
+2. **Code-quality review** — runs only if spec compliance passes. Uses
+   the canonical template above. Catches architecture, testing, and
+   production-readiness gaps.
+
+The order matters: spec compliance is cheap and disqualifies "looks
+clean but builds the wrong thing" implementations. Don't run code
+quality first — you'll waste reviewer cycles on code that has to be
+rewritten anyway.
+
+For one-shot reviews (not subagent-driven), just use the code-quality
+template above. Skip the spec-compliance stage.
+
+## Example dispatch (Claude Code)
+
+\`\`\`typescript
+Task({
+  subagent_type: "code-reviewer",
+  description: "Review writing-plans skill (#271)",
+  prompt: \`<paste the template above with placeholders filled in>\`
+});
+\`\`\`
+
+## Example output
+
+\`\`\`
+### Strengths
+- Clean separation between SKILL.md content and inline prompt template
+- Honest attribution to obra/superpowers MIT with re-implementation note
+- Trigger phrases in description are concrete and match likely user phrasing
+
+### Issues
+
+#### Important
+1. **Missing fallback when code-reviewer agent unavailable**
+   - File: SKILL.md:L42
+   - Issue: skill assumes \`subagent_type: code-reviewer\` exists; on harnesses where the agent isn't bundled, the dispatch will fail silently
+   - Fix: document the \`general-purpose\` fallback explicitly
+
+#### Minor
+1. **Trigger phrase "review this" is broad**
+   - File: SKILL.md:L4
+   - Issue: could over-trigger on conversational uses ("review this list with me")
+   - Impact: low — the user can disambiguate; not worth tightening
+
+### Recommendations
+- Consider linking from the developer agent doctrine to this skill once shipped
+
+### Assessment
+
+**Ready to merge: Yes**
+
+**Reasoning:** Solid first draft of the skill. The single Important item is a small note, not a defect. Minor items are taste calls.
+\`\`\`
+
+## Red flags
+
+**Never:**
+
+- Skip review because "it's simple"
+- Ignore Critical issues
+- Proceed with unfixed Important issues
+- Argue with valid technical feedback
+
+**If the reviewer is wrong:**
+
+- Push back with technical reasoning
+- Show code/tests that prove it works
+- Request clarification
+
+## When NOT to use this skill
+
+- For the final pre-merge check on a feature branch — that's
+  \`/specflow review\`, which has broader scope (architecture, quality
+  gates, fmt/lint/typecheck/tests).
+- For security-specific concerns — dispatch \`security-auditor\` instead.
+- For test-quality concerns specifically — dispatch \`test-reviewer\`.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
     category: "backlog-cmd",
     name: "backlog",
     suffix: null,

--- a/templates/core/skills/requesting-code-review/SKILL.md
+++ b/templates/core/skills/requesting-code-review/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: requesting-code-review
+description: Use when work is complete enough to need an independent eye — after each task in a subagent-driven plan, after a major feature, before merging to main. Trigger phrases include "review this", "request code review", "review the changes", "review my work", "check this before merge". Dispatches a fresh code-reviewer subagent with precise context and a canonical prompt template.
+---
+
+# Requesting Code Review
+
+Dispatch a code reviewer subagent to catch issues before they cascade.
+The reviewer gets precisely crafted context for evaluation — never your
+session's history. This keeps the reviewer focused on the work product,
+not your thought process, and preserves your own context for continued
+work.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/requesting-code-review/SKILL.md` + the
+> `code-reviewer.md` prompt template. Re-implemented for Specflow with
+> the prompt template inlined here (single file) and integrated with
+> Specflow's bundled `code-reviewer` agent.
+
+**Core principle:** Review early, review often.
+
+## When to request review
+
+**Mandatory:**
+
+- After each task in a subagent-driven plan (#272, once shipped)
+- After completing a major feature
+- Before merging to main
+
+**Optional but valuable:**
+
+- When stuck (fresh perspective)
+- Before refactoring (baseline check)
+- After fixing a complex bug
+
+## Specflow integration
+
+Specflow ships a bundled **`code-reviewer` agent**
+(`templates/core/agents/code-reviewer.md`) that this skill dispatches.
+The agent's system prompt covers Specflow conventions (hexagonal
+layers, byte-identity plugin-sync contract, smoke audit, Windsurf cap,
+backlog-script conventions, …). Use it instead of `general-purpose`
+when reviewing changes inside this repo.
+
+For changes that touch security surfaces, also dispatch
+`security-auditor` in parallel. For test-only diffs, `test-reviewer`
+is the right specialist.
+
+## How to request
+
+**Step 1: Get the git range to review.**
+
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main, or last task commit
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+For a subagent-driven task, BASE is the commit at the start of the task,
+HEAD is the current task's commit. For a whole feature, BASE is
+`origin/main` and HEAD is the branch tip.
+
+**Step 2: Dispatch the code-reviewer subagent** with the canonical
+prompt template (see below). Use the `Task` tool with
+`subagent_type: code-reviewer` and pass the four placeholders:
+`{DESCRIPTION}`, `{PLAN_OR_REQUIREMENTS}`, `{BASE_SHA}`, `{HEAD_SHA}`.
+
+**Step 3: Act on the feedback.**
+
+- Fix Critical issues immediately. Do not proceed.
+- Fix Important issues before moving to the next task.
+- Note Minor issues for a follow-up commit or a tidy-up later.
+- Push back if the reviewer is wrong — with code/tests/reasoning, not
+  just assertion.
+
+## The canonical reviewer prompt template
+
+Paste this verbatim into a `Task({subagent_type: "code-reviewer", ...})`
+dispatch, substituting the four placeholders. The format is mandatory —
+Specflow's two-stage review pattern (spec compliance, then code
+quality; see #272 once shipped) depends on the reviewer returning the
+exact sections below.
+
+````
+You are a Senior Code Reviewer with expertise in software architecture,
+design patterns, and best practices. Your job is to review completed
+work against its plan or requirements and identify issues before they
+cascade.
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Requirements / Plan
+
+{PLAN_OR_REQUIREMENTS}
+
+## Git Range to Review
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## What to Check
+
+**Plan alignment:**
+- Does the implementation match the plan / requirements?
+- Are deviations justified improvements, or problematic departures?
+- Is all planned functionality present?
+
+**Code quality:**
+- Clean separation of concerns?
+- Proper error handling?
+- Type safety where applicable?
+- DRY without premature abstraction?
+- Edge cases handled?
+
+**Architecture:**
+- Sound design decisions?
+- Reasonable scalability and performance?
+- Security concerns?
+- Integrates cleanly with surrounding code?
+
+**Testing:**
+- Tests verify real behavior, not mocks?
+- Edge cases covered?
+- Integration tests where they matter?
+- All tests passing?
+
+**Production readiness:**
+- Migration strategy if schema changed?
+- Backward compatibility considered?
+- Documentation complete?
+- No obvious bugs?
+
+## Calibration
+
+Categorize issues by actual severity. Not everything is Critical.
+Acknowledge what was done well before listing issues — accurate praise
+helps the implementer trust the rest of the feedback.
+
+If you find significant deviations from the plan, flag them specifically
+so the implementer can confirm whether the deviation was intentional.
+If you find issues with the plan itself rather than the implementation,
+say so.
+
+## Output Format
+
+### Strengths
+[What's well done? Be specific.]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (Should Fix)
+[Architecture problems, missing features, poor error handling, test gaps]
+
+#### Minor (Nice to Have)
+[Code style, optimization opportunities, documentation polish]
+
+For each issue:
+- File:line reference
+- What's wrong
+- Why it matters
+- How to fix (if not obvious)
+
+### Recommendations
+[Improvements for code quality, architecture, or process]
+
+### Assessment
+
+**Ready to merge?** [Yes | No | With fixes]
+
+**Reasoning:** [1-2 sentence technical assessment]
+
+## Critical Rules
+
+**DO:**
+- Categorize by actual severity
+- Be specific (file:line, not vague)
+- Explain WHY each issue matters
+- Acknowledge strengths
+- Give a clear verdict
+
+**DON'T:**
+- Say "looks good" without checking
+- Mark nitpicks as Critical
+- Give feedback on code you didn't actually read
+- Be vague ("improve error handling")
+- Avoid giving a clear verdict
+````
+
+## Two-stage review pattern (subagent-driven only)
+
+Specflow's `subagent-driven-development` skill (#272, once shipped)
+runs **two reviews per task**, in this order:
+
+1. **Spec-compliance review** — verifies the implementation matches the
+   plan task verbatim. Nothing more, nothing less. Catches scope creep
+   and missed requirements. Uses a different prompt template focused on
+   plan↔code alignment only.
+
+2. **Code-quality review** — runs only if spec compliance passes. Uses
+   the canonical template above. Catches architecture, testing, and
+   production-readiness gaps.
+
+The order matters: spec compliance is cheap and disqualifies "looks
+clean but builds the wrong thing" implementations. Don't run code
+quality first — you'll waste reviewer cycles on code that has to be
+rewritten anyway.
+
+For one-shot reviews (not subagent-driven), just use the code-quality
+template above. Skip the spec-compliance stage.
+
+## Example dispatch (Claude Code)
+
+```typescript
+Task({
+  subagent_type: "code-reviewer",
+  description: "Review writing-plans skill (#271)",
+  prompt: `<paste the template above with placeholders filled in>`
+});
+```
+
+## Example output
+
+```
+### Strengths
+- Clean separation between SKILL.md content and inline prompt template
+- Honest attribution to obra/superpowers MIT with re-implementation note
+- Trigger phrases in description are concrete and match likely user phrasing
+
+### Issues
+
+#### Important
+1. **Missing fallback when code-reviewer agent unavailable**
+   - File: SKILL.md:L42
+   - Issue: skill assumes `subagent_type: code-reviewer` exists; on harnesses where the agent isn't bundled, the dispatch will fail silently
+   - Fix: document the `general-purpose` fallback explicitly
+
+#### Minor
+1. **Trigger phrase "review this" is broad**
+   - File: SKILL.md:L4
+   - Issue: could over-trigger on conversational uses ("review this list with me")
+   - Impact: low — the user can disambiguate; not worth tightening
+
+### Recommendations
+- Consider linking from the developer agent doctrine to this skill once shipped
+
+### Assessment
+
+**Ready to merge: Yes**
+
+**Reasoning:** Solid first draft of the skill. The single Important item is a small note, not a defect. Minor items are taste calls.
+```
+
+## Red flags
+
+**Never:**
+
+- Skip review because "it's simple"
+- Ignore Critical issues
+- Proceed with unfixed Important issues
+- Argue with valid technical feedback
+
+**If the reviewer is wrong:**
+
+- Push back with technical reasoning
+- Show code/tests that prove it works
+- Request clarification
+
+## When NOT to use this skill
+
+- For the final pre-merge check on a feature branch — that's
+  `/specflow review`, which has broader scope (architecture, quality
+  gates, fmt/lint/typecheck/tests).
+- For security-specific concerns — dispatch `security-auditor` instead.
+- For test-quality concerns specifically — dispatch `test-reviewer`.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -24,6 +24,7 @@
     { "category": "phase-script", "name": "release-local", "suffix": "release-local.sh", "source": "core/skills/specflow/scripts/release-local.sh", "executable": true },
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
     { "category": "skill", "name": "writing-plans", "source": "core/skills/writing-plans/SKILL.md" },
+    { "category": "skill", "name": "requesting-code-review", "source": "core/skills/requesting-code-review/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -88,11 +88,11 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
 
     // Top-level skill folders post-consolidation: specflow router +
     // specflow-auto + specflow-review alias + specflow-backlog +
-    // writing-plans (Epic #270 / A1) = 5.
+    // writing-plans (Epic #270 / A1) + requesting-code-review (A3) = 6.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 5);
+    assertEquals(agentsSkillsCount, 6);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -84,11 +84,12 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
 
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review +
-    // writing-plans (#271) + backlog + 11 agents = 30.
+    // writing-plans (#271) + requesting-code-review (#273) + backlog +
+    // 11 agents = 31.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 30);
+    assertEquals(instructionsCount, 31);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -76,11 +76,12 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
 
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review alias +
-    // writing-plans (#271) + backlog + 11 agent workflows = 30.
+    // writing-plans (#271) + requesting-code-review (#273) + backlog +
+    // 11 agent workflows = 31.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 30);
+    assertEquals(workflowsCount, 31);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -54,6 +54,14 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/writing-plans/SKILL.md",
     source: "templates/core/skills/writing-plans/SKILL.md",
   },
+  // requesting-code-review skill — canonical reviewer prompt template +
+  // dispatch guide for Specflow's bundled code-reviewer agent. Foundation
+  // for the two-stage review pattern used by subagent-driven-development
+  // (Epic #270, A3 #273).
+  {
+    plugin: "plugin/skills/requesting-code-review/SKILL.md",
+    source: "templates/core/skills/requesting-code-review/SKILL.md",
+  },
   // Dual-copy agents: 10 sub-agent definitions, each landing as
   // `plugin/agents/<name>.md`. Claude Code resolves agents by file
   // basename in plugin scope; no namespacing needed for invocation


### PR DESCRIPTION
Closes #273. A3 of Epic #270.

## Agent adoption

Specflow now ships a native `requesting-code-review` skill — auto-invoked on user prompts like "review this", "request code review", "review the changes". The skill bundles the **canonical reviewer prompt template** (Strengths / Critical / Important / Minor / Recommendations / Assessment) and documents how to dispatch Specflow's existing `code-reviewer` agent against a precise git range.

The template specifies the exact output format that the upcoming `subagent-driven-development` skill (#272) will require for the code-quality review stage of its two-stage review pattern.

```prompt
After `specflow upgrade`, when you complete a task and want an independent eye, say "review this" or "request code review". The harness auto-invokes the new requesting-code-review skill, which dispatches Specflow's bundled code-reviewer agent (Task subagent_type: code-reviewer) with the canonical prompt template — the same Strengths/Critical/Important/Minor/Assessment format that the developer agent has been using ad-hoc. Now it's a documented contract, not tribal knowledge. The skill also covers the two-stage review pattern (spec compliance first, then code quality) which subagent-driven-development (#272) will mandate.
```

## Single-file design

Upstream `obra/superpowers` splits this into `SKILL.md` (the meta-skill) + `code-reviewer.md` (the prompt template). Specflow inlines the template into `SKILL.md` because we already bundle a `code-reviewer` **agent** (`templates/core/agents/code-reviewer.md`) — this skill becomes the canonical HOW-TO-DISPATCH guide rather than a separate prompt extraction. Cleaner manifest, one fewer file to keep in sync.

## Files

- `templates/core/skills/requesting-code-review/SKILL.md` — 8831 chars
- `plugin/skills/requesting-code-review/SKILL.md` — byte-identical mirror
- `templates/manifest.json` — registers new skill (87 → 88 core entries)
- `tests/plugin/plugin_sync_test.ts` — SYNC_PAIRS extended
- `.claude/skills/test-sandbox/scripts/smoke-features.sh` — 7 new static-grep assertions
- `tests/integration/init_{codex,copilot,windsurf}_test.ts` — scaffolded count +1

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `skills/requesting-code-review/SKILL.md` + `code-reviewer.md`. Re-implemented for Specflow with the template inlined and integrated with Specflow's bundled `code-reviewer` agent.

## Out of scope

- `subagent-driven-development` skill (#272) — the per-task review loop that consumes this skill's template. Lands separately in the next Phase-2 iteration.
- Updating the `developer` agent doctrine to reference this skill — that's a Phase-2 polish item; the agent already dispatches code-reviewer with similar context, the skill just makes the contract explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)