### PR TITLE
test(sandbox): repair two pre-existing smoke-script drift failures

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
@@ -113,8 +113,8 @@ check "ensure-labels.sh verifies the GitHub default '"'"'bug'"'"' label" \
   'grep -qF "bug" .specflow/scripts/backlog/ensure-labels.sh'
 check "SKILL.md mentions ensure-labels.sh (#158)" \
   'grep -q "ensure-labels.sh" .claude/skills/backlog/SKILL.md'
-check "SKILL.md states fields are the source of truth (#194)" \
-  'grep -q "fields are the source of truth" .claude/skills/backlog/SKILL.md'
+check "SKILL.md states fields take priority over labels (#194)" \
+  'grep -q "reserved as a strict fallback" .claude/skills/backlog/SKILL.md'
 
 echo
 echo "═══ #157  Priority/Size native fields documented in SKILL.md ═══"

--- a/.claude/skills/test-sandbox/scripts/smoke-picker.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-picker.sh
@@ -33,6 +33,9 @@ PROJECT_DIR = os.environ["PROJECT_DIR"]
 MAIN_TS = os.environ["MAIN_TS"]
 ARGS = ["deno", "run", "--allow-all", MAIN_TS, "init", "--here", "--no-git"]
 # 2× down + enter (codex harness), 1× down + enter (github backend),
+# enter to accept the scheme picker default (added in #257 — SemVer/date
+# detection now runs after the backend selection, before the URL prompt;
+# accepting the suggested default works for an empty bootstrap fixture),
 # enter to skip the kanban URL prompt (added in #147).
 SCRIPT = [
     (0.5, b"\x1b[B"),
@@ -40,6 +43,7 @@ SCRIPT = [
     (0.3, b"\r"),
     (0.5, b"\x1b[B"),
     (0.3, b"\r"),
+    (0.5, b"\r"),
     (0.5, b"\r"),
 ]
 


### PR DESCRIPTION
Two failures surfaced when re-running the full smoke suite as post-v1.9.0 release validation. Both pre-date Epic #270 / Epic #302 — assertion-side drift, no production code involved.

## smoke-backlog-github.sh

The check at line 116 greps `.claude/skills/backlog/SKILL.md` for `"fields are the source of truth"` — wording last seen during the #194 era. The canonical field-first contract is now phrased as `"Labels are reserved as a strict fallback for projects / orgs without the native field or type."`, but single-line `grep -q` couldn't match it (the wrap puts "Labels are" at the end of one line and the rest on the next).

Switched the assertion to grep for the shorter single-line substring `"reserved as a strict fallback"` — same intent, no wrap dependency.

## smoke-picker.sh

The PTY-driven picker test scripts 6 keystrokes (2× down + enter for harness, 1× down + enter for backend, 1× enter to skip the GitHub project URL prompt). Issue #257 added a SemVer-scheme picker between the backend selection and the URL prompt — the test had no keystroke for that picker, so the 6th enter accepted the scheme default and init then waited forever for URL input, timing out before `.specflow/installed.lock` could be written.

Added one extra `\r` to the SCRIPT array (accept scheme picker default, then skip URL). All 7 picker assertions pass.

## Validation

- `smoke-backlog-github.sh` → **ALL GITHUB BACKLOG CHECKS PASSED**
- `smoke-picker.sh` → **ALL PICKER CHECKS PASSED (7/7)**
- Full smoke suite green on v1.9.0 (already green: features / backlog-local / hooks / tag-release / all-harnesses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)