### PR TITLE
feat: Cursor plugin adapter (#278)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "specflow",
+  "displayName": "Specflow",
+  "description": "Spec-driven planning, TDD, review, and delivery workflows for coding agents — bundled skills, sub-agents, and a SessionStart bootstrap that makes the agent skill-aware on every turn.",
+  "version": "1.8.0",
+  "author": {
+    "name": "MakerLabs",
+    "url": "https://github.com/mkrlabs"
+  },
+  "homepage": "https://specflow.makerlabs.dev",
+  "repository": "https://github.com/mkrlabs/specflow",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "spec-driven",
+    "tdd",
+    "backlog",
+    "workflows",
+    "agents",
+    "best-practices"
+  ],
+  "skills": "./plugin/skills/",
+  "agents": "./plugin/agents/",
+  "hooks": "./plugin/hooks/hooks-cursor.json"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,16 @@ jobs:
             echo "::error::.codex-plugin/plugin.json version ($CODEX_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
             exit 1
           fi
-          echo "✓ plugin manifests valid, scaffold present, versions $PLUGIN_VERSION/$MANIFEST_VERSION/$CODEX_VERSION match binary"
+          # 6. Hard fail if .cursor-plugin/plugin.json version drifts.
+          # Cursor users install directly from the repo; the manifest's
+          # version must match the binary or the install would advertise
+          # a stale version.
+          CURSOR_VERSION=$(jq -r .version .cursor-plugin/plugin.json)
+          if [ "$BIN_VERSION" != "$CURSOR_VERSION" ]; then
+            echo "::error::.cursor-plugin/plugin.json version ($CURSOR_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
+            exit 1
+          fi
+          echo "✓ plugin manifests valid, scaffold present, versions $PLUGIN_VERSION/$MANIFEST_VERSION/$CODEX_VERSION/$CURSOR_VERSION match binary"
       - name: Cross-compile all targets
         run: deno run --allow-read --allow-write --allow-run --allow-env scripts/build.ts
       - name: Compute checksums

--- a/plugin/hooks/hooks-cursor.json
+++ b/plugin/hooks/hooks-cursor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "bash ./plugin/hooks/session-start"
+      }
+    ]
+  }
+}

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -51,6 +51,7 @@ export const VERSIONED_FILES = [
   "plugin/.claude-plugin/plugin.json",
   "templates/manifest.json",
   ".codex-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
 ] as const;
 
 async function readCurrentVersion(baseDir: string): Promise<string> {
@@ -112,6 +113,17 @@ export async function writeVersions(
     `"version": "${next}"`,
   );
   await Deno.writeTextFile(codexManifestPath, updatedCodex);
+
+  // Lockstep the Cursor plugin manifest (Epic #270 / B2 #278). Same
+  // pre-flight drift gate as the Codex manifest; Cursor users install
+  // directly from the repo so the manifest's version must match.
+  const cursorManifestPath = `${baseDir}/.cursor-plugin/plugin.json`;
+  const cursorRaw = await Deno.readTextFile(cursorManifestPath);
+  const updatedCursor = cursorRaw.replace(
+    /"version":\s*"[^"]+"/,
+    `"version": "${next}"`,
+  );
+  await Deno.writeTextFile(cursorManifestPath, updatedCursor);
 }
 
 async function main() {

--- a/tests/scripts/bump_version_test.ts
+++ b/tests/scripts/bump_version_test.ts
@@ -37,6 +37,7 @@ Deno.test("VERSIONED_FILES covers every file the release workflow gates on", () 
       "plugin/.claude-plugin/plugin.json",
       "templates/manifest.json",
       ".codex-plugin/plugin.json",
+      ".cursor-plugin/plugin.json",
     ] as const,
   );
 });
@@ -67,6 +68,11 @@ Deno.test("writeVersions bumps every versioned file in lockstep", async () => {
     await Deno.mkdir(join(tmp, ".codex-plugin"), { recursive: true });
     await Deno.writeTextFile(
       join(tmp, ".codex-plugin/plugin.json"),
+      `{\n  "name": "specflow",\n  "version": "1.2.3"\n}\n`,
+    );
+    await Deno.mkdir(join(tmp, ".cursor-plugin"), { recursive: true });
+    await Deno.writeTextFile(
+      join(tmp, ".cursor-plugin/plugin.json"),
       `{\n  "name": "specflow",\n  "version": "1.2.3"\n}\n`,
     );
 


### PR DESCRIPTION
Closes #278. B2 of Epic #270 — second multi-harness distribution target.

## Agent adoption

Specflow now ships a `.cursor-plugin/plugin.json` manifest + Cursor-specific SessionStart hook. Users on Cursor install with `/add-plugin mkrlabs/specflow` directly in the Agent chat — no marketplace fork, no PAT secret needed (unlike Codex which goes through OpenAI's marketplace).

```prompt
After merging this PR, Cursor users can install Specflow directly via `/add-plugin mkrlabs/specflow` in the Cursor Agent chat. The plugin loads the same skill library that Claude Code users get via /plugin install — writing-plans, requesting-code-review, subagent-driven-development, executing-plans, verification-before-completion, brainstorming, using-specflow bootstrap. The SessionStart hook auto-injects the using-specflow bootstrap content at every session start (matcher: sessionStart). Same agent capability surface, different harness.
```

## Why simpler than Codex (B1 #277)

Cursor's plugin distribution is direct-from-repo:
- ✅ No marketplace fork needed
- ✅ No PAT secret needed
- ✅ No sync script needed
- Just a manifest + a hook config

Vs. Codex (#277) which needs a marketplace fork (`mkrlabs/openai-codex-plugins`), a `CODEX_SYNC_TOKEN` PAT, and a rsync-based sync script.

## Files

- `.cursor-plugin/plugin.json` — Cursor manifest (Specflow brand metadata + skills/agents/hooks path refs)
- `plugin/hooks/hooks-cursor.json` — Cursor SessionStart hook config (v1 schema, sessionStart array, invokes the bash session-start script from B6)
- `scripts/bump-version.ts` — `VERSIONED_FILES` extended (6 entries now); writeVersions bumps the Cursor manifest in lockstep
- `.github/workflows/release.yml` — Plugin pre-flight gates on Cursor manifest version drift
- `tests/scripts/bump_version_test.ts` — VERSIONED_FILES assertion + writeVersions fixture extended

## Reuses existing infra from earlier Phase items

- `plugin/hooks/session-start` (bash script from B6 #282) — Cursor hooks-cursor.json points at the same script; output format is identical (both Claude Code and Cursor consume the same `additionalContext` shape).
- `plugin/skills/*` content — same bundled skills, just loaded by Cursor's plugin loader instead of Claude Code's.
- `assets/composer-icon.svg` + `logo.svg` from B1 #277 — Cursor doesn't reference these in its manifest (no `interface` block), but they're available if Cursor adds gallery card requirements later.

## Out of scope

- B3 (Gemini extension) — different format entirely (`gemini-extension.json` + `GEMINI.md`), separate sibling.
- B4 (OpenCode JS adapter) — code-driven plugin, separate sibling.
- B5 (Copilot CLI marketplace) — separate repo + marketplace registration, separate sibling.

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `.cursor-plugin/plugin.json` and `hooks/hooks-cursor.json` shapes adapted; Specflow-native skill content and version-lockstep integration with the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)