### PR TITLE
feat(audit): /specflow audit security — read-only security sweep (#303)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -71,6 +71,16 @@ check "phase doc release-version.md scaffolded (epic #226)" \
   '[ -f .claude/skills/specflow/phases/release-version.md ]'
 check "phase doc list-skills.md scaffolded (#265)" \
   '[ -f .claude/skills/specflow/phases/list-skills.md ]'
+check "phase doc audit-security.md scaffolded (Epic #302, #303)" \
+  '[ -f .claude/skills/specflow/phases/audit-security.md ]'
+check "audit-security phase doc declares read-only contract" \
+  'grep -q "Read-only contract" .claude/skills/specflow/phases/audit-security.md'
+check "audit-security phase doc dispatches the security-auditor agent" \
+  'grep -q "security-auditor" .claude/skills/specflow/phases/audit-security.md'
+check "audit-security phase doc parses --severity flag" \
+  'grep -q "\-\-severity" .claude/skills/specflow/phases/audit-security.md'
+check "router phase index lists audit security" \
+  'grep -q "audit security" .claude/skills/specflow/SKILL.md'
 check "name: specflow on the router SKILL.md" \
   'head -3 .claude/skills/specflow/SKILL.md | grep -q "name: specflow"'
 check "disable-model-invocation NOT set on the router (Skill-tool chaining must work)" \

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -18,6 +18,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
+  - audit: "audit security / performance / accessibility", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -37,6 +38,15 @@ when_to_use: |
 2. **Phase extraction** — the first remaining token is the phase name.
    Everything after the first whitespace is the argument string for
    that phase.
+
+   **Compound `audit` phase exception** — when the first token is exactly
+   `audit` AND the next token is one of `security`, `performance`, or
+   `accessibility`, treat the pair as a single hyphenated phase name
+   `audit-<axis>` (matching the file `phases/audit-<axis>.md`). The
+   remaining tokens after the axis become the argument string. Examples:
+   `audit security` → phase `audit-security`, args ``; `audit security --severity medium` → phase `audit-security`, args `--severity medium`.
+   Users may also invoke the hyphenated form directly
+   (`/specflow audit-security`); both forms route to the same phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -60,11 +70,19 @@ when_to_use: |
 | `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
 | `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
 | `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay hooks. |
+| `audit security` | `phases/audit-security.md` | Read-only project-wide security sweep; emits a findings report. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
-`checklist`, `groom`, `tag-version`, `release-version`, `list-skills`)
+`checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
+`audit security`)
 are one-shot regardless of chain mode.
+
+`audit <axis>` is dispatched as a two-token phase: the router reads
+`phases/audit-<axis>.md` (e.g. `phases/audit-security.md`). Today only
+`security` is wired; `performance` and `accessibility` land in #304 / #305.
+Until then, `/specflow audit performance` and `/specflow audit accessibility`
+fall through to the unknown-phase branch.
 
 ## Routing
 
@@ -104,7 +122,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, and `list-skills` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/plugin/skills/specflow/phases/audit-security.md
+++ b/plugin/skills/specflow/phases/audit-security.md
@@ -1,0 +1,179 @@
+
+# /specflow audit security
+
+**Read-only** project-wide security sweep. Walks the entire codebase, dispatches
+the `security-auditor` agent in audit mode, and emits a structured findings
+report. **Never mutates project code** — running the phase twice in a row leaves
+`git status --porcelain` identical.
+
+This phase is **manual-only** — invoke explicitly with `/specflow audit security`
+or schedule with `/loop 1d /specflow audit security`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit security` is a periodic systemic sweep that produces backlog
+material, not a pass/fail verdict.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is `critical`,
+`high`, `medium`, or `low`. Default is `high` (Critical + High are surfaced;
+Medium and Low go to "Out of scope" in the report). `--severity medium`
+extends the surfacing down to Medium; `--severity low` surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`. If not a
+   git repo, abort with `error: /specflow audit security requires a git repository (uses git ls-files for scope)` — there is no value in auditing an
+   un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the output:
+   - Source files by language extension
+   - Config / secrets-shaped files (`.env*`, `*.key`, `*.pem`, `id_rsa*`, `secrets.*`)
+   - Dependency manifests (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `composer.json`, `Gemfile`, `requirements*.txt`)
+   - CI / GitHub Actions (`.github/workflows/*.yml`)
+
+3. **Dispatch the `security-auditor` agent** with the dispatch prompt below.
+   The agent operates in audit mode (full codebase scan, NOT per-PR review
+   mode). It has `Read`, `Grep`, `Glob`, and constrained `Bash` access; it
+   MUST NOT call `Edit`, `Write`, `NotebookEdit`, or any mutating tool.
+
+4. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-security.md` (UTC date). If the file
+   already exists for today, append a `## Run 2 (HH:MM UTC)` heading rather
+   than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-security.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical and High
+   > findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the `product-owner`
+   agent with the report path + the instruction: "Create one Epic titled
+   `security audit findings YYYY-MM-DD` with one sub-task per Critical /
+   High finding (batch Medium / Low into a single grouped task if
+   `--severity medium` or `--severity low` was passed)."
+
+## Dispatch prompt for the `security-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY` with
+the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with the resolved
+severity threshold):
+
+```
+You are running in **audit mode** — full-codebase sweep, not per-PR review.
+
+Read-only contract: you MUST NOT call Edit, Write, NotebookEdit, or any tool
+that mutates files. Bash is permitted only for `git ls-files`, `git log`,
+`git show`, `grep`, `rg`, and dependency-listing commands (`npm ls`, `pip list`,
+`cargo tree`, etc.). Any other Bash invocation is a contract violation.
+
+Scope: walk the inventory below and surface findings for each of these axes:
+
+1. **Authentication / authorization** — missing authz on write endpoints,
+   broken session handling, insecure cookies, JWT verification gaps,
+   role-check bypasses.
+2. **Input validation** — route handlers accepting user input without
+   validation, deserialization of untrusted data, type confusion paths.
+3. **Secret leaks** — credentials / API keys / tokens / private keys in
+   source files OR git history (`git log -S '...'` for known patterns).
+   `.env` or `*.key` files committed to history are CRITICAL.
+4. **Injection** — raw SQL concatenation, shell command interpolation with
+   user input, raw HTML / template rendering with unescaped user data,
+   eval-of-string.
+5. **SSRF** — outbound HTTP / network calls to URLs built from user input
+   without allowlist.
+6. **Path traversal / arbitrary file ops** — file-system paths built from
+   user input without normalization + allowlist.
+7. **Supply chain** — outdated dependencies with known CVEs in the
+   dependency manifests, unpinned transitive deps, package installs from
+   non-canonical registries.
+8. **Upload validation** — file upload handlers without MIME / size /
+   extension checks.
+9. **CSRF** — state-changing HTTP routes without CSRF protection (where
+   applicable to the framework).
+10. **Silent error swallowing** — `catch` / `except` blocks that hide errors
+    without logging, especially in security-relevant code paths.
+
+Severity floor for surfacing: $SEVERITY_FLOOR. Findings below this floor go
+into the "Out of scope" section of the report (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Output format: a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+# Security audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "342 source files across TypeScript, Python, shell">
+- Time window: <one line — "git history scanned back to first commit on main">
+- Severity floor: $SEVERITY_FLOOR
+
+## Critical
+
+For each finding:
+- `path/to/file.ts:42` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(same shape — only populated if $SEVERITY_FLOOR is `medium` or `low`)
+
+## Low
+
+(same shape — only populated if $SEVERITY_FLOOR is `low`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+
+End with no VERDICT line. Audit-mode reports are not pass/fail.
+```
+
+## Read-only contract test
+
+After the agent returns, run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new `docs/specflow/audits/YYYY-MM-DD-security.md`
+file (and the parent `docs/specflow/audits/` directory if it had to be created).
+Anything else in the porcelain output is a contract breach — record it as an
+error in the final report and surface to the user.
+
+## Output format (what the user sees)
+
+```
+specflow-audit-security report
+──────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Report:   docs/specflow/audits/YYYY-MM-DD-security.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the security-auditor in PR mode, not audit mode).
+- For triaging GitHub security alerts after a release preflight → the `/release` flow already dispatches `security-auditor` in alert-triage mode (Mode 2 in the agent's prompt).
+- For a single-file security check → invoke `security-auditor` directly with the file paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions.

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -25,7 +25,9 @@ import type { KnownHarness } from "./installed_lock.ts";
  *   - `.claude/agents/<name>.md` (excluding `architect.md` — that's a
  *     contributor-only agent, not bundled into user projects)
  *   - `.claude/skills/specflow/SKILL.md` — the consolidated router skill
- *   - `.claude/skills/specflow/phases/<phase>.md` — the 11 phase docs
+ *   - `.claude/skills/specflow/phases/<phase>.md` — phase reference docs.
+ *     Hyphenated names are valid (`tag-version`, `release-version`,
+ *     `list-skills`, `audit-security`, …).
  *   - `.claude/skills/specflow-review/SKILL.md` — auto-invoke alias
  *   - `.claude/skills/specflow-auto/SKILL.md`
  *
@@ -43,7 +45,13 @@ export function isPluginCoveredPath(
   if (agentMatch !== null) return agentMatch[1] !== "architect";
 
   if (dest === ".claude/skills/specflow/SKILL.md") return true;
-  if (/^\.claude\/skills\/specflow\/phases\/[a-z]+\.md$/.test(dest)) return true;
+  // Hyphenated phase names are valid (`tag-version`, `release-version`,
+  // `audit-security`, …). The earlier `[a-z]+` regex silently failed for
+  // any phase containing a hyphen; the corrected pattern accepts one or
+  // more lowercase alpha tokens separated by single hyphens.
+  if (/^\.claude\/skills\/specflow\/phases\/[a-z]+(?:-[a-z]+)*\.md$/.test(dest)) {
+    return true;
+  }
   if (dest === ".claude/skills/specflow-review/SKILL.md") return true;
   if (dest === ".claude/skills/specflow-auto/SKILL.md") return true;
 
@@ -59,9 +67,15 @@ export function isPluginCoveredPath(
  * (either re-install the plugin or run `specflow upgrade` to restore
  * the bundled snapshot).
  *
- * Kept in sync with `isPluginCoveredPath` above. Total: 24 paths
- * (10 agents excluding architect + 1 router skill + 11 phase docs +
+ * Kept in sync with `isPluginCoveredPath` above. Total: 28 paths
+ * (10 agents excluding architect + 1 router skill + 15 phase docs +
  * specflow-review alias + specflow-auto).
+ *
+ * The phase docs array now includes hyphenated phases that the previous
+ * `[a-z]+` regex silently rejected (`tag-version`, `release-version`,
+ * `list-skills`) plus the new `audit-security` phase (Epic #302, #303).
+ * Upcoming `audit-performance` / `audit-accessibility` siblings land in
+ * #304 / #305 and will join this list there.
  */
 export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
   ...[
@@ -89,6 +103,10 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "constitution",
     "checklist",
     "groom",
+    "tag-version",
+    "release-version",
+    "list-skills",
+    "audit-security",
   ].map((name) => `.claude/skills/specflow/phases/${name}.md`),
   ".claude/skills/specflow-review/SKILL.md",
   ".claude/skills/specflow-auto/SKILL.md",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11,8 +11,8 @@ export const CORE_BUNDLE: CoreBundle = [
     suffix: null,
     content: `---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills). \`/specflow\` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). \`/specflow\` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -29,6 +29,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
+  - audit: "audit security / performance / accessibility", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -48,6 +49,15 @@ when_to_use: |
 2. **Phase extraction** — the first remaining token is the phase name.
    Everything after the first whitespace is the argument string for
    that phase.
+
+   **Compound \`audit\` phase exception** — when the first token is exactly
+   \`audit\` AND the next token is one of \`security\`, \`performance\`, or
+   \`accessibility\`, treat the pair as a single hyphenated phase name
+   \`audit-<axis>\` (matching the file \`phases/audit-<axis>.md\`). The
+   remaining tokens after the axis become the argument string. Examples:
+   \`audit security\` → phase \`audit-security\`, args \`\`; \`audit security --severity medium\` → phase \`audit-security\`, args \`--severity medium\`.
+   Users may also invoke the hyphenated form directly
+   (\`/specflow audit-security\`); both forms route to the same phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    \`\$ARGUMENTS\` was empty to start with), render the **Workflow overview**
@@ -71,11 +81,19 @@ when_to_use: |
 | \`tag-version\` | \`phases/tag-version.md\` | Bump + create an annotated git tag using the project's versioning scheme. |
 | \`release-version\` | \`phases/release-version.md\` | Generate categorized release notes for a tag (default: latest). |
 | \`list-skills\` | \`phases/list-skills.md\` | List installed skills, flagging aliases and overlay hooks. |
+| \`audit security\` | \`phases/audit-security.md\` | Read-only project-wide security sweep; emits a findings report. |
 
 Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
 \`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
-\`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`)
+\`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`,
+\`audit security\`)
 are one-shot regardless of chain mode.
+
+\`audit <axis>\` is dispatched as a two-token phase: the router reads
+\`phases/audit-<axis>.md\` (e.g. \`phases/audit-security.md\`). Today only
+\`security\` is wired; \`performance\` and \`accessibility\` land in #304 / #305.
+Until then, \`/specflow audit performance\` and \`/specflow audit accessibility\`
+fall through to the unknown-phase branch.
 
 ## Routing
 
@@ -115,7 +133,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See \`phases/auto-chain.md\` for the
 chain mechanics.
 
-\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, and \`list-skills\` are out-of-band utilities, not part of the linear flow.
+\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`, and \`audit <axis>\` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
@@ -2506,6 +2524,194 @@ SKILLS — 4 installed (.claude/skills/)
   frontmatter directly.
 - To **detect cycles** in alias chains — that requires the harness to
   resolve at dispatch time, which is out of scope for this phase.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "audit-security",
+    suffix: "audit-security.md",
+    content: `
+# /specflow audit security
+
+**Read-only** project-wide security sweep. Walks the entire codebase, dispatches
+the \`security-auditor\` agent in audit mode, and emits a structured findings
+report. **Never mutates project code** — running the phase twice in a row leaves
+\`git status --porcelain\` identical.
+
+This phase is **manual-only** — invoke explicitly with \`/specflow audit security\`
+or schedule with \`/loop 1d /specflow audit security\`. Unlike \`/specflow review\`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+\`/specflow audit security\` is a periodic systemic sweep that produces backlog
+material, not a pass/fail verdict.
+
+## Argument parsing
+
+\`\$ARGUMENTS\` may contain \`--severity <level>\` where \`<level>\` is \`critical\`,
+\`high\`, \`medium\`, or \`low\`. Default is \`high\` (Critical + High are surfaced;
+Medium and Low go to "Out of scope" in the report). \`--severity medium\`
+extends the surfacing down to Medium; \`--severity low\` surfaces everything.
+
+Reject any other argument with: \`error: unknown argument <token> — accepted: --severity <critical|high|medium|low>\` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use \`git rev-parse --show-toplevel\`. If not a
+   git repo, abort with \`error: /specflow audit security requires a git repository (uses git ls-files for scope)\` — there is no value in auditing an
+   un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run \`git ls-files\` once and group the output:
+   - Source files by language extension
+   - Config / secrets-shaped files (\`.env*\`, \`*.key\`, \`*.pem\`, \`id_rsa*\`, \`secrets.*\`)
+   - Dependency manifests (\`package.json\`, \`pyproject.toml\`, \`Cargo.toml\`, \`go.mod\`, \`composer.json\`, \`Gemfile\`, \`requirements*.txt\`)
+   - CI / GitHub Actions (\`.github/workflows/*.yml\`)
+
+3. **Dispatch the \`security-auditor\` agent** with the dispatch prompt below.
+   The agent operates in audit mode (full codebase scan, NOT per-PR review
+   mode). It has \`Read\`, \`Grep\`, \`Glob\`, and constrained \`Bash\` access; it
+   MUST NOT call \`Edit\`, \`Write\`, \`NotebookEdit\`, or any mutating tool.
+
+4. **Persist the report** at
+   \`docs/specflow/audits/YYYY-MM-DD-security.md\` (UTC date). If the file
+   already exists for today, append a \`## Run 2 (HH:MM UTC)\` heading rather
+   than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to \`docs/specflow/audits/YYYY-MM-DD-security.md\`.
+   > Want me to dispatch the \`product-owner\` agent to convert Critical and High
+   > findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the \`product-owner\`
+   agent with the report path + the instruction: "Create one Epic titled
+   \`security audit findings YYYY-MM-DD\` with one sub-task per Critical /
+   High finding (batch Medium / Low into a single grouped task if
+   \`--severity medium\` or \`--severity low\` was passed)."
+
+## Dispatch prompt for the \`security-auditor\` agent
+
+Pass the agent the following prompt verbatim (substituting \`\$INVENTORY\` with
+the grouped file inventory from step 2 and \`\$SEVERITY_FLOOR\` with the resolved
+severity threshold):
+
+\`\`\`
+You are running in **audit mode** — full-codebase sweep, not per-PR review.
+
+Read-only contract: you MUST NOT call Edit, Write, NotebookEdit, or any tool
+that mutates files. Bash is permitted only for \`git ls-files\`, \`git log\`,
+\`git show\`, \`grep\`, \`rg\`, and dependency-listing commands (\`npm ls\`, \`pip list\`,
+\`cargo tree\`, etc.). Any other Bash invocation is a contract violation.
+
+Scope: walk the inventory below and surface findings for each of these axes:
+
+1. **Authentication / authorization** — missing authz on write endpoints,
+   broken session handling, insecure cookies, JWT verification gaps,
+   role-check bypasses.
+2. **Input validation** — route handlers accepting user input without
+   validation, deserialization of untrusted data, type confusion paths.
+3. **Secret leaks** — credentials / API keys / tokens / private keys in
+   source files OR git history (\`git log -S '...'\` for known patterns).
+   \`.env\` or \`*.key\` files committed to history are CRITICAL.
+4. **Injection** — raw SQL concatenation, shell command interpolation with
+   user input, raw HTML / template rendering with unescaped user data,
+   eval-of-string.
+5. **SSRF** — outbound HTTP / network calls to URLs built from user input
+   without allowlist.
+6. **Path traversal / arbitrary file ops** — file-system paths built from
+   user input without normalization + allowlist.
+7. **Supply chain** — outdated dependencies with known CVEs in the
+   dependency manifests, unpinned transitive deps, package installs from
+   non-canonical registries.
+8. **Upload validation** — file upload handlers without MIME / size /
+   extension checks.
+9. **CSRF** — state-changing HTTP routes without CSRF protection (where
+   applicable to the framework).
+10. **Silent error swallowing** — \`catch\` / \`except\` blocks that hide errors
+    without logging, especially in security-relevant code paths.
+
+Severity floor for surfacing: \$SEVERITY_FLOOR. Findings below this floor go
+into the "Out of scope" section of the report (named, not detailed).
+
+Inventory:
+
+\$INVENTORY
+
+Output format: a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+# Security audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "342 source files across TypeScript, Python, shell">
+- Time window: <one line — "git history scanned back to first commit on main">
+- Severity floor: \$SEVERITY_FLOOR
+
+## Critical
+
+For each finding:
+- \`path/to/file.ts:42\` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(same shape — only populated if \$SEVERITY_FLOOR is \`medium\` or \`low\`)
+
+## Low
+
+(same shape — only populated if \$SEVERITY_FLOOR is \`low\`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+
+End with no VERDICT line. Audit-mode reports are not pass/fail.
+\`\`\`
+
+## Read-only contract test
+
+After the agent returns, run:
+
+\`\`\`bash
+git status --porcelain
+\`\`\`
+
+The only acceptable diff is the new \`docs/specflow/audits/YYYY-MM-DD-security.md\`
+file (and the parent \`docs/specflow/audits/\` directory if it had to be created).
+Anything else in the porcelain output is a contract breach — record it as an
+error in the final report and surface to the user.
+
+## Output format (what the user sees)
+
+\`\`\`
+specflow-audit-security report
+──────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Report:   docs/specflow/audits/YYYY-MM-DD-security.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+\`\`\`
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use \`/specflow review\` (gates merge with the security-auditor in PR mode, not audit mode).
+- For triaging GitHub security alerts after a release preflight → the \`/release\` flow already dispatches \`security-auditor\` in alert-triage mode (Mode 2 in the agent's prompt).
+- For a single-file security check → invoke \`security-auditor\` directly with the file paths.
+
+---
+
+Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions.
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). `/specflow` with no args prints the workflow overview.
+argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
 when_to_use: |
   Trigger phrases that should route here:
   - specify: "spec out a feature", "write a spec", "create a specification"
@@ -18,6 +18,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
+  - audit: "audit security / performance / accessibility", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -37,6 +38,15 @@ when_to_use: |
 2. **Phase extraction** — the first remaining token is the phase name.
    Everything after the first whitespace is the argument string for
    that phase.
+
+   **Compound `audit` phase exception** — when the first token is exactly
+   `audit` AND the next token is one of `security`, `performance`, or
+   `accessibility`, treat the pair as a single hyphenated phase name
+   `audit-<axis>` (matching the file `phases/audit-<axis>.md`). The
+   remaining tokens after the axis become the argument string. Examples:
+   `audit security` → phase `audit-security`, args ``; `audit security --severity medium` → phase `audit-security`, args `--severity medium`.
+   Users may also invoke the hyphenated form directly
+   (`/specflow audit-security`); both forms route to the same phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -60,11 +70,19 @@ when_to_use: |
 | `tag-version` | `phases/tag-version.md` | Bump + create an annotated git tag using the project's versioning scheme. |
 | `release-version` | `phases/release-version.md` | Generate categorized release notes for a tag (default: latest). |
 | `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay hooks. |
+| `audit security` | `phases/audit-security.md` | Read-only project-wide security sweep; emits a findings report. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
-`checklist`, `groom`, `tag-version`, `release-version`, `list-skills`)
+`checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
+`audit security`)
 are one-shot regardless of chain mode.
+
+`audit <axis>` is dispatched as a two-token phase: the router reads
+`phases/audit-<axis>.md` (e.g. `phases/audit-security.md`). Today only
+`security` is wired; `performance` and `accessibility` land in #304 / #305.
+Until then, `/specflow audit performance` and `/specflow audit accessibility`
+fall through to the unknown-phase branch.
 
 ## Routing
 
@@ -104,7 +122,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, and `list-skills` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/templates/core/skills/specflow/phases/audit-security.md
+++ b/templates/core/skills/specflow/phases/audit-security.md
@@ -1,0 +1,179 @@
+
+# /specflow audit security
+
+**Read-only** project-wide security sweep. Walks the entire codebase, dispatches
+the `security-auditor` agent in audit mode, and emits a structured findings
+report. **Never mutates project code** — running the phase twice in a row leaves
+`git status --porcelain` identical.
+
+This phase is **manual-only** — invoke explicitly with `/specflow audit security`
+or schedule with `/loop 1d /specflow audit security`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit security` is a periodic systemic sweep that produces backlog
+material, not a pass/fail verdict.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is `critical`,
+`high`, `medium`, or `low`. Default is `high` (Critical + High are surfaced;
+Medium and Low go to "Out of scope" in the report). `--severity medium`
+extends the surfacing down to Medium; `--severity low` surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`. If not a
+   git repo, abort with `error: /specflow audit security requires a git repository (uses git ls-files for scope)` — there is no value in auditing an
+   un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the output:
+   - Source files by language extension
+   - Config / secrets-shaped files (`.env*`, `*.key`, `*.pem`, `id_rsa*`, `secrets.*`)
+   - Dependency manifests (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `composer.json`, `Gemfile`, `requirements*.txt`)
+   - CI / GitHub Actions (`.github/workflows/*.yml`)
+
+3. **Dispatch the `security-auditor` agent** with the dispatch prompt below.
+   The agent operates in audit mode (full codebase scan, NOT per-PR review
+   mode). It has `Read`, `Grep`, `Glob`, and constrained `Bash` access; it
+   MUST NOT call `Edit`, `Write`, `NotebookEdit`, or any mutating tool.
+
+4. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-security.md` (UTC date). If the file
+   already exists for today, append a `## Run 2 (HH:MM UTC)` heading rather
+   than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-security.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical and High
+   > findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the `product-owner`
+   agent with the report path + the instruction: "Create one Epic titled
+   `security audit findings YYYY-MM-DD` with one sub-task per Critical /
+   High finding (batch Medium / Low into a single grouped task if
+   `--severity medium` or `--severity low` was passed)."
+
+## Dispatch prompt for the `security-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY` with
+the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with the resolved
+severity threshold):
+
+```
+You are running in **audit mode** — full-codebase sweep, not per-PR review.
+
+Read-only contract: you MUST NOT call Edit, Write, NotebookEdit, or any tool
+that mutates files. Bash is permitted only for `git ls-files`, `git log`,
+`git show`, `grep`, `rg`, and dependency-listing commands (`npm ls`, `pip list`,
+`cargo tree`, etc.). Any other Bash invocation is a contract violation.
+
+Scope: walk the inventory below and surface findings for each of these axes:
+
+1. **Authentication / authorization** — missing authz on write endpoints,
+   broken session handling, insecure cookies, JWT verification gaps,
+   role-check bypasses.
+2. **Input validation** — route handlers accepting user input without
+   validation, deserialization of untrusted data, type confusion paths.
+3. **Secret leaks** — credentials / API keys / tokens / private keys in
+   source files OR git history (`git log -S '...'` for known patterns).
+   `.env` or `*.key` files committed to history are CRITICAL.
+4. **Injection** — raw SQL concatenation, shell command interpolation with
+   user input, raw HTML / template rendering with unescaped user data,
+   eval-of-string.
+5. **SSRF** — outbound HTTP / network calls to URLs built from user input
+   without allowlist.
+6. **Path traversal / arbitrary file ops** — file-system paths built from
+   user input without normalization + allowlist.
+7. **Supply chain** — outdated dependencies with known CVEs in the
+   dependency manifests, unpinned transitive deps, package installs from
+   non-canonical registries.
+8. **Upload validation** — file upload handlers without MIME / size /
+   extension checks.
+9. **CSRF** — state-changing HTTP routes without CSRF protection (where
+   applicable to the framework).
+10. **Silent error swallowing** — `catch` / `except` blocks that hide errors
+    without logging, especially in security-relevant code paths.
+
+Severity floor for surfacing: $SEVERITY_FLOOR. Findings below this floor go
+into the "Out of scope" section of the report (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Output format: a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+# Security audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "342 source files across TypeScript, Python, shell">
+- Time window: <one line — "git history scanned back to first commit on main">
+- Severity floor: $SEVERITY_FLOOR
+
+## Critical
+
+For each finding:
+- `path/to/file.ts:42` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(same shape — only populated if $SEVERITY_FLOOR is `medium` or `low`)
+
+## Low
+
+(same shape — only populated if $SEVERITY_FLOOR is `low`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+
+End with no VERDICT line. Audit-mode reports are not pass/fail.
+```
+
+## Read-only contract test
+
+After the agent returns, run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new `docs/specflow/audits/YYYY-MM-DD-security.md`
+file (and the parent `docs/specflow/audits/` directory if it had to be created).
+Anything else in the porcelain output is a contract breach — record it as an
+error in the final report and surface to the user.
+
+## Output format (what the user sees)
+
+```
+specflow-audit-security report
+──────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Report:   docs/specflow/audits/YYYY-MM-DD-security.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the security-auditor in PR mode, not audit mode).
+- For triaging GitHub security alerts after a release preflight → the `/release` flow already dispatches `security-auditor` in alert-triage mode (Mode 2 in the agent's prompt).
+- For a single-file security check → invoke `security-auditor` directly with the file paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -17,6 +17,7 @@
     { "category": "phase", "name": "release-version", "suffix": "release-version.md", "source": "core/skills/specflow/phases/release-version.md" },
     { "category": "phase", "name": "auto-chain", "suffix": "auto-chain.md", "source": "core/skills/specflow/phases/auto-chain.md" },
     { "category": "phase", "name": "list-skills", "suffix": "list-skills.md", "source": "core/skills/specflow/phases/list-skills.md" },
+    { "category": "phase", "name": "audit-security", "suffix": "audit-security.md", "source": "core/skills/specflow/phases/audit-security.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },

--- a/tests/domain/plugin_coverage_test.ts
+++ b/tests/domain/plugin_coverage_test.ts
@@ -67,6 +67,28 @@ Deno.test("isPluginCoveredPath: claude + .claude/skills/specflow/phases/<phase>.
   }
 });
 
+// Hyphenated phase names — the previous `[a-z]+` regex silently failed
+// for these. Locked in by Epic #302 / #303 (which added audit-security).
+Deno.test("isPluginCoveredPath: claude + hyphenated phase names are covered", () => {
+  for (
+    const name of [
+      "tag-version",
+      "release-version",
+      "list-skills",
+      "audit-security",
+    ]
+  ) {
+    assertEquals(
+      isPluginCoveredPath(
+        "claude",
+        `.claude/skills/specflow/phases/${name}.md`,
+      ),
+      true,
+      `hyphenated phase ${name} should be plugin-covered`,
+    );
+  }
+});
+
 Deno.test("isPluginCoveredPath: claude + specflow-auto skill is covered", () => {
   assertEquals(
     isPluginCoveredPath("claude", ".claude/skills/specflow-auto/SKILL.md"),

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -837,9 +837,12 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
         o.name === ".claude/skills/specflow-auto/SKILL.md") &&
       o.status === "warn"
     );
-    // 10 agents + 1 router skill + 11 phase docs + specflow-review alias +
-    // specflow-auto = 24 covered paths, all missing.
-    assertEquals(gapOutcomes.length, 24);
+    // 10 agents + 1 router skill + 15 phase docs (the 11 original +
+    // tag-version + release-version + list-skills + audit-security
+    // #303 — the previous `[a-z]+` regex silently dropped the four
+    // hyphenated phases; fixed in #303) + specflow-review alias +
+    // specflow-auto = 28 covered paths, all missing.
+    assertEquals(gapOutcomes.length, 28);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specflow upgrade"), true);

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -91,7 +91,8 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     // writing-plans (A1) + requesting-code-review (A3) +
     // using-specflow bootstrap (B6) + subagent-driven-development (A2) +
     // executing-plans (A4) + verification-before-completion (A5) +
-    // brainstorming (A6) = 11.
+    // brainstorming (A6) = 11. The audit-security phase (#303) lands
+    // under specflow/phases/, not as a top-level skill — no bump here.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,16 +82,16 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 15 phases (11 original + tag-version + release-version +
-    // auto-chain + list-skills) + specflow-auto + specflow-review +
-    // writing-plans (#271) + requesting-code-review (#273) +
+    // Router + 16 phases (11 original + tag-version + release-version +
+    // auto-chain + list-skills + audit-security #303) + specflow-auto +
+    // specflow-review + writing-plans (#271) + requesting-code-review (#273) +
     // using-specflow (#282) + subagent-driven-development (#272) +
     // executing-plans (#274) + verification-before-completion (#275) +
-    // brainstorming (#276) + backlog + 11 agents = 36.
+    // brainstorming (#276) + backlog + 11 agents = 37.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 36);
+    assertEquals(instructionsCount, 37);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,16 +74,16 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 15 phases (11 original + tag-version + release-version +
-    // auto-chain + list-skills) + specflow-auto + specflow-review alias +
-    // writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + subagent-driven-development (#272) +
+    // Router + 16 phases (11 original + tag-version + release-version +
+    // auto-chain + list-skills + audit-security #303) + specflow-auto +
+    // specflow-review alias + writing-plans (#271) + requesting-code-review
+    // (#273) + using-specflow (#282) + subagent-driven-development (#272) +
     // executing-plans (#274) + verification-before-completion (#275) +
-    // brainstorming (#276) + backlog + 11 agent workflows = 36.
+    // brainstorming (#276) + backlog + 11 agent workflows = 37.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 36);
+    assertEquals(workflowsCount, 37);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -17,7 +17,9 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow/SKILL.md",
     source: "templates/core/skills/specflow/SKILL.md",
   },
-  // 13 phase reference docs, loaded by the router on demand.
+  // 15 phase reference docs, loaded by the router on demand. The
+  // `audit-security` phase (Epic #302 / #303) joined the family alongside
+  // the upcoming `audit-performance` / `audit-accessibility` siblings.
   ...[
     "specify",
     "clarify",
@@ -33,6 +35,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "tag-version",
     "release-version",
     "list-skills",
+    "audit-security",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,


### PR DESCRIPTION
Closes #303. First sub-task of Epic #302 (native audit skills marathon).

## Agent adoption

`/specflow audit security` now exists as a read-only project-wide security sweep. Walks the entire codebase, dispatches the existing `security-auditor` agent in audit mode, and emits a structured findings report at `docs/specflow/audits/YYYY-MM-DD-security.md`.

Severity floor configurable: default `high` (Critical + High); `--severity medium|low` extends the surfacing down. Findings below the floor land in the report's "Out of scope" section (named, not detailed).

After the report lands, the phase offers — but does not auto-execute — a `product-owner` handoff to convert Critical/High findings into an Epic + sub-tasks. The user confirms before any backlog mutation.

```prompt
# Run it on a project
/specflow audit security
/specflow audit security --severity medium

# Schedule via the loop infra
/loop 1d /specflow audit security
```

The discipline (read-only contract, structured report, PO handoff) is inspired by `obra/superpowers` v5.1.0 (MIT, Jesse Vincent), adapted to Specflow's bundled agent + backlog conventions.

## What changed

- **Phase doc** at `templates/core/skills/specflow/phases/audit-security.md` + plugin mirror. Dispatches `security-auditor` in audit mode (full-codebase scope, distinct from the existing per-PR review and release-time alert triage modes).
- **Router extended** with the new phase row, a compound-phase routing note (`/specflow audit security` ↔ `/specflow audit-security`), and an updated non-chainable list.
- **`plugin_coverage.ts` regex fix** — pre-existing bug where the `[a-z]+` regex silently rejected hyphenated phase names (`tag-version`, `release-version`, `list-skills`). Fixed alongside `audit-security` so the same wall isn't hit again. The four previously-missing phase names are now in `PLUGIN_COVERED_PATHS_CLAUDE`. Locked in by a new test case.
- **Manifest + sync test + smoke** wired (4 new smoke assertions). Init test counts bumped on copilot/windsurf (36 → 37); codex unchanged (phases nest, no top-level skill count change).
- **Coverage gap count** in `fs_project_inspector_test.ts` bumped 24 → 28 to reflect the corrected coverage map.

## Design decisions (Epic #302 Notes resolved)

1. Phase doc only — no top-level alias skill. Reason: alias skills collide with phase doc destinations on flat-harness scaffolding (Copilot, Windsurf). The shorter `/audit-security` trigger is deferred (Phase-2 if asked).
2. Security only in this PR; `audit-performance` (#304) and `audit-accessibility` (#305) ship as siblings.
3. Severity threshold: `high` default, `--severity medium|low` opt-in.
4. Manual trigger only; `/loop` covers scheduling.
5. Reuses existing `security-auditor` in audit mode; no new agent in this PR.

## Tests

- `deno task test` — 669 passed, 0 failed locally.
- Smoke audit: 0 coverage gaps, 0 stale assertions.
- Smoke-features on freshly-init'd Claude scaffold: 4 new `audit-security` checks all pass.

## Follow-ups

- #304 — performance audit + NEW `performance-auditor` agent.
- #305 — accessibility audit + NEW `a11y-auditor` agent + FE-detection guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)