### PR TITLE
feat: bundled executing-plans skill (#274)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -151,6 +151,23 @@ check "subagent-driven-development credits obra/superpowers attribution" \
   'grep -q "obra/superpowers" .claude/skills/subagent-driven-development/SKILL.md'
 
 echo
+echo "═══ #274  executing-plans skill (Epic #270 / A4) ═══"
+check "executing-plans skill scaffolded" \
+  '[ -f .claude/skills/executing-plans/SKILL.md ]'
+check "executing-plans frontmatter declares name" \
+  'head -5 .claude/skills/executing-plans/SKILL.md | grep -q "name: executing-plans"'
+check "executing-plans describes checkpoint pauses between tasks" \
+  'grep -q "checkpoint" .claude/skills/executing-plans/SKILL.md'
+check "executing-plans cross-references subagent-driven-development alternative" \
+  'grep -q "subagent-driven-development" .claude/skills/executing-plans/SKILL.md'
+check "executing-plans documents self-review at task boundaries" \
+  'grep -q "self-review\|Self-review" .claude/skills/executing-plans/SKILL.md'
+check "executing-plans references pre-commit gate awareness" \
+  'grep -q "pre-commit\|Pre-commit" .claude/skills/executing-plans/SKILL.md'
+check "executing-plans credits obra/superpowers attribution" \
+  'grep -q "obra/superpowers" .claude/skills/executing-plans/SKILL.md'
+
+echo
 echo "═══ #75  loop.md + groom phase ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
 check "groom phase doc present" \

--- a/plugin/skills/executing-plans/SKILL.md
+++ b/plugin/skills/executing-plans/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: executing-plans
+description: Use to execute an implementation plan task-by-task inline in the current session, with checkpoint pauses for review between tasks. Trigger phrases include "execute this plan inline", "run the plan in-session", "implement task-by-task without subagents", or any handoff from writing-plans where the user picked "inline" over "subagent-driven". Faster for trivial plans where subagent dispatch overhead exceeds the catch rate.
+---
+
+# Executing Plans
+
+Execute an implementation plan **task-by-task in the current session**,
+with explicit checkpoint pauses between tasks for review. The simpler
+sibling of `subagent-driven-development` — no subagent dispatch, no
+two-stage per-task review, just sequential execution with the same TDD
+discipline.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/executing-plans/SKILL.md`. Re-implemented for
+> Specflow with explicit checkpoint semantics and integration with the
+> `writing-plans` execution-handoff fork.
+
+## When to use this skill
+
+Use `executing-plans` when:
+
+- The plan has 1–3 trivial tasks where two-stage review overhead would
+  exceed the catch rate
+- The user explicitly picked "inline" at the `writing-plans`
+  execution-handoff fork
+- Subagent dispatch isn't available on the current harness (rare —
+  check `references/<harness>-tools.md`)
+- You need to preserve session context for downstream coordination
+  (subagents lose context; inline keeps everything in your working set)
+
+Use `subagent-driven-development` instead when:
+
+- The plan has 3+ tasks where a bug in task N would cost real time to
+  unwind in task N+2
+- The cost of an early bug propagating outweighs the dispatch overhead
+- You want spec-compliance + code-quality reviews catching issues
+  between tasks
+
+If unsure, default to `subagent-driven-development`. The two-stage
+review caught 9+ correctness issues in a single day's work that inline
+execution would have shipped to CI.
+
+## The loop — per task
+
+```
+Read next task from plan
+  → execute the task (TDD: write failing test, run, implement, run, commit)
+    → checkpoint: self-review the work
+      → if issues found → fix, re-run tests, re-commit
+      → if clean → next task
+```
+
+**Continuous execution.** Don't pause for human check-in between tasks
+unless the plan explicitly marks a step as `STOP — confirm with user`.
+The user asked you to execute; execute.
+
+Pause only for:
+
+- An explicit `STOP` marker in the plan
+- A test failure you cannot resolve in 2–3 attempts
+- A scope-changing decision the plan didn't pre-resolve
+- All tasks complete
+
+## Step 1 — read the plan once
+
+Read the plan file end-to-end. Note the task list, file structure,
+out-of-scope markers, and any cross-task dependencies. Keep the plan
+file's task list in your working context — you'll be jumping between
+the plan and the code throughout execution.
+
+## Step 2 — execute each task in order
+
+For each task, follow the steps in the plan **literally**:
+
+1. Read the step's code block (test, implementation, commit, etc.)
+2. Apply the change exactly as specified
+3. Run the verification command and confirm the expected output
+4. Move to the next step
+
+If a step's code block has a placeholder ("TODO", "TBD"), STOP — the
+plan failed the `writing-plans` zero-placeholder discipline. Surface
+the placeholder to the user before proceeding.
+
+## Step 3 — self-review at task boundaries
+
+After completing every step in a task, before moving to the next task,
+self-review:
+
+- **Completeness** — did you fully implement what the task spec said?
+  Any silent skips?
+- **Quality** — names clear, types accurate, no obvious bugs?
+- **Tests** — do they verify real behavior, or just mock calls?
+- **Discipline** — followed TDD if the task required it? Committed
+  frequently?
+
+Fix anything you find before moving on. This is the inline equivalent
+of the spec-compliance review stage in `subagent-driven-development` —
+you're the reviewer of your own work.
+
+## Step 4 — final whole-plan review
+
+Once every task in the plan is complete, run a whole-implementation
+review by dispatching `requesting-code-review` over the full git range:
+
+```
+BASE_SHA=origin/main   # or the branch base
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+This is the only subagent dispatch in the executing-plans flow — and
+it's optional if the plan was trivial. Use the canonical template from
+`requesting-code-review` (Strengths / Critical / Important / Minor /
+Assessment).
+
+Fix any Critical or Important issues before opening the PR.
+
+## Step 5 — hand off to PR + merge
+
+After the final review, the plan typically ends with PR creation:
+
+```bash
+git push --set-upstream origin <branch>
+# Open PR via gh api -X POST repos/.../pulls (avoids GraphQL rate-limit)
+# Watch CI, merge once green
+# Dispatch product-owner agent to close the linked issue
+```
+
+The plan should specify the PR title and body. If it doesn't, fall
+back to the conventional-commit subject of the most recent commit.
+
+## Handling test failures
+
+When a verification command fails:
+
+1. Read the actual failure output, don't guess
+2. Compare with the expected output in the plan
+3. If the plan's expected output is wrong → flag it to the user and
+   stop (the plan needs a fix, not the code)
+4. If the implementation is wrong → fix it inline, re-run, continue
+
+After 2–3 failed attempts to make a verification pass, STOP and
+surface the situation. Looping on a stuck test wastes cycles and
+context.
+
+## Red flags
+
+**Never:**
+
+- Skip the self-review at task boundaries
+- Proceed past a failing test you can't explain
+- Apply a placeholder that the plan should have specified
+- Batch-commit multiple tasks (each task gets its own commit per the
+  plan's spec)
+- Skip the final whole-plan review for non-trivial work
+
+**If you find a real bug mid-execution:**
+
+- Don't paper over it
+- If it's in your work, fix and continue
+- If it's in the plan, surface and ask for direction
+
+## Integration with `writing-plans`
+
+The `writing-plans` execution-handoff section offers the user a choice
+between `subagent-driven-development` (recommended for complex plans)
+and `executing-plans` (this skill, for simpler plans). When the user
+picks "inline" at the fork, this skill is the entry point.
+
+For trivial single-step plans, just execute the step without invoking
+this skill explicitly — the overhead of reading the SKILL.md exceeds
+the value.
+
+## Pre-commit gate awareness
+
+Specflow's pre-commit hook runs `deno fmt --check`, `deno lint`,
+`deno task bundle`, and `deno check src/main.ts` on every commit. When
+a commit step fails for one of these reasons:
+
+- `fmt` failure → `deno fmt <file>` to fix, re-stage, re-commit
+- `bundle` regenerated → `git add src/templates_bundle.ts && git commit --amend --no-edit`
+- `lint` / `check` failure → genuine error, surface to user with the
+  exact output
+
+## Pre-flight check
+
+Before starting execution, confirm:
+
+- You're on a feature branch (not `main`); if not, branch first per the
+  plan
+- The working tree is clean OR all dirty files are documented as
+  intentional in the plan
+- The plan file is readable and well-formed (has a Goal, Tasks, and
+  Out-of-scope sections)
+
+If any of these fail, surface and stop.
+
+## Out of scope
+
+This skill does not:
+
+- Write plans (`writing-plans` does)
+- Dispatch implementer subagents (`subagent-driven-development` does)
+- Mutate the backlog (the `product-owner` agent does)
+- Watch CI or merge PRs after task completion (the controller / user
+  does, following the plan's PR-flow specification)
+- Trigger releases (`/release` + `devops-sre` advisory)
+
+## When NOT to use this skill
+
+- Plans with 4+ tasks where bug propagation cost is real — use
+  `subagent-driven-development` instead
+- Single-file trivial changes — just do the change, no skill overhead
+- When the harness lacks the file-modification tools (genuinely rare;
+  every supported Specflow harness has Read/Write/Edit equivalents)

--- a/plugin/skills/using-specflow/SKILL.md
+++ b/plugin/skills/using-specflow/SKILL.md
@@ -40,6 +40,7 @@ not re-read the file with `Read`.
 | `writing-plans` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
 | `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
 | `subagent-driven-development` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by `writing-plans`. |
+| `executing-plans` | Inline alternative to subagent-driven — execute a plan task-by-task in-session with checkpoint pauses. Faster for trivial plans. |
 | `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |

--- a/plugin/skills/writing-plans/SKILL.md
+++ b/plugin/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ another human) can follow step-by-step without re-reading the spec.
 > (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow
 > with `docs/specflow/plans/` as the canonical save path and explicit
 > handoff to Specflow's `subagent-driven-development` / `executing-plans`
-> skill (`subagent-driven-development`) and issue #274 (executing-plans).
+> skills (`subagent-driven-development` and `executing-plans`).
 
 ## When to use this skill
 
@@ -95,8 +95,8 @@ Every plan **MUST** start with this header:
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
 > `specflow:subagent-driven-development` (recommended) or
-> `specflow:executing-plans` (#274 once shipped) to implement this
-> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> `specflow:executing-plans` to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -232,10 +232,8 @@ After saving the plan, offer the user a choice of execution strategy:
 
 **If inline chosen:**
 
-- **REQUIRED SUB-SKILL:** Use `specflow:executing-plans` (issue #274
-  once shipped — otherwise execute tasks in-session with manual
-  checkpoint pauses)
-- Batch execution with explicit checkpoints
+- **REQUIRED SUB-SKILL:** Use `specflow:executing-plans`
+- Sequential in-session execution with checkpoint pauses between tasks
 
 ## Key principles
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3158,7 +3158,7 @@ another human) can follow step-by-step without re-reading the spec.
 > (MIT) — \`skills/writing-plans/SKILL.md\`. Re-implemented for Specflow
 > with \`docs/specflow/plans/\` as the canonical save path and explicit
 > handoff to Specflow's \`subagent-driven-development\` / \`executing-plans\`
-> skill (\`subagent-driven-development\`) and issue #274 (executing-plans).
+> skills (\`subagent-driven-development\` and \`executing-plans\`).
 
 ## When to use this skill
 
@@ -3240,8 +3240,8 @@ Every plan **MUST** start with this header:
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
 > \`specflow:subagent-driven-development\` (recommended) or
-> \`specflow:executing-plans\` (#274 once shipped) to implement this
-> plan task-by-task. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+> \`specflow:executing-plans\` to implement this plan task-by-task.
+> Steps use checkbox (\`- [ ]\`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -3377,10 +3377,8 @@ After saving the plan, offer the user a choice of execution strategy:
 
 **If inline chosen:**
 
-- **REQUIRED SUB-SKILL:** Use \`specflow:executing-plans\` (issue #274
-  once shipped — otherwise execute tasks in-session with manual
-  checkpoint pauses)
-- Batch execution with explicit checkpoints
+- **REQUIRED SUB-SKILL:** Use \`specflow:executing-plans\`
+- Sequential in-session execution with checkpoint pauses between tasks
 
 ## Key principles
 
@@ -3764,6 +3762,7 @@ not re-read the file with \`Read\`.
 | \`writing-plans\` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
 | \`requesting-code-review\` | Work is complete enough to need an independent eye. Dispatch the bundled \`code-reviewer\` agent with the canonical prompt template. |
 | \`subagent-driven-development\` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by \`writing-plans\`. |
+| \`executing-plans\` | Inline alternative to subagent-driven — execute a plan task-by-task in-session with checkpoint pauses. Faster for trivial plans. |
 | \`backlog\` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the \`product-owner\` agent. |
 | \`specflow-auto\` | Auto-chain orchestration (legacy entry point — most users invoke \`/specflow specify\` instead). |
 | \`specflow-review\` | Auto-invoke alias preserved for the \`/specflow review\` phase. |
@@ -4176,6 +4175,230 @@ This skill does not:
 - When dispatch isn't available on the current harness (rare; check
   \`references/<harness>-tools.md\`)
 - When the user explicitly asked for inline execution
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
+    name: "executing-plans",
+    suffix: null,
+    content: `---
+name: executing-plans
+description: Use to execute an implementation plan task-by-task inline in the current session, with checkpoint pauses for review between tasks. Trigger phrases include "execute this plan inline", "run the plan in-session", "implement task-by-task without subagents", or any handoff from writing-plans where the user picked "inline" over "subagent-driven". Faster for trivial plans where subagent dispatch overhead exceeds the catch rate.
+---
+
+# Executing Plans
+
+Execute an implementation plan **task-by-task in the current session**,
+with explicit checkpoint pauses between tasks for review. The simpler
+sibling of \`subagent-driven-development\` — no subagent dispatch, no
+two-stage per-task review, just sequential execution with the same TDD
+discipline.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/executing-plans/SKILL.md\`. Re-implemented for
+> Specflow with explicit checkpoint semantics and integration with the
+> \`writing-plans\` execution-handoff fork.
+
+## When to use this skill
+
+Use \`executing-plans\` when:
+
+- The plan has 1–3 trivial tasks where two-stage review overhead would
+  exceed the catch rate
+- The user explicitly picked "inline" at the \`writing-plans\`
+  execution-handoff fork
+- Subagent dispatch isn't available on the current harness (rare —
+  check \`references/<harness>-tools.md\`)
+- You need to preserve session context for downstream coordination
+  (subagents lose context; inline keeps everything in your working set)
+
+Use \`subagent-driven-development\` instead when:
+
+- The plan has 3+ tasks where a bug in task N would cost real time to
+  unwind in task N+2
+- The cost of an early bug propagating outweighs the dispatch overhead
+- You want spec-compliance + code-quality reviews catching issues
+  between tasks
+
+If unsure, default to \`subagent-driven-development\`. The two-stage
+review caught 9+ correctness issues in a single day's work that inline
+execution would have shipped to CI.
+
+## The loop — per task
+
+\`\`\`
+Read next task from plan
+  → execute the task (TDD: write failing test, run, implement, run, commit)
+    → checkpoint: self-review the work
+      → if issues found → fix, re-run tests, re-commit
+      → if clean → next task
+\`\`\`
+
+**Continuous execution.** Don't pause for human check-in between tasks
+unless the plan explicitly marks a step as \`STOP — confirm with user\`.
+The user asked you to execute; execute.
+
+Pause only for:
+
+- An explicit \`STOP\` marker in the plan
+- A test failure you cannot resolve in 2–3 attempts
+- A scope-changing decision the plan didn't pre-resolve
+- All tasks complete
+
+## Step 1 — read the plan once
+
+Read the plan file end-to-end. Note the task list, file structure,
+out-of-scope markers, and any cross-task dependencies. Keep the plan
+file's task list in your working context — you'll be jumping between
+the plan and the code throughout execution.
+
+## Step 2 — execute each task in order
+
+For each task, follow the steps in the plan **literally**:
+
+1. Read the step's code block (test, implementation, commit, etc.)
+2. Apply the change exactly as specified
+3. Run the verification command and confirm the expected output
+4. Move to the next step
+
+If a step's code block has a placeholder ("TODO", "TBD"), STOP — the
+plan failed the \`writing-plans\` zero-placeholder discipline. Surface
+the placeholder to the user before proceeding.
+
+## Step 3 — self-review at task boundaries
+
+After completing every step in a task, before moving to the next task,
+self-review:
+
+- **Completeness** — did you fully implement what the task spec said?
+  Any silent skips?
+- **Quality** — names clear, types accurate, no obvious bugs?
+- **Tests** — do they verify real behavior, or just mock calls?
+- **Discipline** — followed TDD if the task required it? Committed
+  frequently?
+
+Fix anything you find before moving on. This is the inline equivalent
+of the spec-compliance review stage in \`subagent-driven-development\` —
+you're the reviewer of your own work.
+
+## Step 4 — final whole-plan review
+
+Once every task in the plan is complete, run a whole-implementation
+review by dispatching \`requesting-code-review\` over the full git range:
+
+\`\`\`
+BASE_SHA=origin/main   # or the branch base
+HEAD_SHA=\$(git rev-parse HEAD)
+\`\`\`
+
+This is the only subagent dispatch in the executing-plans flow — and
+it's optional if the plan was trivial. Use the canonical template from
+\`requesting-code-review\` (Strengths / Critical / Important / Minor /
+Assessment).
+
+Fix any Critical or Important issues before opening the PR.
+
+## Step 5 — hand off to PR + merge
+
+After the final review, the plan typically ends with PR creation:
+
+\`\`\`bash
+git push --set-upstream origin <branch>
+# Open PR via gh api -X POST repos/.../pulls (avoids GraphQL rate-limit)
+# Watch CI, merge once green
+# Dispatch product-owner agent to close the linked issue
+\`\`\`
+
+The plan should specify the PR title and body. If it doesn't, fall
+back to the conventional-commit subject of the most recent commit.
+
+## Handling test failures
+
+When a verification command fails:
+
+1. Read the actual failure output, don't guess
+2. Compare with the expected output in the plan
+3. If the plan's expected output is wrong → flag it to the user and
+   stop (the plan needs a fix, not the code)
+4. If the implementation is wrong → fix it inline, re-run, continue
+
+After 2–3 failed attempts to make a verification pass, STOP and
+surface the situation. Looping on a stuck test wastes cycles and
+context.
+
+## Red flags
+
+**Never:**
+
+- Skip the self-review at task boundaries
+- Proceed past a failing test you can't explain
+- Apply a placeholder that the plan should have specified
+- Batch-commit multiple tasks (each task gets its own commit per the
+  plan's spec)
+- Skip the final whole-plan review for non-trivial work
+
+**If you find a real bug mid-execution:**
+
+- Don't paper over it
+- If it's in your work, fix and continue
+- If it's in the plan, surface and ask for direction
+
+## Integration with \`writing-plans\`
+
+The \`writing-plans\` execution-handoff section offers the user a choice
+between \`subagent-driven-development\` (recommended for complex plans)
+and \`executing-plans\` (this skill, for simpler plans). When the user
+picks "inline" at the fork, this skill is the entry point.
+
+For trivial single-step plans, just execute the step without invoking
+this skill explicitly — the overhead of reading the SKILL.md exceeds
+the value.
+
+## Pre-commit gate awareness
+
+Specflow's pre-commit hook runs \`deno fmt --check\`, \`deno lint\`,
+\`deno task bundle\`, and \`deno check src/main.ts\` on every commit. When
+a commit step fails for one of these reasons:
+
+- \`fmt\` failure → \`deno fmt <file>\` to fix, re-stage, re-commit
+- \`bundle\` regenerated → \`git add src/templates_bundle.ts && git commit --amend --no-edit\`
+- \`lint\` / \`check\` failure → genuine error, surface to user with the
+  exact output
+
+## Pre-flight check
+
+Before starting execution, confirm:
+
+- You're on a feature branch (not \`main\`); if not, branch first per the
+  plan
+- The working tree is clean OR all dirty files are documented as
+  intentional in the plan
+- The plan file is readable and well-formed (has a Goal, Tasks, and
+  Out-of-scope sections)
+
+If any of these fail, surface and stop.
+
+## Out of scope
+
+This skill does not:
+
+- Write plans (\`writing-plans\` does)
+- Dispatch implementer subagents (\`subagent-driven-development\` does)
+- Mutate the backlog (the \`product-owner\` agent does)
+- Watch CI or merge PRs after task completion (the controller / user
+  does, following the plan's PR-flow specification)
+- Trigger releases (\`/release\` + \`devops-sre\` advisory)
+
+## When NOT to use this skill
+
+- Plans with 4+ tasks where bug propagation cost is real — use
+  \`subagent-driven-development\` instead
+- Single-file trivial changes — just do the change, no skill overhead
+- When the harness lacks the file-modification tools (genuinely rare;
+  every supported Specflow harness has Read/Write/Edit equivalents)
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/executing-plans/SKILL.md
+++ b/templates/core/skills/executing-plans/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: executing-plans
+description: Use to execute an implementation plan task-by-task inline in the current session, with checkpoint pauses for review between tasks. Trigger phrases include "execute this plan inline", "run the plan in-session", "implement task-by-task without subagents", or any handoff from writing-plans where the user picked "inline" over "subagent-driven". Faster for trivial plans where subagent dispatch overhead exceeds the catch rate.
+---
+
+# Executing Plans
+
+Execute an implementation plan **task-by-task in the current session**,
+with explicit checkpoint pauses between tasks for review. The simpler
+sibling of `subagent-driven-development` — no subagent dispatch, no
+two-stage per-task review, just sequential execution with the same TDD
+discipline.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/executing-plans/SKILL.md`. Re-implemented for
+> Specflow with explicit checkpoint semantics and integration with the
+> `writing-plans` execution-handoff fork.
+
+## When to use this skill
+
+Use `executing-plans` when:
+
+- The plan has 1–3 trivial tasks where two-stage review overhead would
+  exceed the catch rate
+- The user explicitly picked "inline" at the `writing-plans`
+  execution-handoff fork
+- Subagent dispatch isn't available on the current harness (rare —
+  check `references/<harness>-tools.md`)
+- You need to preserve session context for downstream coordination
+  (subagents lose context; inline keeps everything in your working set)
+
+Use `subagent-driven-development` instead when:
+
+- The plan has 3+ tasks where a bug in task N would cost real time to
+  unwind in task N+2
+- The cost of an early bug propagating outweighs the dispatch overhead
+- You want spec-compliance + code-quality reviews catching issues
+  between tasks
+
+If unsure, default to `subagent-driven-development`. The two-stage
+review caught 9+ correctness issues in a single day's work that inline
+execution would have shipped to CI.
+
+## The loop — per task
+
+```
+Read next task from plan
+  → execute the task (TDD: write failing test, run, implement, run, commit)
+    → checkpoint: self-review the work
+      → if issues found → fix, re-run tests, re-commit
+      → if clean → next task
+```
+
+**Continuous execution.** Don't pause for human check-in between tasks
+unless the plan explicitly marks a step as `STOP — confirm with user`.
+The user asked you to execute; execute.
+
+Pause only for:
+
+- An explicit `STOP` marker in the plan
+- A test failure you cannot resolve in 2–3 attempts
+- A scope-changing decision the plan didn't pre-resolve
+- All tasks complete
+
+## Step 1 — read the plan once
+
+Read the plan file end-to-end. Note the task list, file structure,
+out-of-scope markers, and any cross-task dependencies. Keep the plan
+file's task list in your working context — you'll be jumping between
+the plan and the code throughout execution.
+
+## Step 2 — execute each task in order
+
+For each task, follow the steps in the plan **literally**:
+
+1. Read the step's code block (test, implementation, commit, etc.)
+2. Apply the change exactly as specified
+3. Run the verification command and confirm the expected output
+4. Move to the next step
+
+If a step's code block has a placeholder ("TODO", "TBD"), STOP — the
+plan failed the `writing-plans` zero-placeholder discipline. Surface
+the placeholder to the user before proceeding.
+
+## Step 3 — self-review at task boundaries
+
+After completing every step in a task, before moving to the next task,
+self-review:
+
+- **Completeness** — did you fully implement what the task spec said?
+  Any silent skips?
+- **Quality** — names clear, types accurate, no obvious bugs?
+- **Tests** — do they verify real behavior, or just mock calls?
+- **Discipline** — followed TDD if the task required it? Committed
+  frequently?
+
+Fix anything you find before moving on. This is the inline equivalent
+of the spec-compliance review stage in `subagent-driven-development` —
+you're the reviewer of your own work.
+
+## Step 4 — final whole-plan review
+
+Once every task in the plan is complete, run a whole-implementation
+review by dispatching `requesting-code-review` over the full git range:
+
+```
+BASE_SHA=origin/main   # or the branch base
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+This is the only subagent dispatch in the executing-plans flow — and
+it's optional if the plan was trivial. Use the canonical template from
+`requesting-code-review` (Strengths / Critical / Important / Minor /
+Assessment).
+
+Fix any Critical or Important issues before opening the PR.
+
+## Step 5 — hand off to PR + merge
+
+After the final review, the plan typically ends with PR creation:
+
+```bash
+git push --set-upstream origin <branch>
+# Open PR via gh api -X POST repos/.../pulls (avoids GraphQL rate-limit)
+# Watch CI, merge once green
+# Dispatch product-owner agent to close the linked issue
+```
+
+The plan should specify the PR title and body. If it doesn't, fall
+back to the conventional-commit subject of the most recent commit.
+
+## Handling test failures
+
+When a verification command fails:
+
+1. Read the actual failure output, don't guess
+2. Compare with the expected output in the plan
+3. If the plan's expected output is wrong → flag it to the user and
+   stop (the plan needs a fix, not the code)
+4. If the implementation is wrong → fix it inline, re-run, continue
+
+After 2–3 failed attempts to make a verification pass, STOP and
+surface the situation. Looping on a stuck test wastes cycles and
+context.
+
+## Red flags
+
+**Never:**
+
+- Skip the self-review at task boundaries
+- Proceed past a failing test you can't explain
+- Apply a placeholder that the plan should have specified
+- Batch-commit multiple tasks (each task gets its own commit per the
+  plan's spec)
+- Skip the final whole-plan review for non-trivial work
+
+**If you find a real bug mid-execution:**
+
+- Don't paper over it
+- If it's in your work, fix and continue
+- If it's in the plan, surface and ask for direction
+
+## Integration with `writing-plans`
+
+The `writing-plans` execution-handoff section offers the user a choice
+between `subagent-driven-development` (recommended for complex plans)
+and `executing-plans` (this skill, for simpler plans). When the user
+picks "inline" at the fork, this skill is the entry point.
+
+For trivial single-step plans, just execute the step without invoking
+this skill explicitly — the overhead of reading the SKILL.md exceeds
+the value.
+
+## Pre-commit gate awareness
+
+Specflow's pre-commit hook runs `deno fmt --check`, `deno lint`,
+`deno task bundle`, and `deno check src/main.ts` on every commit. When
+a commit step fails for one of these reasons:
+
+- `fmt` failure → `deno fmt <file>` to fix, re-stage, re-commit
+- `bundle` regenerated → `git add src/templates_bundle.ts && git commit --amend --no-edit`
+- `lint` / `check` failure → genuine error, surface to user with the
+  exact output
+
+## Pre-flight check
+
+Before starting execution, confirm:
+
+- You're on a feature branch (not `main`); if not, branch first per the
+  plan
+- The working tree is clean OR all dirty files are documented as
+  intentional in the plan
+- The plan file is readable and well-formed (has a Goal, Tasks, and
+  Out-of-scope sections)
+
+If any of these fail, surface and stop.
+
+## Out of scope
+
+This skill does not:
+
+- Write plans (`writing-plans` does)
+- Dispatch implementer subagents (`subagent-driven-development` does)
+- Mutate the backlog (the `product-owner` agent does)
+- Watch CI or merge PRs after task completion (the controller / user
+  does, following the plan's PR-flow specification)
+- Trigger releases (`/release` + `devops-sre` advisory)
+
+## When NOT to use this skill
+
+- Plans with 4+ tasks where bug propagation cost is real — use
+  `subagent-driven-development` instead
+- Single-file trivial changes — just do the change, no skill overhead
+- When the harness lacks the file-modification tools (genuinely rare;
+  every supported Specflow harness has Read/Write/Edit equivalents)

--- a/templates/core/skills/using-specflow/SKILL.md
+++ b/templates/core/skills/using-specflow/SKILL.md
@@ -40,6 +40,7 @@ not re-read the file with `Read`.
 | `writing-plans` | User wants to plan an issue or a feature without the spec-kit ceremony. Trigger phrases: "plan this", "write a plan for X", "give me an implementation plan". |
 | `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
 | `subagent-driven-development` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by `writing-plans`. |
+| `executing-plans` | Inline alternative to subagent-driven — execute a plan task-by-task in-session with checkpoint pauses. Faster for trivial plans. |
 | `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |

--- a/templates/core/skills/writing-plans/SKILL.md
+++ b/templates/core/skills/writing-plans/SKILL.md
@@ -13,7 +13,7 @@ another human) can follow step-by-step without re-reading the spec.
 > (MIT) — `skills/writing-plans/SKILL.md`. Re-implemented for Specflow
 > with `docs/specflow/plans/` as the canonical save path and explicit
 > handoff to Specflow's `subagent-driven-development` / `executing-plans`
-> skill (`subagent-driven-development`) and issue #274 (executing-plans).
+> skills (`subagent-driven-development` and `executing-plans`).
 
 ## When to use this skill
 
@@ -95,8 +95,8 @@ Every plan **MUST** start with this header:
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use
 > `specflow:subagent-driven-development` (recommended) or
-> `specflow:executing-plans` (#274 once shipped) to implement this
-> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> `specflow:executing-plans` to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -232,10 +232,8 @@ After saving the plan, offer the user a choice of execution strategy:
 
 **If inline chosen:**
 
-- **REQUIRED SUB-SKILL:** Use `specflow:executing-plans` (issue #274
-  once shipped — otherwise execute tasks in-session with manual
-  checkpoint pauses)
-- Batch execution with explicit checkpoints
+- **REQUIRED SUB-SKILL:** Use `specflow:executing-plans`
+- Sequential in-session execution with checkpoint pauses between tasks
 
 ## Key principles
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -27,6 +27,7 @@
     { "category": "skill", "name": "requesting-code-review", "source": "core/skills/requesting-code-review/SKILL.md" },
     { "category": "skill", "name": "using-specflow", "source": "core/skills/using-specflow/SKILL.md" },
     { "category": "skill", "name": "subagent-driven-development", "source": "core/skills/subagent-driven-development/SKILL.md" },
+    { "category": "skill", "name": "executing-plans", "source": "core/skills/executing-plans/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -89,11 +89,12 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     // Top-level skill folders post-consolidation: specflow router +
     // specflow-auto + specflow-review alias + specflow-backlog +
     // writing-plans (A1) + requesting-code-review (A3) +
-    // using-specflow bootstrap (B6) + subagent-driven-development (A2) = 8.
+    // using-specflow bootstrap (B6) + subagent-driven-development (A2) +
+    // executing-plans (A4) = 9.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 8);
+    assertEquals(agentsSkillsCount, 9);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -86,11 +86,11 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     // auto-chain + list-skills) + specflow-auto + specflow-review +
     // writing-plans (#271) + requesting-code-review (#273) +
     // using-specflow (#282) + subagent-driven-development (#272) +
-    // backlog + 11 agents = 33.
+    // executing-plans (#274) + backlog + 11 agents = 34.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 33);
+    assertEquals(instructionsCount, 34);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -78,11 +78,11 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
     // auto-chain + list-skills) + specflow-auto + specflow-review alias +
     // writing-plans (#271) + requesting-code-review (#273) +
     // using-specflow (#282) + subagent-driven-development (#272) +
-    // backlog + 11 agent workflows = 33.
+    // executing-plans (#274) + backlog + 11 agent workflows = 34.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 33);
+    assertEquals(workflowsCount, 34);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -79,6 +79,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/subagent-driven-development/SKILL.md",
     source: "templates/core/skills/subagent-driven-development/SKILL.md",
   },
+  // executing-plans — inline alternative to subagent-driven-development
+  // for trivial plans where dispatch overhead exceeds the catch rate
+  // (Epic #270, A4 #274).
+  {
+    plugin: "plugin/skills/executing-plans/SKILL.md",
+    source: "templates/core/skills/executing-plans/SKILL.md",
+  },
   ...[
     "claude",
     "codex",


### PR DESCRIPTION
Closes #274. A4 of Epic #270 — Phase 2 of the multi-harness parity work.

## Agent adoption

Specflow now ships a native `executing-plans` skill — the inline alternative to `subagent-driven-development` (#272) for trivial plans where two-stage review overhead exceeds the catch rate.

```prompt
After `specflow upgrade`, when you complete `writing-plans` and pick the "inline" option at the execution-handoff fork, this skill takes over: sequential in-session execution with explicit checkpoint pauses for self-review between tasks. Faster than subagent-driven for 1-3 trivial tasks; subagent-driven still recommended for anything where a bug in task N would cost time to unwind in task N+2. Both skills now exist; user picks per plan.
```

## Specflow-native adaptations vs. upstream

- **Explicit checkpoint semantics** between tasks — self-review for completeness, quality, tests, TDD discipline before advancing
- **Pre-commit gate awareness** — documents `deno fmt`, `deno lint`, `deno task bundle`, `deno check src/main.ts` failure modes with remediation
- **Pre-flight check** — branch, clean tree, well-formed plan before execution starts
- **Narrow pause triggers** — STOP marker in plan / stuck test (2-3 retry budget) / scope-changing decision / all tasks done

## Files

- `templates/core/skills/executing-plans/SKILL.md` — 8005 chars
- `plugin/skills/executing-plans/SKILL.md` — byte-identical mirror
- `templates/manifest.json` — registers new skill (90 → 91 core entries)
- `tests/plugin/plugin_sync_test.ts` — +1 SYNC_PAIR
- `.claude/skills/test-sandbox/scripts/smoke-features.sh` — 7 new static-grep assertions
- `tests/integration/init_{codex,copilot,windsurf}_test.ts` — scaffolded count +1

## Forward-reference cleanup

With #274 landing, two sibling skills update their "#274 once shipped" qualifiers:

- `writing-plans/SKILL.md` — header reference and execution-handoff section now point at `executing-plans` directly
- `using-specflow/SKILL.md` — skill registry table gains a row for `executing-plans`

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `skills/executing-plans/SKILL.md`. Re-implemented for Specflow with explicit pre-commit gate awareness and pre-flight checks.

## Out of scope

- A5 (#275) `verification-before-completion` and A6 (#276) `brainstorming` — the remaining Phase 2 items. Land in the next iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)