### PR TITLE
feat: Gemini CLI extension (#279)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,16 @@ jobs:
             echo "::error::.cursor-plugin/plugin.json version ($CURSOR_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
             exit 1
           fi
-          echo "✓ plugin manifests valid, scaffold present, versions $PLUGIN_VERSION/$MANIFEST_VERSION/$CODEX_VERSION/$CURSOR_VERSION match binary"
+          # 7. Hard fail if gemini-extension.json version drifts. Gemini
+          # users install via `gemini extensions install <repo-url>`;
+          # `gemini extensions list` surfaces this version, so drift
+          # would mislabel the installed extension.
+          GEMINI_VERSION=$(jq -r .version gemini-extension.json)
+          if [ "$BIN_VERSION" != "$GEMINI_VERSION" ]; then
+            echo "::error::gemini-extension.json version ($GEMINI_VERSION) does not match deno.json version ($BIN_VERSION). Re-run scripts/bump-version.ts."
+            exit 1
+          fi
+          echo "✓ plugin manifests valid, scaffold present, versions $PLUGIN_VERSION/$MANIFEST_VERSION/$CODEX_VERSION/$CURSOR_VERSION/$GEMINI_VERSION match binary"
       - name: Cross-compile all targets
         run: deno run --allow-read --allow-write --allow-run --allow-env scripts/build.ts
       - name: Compute checksums

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,2 @@
+@./plugin/skills/using-specflow/SKILL.md
+@./plugin/skills/using-specflow/references/gemini-tools.md

--- a/deno.json
+++ b/deno.json
@@ -41,6 +41,7 @@
     ".claude/",
     "packaging/",
     "plugin/skills/",
-    "plugin/agents/"
+    "plugin/agents/",
+    "GEMINI.md"
   ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "specflow",
+  "description": "Spec-driven planning, TDD, review, and delivery workflows for coding agents — bundled skills, sub-agents, and a SessionStart-equivalent bootstrap via Gemini's context file mechanism.",
+  "version": "1.8.0",
+  "contextFileName": "GEMINI.md"
+}

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -52,6 +52,7 @@ export const VERSIONED_FILES = [
   "templates/manifest.json",
   ".codex-plugin/plugin.json",
   ".cursor-plugin/plugin.json",
+  "gemini-extension.json",
 ] as const;
 
 async function readCurrentVersion(baseDir: string): Promise<string> {
@@ -124,6 +125,18 @@ export async function writeVersions(
     `"version": "${next}"`,
   );
   await Deno.writeTextFile(cursorManifestPath, updatedCursor);
+
+  // Lockstep the Gemini CLI extension manifest (Epic #270 / B3 #279).
+  // Gemini users install via `gemini extensions install <repo-url>`;
+  // the extension manifest version is what `gemini extensions list`
+  // surfaces, so drift would mislabel the installed version.
+  const geminiManifestPath = `${baseDir}/gemini-extension.json`;
+  const geminiRaw = await Deno.readTextFile(geminiManifestPath);
+  const updatedGemini = geminiRaw.replace(
+    /"version":\s*"[^"]+"/,
+    `"version": "${next}"`,
+  );
+  await Deno.writeTextFile(geminiManifestPath, updatedGemini);
 }
 
 async function main() {

--- a/tests/scripts/bump_version_test.ts
+++ b/tests/scripts/bump_version_test.ts
@@ -38,6 +38,7 @@ Deno.test("VERSIONED_FILES covers every file the release workflow gates on", () 
       "templates/manifest.json",
       ".codex-plugin/plugin.json",
       ".cursor-plugin/plugin.json",
+      "gemini-extension.json",
     ] as const,
   );
 });
@@ -74,6 +75,10 @@ Deno.test("writeVersions bumps every versioned file in lockstep", async () => {
     await Deno.writeTextFile(
       join(tmp, ".cursor-plugin/plugin.json"),
       `{\n  "name": "specflow",\n  "version": "1.2.3"\n}\n`,
+    );
+    await Deno.writeTextFile(
+      join(tmp, "gemini-extension.json"),
+      `{\n  "name": "specflow",\n  "version": "1.2.3",\n  "contextFileName": "GEMINI.md"\n}\n`,
     );
 
     await writeVersions("1.2.4", tmp);


### PR DESCRIPTION
Closes #279. B3 of Epic #270 — third multi-harness distribution target. **Simplest adapter so far** (no marketplace, no PAT, no sync script, no hooks file).

## Agent adoption

Gemini CLI users install Specflow via `gemini extensions install https://github.com/mkrlabs/specflow`. Gemini auto-loads `GEMINI.md` at session start, which @-references the using-specflow bootstrap skill + the gemini-tools tool-mapping reference — same agent capability surface as Claude Code's SessionStart hook from B6 (#282).

```prompt
After merging this PR, Gemini CLI users install with: gemini extensions install https://github.com/mkrlabs/specflow. The extension's contextFileName points at GEMINI.md, which Gemini auto-loads at session start. GEMINI.md @-references plugin/skills/using-specflow/SKILL.md (the bootstrap skill) and plugin/skills/using-specflow/references/gemini-tools.md (the Claude→Gemini tool name mapping: Read→read_file, Task→@generalist, etc). Same skill library that Claude Code / Cursor / Codex users get, just loaded via Gemini's native extension mechanism.
```

## Files

- `gemini-extension.json` — minimal extension manifest (name, description, version, contextFileName: GEMINI.md)
- `GEMINI.md` — context file with two @-references (bootstrap skill + tool mapping). **Added to deno.json's fmt exclude list** because deno fmt collapses adjacent @-reference lines onto a single line, which would break Gemini's reference resolution.
- `scripts/bump-version.ts` — `VERSIONED_FILES` extended to 7 entries; writeVersions bumps gemini-extension.json in lockstep
- `.github/workflows/release.yml` — Plugin pre-flight gates on Gemini manifest version drift
- `tests/scripts/bump_version_test.ts` — VERSIONED_FILES assertion + fixture extended
- `deno.json` — `exclude` array gains `GEMINI.md` (formatting protection)

## Why simplest

Claude Code → needs full plugin.json + hooks.json + session-start script. ✅ Shipped in #282.
Codex → needs marketplace manifest + fork + PAT secret + sync script. ✅ Shipped in #277 (inert pending Kevin's prereqs).
Cursor → needs plugin.json + hooks-cursor.json. ✅ Shipped in #278.
**Gemini → just two files**: a 5-key manifest + a 2-line context file. Gemini's @-reference mechanism does the bootstrap heavy lifting for free.

## Out of scope

- B4 (OpenCode JS adapter), B5 (Copilot CLI marketplace) — sibling Phase 3 items, land separately.

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `gemini-extension.json` shape and `GEMINI.md` @-reference pattern adapted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)