### PR TITLE
feat: bundled subagent-driven-development skill (#272)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -132,6 +132,25 @@ check "using-specflow credits obra/superpowers attribution" \
   'grep -q "obra/superpowers" .claude/skills/using-specflow/SKILL.md'
 
 echo
+echo "═══ #272  subagent-driven-development skill (Epic #270 / A2) ═══"
+check "subagent-driven-development skill scaffolded" \
+  '[ -f .claude/skills/subagent-driven-development/SKILL.md ]'
+check "subagent-driven-development frontmatter declares name" \
+  'head -5 .claude/skills/subagent-driven-development/SKILL.md | grep -q "name: subagent-driven-development"'
+check "subagent-driven-development describes two-stage review pattern" \
+  'grep -q "two-stage review\|Two-stage review" .claude/skills/subagent-driven-development/SKILL.md'
+check "subagent-driven-development documents developer agent dispatch" \
+  'grep -q "subagent_type: \"developer\"" .claude/skills/subagent-driven-development/SKILL.md'
+check "subagent-driven-development documents code-reviewer agent dispatch" \
+  'grep -q "subagent_type: \"code-reviewer\"" .claude/skills/subagent-driven-development/SKILL.md'
+check "subagent-driven-development handles all 4 status codes" \
+  'grep -q "DONE_WITH_CONCERNS" .claude/skills/subagent-driven-development/SKILL.md && grep -q "NEEDS_CONTEXT" .claude/skills/subagent-driven-development/SKILL.md && grep -q "BLOCKED" .claude/skills/subagent-driven-development/SKILL.md'
+check "subagent-driven-development covers model selection guidance" \
+  'grep -q "Model selection" .claude/skills/subagent-driven-development/SKILL.md'
+check "subagent-driven-development credits obra/superpowers attribution" \
+  'grep -q "obra/superpowers" .claude/skills/subagent-driven-development/SKILL.md'
+
+echo
 echo "═══ #75  loop.md + groom phase ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
 check "groom phase doc present" \

--- a/plugin/skills/requesting-code-review/SKILL.md
+++ b/plugin/skills/requesting-code-review/SKILL.md
@@ -23,7 +23,7 @@ work.
 
 **Mandatory:**
 
-- After each task in a subagent-driven plan (#272, once shipped)
+- After each task in a `subagent-driven-development` plan
 - After completing a major feature
 - Before merging to main
 
@@ -77,7 +77,7 @@ prompt template (see below). Use the `Task` tool with
 Paste this verbatim into a `Task({subagent_type: "code-reviewer", ...})`
 dispatch, substituting the four placeholders. The format is mandatory —
 Specflow's two-stage review pattern (spec compliance, then code
-quality; see #272 once shipped) depends on the reviewer returning the
+quality; see `subagent-driven-development` skill) depends on the reviewer returning the
 exact sections below.
 
 ````
@@ -197,8 +197,8 @@ For each issue:
 
 ## Two-stage review pattern (subagent-driven only)
 
-Specflow's `subagent-driven-development` skill (#272, once shipped)
-runs **two reviews per task**, in this order:
+Specflow's `subagent-driven-development` skill runs **two reviews per
+task**, in this order:
 
 1. **Spec-compliance review** — verifies the implementation matches the
    plan task verbatim. Nothing more, nothing less. Catches scope creep

--- a/plugin/skills/subagent-driven-development/SKILL.md
+++ b/plugin/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: subagent-driven-development
+description: Use to execute an implementation plan task-by-task with mandatory two-stage review per task (spec compliance, then code quality). Trigger phrases include "execute this plan", "implement task by task", "subagent-driven", "run the plan with reviews", or any prompt that asks to drive a multi-task plan to completion with quality gates between tasks. Dispatches Specflow's bundled developer + code-reviewer agents.
+---
+
+# Subagent-Driven Development
+
+Execute a plan by dispatching a **fresh subagent per task**, with a
+**two-stage review** after each: spec compliance first, then code
+quality. The controller (you) extracts each task's text and context
+from the plan, dispatches the implementer subagent with precisely the
+information it needs, then dispatches two reviewer subagents in
+sequence to catch issues before they cascade into the next task.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/subagent-driven-development/SKILL.md`. Re-implemented
+> for Specflow with explicit dispatch to the bundled `developer` agent
+> (implementer role) and `code-reviewer` agent (both review stages, with
+> different prompts).
+
+**Why subagents:** you delegate to specialized agents with isolated
+context. By precisely crafting their instructions, you ensure they
+stay focused and succeed at their task. They should never inherit your
+session's history — you construct exactly what they need. This also
+preserves your own context for coordination work across all tasks.
+
+**Core principle:** Fresh subagent per task + two-stage review (spec
+then quality) = high quality, fast iteration.
+
+## When to use this skill
+
+- After the `writing-plans` skill produced a plan and the user picked
+  "subagent-driven" at the execution-handoff fork
+- For any plan with 3+ tasks where the cost of a bug propagating to
+  later tasks is real (anything cross-cutting or touching critical
+  infrastructure)
+- When you want to preserve your own controller context for the
+  multi-task coordination view (subagents do the heavy reading)
+
+Use the simpler `executing-plans` skill (#274 once shipped) instead
+when:
+
+- The plan has 1–2 trivial tasks where review overhead exceeds the
+  catch rate
+- The user explicitly asked for inline execution
+- Subagent dispatch is unavailable on the current harness (rare —
+  see `references/<harness>-tools.md` for the dispatch mapping)
+
+## The loop — per task
+
+```
+Read plan → extract task N text + context → dispatch implementer
+  → implementer reports DONE
+    → dispatch spec-compliance reviewer
+      → if NOT compliant → implementer fixes → re-review
+      → if compliant → dispatch code-quality reviewer
+        → if issues → implementer fixes → re-review
+        → if approved → mark task complete → next task
+```
+
+**Continuous execution.** Do not pause between tasks for human
+check-ins. Drive every task to completion. The only reasons to stop are:
+
+- An implementer reports `BLOCKED` you cannot resolve
+- A reviewer flags a Critical issue and the implementer can't fix it
+- The plan itself proves wrong and needs a re-plan
+- All tasks are complete
+
+Progress summaries and "should I continue?" prompts waste the user's
+time. They asked you to execute; execute.
+
+## Step 1 — extract all tasks upfront
+
+Read the plan file **once**. Extract every task with full text and any
+context the implementer needs ("Files", "Notes", state from previous
+tasks). Keep the structured task list in your controller context so
+each dispatch is one-shot — the implementer should never need to
+read the plan file.
+
+## Step 2 — dispatch the implementer
+
+Use Specflow's bundled `developer` agent (it knows the project
+conventions: hexagonal layout, TDD discipline, in-code documentation,
+Windsurf cap, byte-identity plugin sync, smoke audit, pre-commit
+hook gates).
+
+```
+Task({
+  subagent_type: "developer",
+  description: "Implement Task N: <short summary>",
+  prompt: `
+    You are implementing Task N of <plan path>.
+
+    ## Task Description
+
+    <FULL TEXT of task — paste verbatim from the plan>
+
+    ## Context
+
+    <Scene-setting: where this fits, dependencies, architectural
+    context from earlier tasks if relevant>
+
+    ## Before You Begin
+
+    If the requirements or approach are unclear, ASK NOW. Don't
+    guess. Raise concerns before starting.
+
+    ## Your Job
+
+    1. Implement exactly what the task specifies
+    2. Follow TDD if the task says to
+    3. Verify the implementation works
+    4. Commit your work
+    5. Self-review (see below)
+    6. Report back
+
+    Work from: <project absolute path>
+
+    ## Report Format
+
+    - Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - What you implemented
+    - What you tested and the results
+    - Files changed + commit sha
+    - Self-review findings
+  `
+})
+```
+
+For trivial mechanical tasks (1–2 file edits, isolated functions), the
+faster `haiku` model is enough. For multi-file integration tasks or
+debugging, use the standard model. For architecture-level work the
+implementer should ESCALATE to you (the controller) rather than guess.
+
+## Step 3 — dispatch the spec-compliance reviewer
+
+After the implementer reports DONE, do **NOT** trust the report —
+verify against the plan independently. Dispatch the `code-reviewer`
+agent in **spec-compliance mode** with this prompt:
+
+```
+Task({
+  subagent_type: "code-reviewer",
+  description: "Spec compliance review — Task N",
+  prompt: `
+    You are reviewing whether an implementation matches its specification.
+
+    ## What Was Requested
+
+    <FULL TEXT of the task from the plan, verbatim>
+
+    ## What Implementer Claims They Built
+
+    <From the implementer's report>
+
+    ## CRITICAL: Do NOT trust the implementer's report.
+
+    The implementer may have skipped requirements or added extras.
+    You MUST verify by reading the actual code.
+
+    ## Your Job — verify line by line
+
+    Read the implementation code and check:
+
+    - Missing requirements — did they implement everything?
+    - Extra/unneeded work — did they over-build?
+    - Misunderstandings — did they solve the wrong problem?
+
+    Use \`git diff --stat <BASE>..<HEAD>\` and \`git diff\` to see
+    the actual changes.
+
+    ## Report
+
+    - ✅ Spec compliant — cite verified line numbers from the actual file.
+    - ❌ Issues found — list each gap with file:line references.
+  `
+})
+```
+
+If the reviewer reports ❌, dispatch the implementer again with the
+spec gaps as the fix list. Re-review until ✅.
+
+## Step 4 — dispatch the code-quality reviewer
+
+Only **after** spec compliance is ✅, run the code-quality review. Use
+the canonical prompt template from the `requesting-code-review` skill
+(see `templates/core/skills/requesting-code-review/SKILL.md` for the
+verbatim template). It returns Strengths / Critical / Important /
+Minor / Recommendations / Assessment.
+
+- **Critical issues** → implementer fixes immediately, re-review.
+- **Important issues** → implementer fixes before moving on, re-review.
+- **Minor issues** → note for follow-up, mark task complete.
+
+## Step 5 — mark task complete, advance
+
+Once both reviews are ✅ (or only Minor remains), mark the task done in
+your tracking, then return to Step 2 for the next task.
+
+## Handling implementer status codes
+
+The implementer reports one of four statuses. Handle each:
+
+| Status | Action |
+|---|---|
+| `DONE` | Proceed to spec compliance review (Step 3). |
+| `DONE_WITH_CONCERNS` | Read the concerns. If correctness-related, fix before review. If observational ("this file is getting large"), note and proceed. |
+| `NEEDS_CONTEXT` | Provide the missing context and re-dispatch (same agent, fresh attempt). |
+| `BLOCKED` | Assess: context problem (re-dispatch with more context) / too hard (re-dispatch with a more capable model) / task too big (break into smaller pieces) / plan wrong (escalate to user). NEVER ignore an escalation or retry with the same model unchanged. |
+
+## Model selection
+
+Use the least capable model that can handle each role:
+
+- **Mechanical implementation** (isolated functions, clear specs, 1–2
+  files): cheap model. Most tasks are mechanical when the plan is
+  well-specified.
+- **Integration / debugging** (multi-file coordination, pattern
+  matching, judgment): standard model.
+- **Architecture / design / review**: most capable model.
+
+Pass `model: "haiku"` for fast cheap dispatches, default otherwise.
+
+## Red flags
+
+**Never:**
+
+- Skip either review (spec OR quality)
+- Proceed with unfixed Critical or Important issues
+- Dispatch multiple implementer subagents in parallel (conflicts)
+- Make the subagent read the plan file (provide the full task text
+  in the dispatch instead)
+- Skip the scene-setting context (subagents have NO history of your
+  session — they need to understand where the task fits)
+- Ignore subagent questions (answer them before they proceed)
+- **Start code quality review before spec compliance is ✅** (wrong order)
+- Move to the next task while either review has open issues
+
+**If the reviewer is wrong:**
+
+- Push back with concrete technical reasoning
+- Show the code / tests that prove correctness
+- Request clarification
+
+**If the implementer fails after retries:**
+
+- Don't try to fix manually — that pollutes your controller context.
+- Dispatch a fix subagent with specific instructions, or escalate to
+  the user for plan adjustment.
+
+## Integration with `writing-plans`
+
+The `writing-plans` skill's execution-handoff section offers the user a
+choice between subagent-driven (this skill) and inline (`executing-plans`).
+When the user picks subagent-driven, this skill is the entry point:
+
+1. Read the plan once
+2. Extract all tasks
+3. Run the per-task loop
+4. After all tasks complete, dispatch a final whole-implementation
+   reviewer (one more `code-reviewer` dispatch with the whole plan
+   diff `BASE_SHA=origin/main..HEAD`)
+5. Hand off to `finishing-a-development-branch` (or the equivalent
+   manual PR + merge + close flow) — typically opens the PR, watches
+   CI, merges, dispatches the `product-owner` agent to close the
+   linked issue
+
+## Out of scope
+
+This skill does not:
+
+- Write plans (`writing-plans` does that)
+- Run tests itself (the implementer does)
+- Mutate the backlog (the `product-owner` agent does)
+- Open branches / PRs (the implementer or controller does, depending
+  on the plan's PR-flow specification)
+- Trigger releases (`/release` + `devops-sre` advisory)
+
+## When NOT to use this skill
+
+- For trivial single-file changes — direct execution is faster than
+  the subagent loop overhead
+- When dispatch isn't available on the current harness (rare; check
+  `references/<harness>-tools.md`)
+- When the user explicitly asked for inline execution

--- a/plugin/skills/using-specflow/SKILL.md
+++ b/plugin/skills/using-specflow/SKILL.md
@@ -39,6 +39,7 @@ not re-read the file with `Read`.
 | `specflow` (router) | User typed `/specflow <phase>` or asked for the spec-kit pipeline (`/specflow specify → plan → tasks → analyze → implement → review → merge`). Greenfield features with formal specs. |
 | `writing-plans` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
 | `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
+| `subagent-driven-development` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by `writing-plans`. |
 | `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |

--- a/plugin/skills/writing-plans/SKILL.md
+++ b/plugin/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ another human) can follow step-by-step without re-reading the spec.
 > (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow
 > with `docs/specflow/plans/` as the canonical save path and explicit
 > handoff to Specflow's `subagent-driven-development` / `executing-plans`
-> skills (issues #272 and #274).
+> skill (`subagent-driven-development`) and issue #274 (executing-plans).
 
 ## When to use this skill
 
@@ -94,8 +94,8 @@ Every plan **MUST** start with this header:
 # [Feature Name] Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
-> `specflow:subagent-driven-development` (recommended; #272 once shipped)
-> or `specflow:executing-plans` (#274 once shipped) to implement this
+> `specflow:subagent-driven-development` (recommended) or
+> `specflow:executing-plans` (#274 once shipped) to implement this
 > plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
@@ -228,8 +228,6 @@ After saving the plan, offer the user a choice of execution strategy:
 **If subagent-driven chosen:**
 
 - **REQUIRED SUB-SKILL:** Use `specflow:subagent-driven-development`
-  (issue #272 once shipped — otherwise fall back to dispatching
-  Specflow's `developer` agent per task with manual two-stage review)
 - Fresh subagent per task + spec compliance + code quality review loop
 
 **If inline chosen:**

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3158,7 +3158,7 @@ another human) can follow step-by-step without re-reading the spec.
 > (MIT) — \`skills/writing-plans/SKILL.md\`. Re-implemented for Specflow
 > with \`docs/specflow/plans/\` as the canonical save path and explicit
 > handoff to Specflow's \`subagent-driven-development\` / \`executing-plans\`
-> skills (issues #272 and #274).
+> skill (\`subagent-driven-development\`) and issue #274 (executing-plans).
 
 ## When to use this skill
 
@@ -3239,8 +3239,8 @@ Every plan **MUST** start with this header:
 # [Feature Name] Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
-> \`specflow:subagent-driven-development\` (recommended; #272 once shipped)
-> or \`specflow:executing-plans\` (#274 once shipped) to implement this
+> \`specflow:subagent-driven-development\` (recommended) or
+> \`specflow:executing-plans\` (#274 once shipped) to implement this
 > plan task-by-task. Steps use checkbox (\`- [ ]\`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
@@ -3373,8 +3373,6 @@ After saving the plan, offer the user a choice of execution strategy:
 **If subagent-driven chosen:**
 
 - **REQUIRED SUB-SKILL:** Use \`specflow:subagent-driven-development\`
-  (issue #272 once shipped — otherwise fall back to dispatching
-  Specflow's \`developer\` agent per task with manual two-stage review)
 - Fresh subagent per task + spec compliance + code quality review loop
 
 **If inline chosen:**
@@ -3457,7 +3455,7 @@ work.
 
 **Mandatory:**
 
-- After each task in a subagent-driven plan (#272, once shipped)
+- After each task in a \`subagent-driven-development\` plan
 - After completing a major feature
 - Before merging to main
 
@@ -3511,7 +3509,7 @@ prompt template (see below). Use the \`Task\` tool with
 Paste this verbatim into a \`Task({subagent_type: "code-reviewer", ...})\`
 dispatch, substituting the four placeholders. The format is mandatory —
 Specflow's two-stage review pattern (spec compliance, then code
-quality; see #272 once shipped) depends on the reviewer returning the
+quality; see \`subagent-driven-development\` skill) depends on the reviewer returning the
 exact sections below.
 
 \`\`\`\`
@@ -3631,8 +3629,8 @@ For each issue:
 
 ## Two-stage review pattern (subagent-driven only)
 
-Specflow's \`subagent-driven-development\` skill (#272, once shipped)
-runs **two reviews per task**, in this order:
+Specflow's \`subagent-driven-development\` skill runs **two reviews per
+task**, in this order:
 
 1. **Spec-compliance review** — verifies the implementation matches the
    plan task verbatim. Nothing more, nothing less. Catches scope creep
@@ -3765,6 +3763,7 @@ not re-read the file with \`Read\`.
 | \`specflow\` (router) | User typed \`/specflow <phase>\` or asked for the spec-kit pipeline (\`/specflow specify → plan → tasks → analyze → implement → review → merge\`). Greenfield features with formal specs. |
 | \`writing-plans\` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
 | \`requesting-code-review\` | Work is complete enough to need an independent eye. Dispatch the bundled \`code-reviewer\` agent with the canonical prompt template. |
+| \`subagent-driven-development\` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by \`writing-plans\`. |
 | \`backlog\` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the \`product-owner\` agent. |
 | \`specflow-auto\` | Auto-chain orchestration (legacy entry point — most users invoke \`/specflow specify\` instead). |
 | \`specflow-review\` | Auto-invoke alias preserved for the \`/specflow review\` phase. |
@@ -3883,6 +3882,300 @@ For per-harness adapter details, see the manifest at
 \`plugin/.claude-plugin/plugin.json\`, \`.cursor-plugin/plugin.json\`,
 \`.codex-plugin/plugin.json\`, \`gemini-extension.json\`, or the
 \`.opencode/plugins/specflow.js\` adapter (issues #277–#280).
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
+    name: "subagent-driven-development",
+    suffix: null,
+    content: `---
+name: subagent-driven-development
+description: Use to execute an implementation plan task-by-task with mandatory two-stage review per task (spec compliance, then code quality). Trigger phrases include "execute this plan", "implement task by task", "subagent-driven", "run the plan with reviews", or any prompt that asks to drive a multi-task plan to completion with quality gates between tasks. Dispatches Specflow's bundled developer + code-reviewer agents.
+---
+
+# Subagent-Driven Development
+
+Execute a plan by dispatching a **fresh subagent per task**, with a
+**two-stage review** after each: spec compliance first, then code
+quality. The controller (you) extracts each task's text and context
+from the plan, dispatches the implementer subagent with precisely the
+information it needs, then dispatches two reviewer subagents in
+sequence to catch issues before they cascade into the next task.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/subagent-driven-development/SKILL.md\`. Re-implemented
+> for Specflow with explicit dispatch to the bundled \`developer\` agent
+> (implementer role) and \`code-reviewer\` agent (both review stages, with
+> different prompts).
+
+**Why subagents:** you delegate to specialized agents with isolated
+context. By precisely crafting their instructions, you ensure they
+stay focused and succeed at their task. They should never inherit your
+session's history — you construct exactly what they need. This also
+preserves your own context for coordination work across all tasks.
+
+**Core principle:** Fresh subagent per task + two-stage review (spec
+then quality) = high quality, fast iteration.
+
+## When to use this skill
+
+- After the \`writing-plans\` skill produced a plan and the user picked
+  "subagent-driven" at the execution-handoff fork
+- For any plan with 3+ tasks where the cost of a bug propagating to
+  later tasks is real (anything cross-cutting or touching critical
+  infrastructure)
+- When you want to preserve your own controller context for the
+  multi-task coordination view (subagents do the heavy reading)
+
+Use the simpler \`executing-plans\` skill (#274 once shipped) instead
+when:
+
+- The plan has 1–2 trivial tasks where review overhead exceeds the
+  catch rate
+- The user explicitly asked for inline execution
+- Subagent dispatch is unavailable on the current harness (rare —
+  see \`references/<harness>-tools.md\` for the dispatch mapping)
+
+## The loop — per task
+
+\`\`\`
+Read plan → extract task N text + context → dispatch implementer
+  → implementer reports DONE
+    → dispatch spec-compliance reviewer
+      → if NOT compliant → implementer fixes → re-review
+      → if compliant → dispatch code-quality reviewer
+        → if issues → implementer fixes → re-review
+        → if approved → mark task complete → next task
+\`\`\`
+
+**Continuous execution.** Do not pause between tasks for human
+check-ins. Drive every task to completion. The only reasons to stop are:
+
+- An implementer reports \`BLOCKED\` you cannot resolve
+- A reviewer flags a Critical issue and the implementer can't fix it
+- The plan itself proves wrong and needs a re-plan
+- All tasks are complete
+
+Progress summaries and "should I continue?" prompts waste the user's
+time. They asked you to execute; execute.
+
+## Step 1 — extract all tasks upfront
+
+Read the plan file **once**. Extract every task with full text and any
+context the implementer needs ("Files", "Notes", state from previous
+tasks). Keep the structured task list in your controller context so
+each dispatch is one-shot — the implementer should never need to
+read the plan file.
+
+## Step 2 — dispatch the implementer
+
+Use Specflow's bundled \`developer\` agent (it knows the project
+conventions: hexagonal layout, TDD discipline, in-code documentation,
+Windsurf cap, byte-identity plugin sync, smoke audit, pre-commit
+hook gates).
+
+\`\`\`
+Task({
+  subagent_type: "developer",
+  description: "Implement Task N: <short summary>",
+  prompt: \`
+    You are implementing Task N of <plan path>.
+
+    ## Task Description
+
+    <FULL TEXT of task — paste verbatim from the plan>
+
+    ## Context
+
+    <Scene-setting: where this fits, dependencies, architectural
+    context from earlier tasks if relevant>
+
+    ## Before You Begin
+
+    If the requirements or approach are unclear, ASK NOW. Don't
+    guess. Raise concerns before starting.
+
+    ## Your Job
+
+    1. Implement exactly what the task specifies
+    2. Follow TDD if the task says to
+    3. Verify the implementation works
+    4. Commit your work
+    5. Self-review (see below)
+    6. Report back
+
+    Work from: <project absolute path>
+
+    ## Report Format
+
+    - Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - What you implemented
+    - What you tested and the results
+    - Files changed + commit sha
+    - Self-review findings
+  \`
+})
+\`\`\`
+
+For trivial mechanical tasks (1–2 file edits, isolated functions), the
+faster \`haiku\` model is enough. For multi-file integration tasks or
+debugging, use the standard model. For architecture-level work the
+implementer should ESCALATE to you (the controller) rather than guess.
+
+## Step 3 — dispatch the spec-compliance reviewer
+
+After the implementer reports DONE, do **NOT** trust the report —
+verify against the plan independently. Dispatch the \`code-reviewer\`
+agent in **spec-compliance mode** with this prompt:
+
+\`\`\`
+Task({
+  subagent_type: "code-reviewer",
+  description: "Spec compliance review — Task N",
+  prompt: \`
+    You are reviewing whether an implementation matches its specification.
+
+    ## What Was Requested
+
+    <FULL TEXT of the task from the plan, verbatim>
+
+    ## What Implementer Claims They Built
+
+    <From the implementer's report>
+
+    ## CRITICAL: Do NOT trust the implementer's report.
+
+    The implementer may have skipped requirements or added extras.
+    You MUST verify by reading the actual code.
+
+    ## Your Job — verify line by line
+
+    Read the implementation code and check:
+
+    - Missing requirements — did they implement everything?
+    - Extra/unneeded work — did they over-build?
+    - Misunderstandings — did they solve the wrong problem?
+
+    Use \\\`git diff --stat <BASE>..<HEAD>\\\` and \\\`git diff\\\` to see
+    the actual changes.
+
+    ## Report
+
+    - ✅ Spec compliant — cite verified line numbers from the actual file.
+    - ❌ Issues found — list each gap with file:line references.
+  \`
+})
+\`\`\`
+
+If the reviewer reports ❌, dispatch the implementer again with the
+spec gaps as the fix list. Re-review until ✅.
+
+## Step 4 — dispatch the code-quality reviewer
+
+Only **after** spec compliance is ✅, run the code-quality review. Use
+the canonical prompt template from the \`requesting-code-review\` skill
+(see \`templates/core/skills/requesting-code-review/SKILL.md\` for the
+verbatim template). It returns Strengths / Critical / Important /
+Minor / Recommendations / Assessment.
+
+- **Critical issues** → implementer fixes immediately, re-review.
+- **Important issues** → implementer fixes before moving on, re-review.
+- **Minor issues** → note for follow-up, mark task complete.
+
+## Step 5 — mark task complete, advance
+
+Once both reviews are ✅ (or only Minor remains), mark the task done in
+your tracking, then return to Step 2 for the next task.
+
+## Handling implementer status codes
+
+The implementer reports one of four statuses. Handle each:
+
+| Status | Action |
+|---|---|
+| \`DONE\` | Proceed to spec compliance review (Step 3). |
+| \`DONE_WITH_CONCERNS\` | Read the concerns. If correctness-related, fix before review. If observational ("this file is getting large"), note and proceed. |
+| \`NEEDS_CONTEXT\` | Provide the missing context and re-dispatch (same agent, fresh attempt). |
+| \`BLOCKED\` | Assess: context problem (re-dispatch with more context) / too hard (re-dispatch with a more capable model) / task too big (break into smaller pieces) / plan wrong (escalate to user). NEVER ignore an escalation or retry with the same model unchanged. |
+
+## Model selection
+
+Use the least capable model that can handle each role:
+
+- **Mechanical implementation** (isolated functions, clear specs, 1–2
+  files): cheap model. Most tasks are mechanical when the plan is
+  well-specified.
+- **Integration / debugging** (multi-file coordination, pattern
+  matching, judgment): standard model.
+- **Architecture / design / review**: most capable model.
+
+Pass \`model: "haiku"\` for fast cheap dispatches, default otherwise.
+
+## Red flags
+
+**Never:**
+
+- Skip either review (spec OR quality)
+- Proceed with unfixed Critical or Important issues
+- Dispatch multiple implementer subagents in parallel (conflicts)
+- Make the subagent read the plan file (provide the full task text
+  in the dispatch instead)
+- Skip the scene-setting context (subagents have NO history of your
+  session — they need to understand where the task fits)
+- Ignore subagent questions (answer them before they proceed)
+- **Start code quality review before spec compliance is ✅** (wrong order)
+- Move to the next task while either review has open issues
+
+**If the reviewer is wrong:**
+
+- Push back with concrete technical reasoning
+- Show the code / tests that prove correctness
+- Request clarification
+
+**If the implementer fails after retries:**
+
+- Don't try to fix manually — that pollutes your controller context.
+- Dispatch a fix subagent with specific instructions, or escalate to
+  the user for plan adjustment.
+
+## Integration with \`writing-plans\`
+
+The \`writing-plans\` skill's execution-handoff section offers the user a
+choice between subagent-driven (this skill) and inline (\`executing-plans\`).
+When the user picks subagent-driven, this skill is the entry point:
+
+1. Read the plan once
+2. Extract all tasks
+3. Run the per-task loop
+4. After all tasks complete, dispatch a final whole-implementation
+   reviewer (one more \`code-reviewer\` dispatch with the whole plan
+   diff \`BASE_SHA=origin/main..HEAD\`)
+5. Hand off to \`finishing-a-development-branch\` (or the equivalent
+   manual PR + merge + close flow) — typically opens the PR, watches
+   CI, merges, dispatches the \`product-owner\` agent to close the
+   linked issue
+
+## Out of scope
+
+This skill does not:
+
+- Write plans (\`writing-plans\` does that)
+- Run tests itself (the implementer does)
+- Mutate the backlog (the \`product-owner\` agent does)
+- Open branches / PRs (the implementer or controller does, depending
+  on the plan's PR-flow specification)
+- Trigger releases (\`/release\` + \`devops-sre\` advisory)
+
+## When NOT to use this skill
+
+- For trivial single-file changes — direct execution is faster than
+  the subagent loop overhead
+- When dispatch isn't available on the current harness (rare; check
+  \`references/<harness>-tools.md\`)
+- When the user explicitly asked for inline execution
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/requesting-code-review/SKILL.md
+++ b/templates/core/skills/requesting-code-review/SKILL.md
@@ -23,7 +23,7 @@ work.
 
 **Mandatory:**
 
-- After each task in a subagent-driven plan (#272, once shipped)
+- After each task in a `subagent-driven-development` plan
 - After completing a major feature
 - Before merging to main
 
@@ -77,7 +77,7 @@ prompt template (see below). Use the `Task` tool with
 Paste this verbatim into a `Task({subagent_type: "code-reviewer", ...})`
 dispatch, substituting the four placeholders. The format is mandatory —
 Specflow's two-stage review pattern (spec compliance, then code
-quality; see #272 once shipped) depends on the reviewer returning the
+quality; see `subagent-driven-development` skill) depends on the reviewer returning the
 exact sections below.
 
 ````
@@ -197,8 +197,8 @@ For each issue:
 
 ## Two-stage review pattern (subagent-driven only)
 
-Specflow's `subagent-driven-development` skill (#272, once shipped)
-runs **two reviews per task**, in this order:
+Specflow's `subagent-driven-development` skill runs **two reviews per
+task**, in this order:
 
 1. **Spec-compliance review** — verifies the implementation matches the
    plan task verbatim. Nothing more, nothing less. Catches scope creep

--- a/templates/core/skills/subagent-driven-development/SKILL.md
+++ b/templates/core/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: subagent-driven-development
+description: Use to execute an implementation plan task-by-task with mandatory two-stage review per task (spec compliance, then code quality). Trigger phrases include "execute this plan", "implement task by task", "subagent-driven", "run the plan with reviews", or any prompt that asks to drive a multi-task plan to completion with quality gates between tasks. Dispatches Specflow's bundled developer + code-reviewer agents.
+---
+
+# Subagent-Driven Development
+
+Execute a plan by dispatching a **fresh subagent per task**, with a
+**two-stage review** after each: spec compliance first, then code
+quality. The controller (you) extracts each task's text and context
+from the plan, dispatches the implementer subagent with precisely the
+information it needs, then dispatches two reviewer subagents in
+sequence to catch issues before they cascade into the next task.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/subagent-driven-development/SKILL.md`. Re-implemented
+> for Specflow with explicit dispatch to the bundled `developer` agent
+> (implementer role) and `code-reviewer` agent (both review stages, with
+> different prompts).
+
+**Why subagents:** you delegate to specialized agents with isolated
+context. By precisely crafting their instructions, you ensure they
+stay focused and succeed at their task. They should never inherit your
+session's history — you construct exactly what they need. This also
+preserves your own context for coordination work across all tasks.
+
+**Core principle:** Fresh subagent per task + two-stage review (spec
+then quality) = high quality, fast iteration.
+
+## When to use this skill
+
+- After the `writing-plans` skill produced a plan and the user picked
+  "subagent-driven" at the execution-handoff fork
+- For any plan with 3+ tasks where the cost of a bug propagating to
+  later tasks is real (anything cross-cutting or touching critical
+  infrastructure)
+- When you want to preserve your own controller context for the
+  multi-task coordination view (subagents do the heavy reading)
+
+Use the simpler `executing-plans` skill (#274 once shipped) instead
+when:
+
+- The plan has 1–2 trivial tasks where review overhead exceeds the
+  catch rate
+- The user explicitly asked for inline execution
+- Subagent dispatch is unavailable on the current harness (rare —
+  see `references/<harness>-tools.md` for the dispatch mapping)
+
+## The loop — per task
+
+```
+Read plan → extract task N text + context → dispatch implementer
+  → implementer reports DONE
+    → dispatch spec-compliance reviewer
+      → if NOT compliant → implementer fixes → re-review
+      → if compliant → dispatch code-quality reviewer
+        → if issues → implementer fixes → re-review
+        → if approved → mark task complete → next task
+```
+
+**Continuous execution.** Do not pause between tasks for human
+check-ins. Drive every task to completion. The only reasons to stop are:
+
+- An implementer reports `BLOCKED` you cannot resolve
+- A reviewer flags a Critical issue and the implementer can't fix it
+- The plan itself proves wrong and needs a re-plan
+- All tasks are complete
+
+Progress summaries and "should I continue?" prompts waste the user's
+time. They asked you to execute; execute.
+
+## Step 1 — extract all tasks upfront
+
+Read the plan file **once**. Extract every task with full text and any
+context the implementer needs ("Files", "Notes", state from previous
+tasks). Keep the structured task list in your controller context so
+each dispatch is one-shot — the implementer should never need to
+read the plan file.
+
+## Step 2 — dispatch the implementer
+
+Use Specflow's bundled `developer` agent (it knows the project
+conventions: hexagonal layout, TDD discipline, in-code documentation,
+Windsurf cap, byte-identity plugin sync, smoke audit, pre-commit
+hook gates).
+
+```
+Task({
+  subagent_type: "developer",
+  description: "Implement Task N: <short summary>",
+  prompt: `
+    You are implementing Task N of <plan path>.
+
+    ## Task Description
+
+    <FULL TEXT of task — paste verbatim from the plan>
+
+    ## Context
+
+    <Scene-setting: where this fits, dependencies, architectural
+    context from earlier tasks if relevant>
+
+    ## Before You Begin
+
+    If the requirements or approach are unclear, ASK NOW. Don't
+    guess. Raise concerns before starting.
+
+    ## Your Job
+
+    1. Implement exactly what the task specifies
+    2. Follow TDD if the task says to
+    3. Verify the implementation works
+    4. Commit your work
+    5. Self-review (see below)
+    6. Report back
+
+    Work from: <project absolute path>
+
+    ## Report Format
+
+    - Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - What you implemented
+    - What you tested and the results
+    - Files changed + commit sha
+    - Self-review findings
+  `
+})
+```
+
+For trivial mechanical tasks (1–2 file edits, isolated functions), the
+faster `haiku` model is enough. For multi-file integration tasks or
+debugging, use the standard model. For architecture-level work the
+implementer should ESCALATE to you (the controller) rather than guess.
+
+## Step 3 — dispatch the spec-compliance reviewer
+
+After the implementer reports DONE, do **NOT** trust the report —
+verify against the plan independently. Dispatch the `code-reviewer`
+agent in **spec-compliance mode** with this prompt:
+
+```
+Task({
+  subagent_type: "code-reviewer",
+  description: "Spec compliance review — Task N",
+  prompt: `
+    You are reviewing whether an implementation matches its specification.
+
+    ## What Was Requested
+
+    <FULL TEXT of the task from the plan, verbatim>
+
+    ## What Implementer Claims They Built
+
+    <From the implementer's report>
+
+    ## CRITICAL: Do NOT trust the implementer's report.
+
+    The implementer may have skipped requirements or added extras.
+    You MUST verify by reading the actual code.
+
+    ## Your Job — verify line by line
+
+    Read the implementation code and check:
+
+    - Missing requirements — did they implement everything?
+    - Extra/unneeded work — did they over-build?
+    - Misunderstandings — did they solve the wrong problem?
+
+    Use \`git diff --stat <BASE>..<HEAD>\` and \`git diff\` to see
+    the actual changes.
+
+    ## Report
+
+    - ✅ Spec compliant — cite verified line numbers from the actual file.
+    - ❌ Issues found — list each gap with file:line references.
+  `
+})
+```
+
+If the reviewer reports ❌, dispatch the implementer again with the
+spec gaps as the fix list. Re-review until ✅.
+
+## Step 4 — dispatch the code-quality reviewer
+
+Only **after** spec compliance is ✅, run the code-quality review. Use
+the canonical prompt template from the `requesting-code-review` skill
+(see `templates/core/skills/requesting-code-review/SKILL.md` for the
+verbatim template). It returns Strengths / Critical / Important /
+Minor / Recommendations / Assessment.
+
+- **Critical issues** → implementer fixes immediately, re-review.
+- **Important issues** → implementer fixes before moving on, re-review.
+- **Minor issues** → note for follow-up, mark task complete.
+
+## Step 5 — mark task complete, advance
+
+Once both reviews are ✅ (or only Minor remains), mark the task done in
+your tracking, then return to Step 2 for the next task.
+
+## Handling implementer status codes
+
+The implementer reports one of four statuses. Handle each:
+
+| Status | Action |
+|---|---|
+| `DONE` | Proceed to spec compliance review (Step 3). |
+| `DONE_WITH_CONCERNS` | Read the concerns. If correctness-related, fix before review. If observational ("this file is getting large"), note and proceed. |
+| `NEEDS_CONTEXT` | Provide the missing context and re-dispatch (same agent, fresh attempt). |
+| `BLOCKED` | Assess: context problem (re-dispatch with more context) / too hard (re-dispatch with a more capable model) / task too big (break into smaller pieces) / plan wrong (escalate to user). NEVER ignore an escalation or retry with the same model unchanged. |
+
+## Model selection
+
+Use the least capable model that can handle each role:
+
+- **Mechanical implementation** (isolated functions, clear specs, 1–2
+  files): cheap model. Most tasks are mechanical when the plan is
+  well-specified.
+- **Integration / debugging** (multi-file coordination, pattern
+  matching, judgment): standard model.
+- **Architecture / design / review**: most capable model.
+
+Pass `model: "haiku"` for fast cheap dispatches, default otherwise.
+
+## Red flags
+
+**Never:**
+
+- Skip either review (spec OR quality)
+- Proceed with unfixed Critical or Important issues
+- Dispatch multiple implementer subagents in parallel (conflicts)
+- Make the subagent read the plan file (provide the full task text
+  in the dispatch instead)
+- Skip the scene-setting context (subagents have NO history of your
+  session — they need to understand where the task fits)
+- Ignore subagent questions (answer them before they proceed)
+- **Start code quality review before spec compliance is ✅** (wrong order)
+- Move to the next task while either review has open issues
+
+**If the reviewer is wrong:**
+
+- Push back with concrete technical reasoning
+- Show the code / tests that prove correctness
+- Request clarification
+
+**If the implementer fails after retries:**
+
+- Don't try to fix manually — that pollutes your controller context.
+- Dispatch a fix subagent with specific instructions, or escalate to
+  the user for plan adjustment.
+
+## Integration with `writing-plans`
+
+The `writing-plans` skill's execution-handoff section offers the user a
+choice between subagent-driven (this skill) and inline (`executing-plans`).
+When the user picks subagent-driven, this skill is the entry point:
+
+1. Read the plan once
+2. Extract all tasks
+3. Run the per-task loop
+4. After all tasks complete, dispatch a final whole-implementation
+   reviewer (one more `code-reviewer` dispatch with the whole plan
+   diff `BASE_SHA=origin/main..HEAD`)
+5. Hand off to `finishing-a-development-branch` (or the equivalent
+   manual PR + merge + close flow) — typically opens the PR, watches
+   CI, merges, dispatches the `product-owner` agent to close the
+   linked issue
+
+## Out of scope
+
+This skill does not:
+
+- Write plans (`writing-plans` does that)
+- Run tests itself (the implementer does)
+- Mutate the backlog (the `product-owner` agent does)
+- Open branches / PRs (the implementer or controller does, depending
+  on the plan's PR-flow specification)
+- Trigger releases (`/release` + `devops-sre` advisory)
+
+## When NOT to use this skill
+
+- For trivial single-file changes — direct execution is faster than
+  the subagent loop overhead
+- When dispatch isn't available on the current harness (rare; check
+  `references/<harness>-tools.md`)
+- When the user explicitly asked for inline execution

--- a/templates/core/skills/using-specflow/SKILL.md
+++ b/templates/core/skills/using-specflow/SKILL.md
@@ -39,6 +39,7 @@ not re-read the file with `Read`.
 | `specflow` (router) | User typed `/specflow <phase>` or asked for the spec-kit pipeline (`/specflow specify → plan → tasks → analyze → implement → review → merge`). Greenfield features with formal specs. |
 | `writing-plans` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
 | `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
+| `subagent-driven-development` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by `writing-plans`. |
 | `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |

--- a/templates/core/skills/writing-plans/SKILL.md
+++ b/templates/core/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ another human) can follow step-by-step without re-reading the spec.
 > (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow
 > with `docs/specflow/plans/` as the canonical save path and explicit
 > handoff to Specflow's `subagent-driven-development` / `executing-plans`
-> skills (issues #272 and #274).
+> skill (`subagent-driven-development`) and issue #274 (executing-plans).
 
 ## When to use this skill
 
@@ -94,8 +94,8 @@ Every plan **MUST** start with this header:
 # [Feature Name] Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
-> `specflow:subagent-driven-development` (recommended; #272 once shipped)
-> or `specflow:executing-plans` (#274 once shipped) to implement this
+> `specflow:subagent-driven-development` (recommended) or
+> `specflow:executing-plans` (#274 once shipped) to implement this
 > plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
@@ -228,8 +228,6 @@ After saving the plan, offer the user a choice of execution strategy:
 **If subagent-driven chosen:**
 
 - **REQUIRED SUB-SKILL:** Use `specflow:subagent-driven-development`
-  (issue #272 once shipped — otherwise fall back to dispatching
-  Specflow's `developer` agent per task with manual two-stage review)
 - Fresh subagent per task + spec compliance + code quality review loop
 
 **If inline chosen:**

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -26,6 +26,7 @@
     { "category": "skill", "name": "writing-plans", "source": "core/skills/writing-plans/SKILL.md" },
     { "category": "skill", "name": "requesting-code-review", "source": "core/skills/requesting-code-review/SKILL.md" },
     { "category": "skill", "name": "using-specflow", "source": "core/skills/using-specflow/SKILL.md" },
+    { "category": "skill", "name": "subagent-driven-development", "source": "core/skills/subagent-driven-development/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -89,11 +89,11 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     // Top-level skill folders post-consolidation: specflow router +
     // specflow-auto + specflow-review alias + specflow-backlog +
     // writing-plans (A1) + requesting-code-review (A3) +
-    // using-specflow bootstrap (B6) = 7.
+    // using-specflow bootstrap (B6) + subagent-driven-development (A2) = 8.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 7);
+    assertEquals(agentsSkillsCount, 8);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -85,11 +85,12 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review +
     // writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + backlog + 11 agents = 32.
+    // using-specflow (#282) + subagent-driven-development (#272) +
+    // backlog + 11 agents = 33.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 32);
+    assertEquals(instructionsCount, 33);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -77,11 +77,12 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
     // Router + 15 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills) + specflow-auto + specflow-review alias +
     // writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + backlog + 11 agent workflows = 32.
+    // using-specflow (#282) + subagent-driven-development (#272) +
+    // backlog + 11 agent workflows = 33.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 32);
+    assertEquals(workflowsCount, 33);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -71,6 +71,14 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/using-specflow/SKILL.md",
     source: "templates/core/skills/using-specflow/SKILL.md",
   },
+  // subagent-driven-development — per-task two-stage review loop
+  // (spec compliance then code quality) that consumes plans produced
+  // by writing-plans and the canonical reviewer prompt template from
+  // requesting-code-review (Epic #270, A2 #272).
+  {
+    plugin: "plugin/skills/subagent-driven-development/SKILL.md",
+    source: "templates/core/skills/subagent-driven-development/SKILL.md",
+  },
   ...[
     "claude",
     "codex",


### PR DESCRIPTION
Closes #272. A2 of Epic #270 — Phase 2 of the multi-harness parity work.

## Agent adoption

Specflow now ships a native `subagent-driven-development` skill — the per-task two-stage review loop (spec compliance, then code quality) that consumes plans produced by `writing-plans` (#271) and the canonical reviewer prompt template from `requesting-code-review` (#273).

```prompt
After `specflow upgrade`, when you complete `writing-plans` and choose the subagent-driven execution option, this skill takes over: it extracts every task from the plan, dispatches Specflow's bundled developer agent as the implementer (fresh subagent per task, no shared session history), then runs two reviews — spec compliance first (cheap, disqualifies wrong-thing builds early) then code quality (uses the requesting-code-review template). Fix loops re-dispatch the implementer until both reviews are ✅. The result on real work (#263 / #264 today) was 9+ issues caught between tasks that inline execution would have shipped to CI.
```

## Specflow-native adaptations vs. upstream

- **Explicit `developer` agent dispatch** for the implementer role — Specflow's bundled agent already knows the conventions (hexagonal, TDD, Windsurf cap, byte-identity plugin sync, smoke audit). Less context needed in dispatch prompts.
- **Explicit `code-reviewer` agent dispatch** for both review stages, with different prompts. Spec compliance and code quality run sequentially; the second stage references the canonical template from `requesting-code-review` skill rather than duplicating it inline.
- **Model selection guidance** — cheap model for mechanical tasks, standard for integration, most capable for architecture work. Pass `model: "haiku"` for fast dispatches.
- **All four implementer status codes handled** — DONE, DONE_WITH_CONCERNS, NEEDS_CONTEXT, BLOCKED — with explicit per-status remediation playbooks.

## Files

- `templates/core/skills/subagent-driven-development/SKILL.md` — 10790 chars (~1400 chars headroom under Windsurf cap)
- `plugin/skills/subagent-driven-development/SKILL.md` — byte-identical mirror
- `templates/manifest.json` — registers new skill (89 → 90 core entries)
- `tests/plugin/plugin_sync_test.ts` — +1 SYNC_PAIR
- `.claude/skills/test-sandbox/scripts/smoke-features.sh` — 8 new static-grep assertions
- `tests/integration/init_{codex,copilot,windsurf}_test.ts` — scaffolded count +1

## Forward-reference cleanup

With #272 now landing, three sibling skills update their "#272 once shipped" qualifiers:

- `writing-plans/SKILL.md` — execution-handoff section now points at `subagent-driven-development` directly
- `requesting-code-review/SKILL.md` — two-stage review section now points at the skill by name
- `using-specflow/SKILL.md` — skill registry table gains a row for `subagent-driven-development`

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `skills/subagent-driven-development/SKILL.md`. Re-implemented for Specflow with bundled `developer` + `code-reviewer` agent dispatch instead of generic `general-purpose`.

## Out of scope

- `executing-plans` (#274) — the inline alternative to subagent-driven execution. Lands in the next Phase-2 iteration; both skills coexist (user picks at the execution-handoff fork in writing-plans).
- Wiring the `developer` agent doctrine to reference this skill as the canonical execution path — that's a Phase-4 polish item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)