### PR TITLE
feat: SessionStart hook + using-specflow bootstrap skill (#282)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -111,6 +111,27 @@ check "requesting-code-review credits obra/superpowers attribution" \
   'grep -q "obra/superpowers" .claude/skills/requesting-code-review/SKILL.md'
 
 echo
+echo "═══ #282  using-specflow bootstrap skill (Epic #270 / B6) ═══"
+check "using-specflow skill scaffolded" \
+  '[ -f .claude/skills/using-specflow/SKILL.md ]'
+check "using-specflow frontmatter declares name" \
+  'head -5 .claude/skills/using-specflow/SKILL.md | grep -q "name: using-specflow"'
+check "using-specflow describes SessionStart auto-injection" \
+  'head -10 .claude/skills/using-specflow/SKILL.md | grep -q "SessionStart hook"'
+check "using-specflow lists writing-plans skill in registry" \
+  'grep -q "writing-plans" .claude/skills/using-specflow/SKILL.md'
+check "using-specflow lists requesting-code-review skill in registry" \
+  'grep -q "requesting-code-review" .claude/skills/using-specflow/SKILL.md'
+check "using-specflow lists product-owner agent + backlog mutation rule" \
+  'grep -q "product-owner" .claude/skills/using-specflow/SKILL.md'
+check "using-specflow lists devops-sre agent + release advisory rule" \
+  'grep -q "devops-sre" .claude/skills/using-specflow/SKILL.md'
+check "using-specflow points at per-harness tool-mapping references" \
+  'grep -q "references/claude-tools.md\|references/codex-tools.md" .claude/skills/using-specflow/SKILL.md'
+check "using-specflow credits obra/superpowers attribution" \
+  'grep -q "obra/superpowers" .claude/skills/using-specflow/SKILL.md'
+
+echo
 echo "═══ #75  loop.md + groom phase ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
 check "groom phase doc present" \

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\"",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/hooks/session-start
+++ b/plugin/hooks/session-start
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SessionStart hook — Claude Code plugin entry point.
+#
+# Reads the `using-specflow` bootstrap skill from the plugin tree and
+# injects it into the new session as `additionalContext`. Effect: the
+# agent starts every session already knowing Specflow's skill registry,
+# agent registry, and routing principles — no explicit `/specflow` or
+# Skill-tool invocation needed to discover what's available.
+#
+# Output format (Claude Code SessionStart hook contract):
+#   {
+#     "hookSpecificOutput": {
+#       "hookEventName": "SessionStart",
+#       "additionalContext": "<bootstrap skill content>"
+#     }
+#   }
+#
+# Matchers in hooks.json: startup | clear | compact — the bootstrap
+# reloads every time the session context resets, not just at first
+# launch.
+#
+# Inspired by obra/superpowers v5.1.0 (MIT) — hooks/session-start.
+# Re-implemented for Specflow.
+
+set -uo pipefail
+
+# CLAUDE_PLUGIN_ROOT is set by Claude Code's plugin loader before the
+# hook runs. If absent (e.g. running this script standalone for
+# testing), fall back to the script's own parent directory.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SKILL_PATH="$PLUGIN_ROOT/skills/using-specflow/SKILL.md"
+
+if [ ! -f "$SKILL_PATH" ]; then
+  # Skill missing — emit empty hook output so Claude Code proceeds
+  # without bootstrap context. Never fail the session start.
+  echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":""}}'
+  exit 0
+fi
+
+# Strip the YAML frontmatter (everything between the first two `---`
+# lines) so the agent receives only the body content. The frontmatter
+# is metadata for the harness's skill discovery, not for the agent.
+BODY=$(awk '
+  BEGIN { in_fm = 0; saw_fm = 0 }
+  /^---$/ {
+    if (!saw_fm) { in_fm = 1; saw_fm = 1; next }
+    if (in_fm) { in_fm = 0; next }
+  }
+  !in_fm && saw_fm { print }
+' "$SKILL_PATH")
+
+# JSON-escape the body. `jq -Rs .` reads stdin as a raw string and
+# emits a properly-quoted JSON string (handles \", \n, \\, control
+# chars, unicode). If jq isn't available, fall back to a basic
+# escape (less robust but adequate for ASCII-only content).
+if command -v jq >/dev/null 2>&1; then
+  ESCAPED=$(printf '%s' "$BODY" | jq -Rs .)
+else
+  # Minimal fallback: escape backslashes, double-quotes, and newlines.
+  ESCAPED=$(printf '%s' "$BODY" \
+    | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+    | awk 'BEGIN{ORS=""} {gsub(/\n/, "\\n"); print}')
+  ESCAPED="\"$ESCAPED\""
+fi
+
+# Emit the SessionStart hook output. `additionalContext` is the
+# documented field name Claude Code reads to inject text into the
+# agent's session context.
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":%s}}\n' "$ESCAPED"

--- a/plugin/skills/using-specflow/SKILL.md
+++ b/plugin/skills/using-specflow/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: using-specflow
+description: Bootstrap skill loaded at session start. Teaches the agent how to discover and invoke Specflow's bundled skills, agents, and slash commands. Auto-injected by the SessionStart hook on harnesses that support hooks (Claude Code, Cursor); on other harnesses, read this file once per session before answering Specflow-related questions.
+---
+
+# Using Specflow
+
+This is the bootstrap skill that makes the agent **Specflow-aware** on
+every turn. It does not do any work itself — it points the agent at the
+right Specflow skill / agent / slash command for the user's intent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/SKILL.md`. Re-implemented for
+> Specflow's skill ecosystem.
+
+## The rule
+
+**If you think there is even a 1% chance a Specflow skill applies to
+what the user is asking, invoke it.** Skills override default behaviour
+where they apply.
+
+User instructions in `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, or direct
+requests always take precedence over a skill's defaults. If the user
+says "skip TDD" and a skill says "always TDD", follow the user.
+
+## How to invoke a Specflow skill
+
+Use the harness's `Skill` tool (Claude Code) or the equivalent
+(`activate_skill` on Gemini, `skill` on Codex/OpenCode/Copilot — see
+`references/<harness>-tools.md` for your harness).
+
+The skill content is loaded into your context. Follow it directly — do
+not re-read the file with `Read`.
+
+## Specflow skill registry
+
+| Skill | When to invoke |
+|---|---|
+| `specflow` (router) | User typed `/specflow <phase>` or asked for the spec-kit pipeline (`/specflow specify → plan → tasks → analyze → implement → review → merge`). Greenfield features with formal specs. |
+| `writing-plans` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
+| `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
+| `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
+| `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
+| `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |
+
+## Specflow agent registry
+
+Dispatch these via `Task({ subagent_type: "<name>", ... })` (or your
+harness's equivalent — see `references/<harness>-tools.md`).
+
+| Agent | When to dispatch |
+|---|---|
+| `developer` | Implementing tasks from a plan (TDD, frequent commits, in-code documentation). |
+| `code-reviewer` | Reviewing diffs against a plan or requirements. Use the prompt template from `requesting-code-review` skill. |
+| `security-auditor` | Security review or alert triage on Specflow-shipped code. |
+| `test-reviewer` | Test-quality-only review (no architecture). |
+| `product-owner` | **Every** backlog mutation goes through this agent — no exceptions. Read-only inspection (`list.sh`, `view.sh`) can be done directly. |
+| `qa-tester` | Run the QA scenario catalogue against the released binary. |
+| `devops-sre` | Advisory pass before editing `.github/workflows/`, `install.sh`, `scripts/build.ts`, the homebrew tap, or running `/release`. |
+| `architect` | Architecture-aware research before non-trivial cross-subsystem changes. |
+| `specflow-expert` | Specflow-specific consulting on the binary, plugin, or scaffolded project state. |
+| `review-coordinator` | Orchestrates the implement → review → fix loop for `/specflow implement`. |
+| `workflow-manager` | High-level workflow orchestration across phases. |
+
+## Routing principles
+
+1. **`/specflow plan` vs `writing-plans`** — both produce plans, but for
+   different inputs:
+   - `/specflow plan` follows the spec-kit flow (consumes `spec.md`,
+     produces `research.md` + `data-model.md` + `contracts/` +
+     `quickstart.md`). Use for greenfield features with formal contracts.
+   - `writing-plans` (skill) takes a free-form issue or requirement and
+     produces a single executable plan file with bite-sized TDD tasks.
+     Use for issue-driven and ad-hoc work.
+
+2. **Backlog mutations → `product-owner`** — never call `add.sh`,
+   `move.sh`, `set-field.sh`, or `gh issue {create,close,edit}`
+   directly. Dispatch the PO. The PO knows about classification gates,
+   sub-issue links, soft date axes, and reporting conventions.
+
+3. **Releases & pipelines → `devops-sre` first** — before editing CI
+   workflows, `install.sh`, build scripts, or running `/release`,
+   dispatch `devops-sre` for an advisory pass. The agent is read-only;
+   the main session executes after the advisory.
+
+4. **Architecture-level work → `architect` first** — non-trivial
+   changes that cross subsystems (new CLI command, new application
+   use case, new port, new infrastructure adapter, new harness target,
+   changes to bundling / install / release flow, changes to the
+   lock-file or backlog-sync contract). The architect returns a design
+   proposal grounded in the current code; main session implements.
+
+## Skill discovery on different harnesses
+
+This file may run on any of Specflow's plugin-distribution targets:
+Claude Code, Codex CLI, Codex App, Cursor, Gemini CLI, OpenCode,
+GitHub Copilot CLI. Each harness uses different tool names —
+`Read` vs `read_file`, `Task` vs `spawn_agent`, etc.
+
+Before invoking any tool, consult the right reference:
+
+- Claude Code (baseline) → `references/claude-tools.md`
+- Codex → `references/codex-tools.md`
+- Cursor → `references/cursor-tools.md`
+- Gemini CLI → `references/gemini-tools.md`
+- OpenCode → `references/opencode-tools.md`
+- Copilot CLI → `references/copilot-tools.md`
+
+Auto-detect the running harness by looking for env hints
+(`CLAUDE_PLUGIN_ROOT`, `CURSOR_*`, `CODEX_*`, etc.) or by inspecting
+the available tool list in your current context.
+
+## Red flags — these thoughts mean "stop and check for a skill"
+
+| Thought | Reality |
+|---|---|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read the current version. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "Kevin asked me to do X, just go" | Kevin's order is honored; the skill tells you HOW to honor it. |
+
+## When NOT to invoke any Specflow skill
+
+- Pure conversation (greetings, clarifying chat, "thanks").
+- Questions about another repo / project unrelated to Specflow.
+- Single-keystroke / single-word user inputs that need clarification
+  before action (ask the user, then re-evaluate).
+
+## Skill priority
+
+When multiple Specflow skills could apply, use this order:
+
+1. **Process skills first** — `writing-plans` before any implementation;
+   `requesting-code-review` after every task in a subagent-driven flow.
+2. **Domain skills second** — `backlog` for backlog inquiries,
+   `specflow` (router) for spec-kit phases.
+
+"Let's build X" → `writing-plans` first, then implementation skills.
+"Fix this bug" → diagnose first (read the code), then `writing-plans`
+if the fix needs more than 2 changes, otherwise just fix.
+
+## Out of scope
+
+This bootstrap skill is loaded by the SessionStart hook to make the
+agent skill-aware. It does not:
+
+- Execute any backlog / git / build commands itself
+- Replace the per-skill SKILL.md files (read those when invoking a
+  specific skill)
+- Override `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` project directives
+
+For per-harness adapter details, see the manifest at
+`plugin/.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, `gemini-extension.json`, or the
+`.opencode/plugins/specflow.js` adapter (issues #277–#280).

--- a/plugin/skills/using-specflow/references/claude-tools.md
+++ b/plugin/skills/using-specflow/references/claude-tools.md
@@ -1,0 +1,51 @@
+# Claude Code — baseline tool reference
+
+Specflow skills are authored using **Claude Code tool names** as the lingua
+franca. This file documents the canonical Claude Code tool set that other
+harness adapters (`codex-tools.md`, `cursor-tools.md`, `gemini-tools.md`,
+`opencode-tools.md`, `copilot-tools.md`) translate.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/`. Re-implemented for
+> Specflow's harness coverage.
+
+## Canonical tool set
+
+| Tool | Purpose |
+|---|---|
+| `Read` | Read a file from disk; supports image / PDF / notebook formats. |
+| `Write` | Write or overwrite a file from scratch. |
+| `Edit` | Exact-string replace in a file (must Read first). |
+| `Bash` | Run a shell command in the project working directory. |
+| `Skill` | Invoke another skill by name (`Skill({skill: "<name>", args: "…"})`). |
+| `Task` | Dispatch a subagent for a delegated task (`Task({subagent_type: "general-purpose", description: "…", prompt: "…"})`). |
+| `TodoWrite` | Persist a checklist for multi-step work. |
+| `WebSearch` | Search the web for current information. |
+| `WebFetch` | Fetch a URL and process it with a prompt. |
+| `Grep` / `Glob` | Search file contents or file paths. |
+
+## Conventions used by Specflow skills
+
+- **File paths** are always absolute, except inside markdown documentation
+  where project-relative paths read better.
+- **Subagents** spawned via `Task` receive precisely the context they need —
+  never the controller's full history. See the
+  [`subagent-driven-development`](../../subagent-driven-development/SKILL.md)
+  skill for the dispatch pattern.
+- **Skills** invoked via `Skill` are listed in the harness-provided
+  "available skills" registry; only use names that appear there.
+- **Slash commands** the user types (`/specflow plan`, `/backlog …`) are
+  resolved by the harness to a skill invocation — Specflow itself never
+  registers raw commands outside the skill layer.
+
+## When this file is the wrong reference
+
+You are on Claude Code only. If you are running in:
+- Codex CLI / App → see `codex-tools.md`
+- Cursor → see `cursor-tools.md`
+- Gemini CLI → see `gemini-tools.md`
+- OpenCode → see `opencode-tools.md`
+- GitHub Copilot CLI → see `copilot-tools.md`
+
+The `using-specflow` bootstrap skill auto-detects the running harness and
+loads the right reference at session start.

--- a/plugin/skills/using-specflow/references/codex-tools.md
+++ b/plugin/skills/using-specflow/references/codex-tools.md
@@ -1,0 +1,60 @@
+# Codex CLI / Codex App — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps every Claude Code tool to its Codex equivalent so a skill that says
+`Use Task to dispatch a subagent` reads correctly when Specflow runs
+inside Codex.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/codex-tools.md`.
+> Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | Codex | Notes |
+|---|---|---|
+| `Read` | `read_file` | Same argument shape (`path`). |
+| `Write` | `write_file` | Same shape; pass `content`. |
+| `Edit` | `apply_patch` | Codex uses a unified-diff style patch tool; the Edit semantic (old_string → new_string) maps to a one-hunk patch. |
+| `Bash` | `shell` | Same shape; Codex's `shell` runs in the workspace cwd. |
+| `Skill` | `skill` | Codex exposes a native `skill` tool — pass the skill name and args. |
+| `Task` | `spawn_agent` / `wait_agent` / `close_agent` | Three-step protocol: spawn, wait for completion, close. Wrap in a helper if you dispatch frequently. |
+| `TodoWrite` | `update_plan` | Codex's planner exposes a structured update API; pass the full updated plan, not deltas. |
+| `WebSearch` | `web.search` | Available only if the user has enabled web tools. |
+| `WebFetch` | `web.fetch` | Same. |
+| `Grep` | `shell` invoking `grep` / `rg` | No native grep tool — shell out. |
+| `Glob` | `shell` invoking `find` / `fd` | No native glob tool — shell out. |
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on Codex, expand to:
+
+```
+id = spawn_agent(agent_type="code-reviewer", prompt="<full prompt>")
+result = wait_agent(id, timeout=900)
+close_agent(id)
+```
+
+If the wait times out, decide whether to retry or to surface the partial
+result to the user.
+
+## Idiom differences worth noting
+
+- **Plan updates** are heavyweight on Codex — `update_plan` rewrites the
+  full plan each call. Don't call it per-step; call it at task boundaries.
+- **`apply_patch`** rejects malformed patches more strictly than Claude
+  Code's `Edit`. Always confirm a Read of the target file before patching.
+- **Subagent timeout** defaults vary; pass `timeout=` explicitly for any
+  dispatch you expect to take > 5 minutes.
+
+## Manifest pointer
+
+For the Codex marketplace adapter (`.codex-plugin/plugin.json`), the
+canonical install entry is:
+
+```
+/plugins  → search "specflow" → install
+```
+
+(Once Specflow ships to the Codex marketplace; see issue #277.)

--- a/plugin/skills/using-specflow/references/copilot-tools.md
+++ b/plugin/skills/using-specflow/references/copilot-tools.md
@@ -1,0 +1,80 @@
+# GitHub Copilot CLI — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its GitHub Copilot CLI equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/copilot-tools.md`.
+> Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | Copilot CLI | Notes |
+|---|---|---|
+| `Read` | `read` | Same shape. |
+| `Write` | `write` | Same. |
+| `Edit` | `edit` | Same. |
+| `Bash` | `bash` | Same. |
+| `Skill` | `skill` | Native — invokes a registered plugin skill. |
+| `Task` | `task` with `agent_type` parameter | Copilot's task tool takes `agent_type` to select a subagent (similar to Claude Code's `subagent_type`). |
+| `TodoWrite` | `sql` with built-in `todos` table | Copilot exposes a SQLite-backed durable state via the `sql` tool; the `todos` table is its checklist primitive. |
+| `WebSearch` | `web_search` | Same. |
+| `WebFetch` | `web_fetch` | Same. |
+| `Grep` | `grep` | Same. |
+| `Glob` | `glob` | Same. |
+
+## Plugin marketplace
+
+Copilot CLI distributes plugins through a **marketplace repository** — a
+separate GitHub repo registered with `copilot plugin marketplace add`.
+The Specflow marketplace (see issue #281) lives at
+`mkrlabs/specflow-marketplace` (planned) and registers Specflow as
+`specflow@specflow-marketplace`.
+
+Install flow for end users:
+
+```bash
+copilot plugin marketplace add mkrlabs/specflow-marketplace
+copilot plugin install specflow@specflow-marketplace
+```
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on Copilot CLI, expand to:
+
+```
+task({
+  agent_type: "code-reviewer",
+  description: "Review changes against the plan",
+  prompt: "<full prompt>"
+})
+```
+
+The agent runs in an isolated context and returns when complete. The
+calling skill gets the subagent's final report as the tool's return
+value.
+
+## Idiom differences worth noting
+
+- **`sql` for state.** Copilot's `TodoWrite` equivalent is a structured
+  database insert/update. Skill prose that says "track this in a TODO
+  list" needs the adapter to translate to a `sql` insert into the
+  `todos` table. The `using-specflow` bootstrap skill explains the
+  schema.
+- **No `WebFetch` slug.** Copilot uses `web_fetch` (snake_case) where
+  Claude Code uses `WebFetch` (PascalCase). The mapping is the only
+  difference — the semantics are identical.
+- **SessionStart hook.** Copilot's hook system uses
+  `{"additionalContext": "..."}` as the injection format (SDK standard).
+  The Specflow Copilot SessionStart hook (see #282) reads the
+  `using-specflow` bootstrap skill and emits this shape at session
+  boot.
+
+## Auto-activation
+
+Copilot honors the same `description:` frontmatter contract as Claude
+Code and Cursor — when the user's prompt matches phrases in a skill's
+`description:` field, Copilot invokes the skill. The SessionStart hook
+(once #282 lands) ensures `using-specflow` is loaded so the agent knows
+which Specflow skill to pick for which user phrasing.

--- a/plugin/skills/using-specflow/references/cursor-tools.md
+++ b/plugin/skills/using-specflow/references/cursor-tools.md
@@ -1,0 +1,53 @@
+# Cursor — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its Cursor Agent equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/`. Re-implemented for
+> Specflow.
+
+## Tool mapping
+
+| Claude Code | Cursor Agent | Notes |
+|---|---|---|
+| `Read` | `read_file` | Cursor's read tool returns the file with line numbers. |
+| `Write` | `edit_file` (full overwrite) | Cursor uses one `edit_file` tool for both create and edit; pass the full new content. |
+| `Edit` | `edit_file` (partial) | Same tool, pass a precise edit specification. |
+| `Bash` | `run_terminal_cmd` | Same shape; pass `command` + `is_background`. |
+| `Skill` | `Skill` | Cursor's Agent plugin format exposes a native `Skill` tool with the same shape as Claude Code. |
+| `Task` | `Task` via Agent plugin | Cursor supports subagent dispatch when the plugin declares `agents` in its manifest. |
+| `TodoWrite` | `todo_write` | Cursor's todo tool, semantically equivalent. |
+| `WebSearch` | `web_search` | Same. |
+| `WebFetch` | `web_search` + manual read | Cursor doesn't expose a separate URL-fetch tool; use `web_search` then `read_file` on the result if it's local. |
+| `Grep` / `Glob` | `grep_search` / `file_search` | Cursor exposes both natively with similar arguments. |
+
+## Idiom differences worth noting
+
+- **`edit_file` is unified.** Cursor doesn't distinguish `Write` (create
+  new) from `Edit` (modify existing); the same tool does both based on
+  whether the path exists. Skill authors should still write "create" or
+  "modify" in prose for clarity to other harnesses.
+- **Hooks live in `hooks-cursor.json`**, not `hooks.json`. Cursor uses
+  `snake_case` field names (`session_start`, `pre_tool_use`) where
+  Claude Code uses `camelCase` (`SessionStart`, `PreToolUse`). The
+  Specflow Cursor adapter handles the translation; skill content stays
+  uniform.
+- **Plugin manifest** uses `.cursor-plugin/plugin.json` with keys
+  `{skills, agents, commands, hooks}` (see issue #278 for the adapter).
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` works
+on Cursor identically to Claude Code, **provided the plugin's
+`.cursor-plugin/plugin.json` declares `agents: "./agents/"`**. Without
+that declaration, Cursor's Agent doesn't see the subagent definitions
+and the dispatch falls back to inline execution.
+
+## Auto-activation
+
+Cursor honors the same `description:` frontmatter contract as Claude
+Code — when the user's prompt matches phrases in a skill's `description:`
+field, Cursor invokes the skill automatically. The `SessionStart` hook
+(via `hooks-cursor.json`) injects the `using-specflow` bootstrap skill
+to make Specflow skill-aware on every turn.

--- a/plugin/skills/using-specflow/references/gemini-tools.md
+++ b/plugin/skills/using-specflow/references/gemini-tools.md
@@ -1,0 +1,69 @@
+# Gemini CLI — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its Gemini CLI equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/references/gemini-tools.md`.
+> Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | Gemini CLI | Notes |
+|---|---|---|
+| `Read` | `read_file` | Same argument shape. |
+| `Write` | `write_file` | Same. |
+| `Edit` | `replace` | Gemini's edit tool is named `replace`; pass `file_path`, `old_string`, `new_string`. |
+| `Bash` | `run_shell_command` | Same shape; pass `command`. |
+| `Skill` | `activate_skill` | Gemini's skill-invocation tool. |
+| `Task` | `@generalist` subagent | Gemini uses `@`-mention syntax for subagent dispatch. The `@generalist` agent is the catch-all equivalent of Claude Code's `general-purpose`. |
+| `TodoWrite` | `save_memory` for persistence; `todo` for in-session checklists | Gemini's persistent state model is split into ephemeral todos and durable memory. Pick the right one for context. |
+| `WebSearch` | `google_web_search` | Native — same shape. |
+| `WebFetch` | `web_fetch` | Same. |
+| `Grep` | `search_file_content` | Native grep equivalent. |
+| `Glob` | `glob` | Native. |
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on Gemini, expand to:
+
+```
+@generalist Please review the following code change against the plan:
+[paste full prompt content]
+```
+
+The `@`-mention triggers a fresh subagent context; pass the entire prompt
+as the message body. Wait for the subagent's response in the same chat
+stream — there is no separate `wait_agent` call.
+
+## Extension manifest
+
+Gemini CLI consumes plugins as **extensions**, not as Claude-style
+plugins. The Specflow extension manifest (see issue #279) lives at the
+repo root:
+
+```json
+{
+  "name": "specflow",
+  "description": "...",
+  "version": "1.x.x",
+  "contextFileName": "GEMINI.md"
+}
+```
+
+The `contextFileName` points at a `GEMINI.md` file that Gemini loads at
+session start (parallel to `CLAUDE.md` for Claude Code). The
+`using-specflow` bootstrap skill references this file from inside Gemini.
+
+## Idiom differences worth noting
+
+- **No persistent plan tool.** Gemini lacks a direct `TodoWrite`
+  equivalent for ephemeral plans; skill prose should describe the plan
+  in markdown and let the LLM maintain it in context, or use
+  `save_memory` for plans that must survive a session boundary.
+- **Subagents share the chat.** Unlike Claude Code's isolated `Task`
+  context, `@generalist` runs in the same conversation thread. Be
+  explicit about what context the subagent should attend to.
+- **Install command**: `gemini extensions install https://github.com/mkrlabs/specflow`
+  (once the extension manifest ships — issue #279).

--- a/plugin/skills/using-specflow/references/opencode-tools.md
+++ b/plugin/skills/using-specflow/references/opencode-tools.md
@@ -1,0 +1,90 @@
+# OpenCode — tool reference
+
+Specflow skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its OpenCode equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `.opencode/plugins/superpowers.js` adapter and inline tool
+> mappings. Re-implemented for Specflow.
+
+## Tool mapping
+
+| Claude Code | OpenCode | Notes |
+|---|---|---|
+| `Read` | `read` | OpenCode's read tool. |
+| `Write` | `write` | Same. |
+| `Edit` | `edit` | Same. |
+| `Bash` | `bash` | Same shape. |
+| `Skill` | `skill` | OpenCode exposes a native skill-invocation tool, lowercase. |
+| `Task` | `@`-mention subagent | OpenCode uses `@<agent-name>` syntax to dispatch subagents declared by the plugin. |
+| `TodoWrite` | `todowrite` | Lowercase variant. |
+| `WebSearch` | `websearch` | Lowercase. |
+| `WebFetch` | `webfetch` | Lowercase. |
+| `Grep` | `grep` | Same. |
+| `Glob` | `glob` | Same. |
+
+## Plugin shape — JavaScript adapter
+
+OpenCode plugins ship as JavaScript files (not JSON manifests). The
+Specflow adapter (see issue #280) lives at
+`.opencode/plugins/specflow.js` and registers itself via OpenCode's
+plugin loader:
+
+```javascript
+// Pseudo-shape based on superpowers' adapter pattern.
+module.exports = function specflow(config) {
+  const skillsDir = path.join(__dirname, "../../skills");
+  config.skills = config.skills || {};
+  config.skills.paths = config.skills.paths || [];
+  if (!config.skills.paths.includes(skillsDir)) {
+    config.skills.paths.push(skillsDir);
+  }
+  // Hook the SessionStart event to inject the using-specflow bootstrap.
+  config.experimental = config.experimental || {};
+  config.experimental.chat = config.experimental.chat || {};
+  config.experimental.chat.messages = config.experimental.chat.messages || {};
+  // ...
+};
+```
+
+Concrete implementation lands in #280.
+
+## Install instructions
+
+Add to the user's `opencode.json`:
+
+```json
+{
+  "plugin": [
+    "specflow@git+https://github.com/mkrlabs/specflow.git"
+  ]
+}
+```
+
+OpenCode fetches the repo, runs the adapter at session start, and the
+Specflow skills register themselves.
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads `Use Task to dispatch a code reviewer subagent` should,
+on OpenCode, expand to:
+
+```
+@code-reviewer Please review the following code change against the plan:
+[paste full prompt content]
+```
+
+The `@`-mention triggers the subagent declared in the plugin's `agents/`
+directory. Wait for the response in the same chat thread.
+
+## Idiom differences worth noting
+
+- **No JSON manifest.** OpenCode's plugin system is code-driven, not
+  declarative. The adapter has to perform skill registration imperatively
+  in its function body.
+- **Skills resolved by path.** OpenCode reads `config.skills.paths` and
+  walks each directory for `SKILL.md` files. Specflow's skills live under
+  the plugin repo's `skills/` directory and are auto-discovered.
+- **Lowercase tool names** throughout. Skill prose that says "use the
+  Bash tool" still works because OpenCode's LLM understands the mapping,
+  but the actual tool name in JSON tool-use blocks is `bash`.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3721,6 +3721,174 @@ Task({
     skipIfExists: false,
   },
   {
+    category: "skill",
+    name: "using-specflow",
+    suffix: null,
+    content: `---
+name: using-specflow
+description: Bootstrap skill loaded at session start. Teaches the agent how to discover and invoke Specflow's bundled skills, agents, and slash commands. Auto-injected by the SessionStart hook on harnesses that support hooks (Claude Code, Cursor); on other harnesses, read this file once per session before answering Specflow-related questions.
+---
+
+# Using Specflow
+
+This is the bootstrap skill that makes the agent **Specflow-aware** on
+every turn. It does not do any work itself — it points the agent at the
+right Specflow skill / agent / slash command for the user's intent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/using-superpowers/SKILL.md\`. Re-implemented for
+> Specflow's skill ecosystem.
+
+## The rule
+
+**If you think there is even a 1% chance a Specflow skill applies to
+what the user is asking, invoke it.** Skills override default behaviour
+where they apply.
+
+User instructions in \`CLAUDE.md\`, \`AGENTS.md\`, \`GEMINI.md\`, or direct
+requests always take precedence over a skill's defaults. If the user
+says "skip TDD" and a skill says "always TDD", follow the user.
+
+## How to invoke a Specflow skill
+
+Use the harness's \`Skill\` tool (Claude Code) or the equivalent
+(\`activate_skill\` on Gemini, \`skill\` on Codex/OpenCode/Copilot — see
+\`references/<harness>-tools.md\` for your harness).
+
+The skill content is loaded into your context. Follow it directly — do
+not re-read the file with \`Read\`.
+
+## Specflow skill registry
+
+| Skill | When to invoke |
+|---|---|
+| \`specflow\` (router) | User typed \`/specflow <phase>\` or asked for the spec-kit pipeline (\`/specflow specify → plan → tasks → analyze → implement → review → merge\`). Greenfield features with formal specs. |
+| \`writing-plans\` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
+| \`requesting-code-review\` | Work is complete enough to need an independent eye. Dispatch the bundled \`code-reviewer\` agent with the canonical prompt template. |
+| \`backlog\` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the \`product-owner\` agent. |
+| \`specflow-auto\` | Auto-chain orchestration (legacy entry point — most users invoke \`/specflow specify\` instead). |
+| \`specflow-review\` | Auto-invoke alias preserved for the \`/specflow review\` phase. |
+
+## Specflow agent registry
+
+Dispatch these via \`Task({ subagent_type: "<name>", ... })\` (or your
+harness's equivalent — see \`references/<harness>-tools.md\`).
+
+| Agent | When to dispatch |
+|---|---|
+| \`developer\` | Implementing tasks from a plan (TDD, frequent commits, in-code documentation). |
+| \`code-reviewer\` | Reviewing diffs against a plan or requirements. Use the prompt template from \`requesting-code-review\` skill. |
+| \`security-auditor\` | Security review or alert triage on Specflow-shipped code. |
+| \`test-reviewer\` | Test-quality-only review (no architecture). |
+| \`product-owner\` | **Every** backlog mutation goes through this agent — no exceptions. Read-only inspection (\`list.sh\`, \`view.sh\`) can be done directly. |
+| \`qa-tester\` | Run the QA scenario catalogue against the released binary. |
+| \`devops-sre\` | Advisory pass before editing \`.github/workflows/\`, \`install.sh\`, \`scripts/build.ts\`, the homebrew tap, or running \`/release\`. |
+| \`architect\` | Architecture-aware research before non-trivial cross-subsystem changes. |
+| \`specflow-expert\` | Specflow-specific consulting on the binary, plugin, or scaffolded project state. |
+| \`review-coordinator\` | Orchestrates the implement → review → fix loop for \`/specflow implement\`. |
+| \`workflow-manager\` | High-level workflow orchestration across phases. |
+
+## Routing principles
+
+1. **\`/specflow plan\` vs \`writing-plans\`** — both produce plans, but for
+   different inputs:
+   - \`/specflow plan\` follows the spec-kit flow (consumes \`spec.md\`,
+     produces \`research.md\` + \`data-model.md\` + \`contracts/\` +
+     \`quickstart.md\`). Use for greenfield features with formal contracts.
+   - \`writing-plans\` (skill) takes a free-form issue or requirement and
+     produces a single executable plan file with bite-sized TDD tasks.
+     Use for issue-driven and ad-hoc work.
+
+2. **Backlog mutations → \`product-owner\`** — never call \`add.sh\`,
+   \`move.sh\`, \`set-field.sh\`, or \`gh issue {create,close,edit}\`
+   directly. Dispatch the PO. The PO knows about classification gates,
+   sub-issue links, soft date axes, and reporting conventions.
+
+3. **Releases & pipelines → \`devops-sre\` first** — before editing CI
+   workflows, \`install.sh\`, build scripts, or running \`/release\`,
+   dispatch \`devops-sre\` for an advisory pass. The agent is read-only;
+   the main session executes after the advisory.
+
+4. **Architecture-level work → \`architect\` first** — non-trivial
+   changes that cross subsystems (new CLI command, new application
+   use case, new port, new infrastructure adapter, new harness target,
+   changes to bundling / install / release flow, changes to the
+   lock-file or backlog-sync contract). The architect returns a design
+   proposal grounded in the current code; main session implements.
+
+## Skill discovery on different harnesses
+
+This file may run on any of Specflow's plugin-distribution targets:
+Claude Code, Codex CLI, Codex App, Cursor, Gemini CLI, OpenCode,
+GitHub Copilot CLI. Each harness uses different tool names —
+\`Read\` vs \`read_file\`, \`Task\` vs \`spawn_agent\`, etc.
+
+Before invoking any tool, consult the right reference:
+
+- Claude Code (baseline) → \`references/claude-tools.md\`
+- Codex → \`references/codex-tools.md\`
+- Cursor → \`references/cursor-tools.md\`
+- Gemini CLI → \`references/gemini-tools.md\`
+- OpenCode → \`references/opencode-tools.md\`
+- Copilot CLI → \`references/copilot-tools.md\`
+
+Auto-detect the running harness by looking for env hints
+(\`CLAUDE_PLUGIN_ROOT\`, \`CURSOR_*\`, \`CODEX_*\`, etc.) or by inspecting
+the available tool list in your current context.
+
+## Red flags — these thoughts mean "stop and check for a skill"
+
+| Thought | Reality |
+|---|---|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read the current version. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "Kevin asked me to do X, just go" | Kevin's order is honored; the skill tells you HOW to honor it. |
+
+## When NOT to invoke any Specflow skill
+
+- Pure conversation (greetings, clarifying chat, "thanks").
+- Questions about another repo / project unrelated to Specflow.
+- Single-keystroke / single-word user inputs that need clarification
+  before action (ask the user, then re-evaluate).
+
+## Skill priority
+
+When multiple Specflow skills could apply, use this order:
+
+1. **Process skills first** — \`writing-plans\` before any implementation;
+   \`requesting-code-review\` after every task in a subagent-driven flow.
+2. **Domain skills second** — \`backlog\` for backlog inquiries,
+   \`specflow\` (router) for spec-kit phases.
+
+"Let's build X" → \`writing-plans\` first, then implementation skills.
+"Fix this bug" → diagnose first (read the code), then \`writing-plans\`
+if the fix needs more than 2 changes, otherwise just fix.
+
+## Out of scope
+
+This bootstrap skill is loaded by the SessionStart hook to make the
+agent skill-aware. It does not:
+
+- Execute any backlog / git / build commands itself
+- Replace the per-skill SKILL.md files (read those when invoking a
+  specific skill)
+- Override \`CLAUDE.md\` / \`AGENTS.md\` / \`GEMINI.md\` project directives
+
+For per-harness adapter details, see the manifest at
+\`plugin/.claude-plugin/plugin.json\`, \`.cursor-plugin/plugin.json\`,
+\`.codex-plugin/plugin.json\`, \`gemini-extension.json\`, or the
+\`.opencode/plugins/specflow.js\` adapter (issues #277–#280).
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
     category: "backlog-cmd",
     name: "backlog",
     suffix: null,

--- a/templates/core/skills/using-specflow/SKILL.md
+++ b/templates/core/skills/using-specflow/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: using-specflow
+description: Bootstrap skill loaded at session start. Teaches the agent how to discover and invoke Specflow's bundled skills, agents, and slash commands. Auto-injected by the SessionStart hook on harnesses that support hooks (Claude Code, Cursor); on other harnesses, read this file once per session before answering Specflow-related questions.
+---
+
+# Using Specflow
+
+This is the bootstrap skill that makes the agent **Specflow-aware** on
+every turn. It does not do any work itself — it points the agent at the
+right Specflow skill / agent / slash command for the user's intent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/using-superpowers/SKILL.md`. Re-implemented for
+> Specflow's skill ecosystem.
+
+## The rule
+
+**If you think there is even a 1% chance a Specflow skill applies to
+what the user is asking, invoke it.** Skills override default behaviour
+where they apply.
+
+User instructions in `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, or direct
+requests always take precedence over a skill's defaults. If the user
+says "skip TDD" and a skill says "always TDD", follow the user.
+
+## How to invoke a Specflow skill
+
+Use the harness's `Skill` tool (Claude Code) or the equivalent
+(`activate_skill` on Gemini, `skill` on Codex/OpenCode/Copilot — see
+`references/<harness>-tools.md` for your harness).
+
+The skill content is loaded into your context. Follow it directly — do
+not re-read the file with `Read`.
+
+## Specflow skill registry
+
+| Skill | When to invoke |
+|---|---|
+| `specflow` (router) | User typed `/specflow <phase>` or asked for the spec-kit pipeline (`/specflow specify → plan → tasks → analyze → implement → review → merge`). Greenfield features with formal specs. |
+| `writing-plans` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
+| `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
+| `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
+| `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
+| `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |
+
+## Specflow agent registry
+
+Dispatch these via `Task({ subagent_type: "<name>", ... })` (or your
+harness's equivalent — see `references/<harness>-tools.md`).
+
+| Agent | When to dispatch |
+|---|---|
+| `developer` | Implementing tasks from a plan (TDD, frequent commits, in-code documentation). |
+| `code-reviewer` | Reviewing diffs against a plan or requirements. Use the prompt template from `requesting-code-review` skill. |
+| `security-auditor` | Security review or alert triage on Specflow-shipped code. |
+| `test-reviewer` | Test-quality-only review (no architecture). |
+| `product-owner` | **Every** backlog mutation goes through this agent — no exceptions. Read-only inspection (`list.sh`, `view.sh`) can be done directly. |
+| `qa-tester` | Run the QA scenario catalogue against the released binary. |
+| `devops-sre` | Advisory pass before editing `.github/workflows/`, `install.sh`, `scripts/build.ts`, the homebrew tap, or running `/release`. |
+| `architect` | Architecture-aware research before non-trivial cross-subsystem changes. |
+| `specflow-expert` | Specflow-specific consulting on the binary, plugin, or scaffolded project state. |
+| `review-coordinator` | Orchestrates the implement → review → fix loop for `/specflow implement`. |
+| `workflow-manager` | High-level workflow orchestration across phases. |
+
+## Routing principles
+
+1. **`/specflow plan` vs `writing-plans`** — both produce plans, but for
+   different inputs:
+   - `/specflow plan` follows the spec-kit flow (consumes `spec.md`,
+     produces `research.md` + `data-model.md` + `contracts/` +
+     `quickstart.md`). Use for greenfield features with formal contracts.
+   - `writing-plans` (skill) takes a free-form issue or requirement and
+     produces a single executable plan file with bite-sized TDD tasks.
+     Use for issue-driven and ad-hoc work.
+
+2. **Backlog mutations → `product-owner`** — never call `add.sh`,
+   `move.sh`, `set-field.sh`, or `gh issue {create,close,edit}`
+   directly. Dispatch the PO. The PO knows about classification gates,
+   sub-issue links, soft date axes, and reporting conventions.
+
+3. **Releases & pipelines → `devops-sre` first** — before editing CI
+   workflows, `install.sh`, build scripts, or running `/release`,
+   dispatch `devops-sre` for an advisory pass. The agent is read-only;
+   the main session executes after the advisory.
+
+4. **Architecture-level work → `architect` first** — non-trivial
+   changes that cross subsystems (new CLI command, new application
+   use case, new port, new infrastructure adapter, new harness target,
+   changes to bundling / install / release flow, changes to the
+   lock-file or backlog-sync contract). The architect returns a design
+   proposal grounded in the current code; main session implements.
+
+## Skill discovery on different harnesses
+
+This file may run on any of Specflow's plugin-distribution targets:
+Claude Code, Codex CLI, Codex App, Cursor, Gemini CLI, OpenCode,
+GitHub Copilot CLI. Each harness uses different tool names —
+`Read` vs `read_file`, `Task` vs `spawn_agent`, etc.
+
+Before invoking any tool, consult the right reference:
+
+- Claude Code (baseline) → `references/claude-tools.md`
+- Codex → `references/codex-tools.md`
+- Cursor → `references/cursor-tools.md`
+- Gemini CLI → `references/gemini-tools.md`
+- OpenCode → `references/opencode-tools.md`
+- Copilot CLI → `references/copilot-tools.md`
+
+Auto-detect the running harness by looking for env hints
+(`CLAUDE_PLUGIN_ROOT`, `CURSOR_*`, `CODEX_*`, etc.) or by inspecting
+the available tool list in your current context.
+
+## Red flags — these thoughts mean "stop and check for a skill"
+
+| Thought | Reality |
+|---|---|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read the current version. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "Kevin asked me to do X, just go" | Kevin's order is honored; the skill tells you HOW to honor it. |
+
+## When NOT to invoke any Specflow skill
+
+- Pure conversation (greetings, clarifying chat, "thanks").
+- Questions about another repo / project unrelated to Specflow.
+- Single-keystroke / single-word user inputs that need clarification
+  before action (ask the user, then re-evaluate).
+
+## Skill priority
+
+When multiple Specflow skills could apply, use this order:
+
+1. **Process skills first** — `writing-plans` before any implementation;
+   `requesting-code-review` after every task in a subagent-driven flow.
+2. **Domain skills second** — `backlog` for backlog inquiries,
+   `specflow` (router) for spec-kit phases.
+
+"Let's build X" → `writing-plans` first, then implementation skills.
+"Fix this bug" → diagnose first (read the code), then `writing-plans`
+if the fix needs more than 2 changes, otherwise just fix.
+
+## Out of scope
+
+This bootstrap skill is loaded by the SessionStart hook to make the
+agent skill-aware. It does not:
+
+- Execute any backlog / git / build commands itself
+- Replace the per-skill SKILL.md files (read those when invoking a
+  specific skill)
+- Override `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` project directives
+
+For per-harness adapter details, see the manifest at
+`plugin/.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, `gemini-extension.json`, or the
+`.opencode/plugins/specflow.js` adapter (issues #277–#280).

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -25,6 +25,7 @@
     { "category": "skill", "name": "specflow-review", "source": "core/skills/specflow-review/SKILL.md" },
     { "category": "skill", "name": "writing-plans", "source": "core/skills/writing-plans/SKILL.md" },
     { "category": "skill", "name": "requesting-code-review", "source": "core/skills/requesting-code-review/SKILL.md" },
+    { "category": "skill", "name": "using-specflow", "source": "core/skills/using-specflow/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -88,11 +88,12 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
 
     // Top-level skill folders post-consolidation: specflow router +
     // specflow-auto + specflow-review alias + specflow-backlog +
-    // writing-plans (Epic #270 / A1) + requesting-code-review (A3) = 6.
+    // writing-plans (A1) + requesting-code-review (A3) +
+    // using-specflow bootstrap (B6) = 7.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 6);
+    assertEquals(agentsSkillsCount, 7);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -84,12 +84,12 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
 
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review +
-    // writing-plans (#271) + requesting-code-review (#273) + backlog +
-    // 11 agents = 31.
+    // writing-plans (#271) + requesting-code-review (#273) +
+    // using-specflow (#282) + backlog + 11 agents = 32.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 31);
+    assertEquals(instructionsCount, 32);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -76,12 +76,12 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
 
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review alias +
-    // writing-plans (#271) + requesting-code-review (#273) + backlog +
-    // 11 agent workflows = 31.
+    // writing-plans (#271) + requesting-code-review (#273) +
+    // using-specflow (#282) + backlog + 11 agent workflows = 32.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 31);
+    assertEquals(workflowsCount, 32);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -62,6 +62,26 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/requesting-code-review/SKILL.md",
     source: "templates/core/skills/requesting-code-review/SKILL.md",
   },
+  // using-specflow bootstrap skill + 6 tool-mapping references — loaded
+  // by the SessionStart hook (plugin/hooks/) to make the agent
+  // skill-aware on every turn. Per-harness references already shipped
+  // in #283; mirror covers them all for the plugin distribution
+  // (Epic #270, B6 #282).
+  {
+    plugin: "plugin/skills/using-specflow/SKILL.md",
+    source: "templates/core/skills/using-specflow/SKILL.md",
+  },
+  ...[
+    "claude",
+    "codex",
+    "cursor",
+    "gemini",
+    "opencode",
+    "copilot",
+  ].map((name) => ({
+    plugin: `plugin/skills/using-specflow/references/${name}-tools.md`,
+    source: `templates/core/skills/using-specflow/references/${name}-tools.md`,
+  })),
   // Dual-copy agents: 10 sub-agent definitions, each landing as
   // `plugin/agents/<name>.md`. Claude Code resolves agents by file
   // basename in plugin scope; no namespacing needed for invocation


### PR DESCRIPTION
Closes #282. B6 of Epic #270 — completes Phase 1 (foundation) of the multi-harness parity work.

## Agent adoption

Claude Code plugins support a SessionStart hook contract that lets a plugin inject content into the agent's session at the moment of every session start, clear, or compact. Specflow now uses this to **auto-load a `using-specflow` bootstrap skill** that teaches the agent the full Specflow ecosystem (skills, agents, routing rules) without requiring the user to remember any `/specflow` invocation.

```prompt
After installing the specflow-plugin on Claude Code (or scaffolding via `specflow init`), the new using-specflow bootstrap skill is auto-injected at every session start. From that point on, the agent already knows that backlog mutations go through the product-owner agent, that release-pipeline changes go through devops-sre first, that the writing-plans skill auto-invokes on planning intent, that requesting-code-review is the canonical dispatch path for the code-reviewer agent — without having to invoke /specflow explicitly. You don't need to do anything to opt in; the hook fires on session boot.
```

## The hook plumbing

- `plugin/hooks/hooks.json` — Claude Code hook config with the `SessionStart` matcher `startup|clear|compact` (re-bootstraps on session reset, not just first launch).
- `plugin/hooks/session-start` — executable bash script: reads `plugin/skills/using-specflow/SKILL.md`, strips the YAML frontmatter, JSON-escapes the body (via `jq -Rs .` with a sed/awk fallback), and emits the canonical `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}` shape. Locally verified the output round-trips cleanly.

## The bootstrap skill content (`using-specflow/SKILL.md`)

- Skill registry — when to invoke `specflow` (router), `writing-plans`, `requesting-code-review`, `backlog`, `specflow-auto`, `specflow-review`
- Agent registry — when to dispatch `developer`, `code-reviewer`, `security-auditor`, `test-reviewer`, `product-owner`, `qa-tester`, `devops-sre`, `architect`, `specflow-expert`, `review-coordinator`, `workflow-manager`
- Routing principles — `/specflow plan` vs `writing-plans` distinction, PO owns backlog mutations, devops-sre owns release pipeline advisory, architect for non-trivial cross-subsystem changes
- Harness detection — points at the per-harness `references/<name>-tools.md` files for tool-name mapping
- Red flags — the "stop and check for a skill" canonical thought-table

## Files

- `templates/core/skills/using-specflow/SKILL.md` (8167 chars, ~3800 chars headroom under Windsurf cap)
- `plugin/skills/using-specflow/SKILL.md` (byte-identical mirror)
- `plugin/skills/using-specflow/references/{claude,codex,cursor,gemini,opencode,copilot}-tools.md` — 6 references mirrored from `templates/core/` (the source-tree files were created in #283; this PR adds the plugin twins and the byte-identity gate in `plugin_sync_test.ts`)
- `plugin/hooks/hooks.json` + `plugin/hooks/session-start` (new)
- `templates/manifest.json` (88 → 89 core entries — only the SKILL.md is manifested; the 6 references stay plugin-only for now)
- `tests/plugin/plugin_sync_test.ts` (+7 SYNC_PAIRS: SKILL.md + 6 references)
- `.claude/skills/test-sandbox/scripts/smoke-features.sh` (9 new assertions)
- `tests/integration/init_{codex,copilot,windsurf}_test.ts` (scaffolded count +1)

## Out of scope

- Cursor SessionStart variant (`hooks-cursor.json`) — lands with the Cursor adapter PR #278.
- Gemini extension equivalent (GEMINI.md auto-load) — lands with #279.
- OpenCode adapter SessionStart equivalent (JS plugin chat-messages-transform hook) — lands with #280.
- Copilot CLI SessionStart variant — lands with #281.
- Bundling the 6 references via the manifest (so `specflow init` also scaffolds them into user projects) — defer to a follow-up; the references currently sit in `templates/core/skills/using-specflow/references/` as documentation source but are only shipped to user projects via the plugin path. Adding them to the manifest needs a new `skill-asset` category in the bundle code which is out of scope here.

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `hooks/`, `hooks/session-start`, and `skills/using-superpowers/SKILL.md`. Re-implemented for Specflow's skill ecosystem with the SKILL.md content adapted to Specflow's actual skill / agent registry and the hook script simplified (no Windows .cmd polyglot — bash-only for the first cut; can be added later if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)