### PR TITLE
feat(audit): /specflow audit accessibility + NEW a11y-auditor agent + FE-gate (#305)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -97,6 +97,22 @@ check "performance-auditor agent enforces read-only Bash allow-list" \
   'grep -q "Read-only contract" .claude/agents/performance-auditor.md'
 check "router phase index lists audit performance" \
   'grep -q "audit performance" .claude/skills/specflow/SKILL.md'
+check "phase doc audit-accessibility.md scaffolded (Epic #302, #305)" \
+  '[ -f .claude/skills/specflow/phases/audit-accessibility.md ]'
+check "audit-accessibility phase doc dispatches the a11y-auditor agent" \
+  'grep -q "a11y-auditor" .claude/skills/specflow/phases/audit-accessibility.md'
+check "audit-accessibility phase documents FE-surface gate" \
+  'grep -q "no FE surface detected" .claude/skills/specflow/phases/audit-accessibility.md'
+check "a11y-auditor agent bundled (Epic #302, #305)" \
+  '[ -f .claude/agents/a11y-auditor.md ]'
+check "a11y-auditor agent declares disable-model-invocation" \
+  'grep -q "disable-model-invocation: true" .claude/agents/a11y-auditor.md'
+check "a11y-auditor agent covers WCAG 2.1 AA" \
+  'grep -q "WCAG 2.1 AA" .claude/agents/a11y-auditor.md'
+check "a11y-auditor agent implements FE-surface gate" \
+  'grep -q "Front-end surface detection" .claude/agents/a11y-auditor.md'
+check "router phase index lists audit accessibility" \
+  'grep -q "audit accessibility" .claude/skills/specflow/SKILL.md'
 check "name: specflow on the router SKILL.md" \
   'head -3 .claude/skills/specflow/SKILL.md | grep -q "name: specflow"'
 check "disable-model-invocation NOT set on the router (Skill-tool chaining must work)" \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -637,10 +637,12 @@ marketplace:
 ```
 
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
-sub-agents — no binary, no `specflow init` required. The 24 plugin assets (the consolidated
-`specflow` router skill with 14 phase docs, the `specflow-review` auto-invoke alias, the deprecated
-`specflow-auto` alias, and 10 sub-agents) are namespaced under `/specflow-plugin:*` so they coexist
-with project-local copies without collision.
+sub-agents — no binary, no `specflow init` required. The plugin assets (the consolidated `specflow`
+router skill with 17 phase docs including the three `audit-*` axes shipped in Epic #302, the
+`specflow-review` auto-invoke alias, the deprecated `specflow-auto` alias, and 12 sub-agents
+including the manual-only `performance-auditor` and `a11y-auditor` introduced with the audit family)
+are namespaced under `/specflow-plugin:*` so they coexist with project-local copies without
+collision.
 
 When both the plugin and the binary are in use, `specflow upgrade` detects the plugin and
 auto-migrates vanilla on-disk agents and command files (backed up, then deleted — the plugin serves

--- a/plugin/agents/a11y-auditor.md
+++ b/plugin/agents/a11y-auditor.md
@@ -1,0 +1,181 @@
+---
+name: a11y-auditor
+description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: cyan
+disable-model-invocation: true
+---
+
+You are an **accessibility auditor** focused on WCAG 2.1 AA conformance.
+You operate in one of two modes depending on the dispatch shape.
+
+## Front-end surface detection (gate)
+
+Before doing ANY review work in either mode, confirm the project has a
+front-end surface. Run `git ls-files` (or use the inventory provided by
+the caller) and check for any of:
+
+- `.html`, `.htm` files
+- `.jsx`, `.tsx` files
+- `.vue`, `.svelte`, `.astro` files
+- A `public/`, `src/app/`, `src/pages/`, `src/routes/`, or `pages/`
+  directory containing markup
+- A `package.json` listing `react`, `vue`, `svelte`, `solid-js`,
+  `preact`, `lit`, `astro`, `@angular/core`, or `qwik` as a dep
+
+If **none** of these signals are present, immediately emit the
+following one-line response and stop:
+
+```
+no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+```
+
+Do NOT continue with axes 1–10. Do NOT emit an empty report. The
+gating signal is the contract — `/specflow audit accessibility` on a
+CLI-only project is a no-op by design.
+
+## Mode 1 — PR review
+
+Spawned by the `review-coordinator` during `/specflow review`. Review
+ONLY the files provided in the prompt (and only if they include FE
+source — otherwise skip per the gate above). Output the
+`FINDING` / `VERDICT` structure used by code-reviewer.
+
+### Always-check rules
+
+1. **Missing alt text**: `<img>` without `alt=` (and not `alt=""` for
+   decorative images), or with `alt="image.jpg"`-style filename
+   placeholder, is HIGH.
+2. **Missing form labels**: `<input>` / `<select>` / `<textarea>`
+   without an associated `<label>` (matched via `for`/`id` or nested
+   inside the label) AND without `aria-label` / `aria-labelledby` is
+   HIGH.
+3. **Non-button click handlers**: `onClick` on a `<div>` or `<span>`
+   without `role="button"` + keyboard handler (`onKeyDown` for
+   Enter/Space) + `tabIndex={0}` is HIGH (keyboard navigation breaks).
+4. **Heading hierarchy skip**: `<h1>` followed by `<h3>` without an
+   `<h2>` in between, or multiple `<h1>` on the same page, is MEDIUM.
+5. **Missing `lang` attribute**: `<html>` without a `lang=` attribute
+   (or root layout component missing it) is MEDIUM.
+6. **Inaccessible focus indicators**: CSS `outline: none` / `outline: 0`
+   without a replacement `:focus-visible` style is HIGH.
+7. **Color contrast (source-only signal)**: hex-pair / rgb-pair patterns
+   in CSS that compute to a contrast ratio < 4.5:1 for body text or
+   < 3:1 for large text are MEDIUM. Compute it inline; do not require
+   a runtime tool.
+8. **ARIA misuse**: `role="button"` on an actual `<button>` (redundant
+   = LOW); `role="presentation"` on interactive elements (HIGH);
+   invented ARIA role values (HIGH); `aria-labelledby` pointing at a
+   non-existent ID (HIGH if greppable).
+9. **Disabled state without `aria-disabled`**: button styled as
+   disabled (`opacity`, `pointer-events: none`) without
+   `aria-disabled="true"` AND without removing from the tab order is
+   MEDIUM.
+10. **`tabindex` > 0**: any `tabindex="2"` / `tabindex="3"` etc. (creates
+    a confusing tab order) is MEDIUM. `tabindex="-1"` and `tabindex="0"`
+    are fine.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by `/specflow audit accessibility`. Read-only; full project
+scope; **subject to the FE-surface gate above**.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool.
+Bash is permitted only for:
+
+- `git ls-files`, `git log`, `git show`, `git grep`
+- `grep`, `rg`, `find`
+- dependency-listing commands: `npm ls`, `pnpm list`, `yarn list`
+- `wc -l` (file-size inspection)
+
+Any other Bash invocation is a contract violation — report it as an
+error in the report's `Out of scope` section and stop.
+
+### Scope checklist (axes to walk in order, only after FE surface confirmed)
+
+1. **Semantic HTML** — `<div>` / `<span>` with `onClick` instead of
+   `<button>` / `<a>`; presence of landmark elements (`<header>`,
+   `<nav>`, `<main>`, `<footer>`); `<table>` for layout (CRITICAL when
+   used for non-tabular content).
+2. **Heading hierarchy** — walk each page / layout component for
+   `<h1>`–`<h6>` ordering. Surface skips and multiple-`<h1>`-per-page.
+3. **Alt text** — every `<img>` without `alt=` or with placeholder
+   text. Decorative images should be `alt=""` explicitly.
+4. **Form labels** — every input control without an accessible name.
+5. **Keyboard navigation** — `outline: none` without `:focus-visible`,
+   `tabindex > 0`, non-button click handlers without keyboard
+   equivalents, focus traps in modals (does the modal restore focus
+   on close?).
+6. **ARIA correctness** — invalid role values, `aria-labelledby`
+   targets that don't exist in the same component, redundant ARIA on
+   semantic elements.
+7. **Color contrast** — grep CSS / inline styles for color pairs;
+   compute contrast for body-text-sized values. Flag < 4.5:1 (normal)
+   or < 3:1 (large/bold).
+8. **`lang` attribute** — root layout / HTML shell.
+9. **Skip links** — landing pages without a "Skip to main content"
+   link before the nav (MEDIUM).
+10. **Live regions** — `aria-live` regions used for announcements?
+    Toasts / notifications without `aria-live` is MEDIUM.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+```markdown
+# Accessibility audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "12 React components, 4 layout files">
+- Severity floor: <critical|high|medium|low>
+- FE surface detected: <one line — "React + Vite, 12 .tsx files, 4 .css files">
+
+## Critical
+
+For each finding:
+- `path/to/Component.tsx:42` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(only populated if severity floor is `medium` or `low`)
+
+## Low
+
+(only populated if severity floor is `low`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+```
+
+No `VERDICT` line. Audit-mode reports are not pass/fail — they are
+backlog material for the PO to triage.
+
+### Per-axis hints
+
+- **Color contrast** is the most likely to false-positive when CSS
+  uses CSS variables / theme tokens. When you cannot resolve the final
+  color values from source, surface the finding at LOW with an
+  explicit note: `(unresolved CSS variable — confirm in browser)`.
+- **Live browser-based testing** (axe-core, Lighthouse, screen reader
+  walkthrough) is out of scope — note this in the report's
+  `Out of scope` section as "axe-core/Lighthouse runtime checks —
+  install separately for runtime coverage".
+- **Mobile a11y** (iOS VoiceOver, Android TalkBack semantics) is out
+  of scope — note this as "mobile-native a11y — web FE only".
+
+## Output format (Mode 1 — PR review)
+
+Same `FINDING` / `VERDICT` structure as code-reviewer.

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -44,9 +44,13 @@ when_to_use: |
    `accessibility`, treat the pair as a single hyphenated phase name
    `audit-<axis>` (matching the file `phases/audit-<axis>.md`). The
    remaining tokens after the axis become the argument string. Examples:
-   `audit security` → phase `audit-security`, args ``; `audit security --severity medium` → phase `audit-security`, args `--severity medium`.
+   `audit security` → phase `audit-security`, args ``;
+   `audit performance --severity medium` → phase `audit-performance`, args `--severity medium`;
+   `audit accessibility` → phase `audit-accessibility`, args ``.
    Users may also invoke the hyphenated form directly
-   (`/specflow audit-security`); both forms route to the same phase doc.
+   (`/specflow audit-security`, `/specflow audit-performance`,
+   `/specflow audit-accessibility`); both forms route to the same
+   phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -72,18 +76,19 @@ when_to_use: |
 | `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay hooks. |
 | `audit security` | `phases/audit-security.md` | Read-only project-wide security sweep; emits a findings report. |
 | `audit performance` | `phases/audit-performance.md` | Read-only project-wide performance sweep; emits a findings report. |
+| `audit accessibility` | `phases/audit-accessibility.md` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
-`audit security`, `audit performance`)
+`audit security`, `audit performance`, `audit accessibility`)
 are one-shot regardless of chain mode.
 
 `audit <axis>` is dispatched as a two-token phase: the router reads
-`phases/audit-<axis>.md` (e.g. `phases/audit-security.md`). `security`
-and `performance` are wired today; `accessibility` lands in #305. Until
-then, `/specflow audit accessibility` falls through to the unknown-phase
-branch.
+`phases/audit-<axis>.md`. All three axes (`security`, `performance`,
+`accessibility`) are wired. The accessibility phase is FE-gated —
+projects without front-end source receive a one-line "skipped — no
+FE surface" response instead of an empty report.
 
 ## Routing
 

--- a/plugin/skills/specflow/phases/audit-accessibility.md
+++ b/plugin/skills/specflow/phases/audit-accessibility.md
@@ -1,0 +1,174 @@
+
+# /specflow audit accessibility
+
+**Read-only** project-wide WCAG 2.1 AA accessibility sweep. Walks the
+front-end surface of the codebase, dispatches the `a11y-auditor` agent
+in audit mode, and emits a structured findings report. **Never mutates
+project code** — running the phase twice in a row leaves
+`git status --porcelain` identical (modulo the new report file).
+
+This phase is **manual-only** — invoke explicitly with
+`/specflow audit accessibility` or schedule with
+`/loop 1d /specflow audit accessibility`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit accessibility` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## FE-surface gate
+
+Before any work, the `a11y-auditor` agent checks for a front-end
+surface (see its agent doc for the full signal list — `.html`, `.jsx`,
+`.tsx`, `.vue`, `.svelte`, `.astro` files, or a `package.json` listing
+a FE framework dep). If none present, the agent emits:
+
+> no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+
+…and stops. This is by design — `/specflow audit accessibility` on a
+CLI-only project is a no-op. The audit reports nothing; do not invent
+findings.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is
+`critical`, `high`, `medium`, or `low`. Default is `high` (Critical +
+High are surfaced; Medium and Low go to "Out of scope" in the report).
+`--severity medium` extends the surfacing down to Medium;
+`--severity low` surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`.
+   If not a git repo, abort with `error: /specflow audit accessibility requires a git repository (uses git ls-files for scope)` — there is no value in auditing an un-versioned directory because the report won't
+   be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the
+   output:
+   - Front-end source: `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`,
+     `.svelte`, `.astro`
+   - Stylesheets: `.css`, `.scss`, `.sass`, `.less`, `.styl`
+   - Layout / app shell files: anything under `src/app/`, `src/pages/`,
+     `src/routes/`, `pages/`, `app/`
+   - Component directories: `src/components/`, `components/`
+   - Dependency manifests: `package.json`
+
+3. **Dispatch the `a11y-auditor` agent** with the dispatch prompt
+   below. The agent first runs the FE-surface gate; if no FE surface
+   exists, it returns the skip-line and the phase exits without
+   writing a report.
+
+4. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-accessibility.md` (UTC date), but
+   ONLY if the agent returned actual findings. If the agent skipped
+   due to no FE surface, print the skip-line to stdout and exit
+   without creating a report file.
+
+   If the file already exists for today, append a `## Run 2 (HH:MM UTC)`
+   heading rather than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute) — only if a report was
+   written. Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-accessibility.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical
+   > and High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   `product-owner` agent with the report path + the instruction:
+   "Create one Epic titled `accessibility audit findings YYYY-MM-DD`
+   with one sub-task per Critical / High finding (batch Medium / Low
+   into a single grouped task if `--severity medium` or
+   `--severity low` was passed)."
+
+## Dispatch prompt for the `a11y-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY`
+with the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with
+the resolved severity threshold):
+
+```
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+FIRST: run the FE-surface gate from your agent doc. If no FE surface
+is detected, emit the skip-line and stop. Do NOT continue to the
+axis walk.
+
+If FE surface is detected, proceed:
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. Any mutating tool call is a contract violation.
+
+Severity floor: $SEVERITY_FLOOR. Findings below this floor go into
+the "Out of scope" section (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Walk the axis checklist from your agent doc in order (semantic HTML,
+heading hierarchy, alt text, form labels, keyboard navigation, ARIA
+correctness, color contrast, lang attribute, skip links, live
+regions). For each axis, record findings at or above the severity
+floor; document axes that produced no findings under "Out of scope"
+when the underlying surface exists.
+
+Output: the Markdown report shape from your agent doc.
+```
+
+## Read-only contract test
+
+After the agent returns (with findings — i.e. not the skip case),
+run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new
+`docs/specflow/audits/YYYY-MM-DD-accessibility.md` file (and the
+parent `docs/specflow/audits/` directory if it had to be created).
+Anything else is a contract breach — record it as an error and surface
+to the user.
+
+In the skip case (no FE surface), `git status --porcelain` should be
+empty.
+
+## Output format (what the user sees)
+
+### With a FE surface
+
+```
+specflow-audit-accessibility report
+───────────────────────────────────
+Codebase: <root>
+FE surface: <one-line summary>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Report:   docs/specflow/audits/YYYY-MM-DD-accessibility.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+### Without a FE surface
+
+```
+specflow-audit-accessibility — skipped
+──────────────────────────────────────
+no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the a11y-auditor in PR mode, not audit mode).
+- For runtime browser-based accessibility testing (axe-core, Lighthouse, screen reader walkthroughs) → out of scope; this phase reads source, not runtime traces.
+- For mobile-native accessibility (iOS VoiceOver, Android TalkBack) → out of scope; web FE only.
+- For a single-component a11y check → invoke `a11y-auditor` directly with the file paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+`a11y-auditor` agent itself is Specflow-native (no upstream sibling).

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -67,16 +67,17 @@ export function isPluginCoveredPath(
  * (either re-install the plugin or run `specflow upgrade` to restore
  * the bundled snapshot).
  *
- * Kept in sync with `isPluginCoveredPath` above. Total: 30 paths
- * (11 agents excluding architect + 1 router skill + 16 phase docs +
+ * Kept in sync with `isPluginCoveredPath` above. Total: 32 paths
+ * (12 agents excluding architect + 1 router skill + 17 phase docs +
  * specflow-review alias + specflow-auto).
  *
  * Phase docs include hyphenated names — the regex was widened in #303
  * after silently dropping `tag-version`, `release-version`, and
- * `list-skills`. The new `audit-security` (#303) and `audit-performance`
- * (#304) phases joined the list; `audit-accessibility` lands in #305.
- * `performance-auditor` (#304) is the eleventh bundled agent;
- * `a11y-auditor` lands in #305.
+ * `list-skills`. The audit family (`audit-security` #303,
+ * `audit-performance` #304, `audit-accessibility` #305) is now
+ * complete. `performance-auditor` (#304) and `a11y-auditor` (#305)
+ * are the eleventh and twelfth bundled agents — both manual-only
+ * (`disable-model-invocation: true`).
  */
 export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
   ...[
@@ -91,6 +92,7 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "test-reviewer",
     "workflow-manager",
     "performance-auditor",
+    "a11y-auditor",
   ].map((name) => `.claude/agents/${name}.md`),
   ".claude/skills/specflow/SKILL.md",
   ...[
@@ -110,6 +112,7 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "list-skills",
     "audit-security",
     "audit-performance",
+    "audit-accessibility",
   ].map((name) => `.claude/skills/specflow/phases/${name}.md`),
   ".claude/skills/specflow-review/SKILL.md",
   ".claude/skills/specflow-auto/SKILL.md",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -55,9 +55,13 @@ when_to_use: |
    \`accessibility\`, treat the pair as a single hyphenated phase name
    \`audit-<axis>\` (matching the file \`phases/audit-<axis>.md\`). The
    remaining tokens after the axis become the argument string. Examples:
-   \`audit security\` → phase \`audit-security\`, args \`\`; \`audit security --severity medium\` → phase \`audit-security\`, args \`--severity medium\`.
+   \`audit security\` → phase \`audit-security\`, args \`\`;
+   \`audit performance --severity medium\` → phase \`audit-performance\`, args \`--severity medium\`;
+   \`audit accessibility\` → phase \`audit-accessibility\`, args \`\`.
    Users may also invoke the hyphenated form directly
-   (\`/specflow audit-security\`); both forms route to the same phase doc.
+   (\`/specflow audit-security\`, \`/specflow audit-performance\`,
+   \`/specflow audit-accessibility\`); both forms route to the same
+   phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    \`\$ARGUMENTS\` was empty to start with), render the **Workflow overview**
@@ -83,18 +87,19 @@ when_to_use: |
 | \`list-skills\` | \`phases/list-skills.md\` | List installed skills, flagging aliases and overlay hooks. |
 | \`audit security\` | \`phases/audit-security.md\` | Read-only project-wide security sweep; emits a findings report. |
 | \`audit performance\` | \`phases/audit-performance.md\` | Read-only project-wide performance sweep; emits a findings report. |
+| \`audit accessibility\` | \`phases/audit-accessibility.md\` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
 
 Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
 \`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
 \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`,
-\`audit security\`, \`audit performance\`)
+\`audit security\`, \`audit performance\`, \`audit accessibility\`)
 are one-shot regardless of chain mode.
 
 \`audit <axis>\` is dispatched as a two-token phase: the router reads
-\`phases/audit-<axis>.md\` (e.g. \`phases/audit-security.md\`). \`security\`
-and \`performance\` are wired today; \`accessibility\` lands in #305. Until
-then, \`/specflow audit accessibility\` falls through to the unknown-phase
-branch.
+\`phases/audit-<axis>.md\`. All three axes (\`security\`, \`performance\`,
+\`accessibility\`) are wired. The accessibility phase is FE-gated —
+projects without front-end source receive a one-line "skipped — no
+FE surface" response instead of an empty report.
 
 ## Routing
 
@@ -2853,6 +2858,189 @@ Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
 Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
 adapted to Specflow's bundled agent + backlog conventions. The
 \`performance-auditor\` agent itself is Specflow-native (no upstream sibling).
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "audit-accessibility",
+    suffix: "audit-accessibility.md",
+    content: `
+# /specflow audit accessibility
+
+**Read-only** project-wide WCAG 2.1 AA accessibility sweep. Walks the
+front-end surface of the codebase, dispatches the \`a11y-auditor\` agent
+in audit mode, and emits a structured findings report. **Never mutates
+project code** — running the phase twice in a row leaves
+\`git status --porcelain\` identical (modulo the new report file).
+
+This phase is **manual-only** — invoke explicitly with
+\`/specflow audit accessibility\` or schedule with
+\`/loop 1d /specflow audit accessibility\`. Unlike \`/specflow review\`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+\`/specflow audit accessibility\` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## FE-surface gate
+
+Before any work, the \`a11y-auditor\` agent checks for a front-end
+surface (see its agent doc for the full signal list — \`.html\`, \`.jsx\`,
+\`.tsx\`, \`.vue\`, \`.svelte\`, \`.astro\` files, or a \`package.json\` listing
+a FE framework dep). If none present, the agent emits:
+
+> no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+
+…and stops. This is by design — \`/specflow audit accessibility\` on a
+CLI-only project is a no-op. The audit reports nothing; do not invent
+findings.
+
+## Argument parsing
+
+\`\$ARGUMENTS\` may contain \`--severity <level>\` where \`<level>\` is
+\`critical\`, \`high\`, \`medium\`, or \`low\`. Default is \`high\` (Critical +
+High are surfaced; Medium and Low go to "Out of scope" in the report).
+\`--severity medium\` extends the surfacing down to Medium;
+\`--severity low\` surfaces everything.
+
+Reject any other argument with: \`error: unknown argument <token> — accepted: --severity <critical|high|medium|low>\` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use \`git rev-parse --show-toplevel\`.
+   If not a git repo, abort with \`error: /specflow audit accessibility requires a git repository (uses git ls-files for scope)\` — there is no value in auditing an un-versioned directory because the report won't
+   be reproducible.
+
+2. **Build the inventory.** Run \`git ls-files\` once and group the
+   output:
+   - Front-end source: \`.html\`, \`.htm\`, \`.jsx\`, \`.tsx\`, \`.vue\`,
+     \`.svelte\`, \`.astro\`
+   - Stylesheets: \`.css\`, \`.scss\`, \`.sass\`, \`.less\`, \`.styl\`
+   - Layout / app shell files: anything under \`src/app/\`, \`src/pages/\`,
+     \`src/routes/\`, \`pages/\`, \`app/\`
+   - Component directories: \`src/components/\`, \`components/\`
+   - Dependency manifests: \`package.json\`
+
+3. **Dispatch the \`a11y-auditor\` agent** with the dispatch prompt
+   below. The agent first runs the FE-surface gate; if no FE surface
+   exists, it returns the skip-line and the phase exits without
+   writing a report.
+
+4. **Persist the report** at
+   \`docs/specflow/audits/YYYY-MM-DD-accessibility.md\` (UTC date), but
+   ONLY if the agent returned actual findings. If the agent skipped
+   due to no FE surface, print the skip-line to stdout and exit
+   without creating a report file.
+
+   If the file already exists for today, append a \`## Run 2 (HH:MM UTC)\`
+   heading rather than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute) — only if a report was
+   written. Print to stdout:
+
+   > Audit report written to \`docs/specflow/audits/YYYY-MM-DD-accessibility.md\`.
+   > Want me to dispatch the \`product-owner\` agent to convert Critical
+   > and High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   \`product-owner\` agent with the report path + the instruction:
+   "Create one Epic titled \`accessibility audit findings YYYY-MM-DD\`
+   with one sub-task per Critical / High finding (batch Medium / Low
+   into a single grouped task if \`--severity medium\` or
+   \`--severity low\` was passed)."
+
+## Dispatch prompt for the \`a11y-auditor\` agent
+
+Pass the agent the following prompt verbatim (substituting \`\$INVENTORY\`
+with the grouped file inventory from step 2 and \`\$SEVERITY_FLOOR\` with
+the resolved severity threshold):
+
+\`\`\`
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+FIRST: run the FE-surface gate from your agent doc. If no FE surface
+is detected, emit the skip-line and stop. Do NOT continue to the
+axis walk.
+
+If FE surface is detected, proceed:
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. Any mutating tool call is a contract violation.
+
+Severity floor: \$SEVERITY_FLOOR. Findings below this floor go into
+the "Out of scope" section (named, not detailed).
+
+Inventory:
+
+\$INVENTORY
+
+Walk the axis checklist from your agent doc in order (semantic HTML,
+heading hierarchy, alt text, form labels, keyboard navigation, ARIA
+correctness, color contrast, lang attribute, skip links, live
+regions). For each axis, record findings at or above the severity
+floor; document axes that produced no findings under "Out of scope"
+when the underlying surface exists.
+
+Output: the Markdown report shape from your agent doc.
+\`\`\`
+
+## Read-only contract test
+
+After the agent returns (with findings — i.e. not the skip case),
+run:
+
+\`\`\`bash
+git status --porcelain
+\`\`\`
+
+The only acceptable diff is the new
+\`docs/specflow/audits/YYYY-MM-DD-accessibility.md\` file (and the
+parent \`docs/specflow/audits/\` directory if it had to be created).
+Anything else is a contract breach — record it as an error and surface
+to the user.
+
+In the skip case (no FE surface), \`git status --porcelain\` should be
+empty.
+
+## Output format (what the user sees)
+
+### With a FE surface
+
+\`\`\`
+specflow-audit-accessibility report
+───────────────────────────────────
+Codebase: <root>
+FE surface: <one-line summary>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Report:   docs/specflow/audits/YYYY-MM-DD-accessibility.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+\`\`\`
+
+### Without a FE surface
+
+\`\`\`
+specflow-audit-accessibility — skipped
+──────────────────────────────────────
+no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+\`\`\`
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use \`/specflow review\` (gates merge with the a11y-auditor in PR mode, not audit mode).
+- For runtime browser-based accessibility testing (axe-core, Lighthouse, screen reader walkthroughs) → out of scope; this phase reads source, not runtime traces.
+- For mobile-native accessibility (iOS VoiceOver, Android TalkBack) → out of scope; web FE only.
+- For a single-component a11y check → invoke \`a11y-auditor\` directly with the file paths.
+
+---
+
+Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+\`a11y-auditor\` agent itself is Specflow-native (no upstream sibling).
 `,
     executable: false,
     backend: null,
@@ -6813,6 +7001,196 @@ material for the PO to triage.
   language-specific tooling if available; otherwise skip.
 - **When in doubt** — surface the finding at LOW rather than dropping it.
   The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "agent",
+    name: "a11y-auditor",
+    suffix: null,
+    content: `---
+name: a11y-auditor
+description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: cyan
+disable-model-invocation: true
+---
+
+You are an **accessibility auditor** focused on WCAG 2.1 AA conformance.
+You operate in one of two modes depending on the dispatch shape.
+
+## Front-end surface detection (gate)
+
+Before doing ANY review work in either mode, confirm the project has a
+front-end surface. Run \`git ls-files\` (or use the inventory provided by
+the caller) and check for any of:
+
+- \`.html\`, \`.htm\` files
+- \`.jsx\`, \`.tsx\` files
+- \`.vue\`, \`.svelte\`, \`.astro\` files
+- A \`public/\`, \`src/app/\`, \`src/pages/\`, \`src/routes/\`, or \`pages/\`
+  directory containing markup
+- A \`package.json\` listing \`react\`, \`vue\`, \`svelte\`, \`solid-js\`,
+  \`preact\`, \`lit\`, \`astro\`, \`@angular/core\`, or \`qwik\` as a dep
+
+If **none** of these signals are present, immediately emit the
+following one-line response and stop:
+
+\`\`\`
+no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+\`\`\`
+
+Do NOT continue with axes 1–10. Do NOT emit an empty report. The
+gating signal is the contract — \`/specflow audit accessibility\` on a
+CLI-only project is a no-op by design.
+
+## Mode 1 — PR review
+
+Spawned by the \`review-coordinator\` during \`/specflow review\`. Review
+ONLY the files provided in the prompt (and only if they include FE
+source — otherwise skip per the gate above). Output the
+\`FINDING\` / \`VERDICT\` structure used by code-reviewer.
+
+### Always-check rules
+
+1. **Missing alt text**: \`<img>\` without \`alt=\` (and not \`alt=""\` for
+   decorative images), or with \`alt="image.jpg"\`-style filename
+   placeholder, is HIGH.
+2. **Missing form labels**: \`<input>\` / \`<select>\` / \`<textarea>\`
+   without an associated \`<label>\` (matched via \`for\`/\`id\` or nested
+   inside the label) AND without \`aria-label\` / \`aria-labelledby\` is
+   HIGH.
+3. **Non-button click handlers**: \`onClick\` on a \`<div>\` or \`<span>\`
+   without \`role="button"\` + keyboard handler (\`onKeyDown\` for
+   Enter/Space) + \`tabIndex={0}\` is HIGH (keyboard navigation breaks).
+4. **Heading hierarchy skip**: \`<h1>\` followed by \`<h3>\` without an
+   \`<h2>\` in between, or multiple \`<h1>\` on the same page, is MEDIUM.
+5. **Missing \`lang\` attribute**: \`<html>\` without a \`lang=\` attribute
+   (or root layout component missing it) is MEDIUM.
+6. **Inaccessible focus indicators**: CSS \`outline: none\` / \`outline: 0\`
+   without a replacement \`:focus-visible\` style is HIGH.
+7. **Color contrast (source-only signal)**: hex-pair / rgb-pair patterns
+   in CSS that compute to a contrast ratio < 4.5:1 for body text or
+   < 3:1 for large text are MEDIUM. Compute it inline; do not require
+   a runtime tool.
+8. **ARIA misuse**: \`role="button"\` on an actual \`<button>\` (redundant
+   = LOW); \`role="presentation"\` on interactive elements (HIGH);
+   invented ARIA role values (HIGH); \`aria-labelledby\` pointing at a
+   non-existent ID (HIGH if greppable).
+9. **Disabled state without \`aria-disabled\`**: button styled as
+   disabled (\`opacity\`, \`pointer-events: none\`) without
+   \`aria-disabled="true"\` AND without removing from the tab order is
+   MEDIUM.
+10. **\`tabindex\` > 0**: any \`tabindex="2"\` / \`tabindex="3"\` etc. (creates
+    a confusing tab order) is MEDIUM. \`tabindex="-1"\` and \`tabindex="0"\`
+    are fine.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by \`/specflow audit accessibility\`. Read-only; full project
+scope; **subject to the FE-surface gate above**.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool.
+Bash is permitted only for:
+
+- \`git ls-files\`, \`git log\`, \`git show\`, \`git grep\`
+- \`grep\`, \`rg\`, \`find\`
+- dependency-listing commands: \`npm ls\`, \`pnpm list\`, \`yarn list\`
+- \`wc -l\` (file-size inspection)
+
+Any other Bash invocation is a contract violation — report it as an
+error in the report's \`Out of scope\` section and stop.
+
+### Scope checklist (axes to walk in order, only after FE surface confirmed)
+
+1. **Semantic HTML** — \`<div>\` / \`<span>\` with \`onClick\` instead of
+   \`<button>\` / \`<a>\`; presence of landmark elements (\`<header>\`,
+   \`<nav>\`, \`<main>\`, \`<footer>\`); \`<table>\` for layout (CRITICAL when
+   used for non-tabular content).
+2. **Heading hierarchy** — walk each page / layout component for
+   \`<h1>\`–\`<h6>\` ordering. Surface skips and multiple-\`<h1>\`-per-page.
+3. **Alt text** — every \`<img>\` without \`alt=\` or with placeholder
+   text. Decorative images should be \`alt=""\` explicitly.
+4. **Form labels** — every input control without an accessible name.
+5. **Keyboard navigation** — \`outline: none\` without \`:focus-visible\`,
+   \`tabindex > 0\`, non-button click handlers without keyboard
+   equivalents, focus traps in modals (does the modal restore focus
+   on close?).
+6. **ARIA correctness** — invalid role values, \`aria-labelledby\`
+   targets that don't exist in the same component, redundant ARIA on
+   semantic elements.
+7. **Color contrast** — grep CSS / inline styles for color pairs;
+   compute contrast for body-text-sized values. Flag < 4.5:1 (normal)
+   or < 3:1 (large/bold).
+8. **\`lang\` attribute** — root layout / HTML shell.
+9. **Skip links** — landing pages without a "Skip to main content"
+   link before the nav (MEDIUM).
+10. **Live regions** — \`aria-live\` regions used for announcements?
+    Toasts / notifications without \`aria-live\` is MEDIUM.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+\`\`\`markdown
+# Accessibility audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "12 React components, 4 layout files">
+- Severity floor: <critical|high|medium|low>
+- FE surface detected: <one line — "React + Vite, 12 .tsx files, 4 .css files">
+
+## Critical
+
+For each finding:
+- \`path/to/Component.tsx:42\` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(only populated if severity floor is \`medium\` or \`low\`)
+
+## Low
+
+(only populated if severity floor is \`low\`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+\`\`\`
+
+No \`VERDICT\` line. Audit-mode reports are not pass/fail — they are
+backlog material for the PO to triage.
+
+### Per-axis hints
+
+- **Color contrast** is the most likely to false-positive when CSS
+  uses CSS variables / theme tokens. When you cannot resolve the final
+  color values from source, surface the finding at LOW with an
+  explicit note: \`(unresolved CSS variable — confirm in browser)\`.
+- **Live browser-based testing** (axe-core, Lighthouse, screen reader
+  walkthrough) is out of scope — note this in the report's
+  \`Out of scope\` section as "axe-core/Lighthouse runtime checks —
+  install separately for runtime coverage".
+- **Mobile a11y** (iOS VoiceOver, Android TalkBack semantics) is out
+  of scope — note this as "mobile-native a11y — web FE only".
 
 ## Output format (Mode 1 — PR review)
 

--- a/templates/core/agents/a11y-auditor.md
+++ b/templates/core/agents/a11y-auditor.md
@@ -1,0 +1,181 @@
+---
+name: a11y-auditor
+description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: cyan
+disable-model-invocation: true
+---
+
+You are an **accessibility auditor** focused on WCAG 2.1 AA conformance.
+You operate in one of two modes depending on the dispatch shape.
+
+## Front-end surface detection (gate)
+
+Before doing ANY review work in either mode, confirm the project has a
+front-end surface. Run `git ls-files` (or use the inventory provided by
+the caller) and check for any of:
+
+- `.html`, `.htm` files
+- `.jsx`, `.tsx` files
+- `.vue`, `.svelte`, `.astro` files
+- A `public/`, `src/app/`, `src/pages/`, `src/routes/`, or `pages/`
+  directory containing markup
+- A `package.json` listing `react`, `vue`, `svelte`, `solid-js`,
+  `preact`, `lit`, `astro`, `@angular/core`, or `qwik` as a dep
+
+If **none** of these signals are present, immediately emit the
+following one-line response and stop:
+
+```
+no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+```
+
+Do NOT continue with axes 1–10. Do NOT emit an empty report. The
+gating signal is the contract — `/specflow audit accessibility` on a
+CLI-only project is a no-op by design.
+
+## Mode 1 — PR review
+
+Spawned by the `review-coordinator` during `/specflow review`. Review
+ONLY the files provided in the prompt (and only if they include FE
+source — otherwise skip per the gate above). Output the
+`FINDING` / `VERDICT` structure used by code-reviewer.
+
+### Always-check rules
+
+1. **Missing alt text**: `<img>` without `alt=` (and not `alt=""` for
+   decorative images), or with `alt="image.jpg"`-style filename
+   placeholder, is HIGH.
+2. **Missing form labels**: `<input>` / `<select>` / `<textarea>`
+   without an associated `<label>` (matched via `for`/`id` or nested
+   inside the label) AND without `aria-label` / `aria-labelledby` is
+   HIGH.
+3. **Non-button click handlers**: `onClick` on a `<div>` or `<span>`
+   without `role="button"` + keyboard handler (`onKeyDown` for
+   Enter/Space) + `tabIndex={0}` is HIGH (keyboard navigation breaks).
+4. **Heading hierarchy skip**: `<h1>` followed by `<h3>` without an
+   `<h2>` in between, or multiple `<h1>` on the same page, is MEDIUM.
+5. **Missing `lang` attribute**: `<html>` without a `lang=` attribute
+   (or root layout component missing it) is MEDIUM.
+6. **Inaccessible focus indicators**: CSS `outline: none` / `outline: 0`
+   without a replacement `:focus-visible` style is HIGH.
+7. **Color contrast (source-only signal)**: hex-pair / rgb-pair patterns
+   in CSS that compute to a contrast ratio < 4.5:1 for body text or
+   < 3:1 for large text are MEDIUM. Compute it inline; do not require
+   a runtime tool.
+8. **ARIA misuse**: `role="button"` on an actual `<button>` (redundant
+   = LOW); `role="presentation"` on interactive elements (HIGH);
+   invented ARIA role values (HIGH); `aria-labelledby` pointing at a
+   non-existent ID (HIGH if greppable).
+9. **Disabled state without `aria-disabled`**: button styled as
+   disabled (`opacity`, `pointer-events: none`) without
+   `aria-disabled="true"` AND without removing from the tab order is
+   MEDIUM.
+10. **`tabindex` > 0**: any `tabindex="2"` / `tabindex="3"` etc. (creates
+    a confusing tab order) is MEDIUM. `tabindex="-1"` and `tabindex="0"`
+    are fine.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by `/specflow audit accessibility`. Read-only; full project
+scope; **subject to the FE-surface gate above**.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool.
+Bash is permitted only for:
+
+- `git ls-files`, `git log`, `git show`, `git grep`
+- `grep`, `rg`, `find`
+- dependency-listing commands: `npm ls`, `pnpm list`, `yarn list`
+- `wc -l` (file-size inspection)
+
+Any other Bash invocation is a contract violation — report it as an
+error in the report's `Out of scope` section and stop.
+
+### Scope checklist (axes to walk in order, only after FE surface confirmed)
+
+1. **Semantic HTML** — `<div>` / `<span>` with `onClick` instead of
+   `<button>` / `<a>`; presence of landmark elements (`<header>`,
+   `<nav>`, `<main>`, `<footer>`); `<table>` for layout (CRITICAL when
+   used for non-tabular content).
+2. **Heading hierarchy** — walk each page / layout component for
+   `<h1>`–`<h6>` ordering. Surface skips and multiple-`<h1>`-per-page.
+3. **Alt text** — every `<img>` without `alt=` or with placeholder
+   text. Decorative images should be `alt=""` explicitly.
+4. **Form labels** — every input control without an accessible name.
+5. **Keyboard navigation** — `outline: none` without `:focus-visible`,
+   `tabindex > 0`, non-button click handlers without keyboard
+   equivalents, focus traps in modals (does the modal restore focus
+   on close?).
+6. **ARIA correctness** — invalid role values, `aria-labelledby`
+   targets that don't exist in the same component, redundant ARIA on
+   semantic elements.
+7. **Color contrast** — grep CSS / inline styles for color pairs;
+   compute contrast for body-text-sized values. Flag < 4.5:1 (normal)
+   or < 3:1 (large/bold).
+8. **`lang` attribute** — root layout / HTML shell.
+9. **Skip links** — landing pages without a "Skip to main content"
+   link before the nav (MEDIUM).
+10. **Live regions** — `aria-live` regions used for announcements?
+    Toasts / notifications without `aria-live` is MEDIUM.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+```markdown
+# Accessibility audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "12 React components, 4 layout files">
+- Severity floor: <critical|high|medium|low>
+- FE surface detected: <one line — "React + Vite, 12 .tsx files, 4 .css files">
+
+## Critical
+
+For each finding:
+- `path/to/Component.tsx:42` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(only populated if severity floor is `medium` or `low`)
+
+## Low
+
+(only populated if severity floor is `low`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+```
+
+No `VERDICT` line. Audit-mode reports are not pass/fail — they are
+backlog material for the PO to triage.
+
+### Per-axis hints
+
+- **Color contrast** is the most likely to false-positive when CSS
+  uses CSS variables / theme tokens. When you cannot resolve the final
+  color values from source, surface the finding at LOW with an
+  explicit note: `(unresolved CSS variable — confirm in browser)`.
+- **Live browser-based testing** (axe-core, Lighthouse, screen reader
+  walkthrough) is out of scope — note this in the report's
+  `Out of scope` section as "axe-core/Lighthouse runtime checks —
+  install separately for runtime coverage".
+- **Mobile a11y** (iOS VoiceOver, Android TalkBack semantics) is out
+  of scope — note this as "mobile-native a11y — web FE only".
+
+## Output format (Mode 1 — PR review)
+
+Same `FINDING` / `VERDICT` structure as code-reviewer.

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -44,9 +44,13 @@ when_to_use: |
    `accessibility`, treat the pair as a single hyphenated phase name
    `audit-<axis>` (matching the file `phases/audit-<axis>.md`). The
    remaining tokens after the axis become the argument string. Examples:
-   `audit security` → phase `audit-security`, args ``; `audit security --severity medium` → phase `audit-security`, args `--severity medium`.
+   `audit security` → phase `audit-security`, args ``;
+   `audit performance --severity medium` → phase `audit-performance`, args `--severity medium`;
+   `audit accessibility` → phase `audit-accessibility`, args ``.
    Users may also invoke the hyphenated form directly
-   (`/specflow audit-security`); both forms route to the same phase doc.
+   (`/specflow audit-security`, `/specflow audit-performance`,
+   `/specflow audit-accessibility`); both forms route to the same
+   phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -72,18 +76,19 @@ when_to_use: |
 | `list-skills` | `phases/list-skills.md` | List installed skills, flagging aliases and overlay hooks. |
 | `audit security` | `phases/audit-security.md` | Read-only project-wide security sweep; emits a findings report. |
 | `audit performance` | `phases/audit-performance.md` | Read-only project-wide performance sweep; emits a findings report. |
+| `audit accessibility` | `phases/audit-accessibility.md` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
-`audit security`, `audit performance`)
+`audit security`, `audit performance`, `audit accessibility`)
 are one-shot regardless of chain mode.
 
 `audit <axis>` is dispatched as a two-token phase: the router reads
-`phases/audit-<axis>.md` (e.g. `phases/audit-security.md`). `security`
-and `performance` are wired today; `accessibility` lands in #305. Until
-then, `/specflow audit accessibility` falls through to the unknown-phase
-branch.
+`phases/audit-<axis>.md`. All three axes (`security`, `performance`,
+`accessibility`) are wired. The accessibility phase is FE-gated —
+projects without front-end source receive a one-line "skipped — no
+FE surface" response instead of an empty report.
 
 ## Routing
 

--- a/templates/core/skills/specflow/phases/audit-accessibility.md
+++ b/templates/core/skills/specflow/phases/audit-accessibility.md
@@ -1,0 +1,174 @@
+
+# /specflow audit accessibility
+
+**Read-only** project-wide WCAG 2.1 AA accessibility sweep. Walks the
+front-end surface of the codebase, dispatches the `a11y-auditor` agent
+in audit mode, and emits a structured findings report. **Never mutates
+project code** — running the phase twice in a row leaves
+`git status --porcelain` identical (modulo the new report file).
+
+This phase is **manual-only** — invoke explicitly with
+`/specflow audit accessibility` or schedule with
+`/loop 1d /specflow audit accessibility`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit accessibility` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## FE-surface gate
+
+Before any work, the `a11y-auditor` agent checks for a front-end
+surface (see its agent doc for the full signal list — `.html`, `.jsx`,
+`.tsx`, `.vue`, `.svelte`, `.astro` files, or a `package.json` listing
+a FE framework dep). If none present, the agent emits:
+
+> no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+
+…and stops. This is by design — `/specflow audit accessibility` on a
+CLI-only project is a no-op. The audit reports nothing; do not invent
+findings.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is
+`critical`, `high`, `medium`, or `low`. Default is `high` (Critical +
+High are surfaced; Medium and Low go to "Out of scope" in the report).
+`--severity medium` extends the surfacing down to Medium;
+`--severity low` surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`.
+   If not a git repo, abort with `error: /specflow audit accessibility requires a git repository (uses git ls-files for scope)` — there is no value in auditing an un-versioned directory because the report won't
+   be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the
+   output:
+   - Front-end source: `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`,
+     `.svelte`, `.astro`
+   - Stylesheets: `.css`, `.scss`, `.sass`, `.less`, `.styl`
+   - Layout / app shell files: anything under `src/app/`, `src/pages/`,
+     `src/routes/`, `pages/`, `app/`
+   - Component directories: `src/components/`, `components/`
+   - Dependency manifests: `package.json`
+
+3. **Dispatch the `a11y-auditor` agent** with the dispatch prompt
+   below. The agent first runs the FE-surface gate; if no FE surface
+   exists, it returns the skip-line and the phase exits without
+   writing a report.
+
+4. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-accessibility.md` (UTC date), but
+   ONLY if the agent returned actual findings. If the agent skipped
+   due to no FE surface, print the skip-line to stdout and exit
+   without creating a report file.
+
+   If the file already exists for today, append a `## Run 2 (HH:MM UTC)`
+   heading rather than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute) — only if a report was
+   written. Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-accessibility.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical
+   > and High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   `product-owner` agent with the report path + the instruction:
+   "Create one Epic titled `accessibility audit findings YYYY-MM-DD`
+   with one sub-task per Critical / High finding (batch Medium / Low
+   into a single grouped task if `--severity medium` or
+   `--severity low` was passed)."
+
+## Dispatch prompt for the `a11y-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY`
+with the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with
+the resolved severity threshold):
+
+```
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+FIRST: run the FE-surface gate from your agent doc. If no FE surface
+is detected, emit the skip-line and stop. Do NOT continue to the
+axis walk.
+
+If FE surface is detected, proceed:
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. Any mutating tool call is a contract violation.
+
+Severity floor: $SEVERITY_FLOOR. Findings below this floor go into
+the "Out of scope" section (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Walk the axis checklist from your agent doc in order (semantic HTML,
+heading hierarchy, alt text, form labels, keyboard navigation, ARIA
+correctness, color contrast, lang attribute, skip links, live
+regions). For each axis, record findings at or above the severity
+floor; document axes that produced no findings under "Out of scope"
+when the underlying surface exists.
+
+Output: the Markdown report shape from your agent doc.
+```
+
+## Read-only contract test
+
+After the agent returns (with findings — i.e. not the skip case),
+run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new
+`docs/specflow/audits/YYYY-MM-DD-accessibility.md` file (and the
+parent `docs/specflow/audits/` directory if it had to be created).
+Anything else is a contract breach — record it as an error and surface
+to the user.
+
+In the skip case (no FE surface), `git status --porcelain` should be
+empty.
+
+## Output format (what the user sees)
+
+### With a FE surface
+
+```
+specflow-audit-accessibility report
+───────────────────────────────────
+Codebase: <root>
+FE surface: <one-line summary>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Report:   docs/specflow/audits/YYYY-MM-DD-accessibility.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+### Without a FE surface
+
+```
+specflow-audit-accessibility — skipped
+──────────────────────────────────────
+no FE surface detected — accessibility audit skipped (this project ships no front-end source the auditor can read).
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the a11y-auditor in PR mode, not audit mode).
+- For runtime browser-based accessibility testing (axe-core, Lighthouse, screen reader walkthroughs) → out of scope; this phase reads source, not runtime traces.
+- For mobile-native accessibility (iOS VoiceOver, Android TalkBack) → out of scope; web FE only.
+- For a single-component a11y check → invoke `a11y-auditor` directly with the file paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+`a11y-auditor` agent itself is Specflow-native (no upstream sibling).

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -19,6 +19,7 @@
     { "category": "phase", "name": "list-skills", "suffix": "list-skills.md", "source": "core/skills/specflow/phases/list-skills.md" },
     { "category": "phase", "name": "audit-security", "suffix": "audit-security.md", "source": "core/skills/specflow/phases/audit-security.md" },
     { "category": "phase", "name": "audit-performance", "suffix": "audit-performance.md", "source": "core/skills/specflow/phases/audit-performance.md" },
+    { "category": "phase", "name": "audit-accessibility", "suffix": "audit-accessibility.md", "source": "core/skills/specflow/phases/audit-accessibility.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },
@@ -46,6 +47,7 @@
     { "category": "agent", "name": "specflow-expert", "source": "core/agents/specflow-expert.md" },
     { "category": "agent", "name": "ui-ux-designer", "source": "core/agents/ui-ux-designer.md" },
     { "category": "agent", "name": "performance-auditor", "source": "core/agents/performance-auditor.md" },
+    { "category": "agent", "name": "a11y-auditor", "source": "core/agents/a11y-auditor.md" },
 
     { "category": "agent-memory", "name": "product-owner", "suffix": "MEMORY.md", "source": "core/agents/product-owner/memory/MEMORY.md" },
     { "category": "agent-memory", "name": "developer", "suffix": "MEMORY.md", "source": "core/agents/developer/memory/MEMORY.md" },

--- a/tests/domain/plugin_coverage_test.ts
+++ b/tests/domain/plugin_coverage_test.ts
@@ -17,6 +17,7 @@ Deno.test("isPluginCoveredPath: claude + .claude/agents/<name>.md (non-architect
       "test-reviewer",
       "workflow-manager",
       "performance-auditor",
+      "a11y-auditor",
     ]
   ) {
     assertEquals(
@@ -78,6 +79,7 @@ Deno.test("isPluginCoveredPath: claude + hyphenated phase names are covered", ()
       "list-skills",
       "audit-security",
       "audit-performance",
+      "audit-accessibility",
     ]
   ) {
     assertEquals(

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -837,12 +837,13 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
         o.name === ".claude/skills/specflow-auto/SKILL.md") &&
       o.status === "warn"
     );
-    // 11 agents (10 original + performance-auditor #304) + 1 router skill +
-    // 16 phase docs (the 11 original + tag-version + release-version +
-    // list-skills + audit-security #303 + audit-performance #304 —
-    // hyphenated phases unblocked by the #303 regex fix) +
-    // specflow-review alias + specflow-auto = 30 covered paths.
-    assertEquals(gapOutcomes.length, 30);
+    // 12 agents (10 original + performance-auditor #304 + a11y-auditor #305)
+    // + 1 router skill + 17 phase docs (the 11 original + tag-version +
+    // release-version + list-skills + audit-security #303 +
+    // audit-performance #304 + audit-accessibility #305 — hyphenated
+    // phases unblocked by the #303 regex fix) + specflow-review alias +
+    // specflow-auto = 32 covered paths.
+    assertEquals(gapOutcomes.length, 32);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specflow upgrade"), true);
@@ -885,7 +886,7 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
       await Deno.mkdir(join(dir, ".claude/agents"), { recursive: true });
       // Scaffold every covered agent EXCEPT product-owner (simulating
       // that one alone got deleted post-migration). The set tracks
-      // PLUGIN_COVERED_PATHS_CLAUDE — 11 agents minus product-owner = 10.
+      // PLUGIN_COVERED_PATHS_CLAUDE — 12 agents minus product-owner = 11.
       for (
         const name of [
           "code-reviewer",
@@ -898,6 +899,7 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
           "test-reviewer",
           "workflow-manager",
           "performance-auditor",
+          "a11y-auditor",
         ]
       ) {
         await Deno.writeTextFile(join(dir, `.claude/agents/${name}.md`), "stub");

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -100,8 +100,8 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;
-    // 11 original + performance-auditor (#304) = 12.
-    assertEquals(codexAgentsCount, 12);
+    // 11 original + performance-auditor (#304) + a11y-auditor (#305) = 13.
+    assertEquals(codexAgentsCount, 13);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,17 +82,18 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 17 phases (11 original + tag-version + release-version +
+    // Router + 18 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
-    // #304) + specflow-auto + specflow-review + writing-plans (#271) +
-    // requesting-code-review (#273) + using-specflow (#282) +
-    // subagent-driven-development (#272) + executing-plans (#274) +
-    // verification-before-completion (#275) + brainstorming (#276) +
-    // backlog + 12 agents (11 original + performance-auditor #304) = 39.
+    // #304 + audit-accessibility #305) + specflow-auto + specflow-review +
+    // writing-plans (#271) + requesting-code-review (#273) +
+    // using-specflow (#282) + subagent-driven-development (#272) +
+    // executing-plans (#274) + verification-before-completion (#275) +
+    // brainstorming (#276) + backlog + 13 agents (11 original +
+    // performance-auditor #304 + a11y-auditor #305) = 41.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 39);
+    assertEquals(instructionsCount, 41);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_gemini_test.ts
+++ b/tests/integration/init_gemini_test.ts
@@ -99,8 +99,8 @@ Deno.test("specflow init --ai gemini scaffolds a Gemini layout", async () => {
     const agentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".gemini/agents")),
     )).length;
-    // 11 original + performance-auditor (#304) = 12.
-    assertEquals(agentsCount, 12);
+    // 11 original + performance-auditor (#304) + a11y-auditor (#305) = 13.
+    assertEquals(agentsCount, 13);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -93,15 +93,16 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
       Deno.readDir(join(root, ".claude/commands")),
     )).length;
     assertEquals(commandsCount, 2);
-    // 12 agent .md files (11 original + performance-auditor #304) + 5
-    // memory subfolders (product-owner, developer, qa-tester, devops-sre,
-    // security-auditor; specflow-expert, ui-ux-designer, and
-    // performance-auditor are stateless and ship without a memory stub)
+    // 13 agent .md files (11 original + performance-auditor #304 +
+    // a11y-auditor #305) + 5 memory subfolders (product-owner, developer,
+    // qa-tester, devops-sre, security-auditor; specflow-expert,
+    // ui-ux-designer, performance-auditor, and a11y-auditor are
+    // stateless and ship without a memory stub)
     const agentDirEntries = await Array.fromAsync(
       Deno.readDir(join(root, ".claude/agents")),
     );
     const agentMdCount = agentDirEntries.filter((e) => e.isFile && e.name.endsWith(".md")).length;
-    assertEquals(agentMdCount, 12);
+    assertEquals(agentMdCount, 13);
     const memoryDirCount = agentDirEntries.filter((e) => e.isDirectory).length;
     assertEquals(memoryDirCount, 5);
     // Spot-check one memory file

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,18 +74,18 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 17 phases (11 original + tag-version + release-version +
+    // Router + 18 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
-    // #304) + specflow-auto + specflow-review alias + writing-plans
-    // (#271) + requesting-code-review (#273) + using-specflow (#282) +
-    // subagent-driven-development (#272) + executing-plans (#274) +
-    // verification-before-completion (#275) + brainstorming (#276) +
-    // backlog + 12 agent workflows (11 original + performance-auditor
-    // #304) = 39.
+    // #304 + audit-accessibility #305) + specflow-auto + specflow-review
+    // alias + writing-plans (#271) + requesting-code-review (#273) +
+    // using-specflow (#282) + subagent-driven-development (#272) +
+    // executing-plans (#274) + verification-before-completion (#275) +
+    // brainstorming (#276) + backlog + 13 agent workflows (11 original +
+    // performance-auditor #304 + a11y-auditor #305) = 41.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 39);
+    assertEquals(workflowsCount, 41);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -37,6 +37,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "list-skills",
     "audit-security",
     "audit-performance",
+    "audit-accessibility",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,
@@ -131,6 +132,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "test-reviewer",
     "workflow-manager",
     "performance-auditor",
+    "a11y-auditor",
   ].map((name) => ({
     plugin: `plugin/agents/${name}.md`,
     source: `templates/core/agents/${name}.md`,


### PR DESCRIPTION
Closes #305. **Third and final** sub-task of Epic #302 (native audit skills marathon) — completes the audit family.

## Agent adoption

`/specflow audit accessibility` now exists as a read-only project-wide WCAG 2.1 AA sweep. The new `a11y-auditor` agent walks 10 axes (semantic HTML, heading hierarchy, alt text, form labels, keyboard navigation, ARIA correctness, color contrast, lang attribute, skip links, live regions) and emits a structured findings report at `docs/specflow/audits/YYYY-MM-DD-accessibility.md`.

**FE-surface gate (new pattern):** before any work the agent checks for `.html`/`.jsx`/`.tsx`/`.vue`/`.svelte`/`.astro` files OR a `package.json` listing a FE framework dep OR a `public/` / `src/app/` / `src/pages/` / `src/routes/` / `pages/` directory. If none present, the audit emits a one-line skip and stops without writing a report. CLI-only / pure-backend projects are a no-op by design — never invented findings, never empty reports.

```prompt
# Run on any project — the agent self-detects FE
/specflow audit accessibility
/specflow audit accessibility --severity medium

# Schedule via the loop infra
/loop 1d /specflow audit accessibility
```

After the report lands, the phase offers (does NOT auto-execute) a `product-owner` handoff to convert Critical/High findings into an Epic + sub-tasks.

## What changed

- **NEW agent**: `templates/core/agents/a11y-auditor.md` (+ plugin mirror). FE-surface gate, two dispatch modes, 10-axis checklist, `disable-model-invocation: true`.
- **Phase doc**: `templates/core/skills/specflow/phases/audit-accessibility.md` (+ plugin mirror). FE-gate baked into both procedure (no report on skip) and user-visible output (separate skip-output template).
- **Router**: phase index closed out (all 3 audit axes present), chainable list updated, compound-phase routing examples extended.
- **Manifest**: 2 new entries (phase + agent).
- **Plugin sync test**: `a11y-auditor` added to agent SYNC_PAIRS, `audit-accessibility` added to phase SYNC_PAIRS.
- **Plugin coverage**: total 32 paths (was 30). 12 agents, 17 phase docs.
- **Smoke**: 8 new assertions covering phase + agent + FE-gate + WCAG 2.1 AA + disable-model-invocation + router phase index.
- **Init test counts**: codex agents 12→13, gemini agents 12→13, copilot 39→41, windsurf 39→41, claude .claude/agents/ 12→13.
- **`docs/llms.md` drift fix** (PO-flagged after #303): plugin-assets prose corrected from "14 phase docs … 10 sub-agents" to "17 phase docs … 12 sub-agents" with the new audit-* phases + auditor agents called out.

## Tests

- `deno task test` — 673 passed, 0 failed locally.
- Smoke audit: 0 coverage gaps, 0 stale assertions.
- Smoke-features: 8 new audit-accessibility checks all green.

## Epic #302 complete after this merge

- #303 → #316 (audit-security + `plugin_coverage` regex fix for hyphenated phases)
- #304 → #317 (audit-performance + NEW performance-auditor)
- #305 → this PR (audit-accessibility + NEW a11y-auditor + FE-gate)

Specflow ships three first-class read-only audit axes with structured findings reports and opt-in PO handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)