### PR TITLE
feat: OpenCode plugin adapter (#280)

### DIFF
--- a/.opencode/plugins/specflow.js
+++ b/.opencode/plugins/specflow.js
@@ -1,0 +1,156 @@
+/**
+ * Specflow plugin for OpenCode.ai
+ *
+ * Injects Specflow bootstrap context via system prompt transform.
+ * Auto-registers the bundled skills directory via config hook — no
+ * symlinks needed.
+ *
+ * Inspired by obra/superpowers v5.1.0 (MIT) —
+ * .opencode/plugins/superpowers.js. Re-implemented for Specflow's
+ * plugin/skills/ tree layout.
+ */
+
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Simple frontmatter extraction (avoid dependency on skills-core for
+// bootstrap — the adapter must work even if no other Specflow tooling
+// is installed).
+const extractAndStripFrontmatter = (content) => {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, content };
+
+  const frontmatterStr = match[1];
+  const body = match[2];
+  const frontmatter = {};
+
+  for (const line of frontmatterStr.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, "");
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, content: body };
+};
+
+// Normalize a path: trim whitespace, expand ~, resolve to absolute.
+const normalizePath = (p, homeDir) => {
+  if (!p || typeof p !== "string") return null;
+  let normalized = p.trim();
+  if (!normalized) return null;
+  if (normalized.startsWith("~/")) {
+    normalized = path.join(homeDir, normalized.slice(2));
+  } else if (normalized === "~") {
+    normalized = homeDir;
+  }
+  return path.resolve(normalized);
+};
+
+// Module-level cache for bootstrap content. The SKILL.md file does not
+// change during a session, so reading + parsing it once eliminates
+// redundant fs.existsSync + fs.readFileSync + regex work on every agent
+// step.
+let _bootstrapCache = undefined; // undefined = not yet loaded, null = file missing
+
+export const SpecflowPlugin = async ({ client: _client, directory: _directory }) => {
+  const homeDir = os.homedir();
+  // Specflow's plugin source lives at `plugin/skills/` relative to the
+  // repo root; this adapter at `.opencode/plugins/specflow.js` walks
+  // up two levels to reach the repo root, then into plugin/skills.
+  const specflowSkillsDir = path.resolve(__dirname, "../../plugin/skills");
+  const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
+  const _configDir = envConfigDir || path.join(homeDir, ".config/opencode");
+
+  // Helper to generate bootstrap content (cached after first call).
+  const getBootstrapContent = () => {
+    if (_bootstrapCache !== undefined) return _bootstrapCache;
+
+    const skillPath = path.join(
+      specflowSkillsDir,
+      "using-specflow",
+      "SKILL.md",
+    );
+    if (!fs.existsSync(skillPath)) {
+      _bootstrapCache = null;
+      return null;
+    }
+
+    const fullContent = fs.readFileSync(skillPath, "utf8");
+    const { content } = extractAndStripFrontmatter(fullContent);
+
+    // Tool mapping inlined here because OpenCode reads the bootstrap
+    // before any skill files are loaded. This is the same content as
+    // plugin/skills/using-specflow/references/opencode-tools.md, just
+    // pre-resolved so the agent doesn't need a second Read on session
+    // start.
+    const toolMapping = `**Tool Mapping for OpenCode:**
+When Specflow skills reference Claude Code tools, substitute OpenCode equivalents:
+- \`TodoWrite\` → \`todowrite\`
+- \`Task\` tool with subagents → OpenCode's @mention subagent syntax
+- \`Skill\` tool → OpenCode's native \`skill\` tool
+- \`Read\`, \`Write\`, \`Edit\`, \`Bash\` → native (lowercase: \`read\`, \`write\`, \`edit\`, \`bash\`)
+
+See plugin/skills/using-specflow/references/opencode-tools.md for the
+full mapping table.`;
+
+    _bootstrapCache = `<EXTREMELY_IMPORTANT>
+You have Specflow.
+
+**IMPORTANT: The using-specflow bootstrap skill content is included below. It is ALREADY LOADED — you are currently following it. Do NOT use the skill tool to load "using-specflow" again; that would be redundant.**
+
+${content}
+
+${toolMapping}
+</EXTREMELY_IMPORTANT>`;
+
+    return _bootstrapCache;
+  };
+
+  return {
+    // Inject skills path into live config so OpenCode discovers the
+    // Specflow skills without requiring manual symlinks or config file
+    // edits. Config.get() returns a cached singleton — modifications
+    // here are visible when skills are lazily discovered later.
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(specflowSkillsDir)) {
+        config.skills.paths.push(specflowSkillsDir);
+      }
+    },
+
+    // Inject bootstrap into the first user message of each session.
+    // Using a user message instead of a system message avoids:
+    //   1. Token bloat from system messages repeated every turn
+    //   2. Multiple system messages breaking some models
+    //
+    // The hook fires on every agent step (not just every turn) because
+    // opencode's prompt.ts reloads messages from DB each step. Fresh
+    // message arrays may need injection again, so getBootstrapContent()
+    // must not do repeated disk work — the module-level cache covers
+    // that.
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const bootstrap = getBootstrapContent();
+      if (!bootstrap || !output.messages.length) return;
+      const firstUser = output.messages.find((m) => m.info.role === "user");
+      if (!firstUser || !firstUser.parts.length) return;
+
+      // Guard: skip if first user message already contains bootstrap.
+      // Prevents double injection when OpenCode passes an already-
+      // transformed in-memory message array through the hook again.
+      if (
+        firstUser.parts.some((p) => p.type === "text" && p.text.includes("EXTREMELY_IMPORTANT"))
+      ) return;
+
+      const ref = firstUser.parts[0];
+      firstUser.parts.unshift({ ...ref, type: "text", text: bootstrap });
+    },
+  };
+};

--- a/deno.json
+++ b/deno.json
@@ -42,6 +42,7 @@
     "packaging/",
     "plugin/skills/",
     "plugin/agents/",
-    "GEMINI.md"
+    "GEMINI.md",
+    ".opencode/"
   ]
 }


### PR DESCRIPTION
Closes #280. B4 of Epic #270 — fourth multi-harness distribution target.

## Agent adoption

OpenCode plugins are **JavaScript files** (not JSON manifests). The Specflow adapter at `.opencode/plugins/specflow.js` exports a `SpecflowPlugin` factory with two hooks that, together, make OpenCode skill-aware on every session start without any user config.

```prompt
After merging this PR, OpenCode users add `"plugin": ["specflow@git+https://github.com/mkrlabs/specflow.git"]` to their opencode.json. On session start, the adapter (a) injects plugin/skills/ into config.skills.paths so OpenCode auto-discovers the Specflow skill library, and (b) transforms the first user message to include the using-specflow bootstrap content wrapped in EXTREMELY_IMPORTANT tags — the same skill registry / agent registry / routing rules Claude Code users get via the SessionStart hook from B6 (#282). Module-level cache + double-injection guard keep the per-step overhead near zero.
```

## The two hooks

- **`config`** — async hook that mutates the live OpenCode config singleton. Pushes `plugin/skills/` (resolved relative to the plugin file's location) into `config.skills.paths`. OpenCode lazily discovers skills from that path when the user invokes one.
- **`experimental.chat.messages.transform`** — async hook called on every agent step. Reads the using-specflow SKILL.md, strips frontmatter, wraps in `<EXTREMELY_IMPORTANT>` tags with the OpenCode tool-name mapping inlined (TodoWrite → todowrite, Task → @mention, Skill → skill, Read/Write/Edit/Bash → native lowercase). Injects into the first user message of the session. Module-level cache prevents repeated disk reads; a string-match guard on `EXTREMELY_IMPORTANT` prevents double-injection across reloads.

## Files

- `.opencode/plugins/specflow.js` — 156 lines, Node ESM
- `deno.json` — `.opencode/` added to the exclude list (this is Node code, not Deno; `deno lint` / `deno fmt` should not touch it)

## Why no version lockstep this time

Unlike Codex / Cursor / Gemini manifests, the OpenCode adapter has no version field of its own — it reads `plugin/skills/using-specflow/SKILL.md` at runtime. The bundled SKILL.md is already version-locked to `deno.json` via the plugin-sync byte-identity test from B6 (#282). No new pre-flight gate in release.yml needed.

## Out of scope

- B5 (Copilot CLI marketplace) — last Phase 3 sibling, lands separately.
- C2 / C3 / C4 / C5 / C6 — Phase 3-late + Phase 4 polish items.

## Attribution

Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers) (MIT) — `.opencode/plugins/superpowers.js`. JS adapter shape (frontmatter extraction helper, normalizePath utility, bootstrap caching, two-hook pattern) adapted; Specflow-native skill paths and using-specflow bootstrap reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)