### PR TITLE
feat: bundled verification-before-completion skill (#275)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -168,6 +168,23 @@ check "executing-plans credits obra/superpowers attribution" \
   'grep -q "obra/superpowers" .claude/skills/executing-plans/SKILL.md'
 
 echo
+echo "═══ #275  verification-before-completion skill (Epic #270 / A5) ═══"
+check "verification-before-completion skill scaffolded" \
+  '[ -f .claude/skills/verification-before-completion/SKILL.md ]'
+check "verification-before-completion frontmatter declares name" \
+  'head -5 .claude/skills/verification-before-completion/SKILL.md | grep -q "name: verification-before-completion"'
+check "verification-before-completion enumerates the 8-item checklist" \
+  'grep -q "deno task test" .claude/skills/verification-before-completion/SKILL.md && grep -q "deno fmt --check" .claude/skills/verification-before-completion/SKILL.md && grep -q "audit.sh" .claude/skills/verification-before-completion/SKILL.md'
+check "verification-before-completion references plugin sync test" \
+  'grep -q "plugin_sync_test" .claude/skills/verification-before-completion/SKILL.md'
+check "verification-before-completion references Windsurf cap" \
+  'grep -q "windsurf_harness_test\|Windsurf 12000-char" .claude/skills/verification-before-completion/SKILL.md'
+check "verification-before-completion documents report shape with evidence" \
+  'grep -q "Verification:" .claude/skills/verification-before-completion/SKILL.md'
+check "verification-before-completion credits obra/superpowers attribution" \
+  'grep -q "obra/superpowers" .claude/skills/verification-before-completion/SKILL.md'
+
+echo
 echo "═══ #75  loop.md + groom phase ═══"
 check ".claude/loop.md scaffolded" '[ -f .claude/loop.md ]'
 check "groom phase doc present" \

--- a/plugin/skills/using-specflow/SKILL.md
+++ b/plugin/skills/using-specflow/SKILL.md
@@ -41,6 +41,7 @@ not re-read the file with `Read`.
 | `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
 | `subagent-driven-development` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by `writing-plans`. |
 | `executing-plans` | Inline alternative to subagent-driven — execute a plan task-by-task in-session with checkpoint pauses. Faster for trivial plans. |
+| `verification-before-completion` | Discipline checklist that any agent MUST run before reporting DONE. Tests green / pre-commit clean / plan boxes ticked / smoke audit / plugin sync / Windsurf cap / requirements addressed. |
 | `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |

--- a/plugin/skills/verification-before-completion/SKILL.md
+++ b/plugin/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: verification-before-completion
+description: Use before reporting any work as DONE — implementing agents (developer subagent, inline executor, the controller) MUST run this verification checklist before claiming completion. Trigger phrases include "verify this is done", "ready to ship", "is this complete", "before I merge", or any moment an agent is about to report DONE on a task or PR. Catches the common failure mode where "done" really means "I think it's done but I haven't actually checked".
+---
+
+# Verification Before Completion
+
+A forcing function for the discipline an agent should already have but
+often skips under time pressure. Run this checklist before reporting
+**any** work as complete — a task, a feature, a PR, a release. Anything
+not verified is not done.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/verification-before-completion/SKILL.md`.
+> Re-implemented for Specflow with explicit pre-commit + smoke + bundle
+> gates that match this repo's actual quality contract.
+
+## When to invoke
+
+Mandatory invocation points:
+
+- Before an implementer subagent reports `DONE` on a task
+- Before a controller reports a feature complete to the user
+- Before opening a PR (CI catches some of these, but not all)
+- Before merging a PR
+- Before tagging a release (the `/release` skill already includes this
+  inline — see `templates/core/skills/release/SKILL.md`)
+
+If you find yourself about to type "✅ done" or report a task complete,
+**stop and run this checklist first**.
+
+## The checklist
+
+Run each item literally. Don't trust memory — the whole point of this
+skill is to override the agent's tendency to say "I'm pretty sure I
+did that already".
+
+### 1. Tests are actually green
+
+```bash
+deno task test
+```
+
+Expected: `<N> passed | 0 failed`. **Read the actual output.** If the
+number of passed tests is lower than the previous baseline AND no
+tests were intentionally removed, that's a silent skip — find it.
+
+A test that didn't run is not a test that passed.
+
+### 2. Pre-commit gates are clean
+
+```bash
+deno fmt --check && deno lint && deno task bundle && deno check src/main.ts
+```
+
+Each gate must exit 0. Specifically:
+
+- `deno fmt --check` — format clean (run `deno fmt <file>` to fix)
+- `deno lint` — no lint violations
+- `deno task bundle` — bundle regenerates without drift; if it
+  produces a non-empty diff, the bundle was stale (commit the regen)
+- `deno check src/main.ts` — TypeScript type-check clean
+
+### 3. Working tree is clean (or all dirty files are intentional)
+
+```bash
+git status --porcelain
+```
+
+Expected: empty, OR every line is intentional + documented. If you
+see uncommitted changes you can't explain, you committed a partial
+state — either commit the rest or `git stash`.
+
+### 4. Plan checkboxes are all ticked
+
+If you're executing a plan from `docs/specflow/plans/`, every `- [ ]`
+under the tasks you claimed to complete must now read `- [x]`. Read
+the plan file with the Read tool, search for `- [ ]` lines under your
+task's section. Any unchecked box = silent skip.
+
+### 5. Smoke coverage audit (when touching scaffolded scripts or skills)
+
+If your change touched `templates/core/skills/` or
+`templates/core/skills/backlog/scripts/`:
+
+```bash
+bash .claude/skills/test-sandbox/scripts/audit.sh
+```
+
+Expected: `0 coverage gap(s), 0 stale assertion(s)`. A new file under
+those paths without a smoke assertion is a contract violation — add
+the assertion before claiming done.
+
+### 6. Plugin byte-identity (when touching scaffolded skills or agents)
+
+If your change touched `templates/core/skills/` or
+`templates/core/agents/`, the mirror under `plugin/skills/` or
+`plugin/agents/` must be byte-identical:
+
+```bash
+deno test --allow-read tests/plugin/plugin_sync_test.ts
+```
+
+Expected: every pair in SYNC_PAIRS green. If a new file landed, add
+the SYNC_PAIR entry.
+
+### 7. Windsurf cap (when touching SKILL.md or agent prompts)
+
+If your change touched any `templates/core/agents/*.md` or
+`templates/core/skills/*/SKILL.md`:
+
+```bash
+deno test --allow-read tests/infrastructure/harness/windsurf_harness_test.ts
+```
+
+The Windsurf 12000-char rendered cap is hard-gated. A file that
+overruns blocks the release.
+
+### 8. Self-review against the requirements
+
+Re-read the task / spec / issue you set out to satisfy. For each
+acceptance criterion or numbered requirement, name the file:line or
+the commit that addresses it. If you can't, that requirement isn't
+done.
+
+## When a verification fails
+
+**Stop. Do not report DONE.** Fix the failure first.
+
+If the failure is in your own work → fix inline, re-verify.
+
+If the failure exposes a real issue in the spec or plan → surface it
+to the user with the exact failure output. Do not paper over it. Do
+not claim "mostly done" or "done with minor issues".
+
+The skill's whole reason for existing is to catch the moment you'd
+otherwise say "yeah I'm pretty sure that works" without checking.
+
+## Report shape
+
+When all 8 checks pass, the agent can report DONE with the verification
+evidence inline:
+
+```
+Status: DONE
+
+Verification:
+- deno task test: 645 passed | 0 failed ✓
+- pre-commit gates: clean ✓
+- git status: clean ✓
+- plan checkboxes: 12/12 ticked ✓
+- audit.sh: 0 gap, 0 stale ✓
+- plugin_sync_test: all SYNC_PAIRS green ✓
+- windsurf cap: <wc -c value> chars rendered (under 12000) ✓
+- requirements: <ACa> @ <file:line> · <ACb> @ <file:line> · ... ✓
+```
+
+The user trusts a report shaped like this far more than a bare "done".
+
+## When NOT to invoke this skill
+
+- For pure conversational replies (you're not reporting work done)
+- For mid-task progress updates ("working on task 3 now") — verification
+  is for the **completion claim**, not the running commentary
+- For exploratory work where the agent is still gathering context
+
+## Integration with other skills
+
+- `developer` agent — should invoke this skill before reporting DONE
+  to the controller
+- `subagent-driven-development` — the controller invokes this skill on
+  the implementer's report before dispatching the spec-compliance
+  reviewer (one more layer of defence)
+- `executing-plans` — the inline executor invokes this skill at the
+  final whole-plan checkpoint before opening the PR
+- `/release` — the release skill already includes inline verification
+  (preflight checks, smoke audit, deno task test). This skill formalises
+  the same discipline for non-release work.
+
+## Out of scope
+
+This skill does not:
+
+- Run the checks for you — you run them yourself, then report the
+  result
+- Replace the `code-reviewer` agent's review — verification is
+  self-checks; review is a fresh-eyes peer check
+- Mutate any state (no commits, no PR operations, no backlog moves)
+- Override user-stated overrides (if the user said "ship it,
+  skip the smoke audit", that authorisation holds — but log the
+  exception in the verification report so the trace is honest)

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -3763,6 +3763,7 @@ not re-read the file with \`Read\`.
 | \`requesting-code-review\` | Work is complete enough to need an independent eye. Dispatch the bundled \`code-reviewer\` agent with the canonical prompt template. |
 | \`subagent-driven-development\` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by \`writing-plans\`. |
 | \`executing-plans\` | Inline alternative to subagent-driven — execute a plan task-by-task in-session with checkpoint pauses. Faster for trivial plans. |
+| \`verification-before-completion\` | Discipline checklist that any agent MUST run before reporting DONE. Tests green / pre-commit clean / plan boxes ticked / smoke audit / plugin sync / Windsurf cap / requirements addressed. |
 | \`backlog\` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the \`product-owner\` agent. |
 | \`specflow-auto\` | Auto-chain orchestration (legacy entry point — most users invoke \`/specflow specify\` instead). |
 | \`specflow-review\` | Auto-invoke alias preserved for the \`/specflow review\` phase. |
@@ -4399,6 +4400,206 @@ This skill does not:
 - Single-file trivial changes — just do the change, no skill overhead
 - When the harness lacks the file-modification tools (genuinely rare;
   every supported Specflow harness has Read/Write/Edit equivalents)
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
+    name: "verification-before-completion",
+    suffix: null,
+    content: `---
+name: verification-before-completion
+description: Use before reporting any work as DONE — implementing agents (developer subagent, inline executor, the controller) MUST run this verification checklist before claiming completion. Trigger phrases include "verify this is done", "ready to ship", "is this complete", "before I merge", or any moment an agent is about to report DONE on a task or PR. Catches the common failure mode where "done" really means "I think it's done but I haven't actually checked".
+---
+
+# Verification Before Completion
+
+A forcing function for the discipline an agent should already have but
+often skips under time pressure. Run this checklist before reporting
+**any** work as complete — a task, a feature, a PR, a release. Anything
+not verified is not done.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/verification-before-completion/SKILL.md\`.
+> Re-implemented for Specflow with explicit pre-commit + smoke + bundle
+> gates that match this repo's actual quality contract.
+
+## When to invoke
+
+Mandatory invocation points:
+
+- Before an implementer subagent reports \`DONE\` on a task
+- Before a controller reports a feature complete to the user
+- Before opening a PR (CI catches some of these, but not all)
+- Before merging a PR
+- Before tagging a release (the \`/release\` skill already includes this
+  inline — see \`templates/core/skills/release/SKILL.md\`)
+
+If you find yourself about to type "✅ done" or report a task complete,
+**stop and run this checklist first**.
+
+## The checklist
+
+Run each item literally. Don't trust memory — the whole point of this
+skill is to override the agent's tendency to say "I'm pretty sure I
+did that already".
+
+### 1. Tests are actually green
+
+\`\`\`bash
+deno task test
+\`\`\`
+
+Expected: \`<N> passed | 0 failed\`. **Read the actual output.** If the
+number of passed tests is lower than the previous baseline AND no
+tests were intentionally removed, that's a silent skip — find it.
+
+A test that didn't run is not a test that passed.
+
+### 2. Pre-commit gates are clean
+
+\`\`\`bash
+deno fmt --check && deno lint && deno task bundle && deno check src/main.ts
+\`\`\`
+
+Each gate must exit 0. Specifically:
+
+- \`deno fmt --check\` — format clean (run \`deno fmt <file>\` to fix)
+- \`deno lint\` — no lint violations
+- \`deno task bundle\` — bundle regenerates without drift; if it
+  produces a non-empty diff, the bundle was stale (commit the regen)
+- \`deno check src/main.ts\` — TypeScript type-check clean
+
+### 3. Working tree is clean (or all dirty files are intentional)
+
+\`\`\`bash
+git status --porcelain
+\`\`\`
+
+Expected: empty, OR every line is intentional + documented. If you
+see uncommitted changes you can't explain, you committed a partial
+state — either commit the rest or \`git stash\`.
+
+### 4. Plan checkboxes are all ticked
+
+If you're executing a plan from \`docs/specflow/plans/\`, every \`- [ ]\`
+under the tasks you claimed to complete must now read \`- [x]\`. Read
+the plan file with the Read tool, search for \`- [ ]\` lines under your
+task's section. Any unchecked box = silent skip.
+
+### 5. Smoke coverage audit (when touching scaffolded scripts or skills)
+
+If your change touched \`templates/core/skills/\` or
+\`templates/core/skills/backlog/scripts/\`:
+
+\`\`\`bash
+bash .claude/skills/test-sandbox/scripts/audit.sh
+\`\`\`
+
+Expected: \`0 coverage gap(s), 0 stale assertion(s)\`. A new file under
+those paths without a smoke assertion is a contract violation — add
+the assertion before claiming done.
+
+### 6. Plugin byte-identity (when touching scaffolded skills or agents)
+
+If your change touched \`templates/core/skills/\` or
+\`templates/core/agents/\`, the mirror under \`plugin/skills/\` or
+\`plugin/agents/\` must be byte-identical:
+
+\`\`\`bash
+deno test --allow-read tests/plugin/plugin_sync_test.ts
+\`\`\`
+
+Expected: every pair in SYNC_PAIRS green. If a new file landed, add
+the SYNC_PAIR entry.
+
+### 7. Windsurf cap (when touching SKILL.md or agent prompts)
+
+If your change touched any \`templates/core/agents/*.md\` or
+\`templates/core/skills/*/SKILL.md\`:
+
+\`\`\`bash
+deno test --allow-read tests/infrastructure/harness/windsurf_harness_test.ts
+\`\`\`
+
+The Windsurf 12000-char rendered cap is hard-gated. A file that
+overruns blocks the release.
+
+### 8. Self-review against the requirements
+
+Re-read the task / spec / issue you set out to satisfy. For each
+acceptance criterion or numbered requirement, name the file:line or
+the commit that addresses it. If you can't, that requirement isn't
+done.
+
+## When a verification fails
+
+**Stop. Do not report DONE.** Fix the failure first.
+
+If the failure is in your own work → fix inline, re-verify.
+
+If the failure exposes a real issue in the spec or plan → surface it
+to the user with the exact failure output. Do not paper over it. Do
+not claim "mostly done" or "done with minor issues".
+
+The skill's whole reason for existing is to catch the moment you'd
+otherwise say "yeah I'm pretty sure that works" without checking.
+
+## Report shape
+
+When all 8 checks pass, the agent can report DONE with the verification
+evidence inline:
+
+\`\`\`
+Status: DONE
+
+Verification:
+- deno task test: 645 passed | 0 failed ✓
+- pre-commit gates: clean ✓
+- git status: clean ✓
+- plan checkboxes: 12/12 ticked ✓
+- audit.sh: 0 gap, 0 stale ✓
+- plugin_sync_test: all SYNC_PAIRS green ✓
+- windsurf cap: <wc -c value> chars rendered (under 12000) ✓
+- requirements: <ACa> @ <file:line> · <ACb> @ <file:line> · ... ✓
+\`\`\`
+
+The user trusts a report shaped like this far more than a bare "done".
+
+## When NOT to invoke this skill
+
+- For pure conversational replies (you're not reporting work done)
+- For mid-task progress updates ("working on task 3 now") — verification
+  is for the **completion claim**, not the running commentary
+- For exploratory work where the agent is still gathering context
+
+## Integration with other skills
+
+- \`developer\` agent — should invoke this skill before reporting DONE
+  to the controller
+- \`subagent-driven-development\` — the controller invokes this skill on
+  the implementer's report before dispatching the spec-compliance
+  reviewer (one more layer of defence)
+- \`executing-plans\` — the inline executor invokes this skill at the
+  final whole-plan checkpoint before opening the PR
+- \`/release\` — the release skill already includes inline verification
+  (preflight checks, smoke audit, deno task test). This skill formalises
+  the same discipline for non-release work.
+
+## Out of scope
+
+This skill does not:
+
+- Run the checks for you — you run them yourself, then report the
+  result
+- Replace the \`code-reviewer\` agent's review — verification is
+  self-checks; review is a fresh-eyes peer check
+- Mutate any state (no commits, no PR operations, no backlog moves)
+- Override user-stated overrides (if the user said "ship it,
+  skip the smoke audit", that authorisation holds — but log the
+  exception in the verification report so the trace is honest)
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/using-specflow/SKILL.md
+++ b/templates/core/skills/using-specflow/SKILL.md
@@ -41,6 +41,7 @@ not re-read the file with `Read`.
 | `requesting-code-review` | Work is complete enough to need an independent eye. Dispatch the bundled `code-reviewer` agent with the canonical prompt template. |
 | `subagent-driven-development` | Execute a plan task-by-task with mandatory two-stage review (spec compliance + code quality) per task. Consumes plans produced by `writing-plans`. |
 | `executing-plans` | Inline alternative to subagent-driven — execute a plan task-by-task in-session with checkpoint pauses. Faster for trivial plans. |
+| `verification-before-completion` | Discipline checklist that any agent MUST run before reporting DONE. Tests green / pre-commit clean / plan boxes ticked / smoke audit / plugin sync / Windsurf cap / requirements addressed. |
 | `backlog` | User asked about a backlog item, the board, an issue. Read-only access; mutations go through the `product-owner` agent. |
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |

--- a/templates/core/skills/verification-before-completion/SKILL.md
+++ b/templates/core/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: verification-before-completion
+description: Use before reporting any work as DONE — implementing agents (developer subagent, inline executor, the controller) MUST run this verification checklist before claiming completion. Trigger phrases include "verify this is done", "ready to ship", "is this complete", "before I merge", or any moment an agent is about to report DONE on a task or PR. Catches the common failure mode where "done" really means "I think it's done but I haven't actually checked".
+---
+
+# Verification Before Completion
+
+A forcing function for the discipline an agent should already have but
+often skips under time pressure. Run this checklist before reporting
+**any** work as complete — a task, a feature, a PR, a release. Anything
+not verified is not done.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — `skills/verification-before-completion/SKILL.md`.
+> Re-implemented for Specflow with explicit pre-commit + smoke + bundle
+> gates that match this repo's actual quality contract.
+
+## When to invoke
+
+Mandatory invocation points:
+
+- Before an implementer subagent reports `DONE` on a task
+- Before a controller reports a feature complete to the user
+- Before opening a PR (CI catches some of these, but not all)
+- Before merging a PR
+- Before tagging a release (the `/release` skill already includes this
+  inline — see `templates/core/skills/release/SKILL.md`)
+
+If you find yourself about to type "✅ done" or report a task complete,
+**stop and run this checklist first**.
+
+## The checklist
+
+Run each item literally. Don't trust memory — the whole point of this
+skill is to override the agent's tendency to say "I'm pretty sure I
+did that already".
+
+### 1. Tests are actually green
+
+```bash
+deno task test
+```
+
+Expected: `<N> passed | 0 failed`. **Read the actual output.** If the
+number of passed tests is lower than the previous baseline AND no
+tests were intentionally removed, that's a silent skip — find it.
+
+A test that didn't run is not a test that passed.
+
+### 2. Pre-commit gates are clean
+
+```bash
+deno fmt --check && deno lint && deno task bundle && deno check src/main.ts
+```
+
+Each gate must exit 0. Specifically:
+
+- `deno fmt --check` — format clean (run `deno fmt <file>` to fix)
+- `deno lint` — no lint violations
+- `deno task bundle` — bundle regenerates without drift; if it
+  produces a non-empty diff, the bundle was stale (commit the regen)
+- `deno check src/main.ts` — TypeScript type-check clean
+
+### 3. Working tree is clean (or all dirty files are intentional)
+
+```bash
+git status --porcelain
+```
+
+Expected: empty, OR every line is intentional + documented. If you
+see uncommitted changes you can't explain, you committed a partial
+state — either commit the rest or `git stash`.
+
+### 4. Plan checkboxes are all ticked
+
+If you're executing a plan from `docs/specflow/plans/`, every `- [ ]`
+under the tasks you claimed to complete must now read `- [x]`. Read
+the plan file with the Read tool, search for `- [ ]` lines under your
+task's section. Any unchecked box = silent skip.
+
+### 5. Smoke coverage audit (when touching scaffolded scripts or skills)
+
+If your change touched `templates/core/skills/` or
+`templates/core/skills/backlog/scripts/`:
+
+```bash
+bash .claude/skills/test-sandbox/scripts/audit.sh
+```
+
+Expected: `0 coverage gap(s), 0 stale assertion(s)`. A new file under
+those paths without a smoke assertion is a contract violation — add
+the assertion before claiming done.
+
+### 6. Plugin byte-identity (when touching scaffolded skills or agents)
+
+If your change touched `templates/core/skills/` or
+`templates/core/agents/`, the mirror under `plugin/skills/` or
+`plugin/agents/` must be byte-identical:
+
+```bash
+deno test --allow-read tests/plugin/plugin_sync_test.ts
+```
+
+Expected: every pair in SYNC_PAIRS green. If a new file landed, add
+the SYNC_PAIR entry.
+
+### 7. Windsurf cap (when touching SKILL.md or agent prompts)
+
+If your change touched any `templates/core/agents/*.md` or
+`templates/core/skills/*/SKILL.md`:
+
+```bash
+deno test --allow-read tests/infrastructure/harness/windsurf_harness_test.ts
+```
+
+The Windsurf 12000-char rendered cap is hard-gated. A file that
+overruns blocks the release.
+
+### 8. Self-review against the requirements
+
+Re-read the task / spec / issue you set out to satisfy. For each
+acceptance criterion or numbered requirement, name the file:line or
+the commit that addresses it. If you can't, that requirement isn't
+done.
+
+## When a verification fails
+
+**Stop. Do not report DONE.** Fix the failure first.
+
+If the failure is in your own work → fix inline, re-verify.
+
+If the failure exposes a real issue in the spec or plan → surface it
+to the user with the exact failure output. Do not paper over it. Do
+not claim "mostly done" or "done with minor issues".
+
+The skill's whole reason for existing is to catch the moment you'd
+otherwise say "yeah I'm pretty sure that works" without checking.
+
+## Report shape
+
+When all 8 checks pass, the agent can report DONE with the verification
+evidence inline:
+
+```
+Status: DONE
+
+Verification:
+- deno task test: 645 passed | 0 failed ✓
+- pre-commit gates: clean ✓
+- git status: clean ✓
+- plan checkboxes: 12/12 ticked ✓
+- audit.sh: 0 gap, 0 stale ✓
+- plugin_sync_test: all SYNC_PAIRS green ✓
+- windsurf cap: <wc -c value> chars rendered (under 12000) ✓
+- requirements: <ACa> @ <file:line> · <ACb> @ <file:line> · ... ✓
+```
+
+The user trusts a report shaped like this far more than a bare "done".
+
+## When NOT to invoke this skill
+
+- For pure conversational replies (you're not reporting work done)
+- For mid-task progress updates ("working on task 3 now") — verification
+  is for the **completion claim**, not the running commentary
+- For exploratory work where the agent is still gathering context
+
+## Integration with other skills
+
+- `developer` agent — should invoke this skill before reporting DONE
+  to the controller
+- `subagent-driven-development` — the controller invokes this skill on
+  the implementer's report before dispatching the spec-compliance
+  reviewer (one more layer of defence)
+- `executing-plans` — the inline executor invokes this skill at the
+  final whole-plan checkpoint before opening the PR
+- `/release` — the release skill already includes inline verification
+  (preflight checks, smoke audit, deno task test). This skill formalises
+  the same discipline for non-release work.
+
+## Out of scope
+
+This skill does not:
+
+- Run the checks for you — you run them yourself, then report the
+  result
+- Replace the `code-reviewer` agent's review — verification is
+  self-checks; review is a fresh-eyes peer check
+- Mutate any state (no commits, no PR operations, no backlog moves)
+- Override user-stated overrides (if the user said "ship it,
+  skip the smoke audit", that authorisation holds — but log the
+  exception in the verification report so the trace is honest)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -28,6 +28,7 @@
     { "category": "skill", "name": "using-specflow", "source": "core/skills/using-specflow/SKILL.md" },
     { "category": "skill", "name": "subagent-driven-development", "source": "core/skills/subagent-driven-development/SKILL.md" },
     { "category": "skill", "name": "executing-plans", "source": "core/skills/executing-plans/SKILL.md" },
+    { "category": "skill", "name": "verification-before-completion", "source": "core/skills/verification-before-completion/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -90,11 +90,11 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     // specflow-auto + specflow-review alias + specflow-backlog +
     // writing-plans (A1) + requesting-code-review (A3) +
     // using-specflow bootstrap (B6) + subagent-driven-development (A2) +
-    // executing-plans (A4) = 9.
+    // executing-plans (A4) + verification-before-completion (A5) = 10.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 9);
+    assertEquals(agentsSkillsCount, 10);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -86,11 +86,12 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     // auto-chain + list-skills) + specflow-auto + specflow-review +
     // writing-plans (#271) + requesting-code-review (#273) +
     // using-specflow (#282) + subagent-driven-development (#272) +
-    // executing-plans (#274) + backlog + 11 agents = 34.
+    // executing-plans (#274) + verification-before-completion (#275) +
+    // backlog + 11 agents = 35.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 34);
+    assertEquals(instructionsCount, 35);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -78,11 +78,12 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
     // auto-chain + list-skills) + specflow-auto + specflow-review alias +
     // writing-plans (#271) + requesting-code-review (#273) +
     // using-specflow (#282) + subagent-driven-development (#272) +
-    // executing-plans (#274) + backlog + 11 agent workflows = 34.
+    // executing-plans (#274) + verification-before-completion (#275) +
+    // backlog + 11 agent workflows = 35.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 34);
+    assertEquals(workflowsCount, 35);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -86,6 +86,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/executing-plans/SKILL.md",
     source: "templates/core/skills/executing-plans/SKILL.md",
   },
+  // verification-before-completion — discipline checklist that
+  // implementing agents MUST run before claiming DONE (Epic #270,
+  // A5 #275).
+  {
+    plugin: "plugin/skills/verification-before-completion/SKILL.md",
+    source: "templates/core/skills/verification-before-completion/SKILL.md",
+  },
   ...[
     "claude",
     "codex",


### PR DESCRIPTION
Closes #275. A5 of Epic #270 — Phase 2 of the multi-harness parity work.

## Agent adoption

Specflow now ships a native `verification-before-completion` skill — a forcing function for the discipline an agent should already have but often skips under time pressure. Before reporting any work as DONE, run the 8-item checklist. Anything not verified is not done.

```prompt
After `specflow upgrade`, any time your agent (developer subagent, inline executor, or you in the controller seat) is about to type "done" or report a task complete, invoke verification-before-completion first. It runs 8 explicit checks: deno task test must actually return passed=N failed=0 (not "I'm pretty sure"), pre-commit gates (fmt+lint+bundle+check), git status clean, every plan checkbox ticked, smoke audit if you touched templates/core/skills/, plugin byte-identity if mirroring applies, Windsurf 12000-char cap if you touched any SKILL.md or agent prompt, and a per-AC requirement check by file:line. Reports DONE with the evidence inline so the trace is honest. The whole point is to catch the moment you'd otherwise say "yeah I'm pretty sure that works" without checking.
```

## Files

- `templates/core/skills/verification-before-completion/SKILL.md` — 6928 chars
- `plugin/skills/verification-before-completion/SKILL.md` — byte-identical mirror
- `templates/manifest.json` — registers new skill (91 → 92 core entries)
- `tests/plugin/plugin_sync_test.ts` — +1 SYNC_PAIR
- `.claude/skills/test-sandbox/scripts/smoke-features.sh` — 7 new static-grep assertions
- `tests/integration/init_{codex,copilot,windsurf}_test.ts` — scaffolded count +1
- `templates/core/skills/using-specflow/SKILL.md` + plugin twin — skill registry table gains verification-before-completion row

## Specflow-native adaptations vs. upstream

- **Explicit checks tied to this repo's quality contract** — pre-commit hook surfaces (fmt/lint/bundle/check), smoke audit (audit.sh), plugin byte-identity (plugin_sync_test), Windsurf 12000-char cap (windsurf_harness_test). Not abstract "verify tests"; specific commands with expected output shapes.
- **Report shape with evidence** — the verification report quotes the actual passed/failed counts and the actual file:line per AC. "DONE" without evidence is not accepted.
- **Integration touchpoints documented** — developer agent invokes pre-DONE; subagent-driven-development controller invokes as one more layer before spec compliance review; executing-plans invokes at the final whole-plan checkpoint; /release skill already includes inline verification.

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `skills/verification-before-completion/SKILL.md`. Re-implemented for Specflow.

## Out of scope

- Wiring the `developer` agent doctrine to mandate this skill before DONE reports — that's a Phase-4 polish item.
- A6 (#276) `brainstorming` skill — last Phase-2 item, lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)