### PR TITLE
feat(audit): /specflow audit architecture + NEW architecture-auditor agent (#321)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -113,6 +113,22 @@ check "a11y-auditor agent implements FE-surface gate" \
   'grep -q "Front-end surface detection" .claude/agents/a11y-auditor.md'
 check "router phase index lists audit accessibility" \
   'grep -q "audit accessibility" .claude/skills/specflow/SKILL.md'
+check "phase doc audit-architecture.md scaffolded (Epic #320, #321)" \
+  '[ -f .claude/skills/specflow/phases/audit-architecture.md ]'
+check "audit-architecture phase doc dispatches the architecture-auditor agent" \
+  'grep -q "architecture-auditor" .claude/skills/specflow/phases/audit-architecture.md'
+check "audit-architecture phase doc declares read-only contract" \
+  'grep -q "Read-only contract" .claude/skills/specflow/phases/audit-architecture.md'
+check "architecture-auditor agent bundled (Epic #320, #321)" \
+  '[ -f .claude/agents/architecture-auditor.md ]'
+check "architecture-auditor agent declares disable-model-invocation" \
+  'grep -q "disable-model-invocation: true" .claude/agents/architecture-auditor.md'
+check "architecture-auditor agent covers hex-layer violations axis" \
+  'grep -q "[Hh]ex-layer" .claude/agents/architecture-auditor.md'
+check "architecture-auditor agent enforces read-only Bash allow-list" \
+  'grep -q "Read-only contract" .claude/agents/architecture-auditor.md'
+check "router phase index lists audit architecture" \
+  'grep -q "audit architecture" .claude/skills/specflow/SKILL.md'
 check "name: specflow on the router SKILL.md" \
   'head -3 .claude/skills/specflow/SKILL.md | grep -q "name: specflow"'
 check "disable-model-invocation NOT set on the router (Skill-tool chaining must work)" \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -638,9 +638,10 @@ marketplace:
 
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
 sub-agents — no binary, no `specflow init` required. The plugin assets (the consolidated `specflow`
-router skill with 17 phase docs including the three `audit-*` axes shipped in Epic #302, the
-`specflow-review` auto-invoke alias, the deprecated `specflow-auto` alias, and 12 sub-agents
-including the manual-only `performance-auditor` and `a11y-auditor` introduced with the audit family)
+router skill with 18 phase docs including the four `audit-*` axes — `security` / `performance` /
+`accessibility` from Epic #302 and `architecture` from Epic #320, the `specflow-review` auto-invoke
+alias, the deprecated `specflow-auto` alias, and 14 sub-agents including the manual-only
+`performance-auditor`, `a11y-auditor`, and `architecture-auditor` introduced with the audit family)
 are namespaced under `/specflow-plugin:*` so they coexist with project-local copies without
 collision.
 

--- a/plugin/agents/architecture-auditor.md
+++ b/plugin/agents/architecture-auditor.md
@@ -1,0 +1,173 @@
+---
+name: architecture-auditor
+description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: blue
+disable-model-invocation: true
+---
+
+You are an **architecture auditor**. You operate in one of two modes
+depending on the dispatch shape.
+
+## Mode 1 — PR review
+
+Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
+the files provided in the prompt. Output the `FINDING` / `VERDICT` structure
+used by code-reviewer.
+
+### Always-check rules
+
+1. **Hex-layer violation**: an import from a lower layer pointing UP
+   (domain importing application; application importing infrastructure;
+   any layer importing CLI). CRITICAL — these break the dependency rule
+   and silently couple the entire codebase.
+2. **Circular dependency introduced by the diff**: module A imports B
+   which (now) imports A, direct or transitive. HIGH — circulars resist
+   refactoring and corrupt module load order.
+3. **God-file threshold crossed**: a source file that grew past 500 LOC
+   in this diff (or a class/type block past 200 LOC). MEDIUM — readability
+   + testability proxy; flag with a split suggestion sketch.
+4. **Implicit global in domain**: a domain-layer file that newly
+   references `Deno.*`, `process.*`, `window.*`, `globalThis.*`, or any
+   non-injected I/O primitive. HIGH — domain code MUST go through an
+   injected port; this leak corrupts the testability guarantee.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by `/specflow audit architecture`. Read-only; full project scope.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool. Bash is
+permitted only for:
+
+- `git ls-files`, `git log`, `git show`, `git grep`
+- `grep`, `rg`, `find`
+- module-graph inspection: `madge`, `tsc --noEmit --listFiles`, `deno info`
+  (read-only when modules are already cached; offline-only — no `deno
+  cache` invocation)
+- size-inspection: `wc -l`, `du -sh`, `ls -la`
+
+Any other Bash invocation is a contract violation — report it as an error
+in the report's `Out of scope` section and stop.
+
+### Scope checklist (axes to walk in order)
+
+1. **Hex-layer / module-layer violations** — detect the project's layer
+   convention from directory structure (`src/domain/`, `src/application/`,
+   `src/infrastructure/`, `src/cli/`; or DDD-style `core/`, `app/`,
+   `adapters/`). For each layer, grep imports pointing UP the dependency
+   chain. CRITICAL when domain ↦ infrastructure, HIGH when application
+   ↦ infrastructure, MEDIUM when infrastructure ↦ CLI.
+2. **Circular dependencies** — module A imports B which imports A
+   (direct or transitive). Surface the cycle path. Use language tooling
+   when available (`madge --circular` for TS/JS, `pylint --enable=R0401`
+   for Python); fall back to `grep` of import statements.
+3. **God files / god classes** — files exceeding 500 LOC (source) or
+   classes/type blocks exceeding 200 LOC. HIGH for top-5-by-size; LOW
+   for the rest. Report the top 10 in absolute terms even when below
+   the floor, so the reader sees the distribution.
+4. **Bounded-context leaks** — types or identifiers from one bounded
+   context imported directly into another without going through a port
+   or interface. Detect bounded contexts from top-level directory or
+   namespace partitioning; flag cross-context type imports.
+5. **Ports/adapters discipline** — infrastructure files bypassing the
+   port interface and calling domain code directly; use cases importing
+   adapters directly; any direct concrete-class reference where an
+   interface should be injected. HIGH — these corrupt the swap-the-
+   adapter testability guarantee.
+6. **Deep nesting** — function bodies or control-flow blocks nested
+   more than 4 levels. MEDIUM (readability + testability proxy).
+   Use `awk` + brace-counting or language-specific complexity tools
+   (`flake8 --max-complexity`, `eslint complexity rule`).
+7. **Anemic domain model** — domain types that are pure data bags with
+   all logic pushed to application or infrastructure. LOW — signals
+   boundary erosion; flag with a count and a few examples, not every
+   instance.
+8. **Implicit dependencies in domain / use cases** — `Deno.*`,
+   `process.*`, `window.*`, `globalThis.*` references in files that
+   should be pure. HIGH for domain, MEDIUM for application.
+9. **Test isolation** — tests importing infrastructure adapters directly
+   instead of using ports/stubs. These are integration tests masquerading
+   as unit tests. MEDIUM — flag with the file count per layer.
+10. **Naming consistency** — module names not matching the layer
+    convention (e.g. an `infrastructure/` file named `*_service.ts`
+    instead of `*_adapter.ts` / `*_store.ts`; a `domain/` file with
+    `_handler` suffix). LOW — pattern hygiene only.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+```markdown
+# Architecture audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "342 source files across TypeScript, Python">
+- Severity floor: <critical|high|medium|low>
+- Layer convention detected: <hex | DDD | flat | none — one line>
+- Languages / frameworks detected: <one line>
+
+## Critical
+
+For each finding:
+- `path/to/file.ts:42` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(only populated if severity floor is `medium` or `low`)
+
+## Low
+
+(only populated if severity floor is `low`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+```
+
+No `VERDICT` line. Audit-mode reports are not pass/fail — they are backlog
+material for the PO to triage.
+
+### Per-axis hints
+
+- **No detectable layer convention** (flat scripting repo, monolithic
+  single-file project) — skip axes 1, 4, 5; record under "Out of scope"
+  as "no hex/module structure detected". Still run axes 2 (circular
+  deps), 3 (god files), 6 (deep nesting), 8 (implicit globals — global
+  scope still matters), 9 (test isolation if a `tests/` dir exists), 10
+  (naming) — these apply universally.
+- **Static-typed languages** — use the language's own import resolver
+  output where possible (`tsc --listFiles`, `mypy --show-error-codes`).
+- **Multi-language polyglot repos** — partition the inventory by
+  language first; report findings under per-language sub-sections within
+  each severity section.
+- **When in doubt** — surface the finding at LOW rather than dropping
+  it. The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
+finding as:
+
+```
+FINDING <severity>: <one-line summary>
+  Path: <file:line>
+  Rationale: <2-3 sentences>
+  Suggested fix: <code sketch or pointer>
+
+VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
+```
+
+Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
+omits VERDICT — backlog material is not pass/fail.

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -18,7 +18,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
-  - audit: "audit security / performance / accessibility", "scan the codebase for X issues"
+  - audit: "audit security / performance / accessibility / architecture", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -40,17 +40,19 @@ when_to_use: |
    that phase.
 
    **Compound `audit` phase exception** — when the first token is exactly
-   `audit` AND the next token is one of `security`, `performance`, or
-   `accessibility`, treat the pair as a single hyphenated phase name
-   `audit-<axis>` (matching the file `phases/audit-<axis>.md`). The
-   remaining tokens after the axis become the argument string. Examples:
+   `audit` AND the next token is one of `security`, `performance`,
+   `accessibility`, or `architecture`, treat the pair as a single
+   hyphenated phase name `audit-<axis>` (matching the file
+   `phases/audit-<axis>.md`). The remaining tokens after the axis become
+   the argument string. Examples:
    `audit security` → phase `audit-security`, args ``;
    `audit performance --severity medium` → phase `audit-performance`, args `--severity medium`;
-   `audit accessibility` → phase `audit-accessibility`, args ``.
+   `audit accessibility` → phase `audit-accessibility`, args ``;
+   `audit architecture` → phase `audit-architecture`, args ``.
    Users may also invoke the hyphenated form directly
    (`/specflow audit-security`, `/specflow audit-performance`,
-   `/specflow audit-accessibility`); both forms route to the same
-   phase doc.
+   `/specflow audit-accessibility`, `/specflow audit-architecture`);
+   both forms route to the same phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -77,18 +79,22 @@ when_to_use: |
 | `audit security` | `phases/audit-security.md` | Read-only project-wide security sweep; emits a findings report. |
 | `audit performance` | `phases/audit-performance.md` | Read-only project-wide performance sweep; emits a findings report. |
 | `audit accessibility` | `phases/audit-accessibility.md` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
+| `audit architecture` | `phases/audit-architecture.md` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
-`audit security`, `audit performance`, `audit accessibility`)
-are one-shot regardless of chain mode.
+`audit security`, `audit performance`, `audit accessibility`,
+`audit architecture`) are one-shot regardless of chain mode.
 
 `audit <axis>` is dispatched as a two-token phase: the router reads
-`phases/audit-<axis>.md`. All three axes (`security`, `performance`,
-`accessibility`) are wired. The accessibility phase is FE-gated —
-projects without front-end source receive a one-line "skipped — no
-FE surface" response instead of an empty report.
+`phases/audit-<axis>.md`. Four axes are wired (`security`,
+`performance`, `accessibility`, `architecture`). The accessibility
+phase is FE-gated — projects without front-end source receive a
+one-line "skipped — no FE surface" response instead of an empty report.
+The architecture phase is always-on (universal applicability); axes
+that don't match the codebase's structure go to "Out of scope" in the
+report rather than skipping the whole run.
 
 ## Routing
 
@@ -128,7 +134,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/plugin/skills/specflow/phases/audit-architecture.md
+++ b/plugin/skills/specflow/phases/audit-architecture.md
@@ -1,0 +1,135 @@
+
+# /specflow audit architecture
+
+**Read-only** project-wide architectural sweep. Walks the entire
+codebase, dispatches the `architecture-auditor` agent in audit mode, and
+emits a structured findings report. **Never mutates project code** —
+running the phase twice in a row leaves `git status --porcelain`
+identical (modulo the new report file).
+
+This phase is **manual-only** — invoke explicitly with
+`/specflow audit architecture` or schedule with
+`/loop 1d /specflow audit architecture`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit architecture` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is `critical`,
+`high`, `medium`, or `low`. Default is `high` (Critical + High are
+surfaced; Medium and Low go to "Out of scope" in the report).
+`--severity medium` extends the surfacing down to Medium; `--severity low`
+surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`. If not
+   a git repo, abort with `error: /specflow audit architecture requires a git repository (uses git ls-files for scope)` — there is no value in auditing
+   an un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the output:
+   - Source files by language extension
+   - Top-level directory layout (used to detect the layer convention —
+     hex / DDD / flat / none)
+   - Test files (`tests/`, `*_test.{ts,py,rs}`, `*.test.{ts,jsx,tsx}`,
+     `*.spec.{ts,jsx,tsx}`)
+   - Dependency manifests (used to detect language ecosystem only)
+
+3. **Dispatch the `architecture-auditor` agent** with the dispatch prompt
+   below. The agent operates in audit mode (full codebase scan, NOT
+   per-PR review mode). It has `Read`, `Grep`, `Glob`, and constrained
+   `Bash` access; it MUST NOT call `Edit`, `Write`, `NotebookEdit`, or
+   any mutating tool.
+
+4. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-architecture.md` (UTC date). If the
+   file already exists for today, append a `## Run 2 (HH:MM UTC)` heading
+   rather than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-architecture.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical and
+   > High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   `product-owner` agent with the report path + the instruction: "Create
+   one Epic titled `architecture audit findings YYYY-MM-DD` with one
+   sub-task per Critical / High finding (batch Medium / Low into a
+   single grouped task if `--severity medium` or `--severity low` was
+   passed)."
+
+## Dispatch prompt for the `architecture-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY`
+with the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with
+the resolved severity threshold):
+
+```
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. Any mutating tool call is a contract violation.
+
+Severity floor: $SEVERITY_FLOOR. Findings below this floor go into the
+"Out of scope" section (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Walk the axis checklist from your agent doc in order (hex-layer
+violations, circular deps, god files, bounded-context leaks,
+ports/adapters discipline, deep nesting, anemic domain, implicit globals,
+test isolation, naming consistency). For each axis, when the codebase
+doesn't have the relevant surface (no layer convention, no bounded
+contexts, etc.), record it under "Out of scope" rather than emitting
+empty findings.
+
+Output: the Markdown report shape from your agent doc.
+```
+
+## Read-only contract test
+
+After the agent returns, run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new
+`docs/specflow/audits/YYYY-MM-DD-architecture.md` file (and the parent
+`docs/specflow/audits/` directory if it had to be created). Anything else
+is a contract breach — record it as an error in the final report and
+surface to the user.
+
+## Output format (what the user sees)
+
+```
+specflow-audit-architecture report
+──────────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Layer convention: <hex|DDD|flat|none>
+Report:   docs/specflow/audits/YYYY-MM-DD-architecture.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the architecture-auditor in PR mode, not audit mode).
+- For codebase-wide refactor planning → out of scope; this phase surfaces drift, it doesn't propose the refactor strategy. Pair with `/specflow specify` to capture the refactor as a spec.
+- For a single-file architecture check → invoke `architecture-auditor` directly with the file paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+`architecture-auditor` agent itself is Specflow-native (no upstream sibling).

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -67,17 +67,19 @@ export function isPluginCoveredPath(
  * (either re-install the plugin or run `specflow upgrade` to restore
  * the bundled snapshot).
  *
- * Kept in sync with `isPluginCoveredPath` above. Total: 32 paths
- * (12 agents excluding architect + 1 router skill + 17 phase docs +
+ * Kept in sync with `isPluginCoveredPath` above. Total: 35 paths
+ * (14 agents excluding architect + 1 router skill + 18 phase docs +
  * specflow-review alias + specflow-auto).
  *
  * Phase docs include hyphenated names — the regex was widened in #303
  * after silently dropping `tag-version`, `release-version`, and
- * `list-skills`. The audit family (`audit-security` #303,
- * `audit-performance` #304, `audit-accessibility` #305) is now
- * complete. `performance-auditor` (#304) and `a11y-auditor` (#305)
- * are the eleventh and twelfth bundled agents — both manual-only
- * (`disable-model-invocation: true`).
+ * `list-skills`. The phase-1 audit family (`audit-security` #303,
+ * `audit-performance` #304, `audit-accessibility` #305) shipped in
+ * v1.9.0; the phase-2 family adds `audit-architecture` (#321) here and
+ * will add `audit-dependencies` in the sibling #322. `ui-ux-designer`
+ * was missing from this array pre-#321 even though it ships in the
+ * Claude scaffold — added here alongside `architecture-auditor` to
+ * close a long-standing drift bug.
  */
 export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
   ...[
@@ -91,8 +93,10 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "specflow-expert",
     "test-reviewer",
     "workflow-manager",
+    "ui-ux-designer",
     "performance-auditor",
     "a11y-auditor",
+    "architecture-auditor",
   ].map((name) => `.claude/agents/${name}.md`),
   ".claude/skills/specflow/SKILL.md",
   ...[
@@ -113,6 +117,7 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "audit-security",
     "audit-performance",
     "audit-accessibility",
+    "audit-architecture",
   ].map((name) => `.claude/skills/specflow/phases/${name}.md`),
   ".claude/skills/specflow-review/SKILL.md",
   ".claude/skills/specflow-auto/SKILL.md",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -29,7 +29,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
-  - audit: "audit security / performance / accessibility", "scan the codebase for X issues"
+  - audit: "audit security / performance / accessibility / architecture", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -51,17 +51,19 @@ when_to_use: |
    that phase.
 
    **Compound \`audit\` phase exception** — when the first token is exactly
-   \`audit\` AND the next token is one of \`security\`, \`performance\`, or
-   \`accessibility\`, treat the pair as a single hyphenated phase name
-   \`audit-<axis>\` (matching the file \`phases/audit-<axis>.md\`). The
-   remaining tokens after the axis become the argument string. Examples:
+   \`audit\` AND the next token is one of \`security\`, \`performance\`,
+   \`accessibility\`, or \`architecture\`, treat the pair as a single
+   hyphenated phase name \`audit-<axis>\` (matching the file
+   \`phases/audit-<axis>.md\`). The remaining tokens after the axis become
+   the argument string. Examples:
    \`audit security\` → phase \`audit-security\`, args \`\`;
    \`audit performance --severity medium\` → phase \`audit-performance\`, args \`--severity medium\`;
-   \`audit accessibility\` → phase \`audit-accessibility\`, args \`\`.
+   \`audit accessibility\` → phase \`audit-accessibility\`, args \`\`;
+   \`audit architecture\` → phase \`audit-architecture\`, args \`\`.
    Users may also invoke the hyphenated form directly
    (\`/specflow audit-security\`, \`/specflow audit-performance\`,
-   \`/specflow audit-accessibility\`); both forms route to the same
-   phase doc.
+   \`/specflow audit-accessibility\`, \`/specflow audit-architecture\`);
+   both forms route to the same phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    \`\$ARGUMENTS\` was empty to start with), render the **Workflow overview**
@@ -88,18 +90,22 @@ when_to_use: |
 | \`audit security\` | \`phases/audit-security.md\` | Read-only project-wide security sweep; emits a findings report. |
 | \`audit performance\` | \`phases/audit-performance.md\` | Read-only project-wide performance sweep; emits a findings report. |
 | \`audit accessibility\` | \`phases/audit-accessibility.md\` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
+| \`audit architecture\` | \`phases/audit-architecture.md\` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
 
 Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
 \`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
 \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`,
-\`audit security\`, \`audit performance\`, \`audit accessibility\`)
-are one-shot regardless of chain mode.
+\`audit security\`, \`audit performance\`, \`audit accessibility\`,
+\`audit architecture\`) are one-shot regardless of chain mode.
 
 \`audit <axis>\` is dispatched as a two-token phase: the router reads
-\`phases/audit-<axis>.md\`. All three axes (\`security\`, \`performance\`,
-\`accessibility\`) are wired. The accessibility phase is FE-gated —
-projects without front-end source receive a one-line "skipped — no
-FE surface" response instead of an empty report.
+\`phases/audit-<axis>.md\`. Four axes are wired (\`security\`,
+\`performance\`, \`accessibility\`, \`architecture\`). The accessibility
+phase is FE-gated — projects without front-end source receive a
+one-line "skipped — no FE surface" response instead of an empty report.
+The architecture phase is always-on (universal applicability); axes
+that don't match the codebase's structure go to "Out of scope" in the
+report rather than skipping the whole run.
 
 ## Routing
 
@@ -139,7 +145,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See \`phases/auto-chain.md\` for the
 chain mechanics.
 
-\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`, and \`audit <axis>\` are out-of-band utilities, not part of the linear flow.
+\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`, and \`audit <axis>\` (any of \`security\`, \`performance\`, \`accessibility\`, \`architecture\`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
@@ -3041,6 +3047,150 @@ no FE surface detected — accessibility audit skipped (this project ships no fr
 Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
 adapted to Specflow's bundled agent + backlog conventions. The
 \`a11y-auditor\` agent itself is Specflow-native (no upstream sibling).
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "audit-architecture",
+    suffix: "audit-architecture.md",
+    content: `
+# /specflow audit architecture
+
+**Read-only** project-wide architectural sweep. Walks the entire
+codebase, dispatches the \`architecture-auditor\` agent in audit mode, and
+emits a structured findings report. **Never mutates project code** —
+running the phase twice in a row leaves \`git status --porcelain\`
+identical (modulo the new report file).
+
+This phase is **manual-only** — invoke explicitly with
+\`/specflow audit architecture\` or schedule with
+\`/loop 1d /specflow audit architecture\`. Unlike \`/specflow review\`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+\`/specflow audit architecture\` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## Argument parsing
+
+\`\$ARGUMENTS\` may contain \`--severity <level>\` where \`<level>\` is \`critical\`,
+\`high\`, \`medium\`, or \`low\`. Default is \`high\` (Critical + High are
+surfaced; Medium and Low go to "Out of scope" in the report).
+\`--severity medium\` extends the surfacing down to Medium; \`--severity low\`
+surfaces everything.
+
+Reject any other argument with: \`error: unknown argument <token> — accepted: --severity <critical|high|medium|low>\` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use \`git rev-parse --show-toplevel\`. If not
+   a git repo, abort with \`error: /specflow audit architecture requires a git repository (uses git ls-files for scope)\` — there is no value in auditing
+   an un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run \`git ls-files\` once and group the output:
+   - Source files by language extension
+   - Top-level directory layout (used to detect the layer convention —
+     hex / DDD / flat / none)
+   - Test files (\`tests/\`, \`*_test.{ts,py,rs}\`, \`*.test.{ts,jsx,tsx}\`,
+     \`*.spec.{ts,jsx,tsx}\`)
+   - Dependency manifests (used to detect language ecosystem only)
+
+3. **Dispatch the \`architecture-auditor\` agent** with the dispatch prompt
+   below. The agent operates in audit mode (full codebase scan, NOT
+   per-PR review mode). It has \`Read\`, \`Grep\`, \`Glob\`, and constrained
+   \`Bash\` access; it MUST NOT call \`Edit\`, \`Write\`, \`NotebookEdit\`, or
+   any mutating tool.
+
+4. **Persist the report** at
+   \`docs/specflow/audits/YYYY-MM-DD-architecture.md\` (UTC date). If the
+   file already exists for today, append a \`## Run 2 (HH:MM UTC)\` heading
+   rather than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to \`docs/specflow/audits/YYYY-MM-DD-architecture.md\`.
+   > Want me to dispatch the \`product-owner\` agent to convert Critical and
+   > High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   \`product-owner\` agent with the report path + the instruction: "Create
+   one Epic titled \`architecture audit findings YYYY-MM-DD\` with one
+   sub-task per Critical / High finding (batch Medium / Low into a
+   single grouped task if \`--severity medium\` or \`--severity low\` was
+   passed)."
+
+## Dispatch prompt for the \`architecture-auditor\` agent
+
+Pass the agent the following prompt verbatim (substituting \`\$INVENTORY\`
+with the grouped file inventory from step 2 and \`\$SEVERITY_FLOOR\` with
+the resolved severity threshold):
+
+\`\`\`
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. Any mutating tool call is a contract violation.
+
+Severity floor: \$SEVERITY_FLOOR. Findings below this floor go into the
+"Out of scope" section (named, not detailed).
+
+Inventory:
+
+\$INVENTORY
+
+Walk the axis checklist from your agent doc in order (hex-layer
+violations, circular deps, god files, bounded-context leaks,
+ports/adapters discipline, deep nesting, anemic domain, implicit globals,
+test isolation, naming consistency). For each axis, when the codebase
+doesn't have the relevant surface (no layer convention, no bounded
+contexts, etc.), record it under "Out of scope" rather than emitting
+empty findings.
+
+Output: the Markdown report shape from your agent doc.
+\`\`\`
+
+## Read-only contract test
+
+After the agent returns, run:
+
+\`\`\`bash
+git status --porcelain
+\`\`\`
+
+The only acceptable diff is the new
+\`docs/specflow/audits/YYYY-MM-DD-architecture.md\` file (and the parent
+\`docs/specflow/audits/\` directory if it had to be created). Anything else
+is a contract breach — record it as an error in the final report and
+surface to the user.
+
+## Output format (what the user sees)
+
+\`\`\`
+specflow-audit-architecture report
+──────────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Layer convention: <hex|DDD|flat|none>
+Report:   docs/specflow/audits/YYYY-MM-DD-architecture.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+\`\`\`
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use \`/specflow review\` (gates merge with the architecture-auditor in PR mode, not audit mode).
+- For codebase-wide refactor planning → out of scope; this phase surfaces drift, it doesn't propose the refactor strategy. Pair with \`/specflow specify\` to capture the refactor as a spec.
+- For a single-file architecture check → invoke \`architecture-auditor\` directly with the file paths.
+
+---
+
+Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+\`architecture-auditor\` agent itself is Specflow-native (no upstream sibling).
 `,
     executable: false,
     backend: null,
@@ -7195,6 +7345,188 @@ backlog material for the PO to triage.
 ## Output format (Mode 1 — PR review)
 
 Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "agent",
+    name: "architecture-auditor",
+    suffix: null,
+    content: `---
+name: architecture-auditor
+description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: blue
+disable-model-invocation: true
+---
+
+You are an **architecture auditor**. You operate in one of two modes
+depending on the dispatch shape.
+
+## Mode 1 — PR review
+
+Spawned by the \`review-coordinator\` during \`/specflow review\`. Review ONLY
+the files provided in the prompt. Output the \`FINDING\` / \`VERDICT\` structure
+used by code-reviewer.
+
+### Always-check rules
+
+1. **Hex-layer violation**: an import from a lower layer pointing UP
+   (domain importing application; application importing infrastructure;
+   any layer importing CLI). CRITICAL — these break the dependency rule
+   and silently couple the entire codebase.
+2. **Circular dependency introduced by the diff**: module A imports B
+   which (now) imports A, direct or transitive. HIGH — circulars resist
+   refactoring and corrupt module load order.
+3. **God-file threshold crossed**: a source file that grew past 500 LOC
+   in this diff (or a class/type block past 200 LOC). MEDIUM — readability
+   + testability proxy; flag with a split suggestion sketch.
+4. **Implicit global in domain**: a domain-layer file that newly
+   references \`Deno.*\`, \`process.*\`, \`window.*\`, \`globalThis.*\`, or any
+   non-injected I/O primitive. HIGH — domain code MUST go through an
+   injected port; this leak corrupts the testability guarantee.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by \`/specflow audit architecture\`. Read-only; full project scope.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool. Bash is
+permitted only for:
+
+- \`git ls-files\`, \`git log\`, \`git show\`, \`git grep\`
+- \`grep\`, \`rg\`, \`find\`
+- module-graph inspection: \`madge\`, \`tsc --noEmit --listFiles\`, \`deno info\`
+  (read-only when modules are already cached; offline-only — no \`deno
+  cache\` invocation)
+- size-inspection: \`wc -l\`, \`du -sh\`, \`ls -la\`
+
+Any other Bash invocation is a contract violation — report it as an error
+in the report's \`Out of scope\` section and stop.
+
+### Scope checklist (axes to walk in order)
+
+1. **Hex-layer / module-layer violations** — detect the project's layer
+   convention from directory structure (\`src/domain/\`, \`src/application/\`,
+   \`src/infrastructure/\`, \`src/cli/\`; or DDD-style \`core/\`, \`app/\`,
+   \`adapters/\`). For each layer, grep imports pointing UP the dependency
+   chain. CRITICAL when domain ↦ infrastructure, HIGH when application
+   ↦ infrastructure, MEDIUM when infrastructure ↦ CLI.
+2. **Circular dependencies** — module A imports B which imports A
+   (direct or transitive). Surface the cycle path. Use language tooling
+   when available (\`madge --circular\` for TS/JS, \`pylint --enable=R0401\`
+   for Python); fall back to \`grep\` of import statements.
+3. **God files / god classes** — files exceeding 500 LOC (source) or
+   classes/type blocks exceeding 200 LOC. HIGH for top-5-by-size; LOW
+   for the rest. Report the top 10 in absolute terms even when below
+   the floor, so the reader sees the distribution.
+4. **Bounded-context leaks** — types or identifiers from one bounded
+   context imported directly into another without going through a port
+   or interface. Detect bounded contexts from top-level directory or
+   namespace partitioning; flag cross-context type imports.
+5. **Ports/adapters discipline** — infrastructure files bypassing the
+   port interface and calling domain code directly; use cases importing
+   adapters directly; any direct concrete-class reference where an
+   interface should be injected. HIGH — these corrupt the swap-the-
+   adapter testability guarantee.
+6. **Deep nesting** — function bodies or control-flow blocks nested
+   more than 4 levels. MEDIUM (readability + testability proxy).
+   Use \`awk\` + brace-counting or language-specific complexity tools
+   (\`flake8 --max-complexity\`, \`eslint complexity rule\`).
+7. **Anemic domain model** — domain types that are pure data bags with
+   all logic pushed to application or infrastructure. LOW — signals
+   boundary erosion; flag with a count and a few examples, not every
+   instance.
+8. **Implicit dependencies in domain / use cases** — \`Deno.*\`,
+   \`process.*\`, \`window.*\`, \`globalThis.*\` references in files that
+   should be pure. HIGH for domain, MEDIUM for application.
+9. **Test isolation** — tests importing infrastructure adapters directly
+   instead of using ports/stubs. These are integration tests masquerading
+   as unit tests. MEDIUM — flag with the file count per layer.
+10. **Naming consistency** — module names not matching the layer
+    convention (e.g. an \`infrastructure/\` file named \`*_service.ts\`
+    instead of \`*_adapter.ts\` / \`*_store.ts\`; a \`domain/\` file with
+    \`_handler\` suffix). LOW — pattern hygiene only.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+\`\`\`markdown
+# Architecture audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "342 source files across TypeScript, Python">
+- Severity floor: <critical|high|medium|low>
+- Layer convention detected: <hex | DDD | flat | none — one line>
+- Languages / frameworks detected: <one line>
+
+## Critical
+
+For each finding:
+- \`path/to/file.ts:42\` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(only populated if severity floor is \`medium\` or \`low\`)
+
+## Low
+
+(only populated if severity floor is \`low\`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+\`\`\`
+
+No \`VERDICT\` line. Audit-mode reports are not pass/fail — they are backlog
+material for the PO to triage.
+
+### Per-axis hints
+
+- **No detectable layer convention** (flat scripting repo, monolithic
+  single-file project) — skip axes 1, 4, 5; record under "Out of scope"
+  as "no hex/module structure detected". Still run axes 2 (circular
+  deps), 3 (god files), 6 (deep nesting), 8 (implicit globals — global
+  scope still matters), 9 (test isolation if a \`tests/\` dir exists), 10
+  (naming) — these apply universally.
+- **Static-typed languages** — use the language's own import resolver
+  output where possible (\`tsc --listFiles\`, \`mypy --show-error-codes\`).
+- **Multi-language polyglot repos** — partition the inventory by
+  language first; report findings under per-language sub-sections within
+  each severity section.
+- **When in doubt** — surface the finding at LOW rather than dropping
+  it. The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same \`FINDING\` / \`VERDICT\` structure as code-reviewer. Format each
+finding as:
+
+\`\`\`
+FINDING <severity>: <one-line summary>
+  Path: <file:line>
+  Rationale: <2-3 sentences>
+  Suggested fix: <code sketch or pointer>
+
+VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
+\`\`\`
+
+Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
+omits VERDICT — backlog material is not pass/fail.
 `,
     executable: false,
     backend: null,

--- a/templates/core/agents/architecture-auditor.md
+++ b/templates/core/agents/architecture-auditor.md
@@ -1,0 +1,173 @@
+---
+name: architecture-auditor
+description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: blue
+disable-model-invocation: true
+---
+
+You are an **architecture auditor**. You operate in one of two modes
+depending on the dispatch shape.
+
+## Mode 1 — PR review
+
+Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
+the files provided in the prompt. Output the `FINDING` / `VERDICT` structure
+used by code-reviewer.
+
+### Always-check rules
+
+1. **Hex-layer violation**: an import from a lower layer pointing UP
+   (domain importing application; application importing infrastructure;
+   any layer importing CLI). CRITICAL — these break the dependency rule
+   and silently couple the entire codebase.
+2. **Circular dependency introduced by the diff**: module A imports B
+   which (now) imports A, direct or transitive. HIGH — circulars resist
+   refactoring and corrupt module load order.
+3. **God-file threshold crossed**: a source file that grew past 500 LOC
+   in this diff (or a class/type block past 200 LOC). MEDIUM — readability
+   + testability proxy; flag with a split suggestion sketch.
+4. **Implicit global in domain**: a domain-layer file that newly
+   references `Deno.*`, `process.*`, `window.*`, `globalThis.*`, or any
+   non-injected I/O primitive. HIGH — domain code MUST go through an
+   injected port; this leak corrupts the testability guarantee.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by `/specflow audit architecture`. Read-only; full project scope.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool. Bash is
+permitted only for:
+
+- `git ls-files`, `git log`, `git show`, `git grep`
+- `grep`, `rg`, `find`
+- module-graph inspection: `madge`, `tsc --noEmit --listFiles`, `deno info`
+  (read-only when modules are already cached; offline-only — no `deno
+  cache` invocation)
+- size-inspection: `wc -l`, `du -sh`, `ls -la`
+
+Any other Bash invocation is a contract violation — report it as an error
+in the report's `Out of scope` section and stop.
+
+### Scope checklist (axes to walk in order)
+
+1. **Hex-layer / module-layer violations** — detect the project's layer
+   convention from directory structure (`src/domain/`, `src/application/`,
+   `src/infrastructure/`, `src/cli/`; or DDD-style `core/`, `app/`,
+   `adapters/`). For each layer, grep imports pointing UP the dependency
+   chain. CRITICAL when domain ↦ infrastructure, HIGH when application
+   ↦ infrastructure, MEDIUM when infrastructure ↦ CLI.
+2. **Circular dependencies** — module A imports B which imports A
+   (direct or transitive). Surface the cycle path. Use language tooling
+   when available (`madge --circular` for TS/JS, `pylint --enable=R0401`
+   for Python); fall back to `grep` of import statements.
+3. **God files / god classes** — files exceeding 500 LOC (source) or
+   classes/type blocks exceeding 200 LOC. HIGH for top-5-by-size; LOW
+   for the rest. Report the top 10 in absolute terms even when below
+   the floor, so the reader sees the distribution.
+4. **Bounded-context leaks** — types or identifiers from one bounded
+   context imported directly into another without going through a port
+   or interface. Detect bounded contexts from top-level directory or
+   namespace partitioning; flag cross-context type imports.
+5. **Ports/adapters discipline** — infrastructure files bypassing the
+   port interface and calling domain code directly; use cases importing
+   adapters directly; any direct concrete-class reference where an
+   interface should be injected. HIGH — these corrupt the swap-the-
+   adapter testability guarantee.
+6. **Deep nesting** — function bodies or control-flow blocks nested
+   more than 4 levels. MEDIUM (readability + testability proxy).
+   Use `awk` + brace-counting or language-specific complexity tools
+   (`flake8 --max-complexity`, `eslint complexity rule`).
+7. **Anemic domain model** — domain types that are pure data bags with
+   all logic pushed to application or infrastructure. LOW — signals
+   boundary erosion; flag with a count and a few examples, not every
+   instance.
+8. **Implicit dependencies in domain / use cases** — `Deno.*`,
+   `process.*`, `window.*`, `globalThis.*` references in files that
+   should be pure. HIGH for domain, MEDIUM for application.
+9. **Test isolation** — tests importing infrastructure adapters directly
+   instead of using ports/stubs. These are integration tests masquerading
+   as unit tests. MEDIUM — flag with the file count per layer.
+10. **Naming consistency** — module names not matching the layer
+    convention (e.g. an `infrastructure/` file named `*_service.ts`
+    instead of `*_adapter.ts` / `*_store.ts`; a `domain/` file with
+    `_handler` suffix). LOW — pattern hygiene only.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+```markdown
+# Architecture audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Codebase scope: <one line — "342 source files across TypeScript, Python">
+- Severity floor: <critical|high|medium|low>
+- Layer convention detected: <hex | DDD | flat | none — one line>
+- Languages / frameworks detected: <one line>
+
+## Critical
+
+For each finding:
+- `path/to/file.ts:42` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape)
+
+## Medium
+
+(only populated if severity floor is `medium` or `low`)
+
+## Low
+
+(only populated if severity floor is `low`)
+
+## Out of scope
+
+- <named axis> — <one line on why not surfaced this run>
+```
+
+No `VERDICT` line. Audit-mode reports are not pass/fail — they are backlog
+material for the PO to triage.
+
+### Per-axis hints
+
+- **No detectable layer convention** (flat scripting repo, monolithic
+  single-file project) — skip axes 1, 4, 5; record under "Out of scope"
+  as "no hex/module structure detected". Still run axes 2 (circular
+  deps), 3 (god files), 6 (deep nesting), 8 (implicit globals — global
+  scope still matters), 9 (test isolation if a `tests/` dir exists), 10
+  (naming) — these apply universally.
+- **Static-typed languages** — use the language's own import resolver
+  output where possible (`tsc --listFiles`, `mypy --show-error-codes`).
+- **Multi-language polyglot repos** — partition the inventory by
+  language first; report findings under per-language sub-sections within
+  each severity section.
+- **When in doubt** — surface the finding at LOW rather than dropping
+  it. The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
+finding as:
+
+```
+FINDING <severity>: <one-line summary>
+  Path: <file:line>
+  Rationale: <2-3 sentences>
+  Suggested fix: <code sketch or pointer>
+
+VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
+```
+
+Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
+omits VERDICT — backlog material is not pass/fail.

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -18,7 +18,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
-  - audit: "audit security / performance / accessibility", "scan the codebase for X issues"
+  - audit: "audit security / performance / accessibility / architecture", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -40,17 +40,19 @@ when_to_use: |
    that phase.
 
    **Compound `audit` phase exception** — when the first token is exactly
-   `audit` AND the next token is one of `security`, `performance`, or
-   `accessibility`, treat the pair as a single hyphenated phase name
-   `audit-<axis>` (matching the file `phases/audit-<axis>.md`). The
-   remaining tokens after the axis become the argument string. Examples:
+   `audit` AND the next token is one of `security`, `performance`,
+   `accessibility`, or `architecture`, treat the pair as a single
+   hyphenated phase name `audit-<axis>` (matching the file
+   `phases/audit-<axis>.md`). The remaining tokens after the axis become
+   the argument string. Examples:
    `audit security` → phase `audit-security`, args ``;
    `audit performance --severity medium` → phase `audit-performance`, args `--severity medium`;
-   `audit accessibility` → phase `audit-accessibility`, args ``.
+   `audit accessibility` → phase `audit-accessibility`, args ``;
+   `audit architecture` → phase `audit-architecture`, args ``.
    Users may also invoke the hyphenated form directly
    (`/specflow audit-security`, `/specflow audit-performance`,
-   `/specflow audit-accessibility`); both forms route to the same
-   phase doc.
+   `/specflow audit-accessibility`, `/specflow audit-architecture`);
+   both forms route to the same phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -77,18 +79,22 @@ when_to_use: |
 | `audit security` | `phases/audit-security.md` | Read-only project-wide security sweep; emits a findings report. |
 | `audit performance` | `phases/audit-performance.md` | Read-only project-wide performance sweep; emits a findings report. |
 | `audit accessibility` | `phases/audit-accessibility.md` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
+| `audit architecture` | `phases/audit-architecture.md` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
-`audit security`, `audit performance`, `audit accessibility`)
-are one-shot regardless of chain mode.
+`audit security`, `audit performance`, `audit accessibility`,
+`audit architecture`) are one-shot regardless of chain mode.
 
 `audit <axis>` is dispatched as a two-token phase: the router reads
-`phases/audit-<axis>.md`. All three axes (`security`, `performance`,
-`accessibility`) are wired. The accessibility phase is FE-gated —
-projects without front-end source receive a one-line "skipped — no
-FE surface" response instead of an empty report.
+`phases/audit-<axis>.md`. Four axes are wired (`security`,
+`performance`, `accessibility`, `architecture`). The accessibility
+phase is FE-gated — projects without front-end source receive a
+one-line "skipped — no FE surface" response instead of an empty report.
+The architecture phase is always-on (universal applicability); axes
+that don't match the codebase's structure go to "Out of scope" in the
+report rather than skipping the whole run.
 
 ## Routing
 
@@ -128,7 +134,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/templates/core/skills/specflow/phases/audit-architecture.md
+++ b/templates/core/skills/specflow/phases/audit-architecture.md
@@ -1,0 +1,135 @@
+
+# /specflow audit architecture
+
+**Read-only** project-wide architectural sweep. Walks the entire
+codebase, dispatches the `architecture-auditor` agent in audit mode, and
+emits a structured findings report. **Never mutates project code** —
+running the phase twice in a row leaves `git status --porcelain`
+identical (modulo the new report file).
+
+This phase is **manual-only** — invoke explicitly with
+`/specflow audit architecture` or schedule with
+`/loop 1d /specflow audit architecture`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit architecture` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is `critical`,
+`high`, `medium`, or `low`. Default is `high` (Critical + High are
+surfaced; Medium and Low go to "Out of scope" in the report).
+`--severity medium` extends the surfacing down to Medium; `--severity low`
+surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`. If not
+   a git repo, abort with `error: /specflow audit architecture requires a git repository (uses git ls-files for scope)` — there is no value in auditing
+   an un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the output:
+   - Source files by language extension
+   - Top-level directory layout (used to detect the layer convention —
+     hex / DDD / flat / none)
+   - Test files (`tests/`, `*_test.{ts,py,rs}`, `*.test.{ts,jsx,tsx}`,
+     `*.spec.{ts,jsx,tsx}`)
+   - Dependency manifests (used to detect language ecosystem only)
+
+3. **Dispatch the `architecture-auditor` agent** with the dispatch prompt
+   below. The agent operates in audit mode (full codebase scan, NOT
+   per-PR review mode). It has `Read`, `Grep`, `Glob`, and constrained
+   `Bash` access; it MUST NOT call `Edit`, `Write`, `NotebookEdit`, or
+   any mutating tool.
+
+4. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-architecture.md` (UTC date). If the
+   file already exists for today, append a `## Run 2 (HH:MM UTC)` heading
+   rather than overwriting.
+
+5. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-architecture.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical and
+   > High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   `product-owner` agent with the report path + the instruction: "Create
+   one Epic titled `architecture audit findings YYYY-MM-DD` with one
+   sub-task per Critical / High finding (batch Medium / Low into a
+   single grouped task if `--severity medium` or `--severity low` was
+   passed)."
+
+## Dispatch prompt for the `architecture-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY`
+with the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with
+the resolved severity threshold):
+
+```
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. Any mutating tool call is a contract violation.
+
+Severity floor: $SEVERITY_FLOOR. Findings below this floor go into the
+"Out of scope" section (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Walk the axis checklist from your agent doc in order (hex-layer
+violations, circular deps, god files, bounded-context leaks,
+ports/adapters discipline, deep nesting, anemic domain, implicit globals,
+test isolation, naming consistency). For each axis, when the codebase
+doesn't have the relevant surface (no layer convention, no bounded
+contexts, etc.), record it under "Out of scope" rather than emitting
+empty findings.
+
+Output: the Markdown report shape from your agent doc.
+```
+
+## Read-only contract test
+
+After the agent returns, run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new
+`docs/specflow/audits/YYYY-MM-DD-architecture.md` file (and the parent
+`docs/specflow/audits/` directory if it had to be created). Anything else
+is a contract breach — record it as an error in the final report and
+surface to the user.
+
+## Output format (what the user sees)
+
+```
+specflow-audit-architecture report
+──────────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Layer convention: <hex|DDD|flat|none>
+Report:   docs/specflow/audits/YYYY-MM-DD-architecture.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the architecture-auditor in PR mode, not audit mode).
+- For codebase-wide refactor planning → out of scope; this phase surfaces drift, it doesn't propose the refactor strategy. Pair with `/specflow specify` to capture the refactor as a spec.
+- For a single-file architecture check → invoke `architecture-auditor` directly with the file paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+`architecture-auditor` agent itself is Specflow-native (no upstream sibling).

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -20,6 +20,7 @@
     { "category": "phase", "name": "audit-security", "suffix": "audit-security.md", "source": "core/skills/specflow/phases/audit-security.md" },
     { "category": "phase", "name": "audit-performance", "suffix": "audit-performance.md", "source": "core/skills/specflow/phases/audit-performance.md" },
     { "category": "phase", "name": "audit-accessibility", "suffix": "audit-accessibility.md", "source": "core/skills/specflow/phases/audit-accessibility.md" },
+    { "category": "phase", "name": "audit-architecture", "suffix": "audit-architecture.md", "source": "core/skills/specflow/phases/audit-architecture.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },
@@ -48,6 +49,7 @@
     { "category": "agent", "name": "ui-ux-designer", "source": "core/agents/ui-ux-designer.md" },
     { "category": "agent", "name": "performance-auditor", "source": "core/agents/performance-auditor.md" },
     { "category": "agent", "name": "a11y-auditor", "source": "core/agents/a11y-auditor.md" },
+    { "category": "agent", "name": "architecture-auditor", "source": "core/agents/architecture-auditor.md" },
 
     { "category": "agent-memory", "name": "product-owner", "suffix": "MEMORY.md", "source": "core/agents/product-owner/memory/MEMORY.md" },
     { "category": "agent-memory", "name": "developer", "suffix": "MEMORY.md", "source": "core/agents/developer/memory/MEMORY.md" },

--- a/tests/domain/plugin_coverage_test.ts
+++ b/tests/domain/plugin_coverage_test.ts
@@ -16,8 +16,10 @@ Deno.test("isPluginCoveredPath: claude + .claude/agents/<name>.md (non-architect
       "specflow-expert",
       "test-reviewer",
       "workflow-manager",
+      "ui-ux-designer",
       "performance-auditor",
       "a11y-auditor",
+      "architecture-auditor",
     ]
   ) {
     assertEquals(
@@ -80,6 +82,7 @@ Deno.test("isPluginCoveredPath: claude + hyphenated phase names are covered", ()
       "audit-security",
       "audit-performance",
       "audit-accessibility",
+      "audit-architecture",
     ]
   ) {
     assertEquals(

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -837,13 +837,13 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
         o.name === ".claude/skills/specflow-auto/SKILL.md") &&
       o.status === "warn"
     );
-    // 12 agents (10 original + performance-auditor #304 + a11y-auditor #305)
-    // + 1 router skill + 17 phase docs (the 11 original + tag-version +
-    // release-version + list-skills + audit-security #303 +
-    // audit-performance #304 + audit-accessibility #305 — hyphenated
-    // phases unblocked by the #303 regex fix) + specflow-review alias +
-    // specflow-auto = 32 covered paths.
-    assertEquals(gapOutcomes.length, 32);
+    // 14 agents (10 original + ui-ux-designer drift fix #321 +
+    // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
+    // #321) + 1 router skill + 18 phase docs (the 11 original +
+    // tag-version + release-version + list-skills + audit-security #303 +
+    // audit-performance #304 + audit-accessibility #305 + audit-architecture
+    // #321) + specflow-review alias + specflow-auto = 35 covered paths.
+    assertEquals(gapOutcomes.length, 35);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specflow upgrade"), true);
@@ -886,7 +886,7 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
       await Deno.mkdir(join(dir, ".claude/agents"), { recursive: true });
       // Scaffold every covered agent EXCEPT product-owner (simulating
       // that one alone got deleted post-migration). The set tracks
-      // PLUGIN_COVERED_PATHS_CLAUDE — 12 agents minus product-owner = 11.
+      // PLUGIN_COVERED_PATHS_CLAUDE — 14 agents minus product-owner = 13.
       for (
         const name of [
           "code-reviewer",
@@ -898,8 +898,10 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
           "specflow-expert",
           "test-reviewer",
           "workflow-manager",
+          "ui-ux-designer",
           "performance-auditor",
           "a11y-auditor",
+          "architecture-auditor",
         ]
       ) {
         await Deno.writeTextFile(join(dir, `.claude/agents/${name}.md`), "stub");

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -100,8 +100,9 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;
-    // 11 original + performance-auditor (#304) + a11y-auditor (#305) = 13.
-    assertEquals(codexAgentsCount, 13);
+    // 11 original + performance-auditor (#304) + a11y-auditor (#305) +
+    // architecture-auditor (#321) = 14.
+    assertEquals(codexAgentsCount, 14);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,18 +82,19 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 18 phases (11 original + tag-version + release-version +
+    // Router + 19 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
-    // #304 + audit-accessibility #305) + specflow-auto + specflow-review +
-    // writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + subagent-driven-development (#272) +
-    // executing-plans (#274) + verification-before-completion (#275) +
-    // brainstorming (#276) + backlog + 13 agents (11 original +
-    // performance-auditor #304 + a11y-auditor #305) = 41.
+    // #304 + audit-accessibility #305 + audit-architecture #321) +
+    // specflow-auto + specflow-review + writing-plans (#271) +
+    // requesting-code-review (#273) + using-specflow (#282) +
+    // subagent-driven-development (#272) + executing-plans (#274) +
+    // verification-before-completion (#275) + brainstorming (#276) +
+    // backlog + 14 agents (11 original + performance-auditor #304 +
+    // a11y-auditor #305 + architecture-auditor #321) = 43.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 41);
+    assertEquals(instructionsCount, 43);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_gemini_test.ts
+++ b/tests/integration/init_gemini_test.ts
@@ -99,8 +99,9 @@ Deno.test("specflow init --ai gemini scaffolds a Gemini layout", async () => {
     const agentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".gemini/agents")),
     )).length;
-    // 11 original + performance-auditor (#304) + a11y-auditor (#305) = 13.
-    assertEquals(agentsCount, 13);
+    // 11 original + performance-auditor (#304) + a11y-auditor (#305) +
+    // architecture-auditor (#321) = 14.
+    assertEquals(agentsCount, 14);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -93,16 +93,17 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
       Deno.readDir(join(root, ".claude/commands")),
     )).length;
     assertEquals(commandsCount, 2);
-    // 13 agent .md files (11 original + performance-auditor #304 +
-    // a11y-auditor #305) + 5 memory subfolders (product-owner, developer,
-    // qa-tester, devops-sre, security-auditor; specflow-expert,
-    // ui-ux-designer, performance-auditor, and a11y-auditor are
+    // 14 agent .md files (11 original + performance-auditor #304 +
+    // a11y-auditor #305 + architecture-auditor #321) + 5 memory
+    // subfolders (product-owner, developer, qa-tester, devops-sre,
+    // security-auditor; specflow-expert, ui-ux-designer,
+    // performance-auditor, a11y-auditor, and architecture-auditor are
     // stateless and ship without a memory stub)
     const agentDirEntries = await Array.fromAsync(
       Deno.readDir(join(root, ".claude/agents")),
     );
     const agentMdCount = agentDirEntries.filter((e) => e.isFile && e.name.endsWith(".md")).length;
-    assertEquals(agentMdCount, 13);
+    assertEquals(agentMdCount, 14);
     const memoryDirCount = agentDirEntries.filter((e) => e.isDirectory).length;
     assertEquals(memoryDirCount, 5);
     // Spot-check one memory file

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,18 +74,19 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 18 phases (11 original + tag-version + release-version +
+    // Router + 19 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
-    // #304 + audit-accessibility #305) + specflow-auto + specflow-review
-    // alias + writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + subagent-driven-development (#272) +
-    // executing-plans (#274) + verification-before-completion (#275) +
-    // brainstorming (#276) + backlog + 13 agent workflows (11 original +
-    // performance-auditor #304 + a11y-auditor #305) = 41.
+    // #304 + audit-accessibility #305 + audit-architecture #321) +
+    // specflow-auto + specflow-review alias + writing-plans (#271) +
+    // requesting-code-review (#273) + using-specflow (#282) +
+    // subagent-driven-development (#272) + executing-plans (#274) +
+    // verification-before-completion (#275) + brainstorming (#276) +
+    // backlog + 14 agent workflows (11 original + performance-auditor
+    // #304 + a11y-auditor #305 + architecture-auditor #321) = 43.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 41);
+    assertEquals(workflowsCount, 43);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -17,9 +17,11 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow/SKILL.md",
     source: "templates/core/skills/specflow/SKILL.md",
   },
-  // 15 phase reference docs, loaded by the router on demand. The
-  // `audit-security` phase (Epic #302 / #303) joined the family alongside
-  // the upcoming `audit-performance` / `audit-accessibility` siblings.
+  // 18 phase reference docs, loaded by the router on demand. The
+  // phase-1 audit trio (`audit-security` #303, `audit-performance` #304,
+  // `audit-accessibility` #305) shipped in v1.9.0; `audit-architecture`
+  // (#321) is the first of the phase-2 family (Epic #320). The
+  // upcoming `audit-dependencies` will join via #322.
   ...[
     "specify",
     "clarify",
@@ -38,6 +40,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "audit-security",
     "audit-performance",
     "audit-accessibility",
+    "audit-architecture",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,
@@ -116,10 +119,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: `plugin/skills/using-specflow/references/${name}-tools.md`,
     source: `templates/core/skills/using-specflow/references/${name}-tools.md`,
   })),
-  // Dual-copy agents: 10 sub-agent definitions, each landing as
+  // Dual-copy agents: 14 sub-agent definitions, each landing as
   // `plugin/agents/<name>.md`. Claude Code resolves agents by file
   // basename in plugin scope; no namespacing needed for invocation
   // (agents are not user-invokable like slash commands).
+  // Counts: 10 original + ui-ux-designer (#198, sync-test drift fix in
+  // #321) + performance-auditor (#304) + a11y-auditor (#305) +
+  // architecture-auditor (#321) = 14.
   ...[
     "code-reviewer",
     "developer",
@@ -131,8 +137,10 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "specflow-expert",
     "test-reviewer",
     "workflow-manager",
+    "ui-ux-designer",
     "performance-auditor",
     "a11y-auditor",
+    "architecture-auditor",
   ].map((name) => ({
     plugin: `plugin/agents/${name}.md`,
     source: `templates/core/agents/${name}.md`,


### PR DESCRIPTION
## Summary

Phase-2 audit family kicks off (Epic #320) with the **architecture** axis. New `architecture-auditor` agent + `/specflow audit architecture` phase doc, mirroring the v1.9.0 pattern (security #303 / performance #304 / accessibility #305). Read-only sweep, structured findings report at `docs/specflow/audits/YYYY-MM-DD-architecture.md`, optional PO handoff to convert High/Critical findings into a backlog Epic. Closes #321.

## Agent adoption

Existing Specflow projects get `/specflow audit architecture` as a new top-level phase after running `specflow upgrade`. No project-side configuration change required — the new agent (`architecture-auditor`, `disable-model-invocation: true` — manual-only) and the new phase doc land alongside the existing audit family. Invocation:

```
/specflow audit architecture                       # severity floor: high (default)
/specflow audit architecture --severity medium     # also surface Medium findings
/specflow audit-architecture                       # hyphenated form (alias)
```

The phase is **always-on** (no project-shape gate): codebases without a detectable layer convention (flat scripting repos, monoliths) still get the universal axes (circular deps, god files, deep nesting, implicit globals, test isolation, naming) reported, while hex-specific axes (layer violations, bounded-context leaks, ports/adapters discipline) are deferred to the report's `Out of scope` section.

```prompt
You're on a Specflow-scaffolded project that just upgraded to a release with `/specflow audit architecture` available. Run a first architecture audit pass against the current codebase, then surface the report path and offer to dispatch the product-owner agent to convert High/Critical findings into a backlog Epic.

Steps:
1. Run `/specflow audit architecture` (default severity = high).
2. When the phase completes, it writes the report to `docs/specflow/audits/YYYY-MM-DD-architecture.md` and prints a summary.
3. If any High or Critical findings were surfaced, ask the user "Want me to dispatch the product-owner agent to convert these into a backlog Epic + sub-tasks?" and wait for confirmation before mutating the backlog.
4. If the answer is yes, dispatch the product-owner agent with the report path and the instruction to create one Epic titled `architecture audit findings YYYY-MM-DD` with one sub-task per High/Critical finding.
5. If you want broader surfacing on a follow-up run, invoke with `--severity medium` or `--severity low` — both extend the surface but also extend the noise floor; default `high` is usually the right starting point.

The audit is read-only — running it twice on the same day leaves `git status --porcelain` identical except for the report file (re-runs append `## Run 2` rather than overwriting).
```

## Checklist axes (Mode 2 — full audit)

| # | Axis | Default severity |
|---|---|---|
| 1 | Hex-layer / module-layer violations | CRITICAL → MEDIUM by direction |
| 2 | Circular dependencies | HIGH |
| 3 | God files / god classes (>500 LOC source / >200 LOC class) | HIGH (top-5), LOW (rest) |
| 4 | Bounded-context leaks | HIGH |
| 5 | Ports/adapters discipline | HIGH |
| 6 | Deep nesting (>4 levels) | MEDIUM |
| 7 | Anemic domain model | LOW |
| 8 | Implicit globals in domain / use cases | HIGH (domain) / MEDIUM (application) |
| 9 | Test isolation (integration-tests-as-unit) | MEDIUM |
| 10 | Naming consistency (layer suffix conventions) | LOW |

## Pre-flight drift fix bundled

The architect's design pass caught a long-standing drift: `ui-ux-designer` (shipped since #198) was missing from both `PLUGIN_COVERED_PATHS_CLAUDE` and `plugin_sync_test.ts` SYNC_PAIRS, despite physically existing in `plugin/agents/ui-ux-designer.md`. This PR closes that gap alongside the new agent — same pattern as #303 bundling the hyphenated-phase regex fix. Net delta: +2 agents (`ui-ux-designer` drift fix + `architecture-auditor` new), +1 phase, total coverage 32 → **35 paths**.

## Test deltas

- `plugin_coverage`: 32 → 35
- `init_test` agentMdCount: 13 → 14
- `init_codex_test` codexAgentsCount: 13 → 14
- `init_gemini_test` agentsCount: 13 → 14
- `init_copilot_test` instructionsCount: 41 → 43 (+1 phase +1 agent)
- `init_windsurf_test` workflowsCount: 41 → 43 (+1 phase +1 agent)
- `plugin_sync_test` SYNC_PAIRS: +1 phase pair + 2 agent pairs (arch + ui-ux fix)
- `smoke-features.sh`: +8 assertions
- `docs/llms.md`: phase + agent counts bumped (17→18 / 12→14)

All 676 unit/integration tests pass locally; pre-commit hook ran fmt/lint/bundle/check (green).

## Compound-form routing

The `audit <axis>` two-token form in the specflow router SKILL.md now accepts `architecture` alongside `security`/`performance`/`accessibility`. Both `audit architecture` and `audit-architecture` resolve to the same phase doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)