### PR TITLE
feat(audit): /specflow audit dependencies + NEW dependency-auditor agent (#322)

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-features.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-features.sh
@@ -129,6 +129,26 @@ check "architecture-auditor agent enforces read-only Bash allow-list" \
   'grep -q "Read-only contract" .claude/agents/architecture-auditor.md'
 check "router phase index lists audit architecture" \
   'grep -q "audit architecture" .claude/skills/specflow/SKILL.md'
+check "phase doc audit-dependencies.md scaffolded (Epic #320, #322)" \
+  '[ -f .claude/skills/specflow/phases/audit-dependencies.md ]'
+check "audit-dependencies phase doc dispatches the dependency-auditor agent" \
+  'grep -q "dependency-auditor" .claude/skills/specflow/phases/audit-dependencies.md'
+check "audit-dependencies phase doc declares read-only contract" \
+  'grep -q "Read-only contract" .claude/skills/specflow/phases/audit-dependencies.md'
+check "audit-dependencies phase doc bans live advisory tooling" \
+  'grep -q "npm audit\|cargo audit\|pip-audit" .claude/skills/specflow/phases/audit-dependencies.md'
+check "dependency-auditor agent bundled (Epic #320, #322)" \
+  '[ -f .claude/agents/dependency-auditor.md ]'
+check "dependency-auditor agent declares disable-model-invocation" \
+  'grep -q "disable-model-invocation: true" .claude/agents/dependency-auditor.md'
+check "dependency-auditor agent covers multi-manifest detection" \
+  'grep -q "package.json" .claude/agents/dependency-auditor.md && grep -q "pyproject.toml" .claude/agents/dependency-auditor.md && grep -q "Cargo.toml" .claude/agents/dependency-auditor.md'
+check "dependency-auditor agent documents the SPDX license allowlist" \
+  'grep -q "MIT, Apache-2.0" .claude/agents/dependency-auditor.md'
+check "dependency-auditor agent supports project-side allowlist override" \
+  'grep -q ".specflow/license-allowlist.txt" .claude/agents/dependency-auditor.md'
+check "router phase index lists audit dependencies" \
+  'grep -q "audit dependencies" .claude/skills/specflow/SKILL.md'
 check "name: specflow on the router SKILL.md" \
   'head -3 .claude/skills/specflow/SKILL.md | grep -q "name: specflow"'
 check "disable-model-invocation NOT set on the router (Skill-tool chaining must work)" \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -638,12 +638,12 @@ marketplace:
 
 The plugin gives any Claude Code user instant access to the full Specflow slash-command suite and
 sub-agents — no binary, no `specflow init` required. The plugin assets (the consolidated `specflow`
-router skill with 18 phase docs including the four `audit-*` axes — `security` / `performance` /
-`accessibility` from Epic #302 and `architecture` from Epic #320, the `specflow-review` auto-invoke
-alias, the deprecated `specflow-auto` alias, and 14 sub-agents including the manual-only
-`performance-auditor`, `a11y-auditor`, and `architecture-auditor` introduced with the audit family)
-are namespaced under `/specflow-plugin:*` so they coexist with project-local copies without
-collision.
+router skill with 19 phase docs including the five `audit-*` axes — `security` / `performance` /
+`accessibility` from Epic #302 and `architecture` / `dependencies` from Epic #320, the
+`specflow-review` auto-invoke alias, the deprecated `specflow-auto` alias, and 15 sub-agents
+including the manual-only `performance-auditor`, `a11y-auditor`, `architecture-auditor`, and
+`dependency-auditor` introduced with the audit family) are namespaced under `/specflow-plugin:*` so
+they coexist with project-local copies without collision.
 
 When both the plugin and the binary are in use, `specflow upgrade` detects the plugin and
 auto-migrates vanilla on-disk agents and command files (backed up, then deleted — the plugin serves

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -1,0 +1,225 @@
+---
+name: dependency-auditor
+description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: magenta
+disable-model-invocation: true
+---
+
+You are a **dependency auditor**. You operate in one of two modes
+depending on the dispatch shape.
+
+## Mode 1 — PR review
+
+Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
+the files provided in the prompt (typically dependency manifests +
+lockfiles touched by the diff). Output the `FINDING` / `VERDICT` structure
+used by code-reviewer.
+
+### Always-check rules
+
+1. **Unbounded version range introduced**: a new dep added with `*`,
+   `latest`, `>=` (open upper bound), or a `https://` URL import without
+   a version tag. HIGH — drift vector that breaks reproducibility.
+2. **Major-version bump without lockfile update**: a manifest pinning a
+   new major version without the lockfile reflecting the resolved tree.
+   HIGH — install will diverge between machines.
+3. **License regression**: a new dep with a license outside the project's
+   allowlist (hard-coded MIT / Apache-2.0 / BSD-2-Clause / BSD-3-Clause /
+   ISC / Unlicense / 0BSD / CC0, or whatever is in
+   `.specflow/license-allowlist.txt` if it exists). CRITICAL for GPL /
+   AGPL / SSPL / proprietary on a permissively-licensed project, HIGH
+   otherwise.
+4. **Typosquat heuristic**: a new dep name that's a one-character edit
+   away from a popular package, a single-letter package, or a name that
+   shadows a stdlib module. CRITICAL — most known supply-chain attacks
+   match this shape.
+5. **Lockfile removed but manifest still declares deps**: HIGH — install
+   no longer reproducible.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by `/specflow audit dependencies`. Read-only; full project scope.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool. Bash is
+permitted only for:
+
+- `git ls-files`, `git log`, `git show`, `git grep`
+- `grep`, `rg`, `find`
+- manifest-listing commands when modules are already locally cached and
+  no network call is required: `npm ls --offline`, `pip show`,
+  `cargo metadata --offline`, `composer show --no-update`, `bundle list`,
+  `go list -m all`
+- size-inspection: `wc -l`, `du -sh`, `ls -la`
+
+You MUST NOT invoke `npm audit`, `cargo audit`, `pip-audit`, `pnpm audit`,
+`yarn audit`, `bundle audit`, `osv-scanner`, `snyk`, or any other live
+advisory / CVE database fetch — these are out of scope for the audit
+contract (no third-party scanners, no network). Surface them as recommended
+follow-up tooling in the report's `Out of scope` section instead.
+
+Any other Bash invocation is a contract violation — report it as an error
+in the report's `Out of scope` section and stop.
+
+### Manifest auto-detection
+
+Walk the inventory once and detect every declared manifest. Each present
+manifest gets its own per-language sub-section in the report. Supported
+shapes:
+
+| Manifest | Ecosystem |
+|---|---|
+| `package.json` (+ `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) | npm / Node |
+| `pyproject.toml` (+ `poetry.lock`, `uv.lock`, `requirements*.txt`) | Python |
+| `Cargo.toml` (+ `Cargo.lock`) | Rust |
+| `composer.json` (+ `composer.lock`) | PHP |
+| `Gemfile` (+ `Gemfile.lock`) | Ruby |
+| `go.mod` (+ `go.sum`) | Go |
+| `deno.json` / `deno.jsonc` (+ `deno.lock`) | Deno |
+
+Absent manifests are NOT findings — they are simply not part of the run.
+Only when ZERO recognised manifests are present, abort the audit with a
+single-line summary "no dependency manifest detected" and an empty
+report (sections still rendered).
+
+### License allowlist resolution
+
+Default allowlist (hard-coded, SPDX identifiers):
+
+```
+MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, 0BSD, CC0
+```
+
+If `.specflow/license-allowlist.txt` exists at the project root, read it
+and MERGE its entries (one SPDX identifier per line, `#`-prefixed lines
+are comments) with the default list. The merged set is the project's
+effective allowlist. A license that's neither in the default nor in the
+project file is a finding — HIGH severity by default, CRITICAL when the
+new license is copyleft on a permissively-licensed project (any direct
+dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked `UNLICENSED`).
+
+### Scope checklist (axes to walk in order)
+
+1. **Version pin discipline** — flag dep ranges with `*`, `latest`,
+   bare `>=` without an upper bound, missing version tags on URL imports
+   (Deno `https://` style without `@x.y.z`). HIGH for direct deps,
+   MEDIUM for dev/test deps.
+2. **Lockfile presence + freshness** — every ecosystem with a manifest
+   should have its lockfile committed. Lockfile missing = HIGH. Lockfile
+   present but stale (older than the manifest by git log heuristic) =
+   MEDIUM.
+3. **Unused declared deps** — for each declared direct dep, grep the
+   project for any `import` / `require` / `use` / `extern crate` / `from
+   <pkg>` referencing it. Zero hits = MEDIUM unused-dep finding. Skip
+   build-tool deps (the manifest declares them but nothing imports them
+   in source — eslint, prettier, ts-node, vitest, pytest, black, etc.).
+4. **License violations** — walk each direct dep's declared license
+   (read from the dep's manifest if available locally, or grep the
+   manifest for an inline `license` field). Cross-check against the
+   effective allowlist (see above). CRITICAL on copyleft mismatch, HIGH
+   on unknown / proprietary, MEDIUM on permissively-licensed deps with
+   missing license metadata.
+5. **Outdated by major** — for each direct dep, check git log for the
+   pin's age. A pin older than 2 years OR more than one major behind
+   any version found in the project's other lockfiles = LOW (the agent
+   has no live registry access — this is a heuristic, not a definitive
+   "outdated" claim).
+6. **Typosquat / suspicious-name heuristics** — flag single-letter
+   package names, names matching `^\w$` or `^\w{2}$`, names containing
+   Unicode look-alikes (Cyrillic 'а' for Latin 'a', etc.), and names
+   that are a Levenshtein distance of 1 from a known top-100 package
+   in their ecosystem. CRITICAL — supply-chain attack vector.
+7. **Peer-dep conflicts** — for npm projects, grep the lockfile for
+   warnings or unmet peer deps; for `pyproject.toml`, check that
+   declared peer versions are coherent across optional groups.
+   MEDIUM.
+8. **Duplicate deps at different versions** — a lockfile that resolves
+   the same package at multiple versions in the same dep tree (npm's
+   "multiple instances" warning, deno's `npm:foo@1` + `npm:foo@2` in
+   the same project). LOW — bundle bloat + nondeterministic behavior
+   risk.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+```markdown
+# Dependency audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Manifests detected: <one line — "package.json, deno.json">
+- Severity floor: <critical|high|medium|low>
+- License allowlist source: <"default (8 SPDX ids)" | "default + .specflow/license-allowlist.txt (N additional)">
+
+## Critical
+
+For each finding, group by manifest (### npm / ### Deno / ### Python / …):
+- `<manifest>: <dep>@<version>` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape, grouped by manifest)
+
+## Medium
+
+(only populated if severity floor is `medium` or `low`)
+
+## Low
+
+(only populated if severity floor is `low`)
+
+## Out of scope
+
+- live advisory / CVE cross-reference — runtime tooling (`npm audit`,
+  `cargo audit`, `pip-audit`, `osv-scanner`, …) is excluded by the
+  read-only audit contract. Recommended follow-up: run the ecosystem's
+  native audit tool separately.
+- <named axis> — <one line on why else not surfaced this run>
+```
+
+No `VERDICT` line. Audit-mode reports are not pass/fail — they are backlog
+material for the PO to triage.
+
+### Per-axis hints
+
+- **Polyglot repo** — emit findings per-manifest sub-section. Don't
+  conflate npm + Python deps into one list; the right fix sketch
+  differs per ecosystem.
+- **`deno.json` projects** — "outdated" is harder (no central registry
+  to query). Focus axes 1 (unbounded ranges), 2 (deno.lock presence),
+  3 (unused imports). Skip axis 5 unless a specific dep is clearly
+  ancient by git log.
+- **Build-tool deps** — declared but not imported. Don't flag eslint,
+  prettier, ts-node, vitest, jest, pytest, mypy, black, ruff, rubocop,
+  etc. as "unused" — they're invoked from package scripts / CI, not
+  source code.
+- **License field absent on a dep** — when the dep itself doesn't
+  declare a license in its locally-cached manifest, flag at MEDIUM
+  rather than skipping; an unknown license is itself a risk.
+- **When in doubt** — surface the finding at LOW rather than dropping
+  it. The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
+finding as:
+
+```
+FINDING <severity>: <one-line summary>
+  Path: <manifest:line>
+  Rationale: <2-3 sentences>
+  Suggested fix: <code sketch or pointer>
+
+VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
+```
+
+Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
+omits VERDICT — backlog material is not pass/fail.

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -18,7 +18,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
-  - audit: "audit security / performance / accessibility / architecture", "scan the codebase for X issues"
+  - audit: "audit security / performance / accessibility / architecture / dependencies", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -41,18 +41,20 @@ when_to_use: |
 
    **Compound `audit` phase exception** — when the first token is exactly
    `audit` AND the next token is one of `security`, `performance`,
-   `accessibility`, or `architecture`, treat the pair as a single
-   hyphenated phase name `audit-<axis>` (matching the file
+   `accessibility`, `architecture`, or `dependencies`, treat the pair
+   as a single hyphenated phase name `audit-<axis>` (matching the file
    `phases/audit-<axis>.md`). The remaining tokens after the axis become
    the argument string. Examples:
    `audit security` → phase `audit-security`, args ``;
    `audit performance --severity medium` → phase `audit-performance`, args `--severity medium`;
    `audit accessibility` → phase `audit-accessibility`, args ``;
-   `audit architecture` → phase `audit-architecture`, args ``.
+   `audit architecture` → phase `audit-architecture`, args ``;
+   `audit dependencies` → phase `audit-dependencies`, args ``.
    Users may also invoke the hyphenated form directly
    (`/specflow audit-security`, `/specflow audit-performance`,
-   `/specflow audit-accessibility`, `/specflow audit-architecture`);
-   both forms route to the same phase doc.
+   `/specflow audit-accessibility`, `/specflow audit-architecture`,
+   `/specflow audit-dependencies`); both forms route to the same
+   phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -80,21 +82,25 @@ when_to_use: |
 | `audit performance` | `phases/audit-performance.md` | Read-only project-wide performance sweep; emits a findings report. |
 | `audit accessibility` | `phases/audit-accessibility.md` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
 | `audit architecture` | `phases/audit-architecture.md` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
+| `audit dependencies` | `phases/audit-dependencies.md` | Read-only multi-manifest dependency-hygiene sweep — unbounded ranges, missing lockfiles, unused deps, license violations, typosquats. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
 `audit security`, `audit performance`, `audit accessibility`,
-`audit architecture`) are one-shot regardless of chain mode.
+`audit architecture`, `audit dependencies`) are one-shot regardless
+of chain mode.
 
 `audit <axis>` is dispatched as a two-token phase: the router reads
-`phases/audit-<axis>.md`. Four axes are wired (`security`,
-`performance`, `accessibility`, `architecture`). The accessibility
-phase is FE-gated — projects without front-end source receive a
-one-line "skipped — no FE surface" response instead of an empty report.
-The architecture phase is always-on (universal applicability); axes
-that don't match the codebase's structure go to "Out of scope" in the
-report rather than skipping the whole run.
+`phases/audit-<axis>.md`. Five axes are wired (`security`,
+`performance`, `accessibility`, `architecture`, `dependencies`). The
+accessibility phase is FE-gated — projects without front-end source
+receive a one-line "skipped — no FE surface" response instead of an
+empty report. The dependencies phase aborts with "skipped — no
+dependency manifest detected" when zero recognised manifests are
+present. The architecture phase is always-on (universal applicability);
+axes that don't match the codebase's structure go to "Out of scope" in
+the report rather than skipping the whole run.
 
 ## Routing
 
@@ -134,7 +140,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`) are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`, `dependencies`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/plugin/skills/specflow/phases/audit-dependencies.md
+++ b/plugin/skills/specflow/phases/audit-dependencies.md
@@ -1,0 +1,150 @@
+
+# /specflow audit dependencies
+
+**Read-only** project-wide dependency-hygiene sweep. Walks every detected
+manifest (`package.json`, `pyproject.toml`, `Cargo.toml`, `composer.json`,
+`Gemfile`, `go.mod`, `deno.json` / `deno.jsonc`), dispatches the
+`dependency-auditor` agent in audit mode, and emits a structured findings
+report. **Never mutates project code** — running the phase twice in a
+row leaves `git status --porcelain` identical (modulo the new report
+file).
+
+This phase is **manual-only** — invoke explicitly with
+`/specflow audit dependencies` or schedule with
+`/loop 1d /specflow audit dependencies`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit dependencies` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is `critical`,
+`high`, `medium`, or `low`. Default is `high` (Critical + High are
+surfaced; Medium and Low go to "Out of scope" in the report).
+`--severity medium` extends the surfacing down to Medium; `--severity low`
+surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`. If not
+   a git repo, abort with `error: /specflow audit dependencies requires a git repository (uses git ls-files for scope)` — there is no value in auditing
+   an un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the output:
+   - Dependency manifests (`package.json`, `pyproject.toml`, `Cargo.toml`,
+     `composer.json`, `Gemfile`, `go.mod`, `deno.json` / `deno.jsonc`)
+   - Lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`,
+     `poetry.lock`, `uv.lock`, `Cargo.lock`, `composer.lock`,
+     `Gemfile.lock`, `go.sum`, `deno.lock`)
+   - License allowlist override (`.specflow/license-allowlist.txt`) if
+     present
+   - Source files by language extension — used to verify declared deps
+     are actually imported (axis 3, unused-dep detection)
+
+3. **If zero recognised manifests are detected**, abort the audit with
+   a single-line "skipped — no dependency manifest detected" report
+   (full section shape still rendered, all findings sections empty).
+
+4. **Dispatch the `dependency-auditor` agent** with the dispatch prompt
+   below. The agent operates in audit mode (full codebase scan, NOT
+   per-PR review mode). It has `Read`, `Grep`, `Glob`, and constrained
+   `Bash` access; it MUST NOT call `Edit`, `Write`, `NotebookEdit`, or
+   any mutating tool. The Bash allow-list explicitly EXCLUDES `npm
+   audit`, `cargo audit`, `pip-audit`, `osv-scanner`, etc. — live
+   advisory queries are out of scope for this phase (see the agent doc's
+   "Read-only contract" section).
+
+5. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-dependencies.md` (UTC date). If the
+   file already exists for today, append a `## Run 2 (HH:MM UTC)` heading
+   rather than overwriting.
+
+6. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-dependencies.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical and
+   > High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   `product-owner` agent with the report path + the instruction: "Create
+   one Epic titled `dependency audit findings YYYY-MM-DD` with one
+   sub-task per Critical / High finding (batch Medium / Low into a
+   single grouped task if `--severity medium` or `--severity low` was
+   passed)."
+
+## Dispatch prompt for the `dependency-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY`
+with the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with
+the resolved severity threshold):
+
+```
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. You MUST NOT invoke `npm audit`, `cargo audit`,
+`pip-audit`, `osv-scanner`, or any live advisory / CVE database fetch —
+those are out of scope. Any mutating tool call is a contract violation.
+
+Severity floor: $SEVERITY_FLOOR. Findings below this floor go into the
+"Out of scope" section (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Walk the axis checklist from your agent doc in order (version pin
+discipline, lockfile presence/freshness, unused declared deps, license
+violations, outdated by major, typosquat heuristics, peer-dep conflicts,
+duplicate deps). Detect every present manifest and report per-manifest
+sub-sections in each severity section. When a manifest's ecosystem
+doesn't have the relevant axis surface, record it under "Out of scope"
+rather than emitting empty findings.
+
+Output: the Markdown report shape from your agent doc.
+```
+
+## Read-only contract test
+
+After the agent returns, run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new
+`docs/specflow/audits/YYYY-MM-DD-dependencies.md` file (and the parent
+`docs/specflow/audits/` directory if it had to be created). Anything else
+is a contract breach — record it as an error in the final report and
+surface to the user.
+
+## Output format (what the user sees)
+
+```
+specflow-audit-dependencies report
+──────────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Manifests: <one line — "package.json, deno.json">
+License allowlist: <"default (8 SPDX ids)" | "default + .specflow/license-allowlist.txt (N more)">
+Report:   docs/specflow/audits/YYYY-MM-DD-dependencies.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the dependency-auditor in PR mode, not audit mode).
+- For live CVE / advisory cross-reference → out of scope; run your ecosystem's native audit tool separately (`npm audit`, `cargo audit`, `pip-audit`, `bundle audit`, `osv-scanner`). The audit-dependencies phase intentionally avoids these because they require network access + cached package databases that drift between runs, breaking reproducibility.
+- For a single-file dependency check → invoke `dependency-auditor` directly with the manifest paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+`dependency-auditor` agent itself is Specflow-native (no upstream sibling).

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -67,19 +67,19 @@ export function isPluginCoveredPath(
  * (either re-install the plugin or run `specflow upgrade` to restore
  * the bundled snapshot).
  *
- * Kept in sync with `isPluginCoveredPath` above. Total: 35 paths
- * (14 agents excluding architect + 1 router skill + 18 phase docs +
+ * Kept in sync with `isPluginCoveredPath` above. Total: 37 paths
+ * (15 agents excluding architect + 1 router skill + 19 phase docs +
  * specflow-review alias + specflow-auto).
  *
  * Phase docs include hyphenated names — the regex was widened in #303
  * after silently dropping `tag-version`, `release-version`, and
  * `list-skills`. The phase-1 audit family (`audit-security` #303,
  * `audit-performance` #304, `audit-accessibility` #305) shipped in
- * v1.9.0; the phase-2 family adds `audit-architecture` (#321) here and
- * will add `audit-dependencies` in the sibling #322. `ui-ux-designer`
- * was missing from this array pre-#321 even though it ships in the
- * Claude scaffold — added here alongside `architecture-auditor` to
- * close a long-standing drift bug.
+ * v1.9.0; the phase-2 family added `audit-architecture` (#321) and
+ * now `audit-dependencies` (#322) closes Epic #320.
+ * `ui-ux-designer` was added alongside `architecture-auditor` in #321
+ * to close a long-standing drift bug; this array continues to mirror
+ * the bundled Claude scaffold exactly.
  */
 export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
   ...[
@@ -97,6 +97,7 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "performance-auditor",
     "a11y-auditor",
     "architecture-auditor",
+    "dependency-auditor",
   ].map((name) => `.claude/agents/${name}.md`),
   ".claude/skills/specflow/SKILL.md",
   ...[
@@ -118,6 +119,7 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "audit-performance",
     "audit-accessibility",
     "audit-architecture",
+    "audit-dependencies",
   ].map((name) => `.claude/skills/specflow/phases/${name}.md`),
   ".claude/skills/specflow-review/SKILL.md",
   ".claude/skills/specflow-auto/SKILL.md",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -29,7 +29,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
-  - audit: "audit security / performance / accessibility / architecture", "scan the codebase for X issues"
+  - audit: "audit security / performance / accessibility / architecture / dependencies", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -52,18 +52,20 @@ when_to_use: |
 
    **Compound \`audit\` phase exception** — when the first token is exactly
    \`audit\` AND the next token is one of \`security\`, \`performance\`,
-   \`accessibility\`, or \`architecture\`, treat the pair as a single
-   hyphenated phase name \`audit-<axis>\` (matching the file
+   \`accessibility\`, \`architecture\`, or \`dependencies\`, treat the pair
+   as a single hyphenated phase name \`audit-<axis>\` (matching the file
    \`phases/audit-<axis>.md\`). The remaining tokens after the axis become
    the argument string. Examples:
    \`audit security\` → phase \`audit-security\`, args \`\`;
    \`audit performance --severity medium\` → phase \`audit-performance\`, args \`--severity medium\`;
    \`audit accessibility\` → phase \`audit-accessibility\`, args \`\`;
-   \`audit architecture\` → phase \`audit-architecture\`, args \`\`.
+   \`audit architecture\` → phase \`audit-architecture\`, args \`\`;
+   \`audit dependencies\` → phase \`audit-dependencies\`, args \`\`.
    Users may also invoke the hyphenated form directly
    (\`/specflow audit-security\`, \`/specflow audit-performance\`,
-   \`/specflow audit-accessibility\`, \`/specflow audit-architecture\`);
-   both forms route to the same phase doc.
+   \`/specflow audit-accessibility\`, \`/specflow audit-architecture\`,
+   \`/specflow audit-dependencies\`); both forms route to the same
+   phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    \`\$ARGUMENTS\` was empty to start with), render the **Workflow overview**
@@ -91,21 +93,25 @@ when_to_use: |
 | \`audit performance\` | \`phases/audit-performance.md\` | Read-only project-wide performance sweep; emits a findings report. |
 | \`audit accessibility\` | \`phases/audit-accessibility.md\` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
 | \`audit architecture\` | \`phases/audit-architecture.md\` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
+| \`audit dependencies\` | \`phases/audit-dependencies.md\` | Read-only multi-manifest dependency-hygiene sweep — unbounded ranges, missing lockfiles, unused deps, license violations, typosquats. |
 
 Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
 \`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
 \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`,
 \`audit security\`, \`audit performance\`, \`audit accessibility\`,
-\`audit architecture\`) are one-shot regardless of chain mode.
+\`audit architecture\`, \`audit dependencies\`) are one-shot regardless
+of chain mode.
 
 \`audit <axis>\` is dispatched as a two-token phase: the router reads
-\`phases/audit-<axis>.md\`. Four axes are wired (\`security\`,
-\`performance\`, \`accessibility\`, \`architecture\`). The accessibility
-phase is FE-gated — projects without front-end source receive a
-one-line "skipped — no FE surface" response instead of an empty report.
-The architecture phase is always-on (universal applicability); axes
-that don't match the codebase's structure go to "Out of scope" in the
-report rather than skipping the whole run.
+\`phases/audit-<axis>.md\`. Five axes are wired (\`security\`,
+\`performance\`, \`accessibility\`, \`architecture\`, \`dependencies\`). The
+accessibility phase is FE-gated — projects without front-end source
+receive a one-line "skipped — no FE surface" response instead of an
+empty report. The dependencies phase aborts with "skipped — no
+dependency manifest detected" when zero recognised manifests are
+present. The architecture phase is always-on (universal applicability);
+axes that don't match the codebase's structure go to "Out of scope" in
+the report rather than skipping the whole run.
 
 ## Routing
 
@@ -145,7 +151,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See \`phases/auto-chain.md\` for the
 chain mechanics.
 
-\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`, and \`audit <axis>\` (any of \`security\`, \`performance\`, \`accessibility\`, \`architecture\`) are out-of-band utilities, not part of the linear flow.
+\`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`, and \`audit <axis>\` (any of \`security\`, \`performance\`, \`accessibility\`, \`architecture\`, \`dependencies\`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 
@@ -3191,6 +3197,165 @@ Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
 Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
 adapted to Specflow's bundled agent + backlog conventions. The
 \`architecture-auditor\` agent itself is Specflow-native (no upstream sibling).
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "audit-dependencies",
+    suffix: "audit-dependencies.md",
+    content: `
+# /specflow audit dependencies
+
+**Read-only** project-wide dependency-hygiene sweep. Walks every detected
+manifest (\`package.json\`, \`pyproject.toml\`, \`Cargo.toml\`, \`composer.json\`,
+\`Gemfile\`, \`go.mod\`, \`deno.json\` / \`deno.jsonc\`), dispatches the
+\`dependency-auditor\` agent in audit mode, and emits a structured findings
+report. **Never mutates project code** — running the phase twice in a
+row leaves \`git status --porcelain\` identical (modulo the new report
+file).
+
+This phase is **manual-only** — invoke explicitly with
+\`/specflow audit dependencies\` or schedule with
+\`/loop 1d /specflow audit dependencies\`. Unlike \`/specflow review\`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+\`/specflow audit dependencies\` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## Argument parsing
+
+\`\$ARGUMENTS\` may contain \`--severity <level>\` where \`<level>\` is \`critical\`,
+\`high\`, \`medium\`, or \`low\`. Default is \`high\` (Critical + High are
+surfaced; Medium and Low go to "Out of scope" in the report).
+\`--severity medium\` extends the surfacing down to Medium; \`--severity low\`
+surfaces everything.
+
+Reject any other argument with: \`error: unknown argument <token> — accepted: --severity <critical|high|medium|low>\` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use \`git rev-parse --show-toplevel\`. If not
+   a git repo, abort with \`error: /specflow audit dependencies requires a git repository (uses git ls-files for scope)\` — there is no value in auditing
+   an un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run \`git ls-files\` once and group the output:
+   - Dependency manifests (\`package.json\`, \`pyproject.toml\`, \`Cargo.toml\`,
+     \`composer.json\`, \`Gemfile\`, \`go.mod\`, \`deno.json\` / \`deno.jsonc\`)
+   - Lockfiles (\`package-lock.json\`, \`pnpm-lock.yaml\`, \`yarn.lock\`,
+     \`poetry.lock\`, \`uv.lock\`, \`Cargo.lock\`, \`composer.lock\`,
+     \`Gemfile.lock\`, \`go.sum\`, \`deno.lock\`)
+   - License allowlist override (\`.specflow/license-allowlist.txt\`) if
+     present
+   - Source files by language extension — used to verify declared deps
+     are actually imported (axis 3, unused-dep detection)
+
+3. **If zero recognised manifests are detected**, abort the audit with
+   a single-line "skipped — no dependency manifest detected" report
+   (full section shape still rendered, all findings sections empty).
+
+4. **Dispatch the \`dependency-auditor\` agent** with the dispatch prompt
+   below. The agent operates in audit mode (full codebase scan, NOT
+   per-PR review mode). It has \`Read\`, \`Grep\`, \`Glob\`, and constrained
+   \`Bash\` access; it MUST NOT call \`Edit\`, \`Write\`, \`NotebookEdit\`, or
+   any mutating tool. The Bash allow-list explicitly EXCLUDES \`npm
+   audit\`, \`cargo audit\`, \`pip-audit\`, \`osv-scanner\`, etc. — live
+   advisory queries are out of scope for this phase (see the agent doc's
+   "Read-only contract" section).
+
+5. **Persist the report** at
+   \`docs/specflow/audits/YYYY-MM-DD-dependencies.md\` (UTC date). If the
+   file already exists for today, append a \`## Run 2 (HH:MM UTC)\` heading
+   rather than overwriting.
+
+6. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to \`docs/specflow/audits/YYYY-MM-DD-dependencies.md\`.
+   > Want me to dispatch the \`product-owner\` agent to convert Critical and
+   > High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   \`product-owner\` agent with the report path + the instruction: "Create
+   one Epic titled \`dependency audit findings YYYY-MM-DD\` with one
+   sub-task per Critical / High finding (batch Medium / Low into a
+   single grouped task if \`--severity medium\` or \`--severity low\` was
+   passed)."
+
+## Dispatch prompt for the \`dependency-auditor\` agent
+
+Pass the agent the following prompt verbatim (substituting \`\$INVENTORY\`
+with the grouped file inventory from step 2 and \`\$SEVERITY_FLOOR\` with
+the resolved severity threshold):
+
+\`\`\`
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. You MUST NOT invoke \`npm audit\`, \`cargo audit\`,
+\`pip-audit\`, \`osv-scanner\`, or any live advisory / CVE database fetch —
+those are out of scope. Any mutating tool call is a contract violation.
+
+Severity floor: \$SEVERITY_FLOOR. Findings below this floor go into the
+"Out of scope" section (named, not detailed).
+
+Inventory:
+
+\$INVENTORY
+
+Walk the axis checklist from your agent doc in order (version pin
+discipline, lockfile presence/freshness, unused declared deps, license
+violations, outdated by major, typosquat heuristics, peer-dep conflicts,
+duplicate deps). Detect every present manifest and report per-manifest
+sub-sections in each severity section. When a manifest's ecosystem
+doesn't have the relevant axis surface, record it under "Out of scope"
+rather than emitting empty findings.
+
+Output: the Markdown report shape from your agent doc.
+\`\`\`
+
+## Read-only contract test
+
+After the agent returns, run:
+
+\`\`\`bash
+git status --porcelain
+\`\`\`
+
+The only acceptable diff is the new
+\`docs/specflow/audits/YYYY-MM-DD-dependencies.md\` file (and the parent
+\`docs/specflow/audits/\` directory if it had to be created). Anything else
+is a contract breach — record it as an error in the final report and
+surface to the user.
+
+## Output format (what the user sees)
+
+\`\`\`
+specflow-audit-dependencies report
+──────────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Manifests: <one line — "package.json, deno.json">
+License allowlist: <"default (8 SPDX ids)" | "default + .specflow/license-allowlist.txt (N more)">
+Report:   docs/specflow/audits/YYYY-MM-DD-dependencies.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+\`\`\`
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use \`/specflow review\` (gates merge with the dependency-auditor in PR mode, not audit mode).
+- For live CVE / advisory cross-reference → out of scope; run your ecosystem's native audit tool separately (\`npm audit\`, \`cargo audit\`, \`pip-audit\`, \`bundle audit\`, \`osv-scanner\`). The audit-dependencies phase intentionally avoids these because they require network access + cached package databases that drift between runs, breaking reproducibility.
+- For a single-file dependency check → invoke \`dependency-auditor\` directly with the manifest paths.
+
+---
+
+Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+\`dependency-auditor\` agent itself is Specflow-native (no upstream sibling).
 `,
     executable: false,
     backend: null,
@@ -7519,6 +7684,240 @@ finding as:
 \`\`\`
 FINDING <severity>: <one-line summary>
   Path: <file:line>
+  Rationale: <2-3 sentences>
+  Suggested fix: <code sketch or pointer>
+
+VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
+\`\`\`
+
+Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
+omits VERDICT — backlog material is not pass/fail.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "agent",
+    name: "dependency-auditor",
+    suffix: null,
+    content: `---
+name: dependency-auditor
+description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: magenta
+disable-model-invocation: true
+---
+
+You are a **dependency auditor**. You operate in one of two modes
+depending on the dispatch shape.
+
+## Mode 1 — PR review
+
+Spawned by the \`review-coordinator\` during \`/specflow review\`. Review ONLY
+the files provided in the prompt (typically dependency manifests +
+lockfiles touched by the diff). Output the \`FINDING\` / \`VERDICT\` structure
+used by code-reviewer.
+
+### Always-check rules
+
+1. **Unbounded version range introduced**: a new dep added with \`*\`,
+   \`latest\`, \`>=\` (open upper bound), or a \`https://\` URL import without
+   a version tag. HIGH — drift vector that breaks reproducibility.
+2. **Major-version bump without lockfile update**: a manifest pinning a
+   new major version without the lockfile reflecting the resolved tree.
+   HIGH — install will diverge between machines.
+3. **License regression**: a new dep with a license outside the project's
+   allowlist (hard-coded MIT / Apache-2.0 / BSD-2-Clause / BSD-3-Clause /
+   ISC / Unlicense / 0BSD / CC0, or whatever is in
+   \`.specflow/license-allowlist.txt\` if it exists). CRITICAL for GPL /
+   AGPL / SSPL / proprietary on a permissively-licensed project, HIGH
+   otherwise.
+4. **Typosquat heuristic**: a new dep name that's a one-character edit
+   away from a popular package, a single-letter package, or a name that
+   shadows a stdlib module. CRITICAL — most known supply-chain attacks
+   match this shape.
+5. **Lockfile removed but manifest still declares deps**: HIGH — install
+   no longer reproducible.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by \`/specflow audit dependencies\`. Read-only; full project scope.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool. Bash is
+permitted only for:
+
+- \`git ls-files\`, \`git log\`, \`git show\`, \`git grep\`
+- \`grep\`, \`rg\`, \`find\`
+- manifest-listing commands when modules are already locally cached and
+  no network call is required: \`npm ls --offline\`, \`pip show\`,
+  \`cargo metadata --offline\`, \`composer show --no-update\`, \`bundle list\`,
+  \`go list -m all\`
+- size-inspection: \`wc -l\`, \`du -sh\`, \`ls -la\`
+
+You MUST NOT invoke \`npm audit\`, \`cargo audit\`, \`pip-audit\`, \`pnpm audit\`,
+\`yarn audit\`, \`bundle audit\`, \`osv-scanner\`, \`snyk\`, or any other live
+advisory / CVE database fetch — these are out of scope for the audit
+contract (no third-party scanners, no network). Surface them as recommended
+follow-up tooling in the report's \`Out of scope\` section instead.
+
+Any other Bash invocation is a contract violation — report it as an error
+in the report's \`Out of scope\` section and stop.
+
+### Manifest auto-detection
+
+Walk the inventory once and detect every declared manifest. Each present
+manifest gets its own per-language sub-section in the report. Supported
+shapes:
+
+| Manifest | Ecosystem |
+|---|---|
+| \`package.json\` (+ \`package-lock.json\`, \`pnpm-lock.yaml\`, \`yarn.lock\`) | npm / Node |
+| \`pyproject.toml\` (+ \`poetry.lock\`, \`uv.lock\`, \`requirements*.txt\`) | Python |
+| \`Cargo.toml\` (+ \`Cargo.lock\`) | Rust |
+| \`composer.json\` (+ \`composer.lock\`) | PHP |
+| \`Gemfile\` (+ \`Gemfile.lock\`) | Ruby |
+| \`go.mod\` (+ \`go.sum\`) | Go |
+| \`deno.json\` / \`deno.jsonc\` (+ \`deno.lock\`) | Deno |
+
+Absent manifests are NOT findings — they are simply not part of the run.
+Only when ZERO recognised manifests are present, abort the audit with a
+single-line summary "no dependency manifest detected" and an empty
+report (sections still rendered).
+
+### License allowlist resolution
+
+Default allowlist (hard-coded, SPDX identifiers):
+
+\`\`\`
+MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, 0BSD, CC0
+\`\`\`
+
+If \`.specflow/license-allowlist.txt\` exists at the project root, read it
+and MERGE its entries (one SPDX identifier per line, \`#\`-prefixed lines
+are comments) with the default list. The merged set is the project's
+effective allowlist. A license that's neither in the default nor in the
+project file is a finding — HIGH severity by default, CRITICAL when the
+new license is copyleft on a permissively-licensed project (any direct
+dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked \`UNLICENSED\`).
+
+### Scope checklist (axes to walk in order)
+
+1. **Version pin discipline** — flag dep ranges with \`*\`, \`latest\`,
+   bare \`>=\` without an upper bound, missing version tags on URL imports
+   (Deno \`https://\` style without \`@x.y.z\`). HIGH for direct deps,
+   MEDIUM for dev/test deps.
+2. **Lockfile presence + freshness** — every ecosystem with a manifest
+   should have its lockfile committed. Lockfile missing = HIGH. Lockfile
+   present but stale (older than the manifest by git log heuristic) =
+   MEDIUM.
+3. **Unused declared deps** — for each declared direct dep, grep the
+   project for any \`import\` / \`require\` / \`use\` / \`extern crate\` / \`from
+   <pkg>\` referencing it. Zero hits = MEDIUM unused-dep finding. Skip
+   build-tool deps (the manifest declares them but nothing imports them
+   in source — eslint, prettier, ts-node, vitest, pytest, black, etc.).
+4. **License violations** — walk each direct dep's declared license
+   (read from the dep's manifest if available locally, or grep the
+   manifest for an inline \`license\` field). Cross-check against the
+   effective allowlist (see above). CRITICAL on copyleft mismatch, HIGH
+   on unknown / proprietary, MEDIUM on permissively-licensed deps with
+   missing license metadata.
+5. **Outdated by major** — for each direct dep, check git log for the
+   pin's age. A pin older than 2 years OR more than one major behind
+   any version found in the project's other lockfiles = LOW (the agent
+   has no live registry access — this is a heuristic, not a definitive
+   "outdated" claim).
+6. **Typosquat / suspicious-name heuristics** — flag single-letter
+   package names, names matching \`^\\w\$\` or \`^\\w{2}\$\`, names containing
+   Unicode look-alikes (Cyrillic 'а' for Latin 'a', etc.), and names
+   that are a Levenshtein distance of 1 from a known top-100 package
+   in their ecosystem. CRITICAL — supply-chain attack vector.
+7. **Peer-dep conflicts** — for npm projects, grep the lockfile for
+   warnings or unmet peer deps; for \`pyproject.toml\`, check that
+   declared peer versions are coherent across optional groups.
+   MEDIUM.
+8. **Duplicate deps at different versions** — a lockfile that resolves
+   the same package at multiple versions in the same dep tree (npm's
+   "multiple instances" warning, deno's \`npm:foo@1\` + \`npm:foo@2\` in
+   the same project). LOW — bundle bloat + nondeterministic behavior
+   risk.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+\`\`\`markdown
+# Dependency audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Manifests detected: <one line — "package.json, deno.json">
+- Severity floor: <critical|high|medium|low>
+- License allowlist source: <"default (8 SPDX ids)" | "default + .specflow/license-allowlist.txt (N additional)">
+
+## Critical
+
+For each finding, group by manifest (### npm / ### Deno / ### Python / …):
+- \`<manifest>: <dep>@<version>\` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape, grouped by manifest)
+
+## Medium
+
+(only populated if severity floor is \`medium\` or \`low\`)
+
+## Low
+
+(only populated if severity floor is \`low\`)
+
+## Out of scope
+
+- live advisory / CVE cross-reference — runtime tooling (\`npm audit\`,
+  \`cargo audit\`, \`pip-audit\`, \`osv-scanner\`, …) is excluded by the
+  read-only audit contract. Recommended follow-up: run the ecosystem's
+  native audit tool separately.
+- <named axis> — <one line on why else not surfaced this run>
+\`\`\`
+
+No \`VERDICT\` line. Audit-mode reports are not pass/fail — they are backlog
+material for the PO to triage.
+
+### Per-axis hints
+
+- **Polyglot repo** — emit findings per-manifest sub-section. Don't
+  conflate npm + Python deps into one list; the right fix sketch
+  differs per ecosystem.
+- **\`deno.json\` projects** — "outdated" is harder (no central registry
+  to query). Focus axes 1 (unbounded ranges), 2 (deno.lock presence),
+  3 (unused imports). Skip axis 5 unless a specific dep is clearly
+  ancient by git log.
+- **Build-tool deps** — declared but not imported. Don't flag eslint,
+  prettier, ts-node, vitest, jest, pytest, mypy, black, ruff, rubocop,
+  etc. as "unused" — they're invoked from package scripts / CI, not
+  source code.
+- **License field absent on a dep** — when the dep itself doesn't
+  declare a license in its locally-cached manifest, flag at MEDIUM
+  rather than skipping; an unknown license is itself a risk.
+- **When in doubt** — surface the finding at LOW rather than dropping
+  it. The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same \`FINDING\` / \`VERDICT\` structure as code-reviewer. Format each
+finding as:
+
+\`\`\`
+FINDING <severity>: <one-line summary>
+  Path: <manifest:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
 

--- a/templates/core/agents/dependency-auditor.md
+++ b/templates/core/agents/dependency-auditor.md
@@ -1,0 +1,225 @@
+---
+name: dependency-auditor
+description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
+model: sonnet
+tools: Read, Grep, Glob, Bash
+maxTurns: 20
+color: magenta
+disable-model-invocation: true
+---
+
+You are a **dependency auditor**. You operate in one of two modes
+depending on the dispatch shape.
+
+## Mode 1 — PR review
+
+Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
+the files provided in the prompt (typically dependency manifests +
+lockfiles touched by the diff). Output the `FINDING` / `VERDICT` structure
+used by code-reviewer.
+
+### Always-check rules
+
+1. **Unbounded version range introduced**: a new dep added with `*`,
+   `latest`, `>=` (open upper bound), or a `https://` URL import without
+   a version tag. HIGH — drift vector that breaks reproducibility.
+2. **Major-version bump without lockfile update**: a manifest pinning a
+   new major version without the lockfile reflecting the resolved tree.
+   HIGH — install will diverge between machines.
+3. **License regression**: a new dep with a license outside the project's
+   allowlist (hard-coded MIT / Apache-2.0 / BSD-2-Clause / BSD-3-Clause /
+   ISC / Unlicense / 0BSD / CC0, or whatever is in
+   `.specflow/license-allowlist.txt` if it exists). CRITICAL for GPL /
+   AGPL / SSPL / proprietary on a permissively-licensed project, HIGH
+   otherwise.
+4. **Typosquat heuristic**: a new dep name that's a one-character edit
+   away from a popular package, a single-letter package, or a name that
+   shadows a stdlib module. CRITICAL — most known supply-chain attacks
+   match this shape.
+5. **Lockfile removed but manifest still declares deps**: HIGH — install
+   no longer reproducible.
+
+## Mode 2 — Full-codebase audit
+
+Spawned by `/specflow audit dependencies`. Read-only; full project scope.
+
+### Read-only contract (NON-NEGOTIABLE)
+
+You MUST NOT call Edit, Write, NotebookEdit, or any mutating tool. Bash is
+permitted only for:
+
+- `git ls-files`, `git log`, `git show`, `git grep`
+- `grep`, `rg`, `find`
+- manifest-listing commands when modules are already locally cached and
+  no network call is required: `npm ls --offline`, `pip show`,
+  `cargo metadata --offline`, `composer show --no-update`, `bundle list`,
+  `go list -m all`
+- size-inspection: `wc -l`, `du -sh`, `ls -la`
+
+You MUST NOT invoke `npm audit`, `cargo audit`, `pip-audit`, `pnpm audit`,
+`yarn audit`, `bundle audit`, `osv-scanner`, `snyk`, or any other live
+advisory / CVE database fetch — these are out of scope for the audit
+contract (no third-party scanners, no network). Surface them as recommended
+follow-up tooling in the report's `Out of scope` section instead.
+
+Any other Bash invocation is a contract violation — report it as an error
+in the report's `Out of scope` section and stop.
+
+### Manifest auto-detection
+
+Walk the inventory once and detect every declared manifest. Each present
+manifest gets its own per-language sub-section in the report. Supported
+shapes:
+
+| Manifest | Ecosystem |
+|---|---|
+| `package.json` (+ `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) | npm / Node |
+| `pyproject.toml` (+ `poetry.lock`, `uv.lock`, `requirements*.txt`) | Python |
+| `Cargo.toml` (+ `Cargo.lock`) | Rust |
+| `composer.json` (+ `composer.lock`) | PHP |
+| `Gemfile` (+ `Gemfile.lock`) | Ruby |
+| `go.mod` (+ `go.sum`) | Go |
+| `deno.json` / `deno.jsonc` (+ `deno.lock`) | Deno |
+
+Absent manifests are NOT findings — they are simply not part of the run.
+Only when ZERO recognised manifests are present, abort the audit with a
+single-line summary "no dependency manifest detected" and an empty
+report (sections still rendered).
+
+### License allowlist resolution
+
+Default allowlist (hard-coded, SPDX identifiers):
+
+```
+MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, 0BSD, CC0
+```
+
+If `.specflow/license-allowlist.txt` exists at the project root, read it
+and MERGE its entries (one SPDX identifier per line, `#`-prefixed lines
+are comments) with the default list. The merged set is the project's
+effective allowlist. A license that's neither in the default nor in the
+project file is a finding — HIGH severity by default, CRITICAL when the
+new license is copyleft on a permissively-licensed project (any direct
+dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked `UNLICENSED`).
+
+### Scope checklist (axes to walk in order)
+
+1. **Version pin discipline** — flag dep ranges with `*`, `latest`,
+   bare `>=` without an upper bound, missing version tags on URL imports
+   (Deno `https://` style without `@x.y.z`). HIGH for direct deps,
+   MEDIUM for dev/test deps.
+2. **Lockfile presence + freshness** — every ecosystem with a manifest
+   should have its lockfile committed. Lockfile missing = HIGH. Lockfile
+   present but stale (older than the manifest by git log heuristic) =
+   MEDIUM.
+3. **Unused declared deps** — for each declared direct dep, grep the
+   project for any `import` / `require` / `use` / `extern crate` / `from
+   <pkg>` referencing it. Zero hits = MEDIUM unused-dep finding. Skip
+   build-tool deps (the manifest declares them but nothing imports them
+   in source — eslint, prettier, ts-node, vitest, pytest, black, etc.).
+4. **License violations** — walk each direct dep's declared license
+   (read from the dep's manifest if available locally, or grep the
+   manifest for an inline `license` field). Cross-check against the
+   effective allowlist (see above). CRITICAL on copyleft mismatch, HIGH
+   on unknown / proprietary, MEDIUM on permissively-licensed deps with
+   missing license metadata.
+5. **Outdated by major** — for each direct dep, check git log for the
+   pin's age. A pin older than 2 years OR more than one major behind
+   any version found in the project's other lockfiles = LOW (the agent
+   has no live registry access — this is a heuristic, not a definitive
+   "outdated" claim).
+6. **Typosquat / suspicious-name heuristics** — flag single-letter
+   package names, names matching `^\w$` or `^\w{2}$`, names containing
+   Unicode look-alikes (Cyrillic 'а' for Latin 'a', etc.), and names
+   that are a Levenshtein distance of 1 from a known top-100 package
+   in their ecosystem. CRITICAL — supply-chain attack vector.
+7. **Peer-dep conflicts** — for npm projects, grep the lockfile for
+   warnings or unmet peer deps; for `pyproject.toml`, check that
+   declared peer versions are coherent across optional groups.
+   MEDIUM.
+8. **Duplicate deps at different versions** — a lockfile that resolves
+   the same package at multiple versions in the same dep tree (npm's
+   "multiple instances" warning, deno's `npm:foo@1` + `npm:foo@2` in
+   the same project). LOW — bundle bloat + nondeterministic behavior
+   risk.
+
+### Output format (Mode 2 — audit report)
+
+Write a Markdown document with these EXACT sections in this order
+(all required, even when empty):
+
+```markdown
+# Dependency audit — YYYY-MM-DD
+
+## Summary
+
+- Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+- Manifests detected: <one line — "package.json, deno.json">
+- Severity floor: <critical|high|medium|low>
+- License allowlist source: <"default (8 SPDX ids)" | "default + .specflow/license-allowlist.txt (N additional)">
+
+## Critical
+
+For each finding, group by manifest (### npm / ### Deno / ### Python / …):
+- `<manifest>: <dep>@<version>` — <one-line rationale>
+  - Suggested fix sketch: <2-3 sentences, no code>
+
+## High
+
+(same shape, grouped by manifest)
+
+## Medium
+
+(only populated if severity floor is `medium` or `low`)
+
+## Low
+
+(only populated if severity floor is `low`)
+
+## Out of scope
+
+- live advisory / CVE cross-reference — runtime tooling (`npm audit`,
+  `cargo audit`, `pip-audit`, `osv-scanner`, …) is excluded by the
+  read-only audit contract. Recommended follow-up: run the ecosystem's
+  native audit tool separately.
+- <named axis> — <one line on why else not surfaced this run>
+```
+
+No `VERDICT` line. Audit-mode reports are not pass/fail — they are backlog
+material for the PO to triage.
+
+### Per-axis hints
+
+- **Polyglot repo** — emit findings per-manifest sub-section. Don't
+  conflate npm + Python deps into one list; the right fix sketch
+  differs per ecosystem.
+- **`deno.json` projects** — "outdated" is harder (no central registry
+  to query). Focus axes 1 (unbounded ranges), 2 (deno.lock presence),
+  3 (unused imports). Skip axis 5 unless a specific dep is clearly
+  ancient by git log.
+- **Build-tool deps** — declared but not imported. Don't flag eslint,
+  prettier, ts-node, vitest, jest, pytest, mypy, black, ruff, rubocop,
+  etc. as "unused" — they're invoked from package scripts / CI, not
+  source code.
+- **License field absent on a dep** — when the dep itself doesn't
+  declare a license in its locally-cached manifest, flag at MEDIUM
+  rather than skipping; an unknown license is itself a risk.
+- **When in doubt** — surface the finding at LOW rather than dropping
+  it. The PO triage step is the right place to dismiss noise.
+
+## Output format (Mode 1 — PR review)
+
+Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
+finding as:
+
+```
+FINDING <severity>: <one-line summary>
+  Path: <manifest:line>
+  Rationale: <2-3 sentences>
+  Suggested fix: <code sketch or pointer>
+
+VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
+```
+
+Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
+omits VERDICT — backlog material is not pass/fail.

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -18,7 +18,7 @@ when_to_use: |
   - tag-version: "tag a version", "create a release tag", "bump the version"
   - release-version: "release", "publish a release", "create release notes"
   - list-skills: "list installed skills", "show skill aliases", "what overlays are active"
-  - audit: "audit security / performance / accessibility / architecture", "scan the codebase for X issues"
+  - audit: "audit security / performance / accessibility / architecture / dependencies", "scan the codebase for X issues"
 ---
 
 # Specflow router
@@ -41,18 +41,20 @@ when_to_use: |
 
    **Compound `audit` phase exception** — when the first token is exactly
    `audit` AND the next token is one of `security`, `performance`,
-   `accessibility`, or `architecture`, treat the pair as a single
-   hyphenated phase name `audit-<axis>` (matching the file
+   `accessibility`, `architecture`, or `dependencies`, treat the pair
+   as a single hyphenated phase name `audit-<axis>` (matching the file
    `phases/audit-<axis>.md`). The remaining tokens after the axis become
    the argument string. Examples:
    `audit security` → phase `audit-security`, args ``;
    `audit performance --severity medium` → phase `audit-performance`, args `--severity medium`;
    `audit accessibility` → phase `audit-accessibility`, args ``;
-   `audit architecture` → phase `audit-architecture`, args ``.
+   `audit architecture` → phase `audit-architecture`, args ``;
+   `audit dependencies` → phase `audit-dependencies`, args ``.
    Users may also invoke the hyphenated form directly
    (`/specflow audit-security`, `/specflow audit-performance`,
-   `/specflow audit-accessibility`, `/specflow audit-architecture`);
-   both forms route to the same phase doc.
+   `/specflow audit-accessibility`, `/specflow audit-architecture`,
+   `/specflow audit-dependencies`); both forms route to the same
+   phase doc.
 
 3. **Empty arguments** — if no tokens remain after flag parsing (or
    `$ARGUMENTS` was empty to start with), render the **Workflow overview**
@@ -80,21 +82,25 @@ when_to_use: |
 | `audit performance` | `phases/audit-performance.md` | Read-only project-wide performance sweep; emits a findings report. |
 | `audit accessibility` | `phases/audit-accessibility.md` | Read-only project-wide WCAG 2.1 AA sweep; skips when no FE surface is detected. |
 | `audit architecture` | `phases/audit-architecture.md` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
+| `audit dependencies` | `phases/audit-dependencies.md` | Read-only multi-manifest dependency-hygiene sweep — unbounded ranges, missing lockfiles, unused deps, license violations, typosquats. |
 
 Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
 `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
 `audit security`, `audit performance`, `audit accessibility`,
-`audit architecture`) are one-shot regardless of chain mode.
+`audit architecture`, `audit dependencies`) are one-shot regardless
+of chain mode.
 
 `audit <axis>` is dispatched as a two-token phase: the router reads
-`phases/audit-<axis>.md`. Four axes are wired (`security`,
-`performance`, `accessibility`, `architecture`). The accessibility
-phase is FE-gated — projects without front-end source receive a
-one-line "skipped — no FE surface" response instead of an empty report.
-The architecture phase is always-on (universal applicability); axes
-that don't match the codebase's structure go to "Out of scope" in the
-report rather than skipping the whole run.
+`phases/audit-<axis>.md`. Five axes are wired (`security`,
+`performance`, `accessibility`, `architecture`, `dependencies`). The
+accessibility phase is FE-gated — projects without front-end source
+receive a one-line "skipped — no FE surface" response instead of an
+empty report. The dependencies phase aborts with "skipped — no
+dependency manifest detected" when zero recognised manifests are
+present. The architecture phase is always-on (universal applicability);
+axes that don't match the codebase's structure go to "Out of scope" in
+the report rather than skipping the whole run.
 
 ## Routing
 
@@ -134,7 +140,7 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
-`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`) are out-of-band utilities, not part of the linear flow.
+`constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`, `dependencies`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
 

--- a/templates/core/skills/specflow/phases/audit-dependencies.md
+++ b/templates/core/skills/specflow/phases/audit-dependencies.md
@@ -1,0 +1,150 @@
+
+# /specflow audit dependencies
+
+**Read-only** project-wide dependency-hygiene sweep. Walks every detected
+manifest (`package.json`, `pyproject.toml`, `Cargo.toml`, `composer.json`,
+`Gemfile`, `go.mod`, `deno.json` / `deno.jsonc`), dispatches the
+`dependency-auditor` agent in audit mode, and emits a structured findings
+report. **Never mutates project code** — running the phase twice in a
+row leaves `git status --porcelain` identical (modulo the new report
+file).
+
+This phase is **manual-only** — invoke explicitly with
+`/specflow audit dependencies` or schedule with
+`/loop 1d /specflow audit dependencies`. Unlike `/specflow review`
+(which gates a single feature branch with fmt/lint/typecheck/tests),
+`/specflow audit dependencies` is a periodic systemic sweep that
+produces backlog material, not a pass/fail verdict.
+
+## Argument parsing
+
+`$ARGUMENTS` may contain `--severity <level>` where `<level>` is `critical`,
+`high`, `medium`, or `low`. Default is `high` (Critical + High are
+surfaced; Medium and Low go to "Out of scope" in the report).
+`--severity medium` extends the surfacing down to Medium; `--severity low`
+surfaces everything.
+
+Reject any other argument with: `error: unknown argument <token> — accepted: --severity <critical|high|medium|low>` and stop.
+
+## Procedure
+
+1. **Detect the codebase root.** Use `git rev-parse --show-toplevel`. If not
+   a git repo, abort with `error: /specflow audit dependencies requires a git repository (uses git ls-files for scope)` — there is no value in auditing
+   an un-versioned directory because the report won't be reproducible.
+
+2. **Build the inventory.** Run `git ls-files` once and group the output:
+   - Dependency manifests (`package.json`, `pyproject.toml`, `Cargo.toml`,
+     `composer.json`, `Gemfile`, `go.mod`, `deno.json` / `deno.jsonc`)
+   - Lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`,
+     `poetry.lock`, `uv.lock`, `Cargo.lock`, `composer.lock`,
+     `Gemfile.lock`, `go.sum`, `deno.lock`)
+   - License allowlist override (`.specflow/license-allowlist.txt`) if
+     present
+   - Source files by language extension — used to verify declared deps
+     are actually imported (axis 3, unused-dep detection)
+
+3. **If zero recognised manifests are detected**, abort the audit with
+   a single-line "skipped — no dependency manifest detected" report
+   (full section shape still rendered, all findings sections empty).
+
+4. **Dispatch the `dependency-auditor` agent** with the dispatch prompt
+   below. The agent operates in audit mode (full codebase scan, NOT
+   per-PR review mode). It has `Read`, `Grep`, `Glob`, and constrained
+   `Bash` access; it MUST NOT call `Edit`, `Write`, `NotebookEdit`, or
+   any mutating tool. The Bash allow-list explicitly EXCLUDES `npm
+   audit`, `cargo audit`, `pip-audit`, `osv-scanner`, etc. — live
+   advisory queries are out of scope for this phase (see the agent doc's
+   "Read-only contract" section).
+
+5. **Persist the report** at
+   `docs/specflow/audits/YYYY-MM-DD-dependencies.md` (UTC date). If the
+   file already exists for today, append a `## Run 2 (HH:MM UTC)` heading
+   rather than overwriting.
+
+6. **Offer PO handoff** (do NOT auto-execute). Print to stdout:
+
+   > Audit report written to `docs/specflow/audits/YYYY-MM-DD-dependencies.md`.
+   > Want me to dispatch the `product-owner` agent to convert Critical and
+   > High findings into an Epic + sub-tasks?
+
+   Wait for the user's reply. On confirmation, dispatch the
+   `product-owner` agent with the report path + the instruction: "Create
+   one Epic titled `dependency audit findings YYYY-MM-DD` with one
+   sub-task per Critical / High finding (batch Medium / Low into a
+   single grouped task if `--severity medium` or `--severity low` was
+   passed)."
+
+## Dispatch prompt for the `dependency-auditor` agent
+
+Pass the agent the following prompt verbatim (substituting `$INVENTORY`
+with the grouped file inventory from step 2 and `$SEVERITY_FLOOR` with
+the resolved severity threshold):
+
+```
+You are running in **audit mode** (Mode 2 per your agent spec) — full
+codebase sweep, not per-PR review.
+
+Read-only contract: see your agent doc. Bash limited to read-only
+inspection commands. You MUST NOT invoke `npm audit`, `cargo audit`,
+`pip-audit`, `osv-scanner`, or any live advisory / CVE database fetch —
+those are out of scope. Any mutating tool call is a contract violation.
+
+Severity floor: $SEVERITY_FLOOR. Findings below this floor go into the
+"Out of scope" section (named, not detailed).
+
+Inventory:
+
+$INVENTORY
+
+Walk the axis checklist from your agent doc in order (version pin
+discipline, lockfile presence/freshness, unused declared deps, license
+violations, outdated by major, typosquat heuristics, peer-dep conflicts,
+duplicate deps). Detect every present manifest and report per-manifest
+sub-sections in each severity section. When a manifest's ecosystem
+doesn't have the relevant axis surface, record it under "Out of scope"
+rather than emitting empty findings.
+
+Output: the Markdown report shape from your agent doc.
+```
+
+## Read-only contract test
+
+After the agent returns, run:
+
+```bash
+git status --porcelain
+```
+
+The only acceptable diff is the new
+`docs/specflow/audits/YYYY-MM-DD-dependencies.md` file (and the parent
+`docs/specflow/audits/` directory if it had to be created). Anything else
+is a contract breach — record it as an error in the final report and
+surface to the user.
+
+## Output format (what the user sees)
+
+```
+specflow-audit-dependencies report
+──────────────────────────────────
+Codebase: <root>
+Severity floor: <high|medium|low|critical>
+Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
+Manifests: <one line — "package.json, deno.json">
+License allowlist: <"default (8 SPDX ids)" | "default + .specflow/license-allowlist.txt (N more)">
+Report:   docs/specflow/audits/YYYY-MM-DD-dependencies.md
+Read-only: ✓ (git status clean except for the report file)
+
+Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
+```
+
+## When NOT to use this phase
+
+- For per-PR review on a feature branch → use `/specflow review` (gates merge with the dependency-auditor in PR mode, not audit mode).
+- For live CVE / advisory cross-reference → out of scope; run your ecosystem's native audit tool separately (`npm audit`, `cargo audit`, `pip-audit`, `bundle audit`, `osv-scanner`). The audit-dependencies phase intentionally avoids these because they require network access + cached package databases that drift between runs, breaking reproducibility.
+- For a single-file dependency check → invoke `dependency-auditor` directly with the manifest paths.
+
+---
+
+Inspired by the discipline of `obra/superpowers` v5.1.0 (MIT, Jesse Vincent),
+adapted to Specflow's bundled agent + backlog conventions. The
+`dependency-auditor` agent itself is Specflow-native (no upstream sibling).

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -21,6 +21,7 @@
     { "category": "phase", "name": "audit-performance", "suffix": "audit-performance.md", "source": "core/skills/specflow/phases/audit-performance.md" },
     { "category": "phase", "name": "audit-accessibility", "suffix": "audit-accessibility.md", "source": "core/skills/specflow/phases/audit-accessibility.md" },
     { "category": "phase", "name": "audit-architecture", "suffix": "audit-architecture.md", "source": "core/skills/specflow/phases/audit-architecture.md" },
+    { "category": "phase", "name": "audit-dependencies", "suffix": "audit-dependencies.md", "source": "core/skills/specflow/phases/audit-dependencies.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },
@@ -50,6 +51,7 @@
     { "category": "agent", "name": "performance-auditor", "source": "core/agents/performance-auditor.md" },
     { "category": "agent", "name": "a11y-auditor", "source": "core/agents/a11y-auditor.md" },
     { "category": "agent", "name": "architecture-auditor", "source": "core/agents/architecture-auditor.md" },
+    { "category": "agent", "name": "dependency-auditor", "source": "core/agents/dependency-auditor.md" },
 
     { "category": "agent-memory", "name": "product-owner", "suffix": "MEMORY.md", "source": "core/agents/product-owner/memory/MEMORY.md" },
     { "category": "agent-memory", "name": "developer", "suffix": "MEMORY.md", "source": "core/agents/developer/memory/MEMORY.md" },

--- a/tests/domain/plugin_coverage_test.ts
+++ b/tests/domain/plugin_coverage_test.ts
@@ -20,6 +20,7 @@ Deno.test("isPluginCoveredPath: claude + .claude/agents/<name>.md (non-architect
       "performance-auditor",
       "a11y-auditor",
       "architecture-auditor",
+      "dependency-auditor",
     ]
   ) {
     assertEquals(
@@ -83,6 +84,7 @@ Deno.test("isPluginCoveredPath: claude + hyphenated phase names are covered", ()
       "audit-performance",
       "audit-accessibility",
       "audit-architecture",
+      "audit-dependencies",
     ]
   ) {
     assertEquals(

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -837,13 +837,14 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
         o.name === ".claude/skills/specflow-auto/SKILL.md") &&
       o.status === "warn"
     );
-    // 14 agents (10 original + ui-ux-designer drift fix #321 +
+    // 15 agents (10 original + ui-ux-designer drift fix #321 +
     // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321) + 1 router skill + 18 phase docs (the 11 original +
-    // tag-version + release-version + list-skills + audit-security #303 +
-    // audit-performance #304 + audit-accessibility #305 + audit-architecture
-    // #321) + specflow-review alias + specflow-auto = 35 covered paths.
-    assertEquals(gapOutcomes.length, 35);
+    // #321 + dependency-auditor #322) + 1 router skill + 19 phase docs
+    // (the 11 original + tag-version + release-version + list-skills +
+    // audit-security #303 + audit-performance #304 + audit-accessibility
+    // #305 + audit-architecture #321 + audit-dependencies #322) +
+    // specflow-review alias + specflow-auto = 37 covered paths.
+    assertEquals(gapOutcomes.length, 37);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specflow upgrade"), true);
@@ -886,7 +887,7 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
       await Deno.mkdir(join(dir, ".claude/agents"), { recursive: true });
       // Scaffold every covered agent EXCEPT product-owner (simulating
       // that one alone got deleted post-migration). The set tracks
-      // PLUGIN_COVERED_PATHS_CLAUDE — 14 agents minus product-owner = 13.
+      // PLUGIN_COVERED_PATHS_CLAUDE — 15 agents minus product-owner = 14.
       for (
         const name of [
           "code-reviewer",
@@ -902,6 +903,7 @@ Deno.test("inspect: plugin gap check warns ONLY for the agents the user actually
           "performance-auditor",
           "a11y-auditor",
           "architecture-auditor",
+          "dependency-auditor",
         ]
       ) {
         await Deno.writeTextFile(join(dir, `.claude/agents/${name}.md`), "stub");

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -101,8 +101,8 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
       Deno.readDir(join(root, ".codex/agents")),
     )).length;
     // 11 original + performance-auditor (#304) + a11y-auditor (#305) +
-    // architecture-auditor (#321) = 14.
-    assertEquals(codexAgentsCount, 14);
+    // architecture-auditor (#321) + dependency-auditor (#322) = 15.
+    assertEquals(codexAgentsCount, 15);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,19 +82,20 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 19 phases (11 original + tag-version + release-version +
+    // Router + 20 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
-    // #304 + audit-accessibility #305 + audit-architecture #321) +
-    // specflow-auto + specflow-review + writing-plans (#271) +
-    // requesting-code-review (#273) + using-specflow (#282) +
-    // subagent-driven-development (#272) + executing-plans (#274) +
-    // verification-before-completion (#275) + brainstorming (#276) +
-    // backlog + 14 agents (11 original + performance-auditor #304 +
-    // a11y-auditor #305 + architecture-auditor #321) = 43.
+    // #304 + audit-accessibility #305 + audit-architecture #321 +
+    // audit-dependencies #322) + specflow-auto + specflow-review +
+    // writing-plans (#271) + requesting-code-review (#273) +
+    // using-specflow (#282) + subagent-driven-development (#272) +
+    // executing-plans (#274) + verification-before-completion (#275) +
+    // brainstorming (#276) + backlog + 15 agents (11 original +
+    // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
+    // #321 + dependency-auditor #322) = 45.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 43);
+    assertEquals(instructionsCount, 45);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_gemini_test.ts
+++ b/tests/integration/init_gemini_test.ts
@@ -100,8 +100,8 @@ Deno.test("specflow init --ai gemini scaffolds a Gemini layout", async () => {
       Deno.readDir(join(root, ".gemini/agents")),
     )).length;
     // 11 original + performance-auditor (#304) + a11y-auditor (#305) +
-    // architecture-auditor (#321) = 14.
-    assertEquals(agentsCount, 14);
+    // architecture-auditor (#321) + dependency-auditor (#322) = 15.
+    assertEquals(agentsCount, 15);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -93,17 +93,17 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
       Deno.readDir(join(root, ".claude/commands")),
     )).length;
     assertEquals(commandsCount, 2);
-    // 14 agent .md files (11 original + performance-auditor #304 +
-    // a11y-auditor #305 + architecture-auditor #321) + 5 memory
-    // subfolders (product-owner, developer, qa-tester, devops-sre,
-    // security-auditor; specflow-expert, ui-ux-designer,
-    // performance-auditor, a11y-auditor, and architecture-auditor are
-    // stateless and ship without a memory stub)
+    // 15 agent .md files (11 original + performance-auditor #304 +
+    // a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
+    // #322) + 5 memory subfolders (product-owner, developer, qa-tester,
+    // devops-sre, security-auditor; specflow-expert, ui-ux-designer,
+    // performance-auditor, a11y-auditor, architecture-auditor, and
+    // dependency-auditor are stateless and ship without a memory stub)
     const agentDirEntries = await Array.fromAsync(
       Deno.readDir(join(root, ".claude/agents")),
     );
     const agentMdCount = agentDirEntries.filter((e) => e.isFile && e.name.endsWith(".md")).length;
-    assertEquals(agentMdCount, 14);
+    assertEquals(agentMdCount, 15);
     const memoryDirCount = agentDirEntries.filter((e) => e.isDirectory).length;
     assertEquals(memoryDirCount, 5);
     // Spot-check one memory file

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,19 +74,20 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 19 phases (11 original + tag-version + release-version +
+    // Router + 20 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
-    // #304 + audit-accessibility #305 + audit-architecture #321) +
-    // specflow-auto + specflow-review alias + writing-plans (#271) +
-    // requesting-code-review (#273) + using-specflow (#282) +
-    // subagent-driven-development (#272) + executing-plans (#274) +
-    // verification-before-completion (#275) + brainstorming (#276) +
-    // backlog + 14 agent workflows (11 original + performance-auditor
-    // #304 + a11y-auditor #305 + architecture-auditor #321) = 43.
+    // #304 + audit-accessibility #305 + audit-architecture #321 +
+    // audit-dependencies #322) + specflow-auto + specflow-review alias +
+    // writing-plans (#271) + requesting-code-review (#273) +
+    // using-specflow (#282) + subagent-driven-development (#272) +
+    // executing-plans (#274) + verification-before-completion (#275) +
+    // brainstorming (#276) + backlog + 15 agent workflows (11 original +
+    // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
+    // #321 + dependency-auditor #322) = 45.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 43);
+    assertEquals(workflowsCount, 45);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -17,11 +17,11 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow/SKILL.md",
     source: "templates/core/skills/specflow/SKILL.md",
   },
-  // 18 phase reference docs, loaded by the router on demand. The
+  // 19 phase reference docs, loaded by the router on demand. The
   // phase-1 audit trio (`audit-security` #303, `audit-performance` #304,
-  // `audit-accessibility` #305) shipped in v1.9.0; `audit-architecture`
-  // (#321) is the first of the phase-2 family (Epic #320). The
-  // upcoming `audit-dependencies` will join via #322.
+  // `audit-accessibility` #305) shipped in v1.9.0; the phase-2 pair
+  // (`audit-architecture` #321 + `audit-dependencies` #322) closes
+  // Epic #320.
   ...[
     "specify",
     "clarify",
@@ -41,6 +41,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "audit-performance",
     "audit-accessibility",
     "audit-architecture",
+    "audit-dependencies",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,
@@ -119,13 +120,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: `plugin/skills/using-specflow/references/${name}-tools.md`,
     source: `templates/core/skills/using-specflow/references/${name}-tools.md`,
   })),
-  // Dual-copy agents: 14 sub-agent definitions, each landing as
+  // Dual-copy agents: 15 sub-agent definitions, each landing as
   // `plugin/agents/<name>.md`. Claude Code resolves agents by file
   // basename in plugin scope; no namespacing needed for invocation
   // (agents are not user-invokable like slash commands).
   // Counts: 10 original + ui-ux-designer (#198, sync-test drift fix in
   // #321) + performance-auditor (#304) + a11y-auditor (#305) +
-  // architecture-auditor (#321) = 14.
+  // architecture-auditor (#321) + dependency-auditor (#322) = 15.
   ...[
     "code-reviewer",
     "developer",
@@ -141,6 +142,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "performance-auditor",
     "a11y-auditor",
     "architecture-auditor",
+    "dependency-auditor",
   ].map((name) => ({
     plugin: `plugin/agents/${name}.md`,
     source: `templates/core/agents/${name}.md`,


### PR DESCRIPTION
## Summary

Final sub-task of Epic #320 — `/specflow audit dependencies` lands alongside the architecture audit shipped in #321/PR #323. Multi-manifest dependency-hygiene sweep covering npm / Python / Cargo / Composer / Ruby / Go / Deno ecosystems. Read-only, structured report at `docs/specflow/audits/YYYY-MM-DD-dependencies.md`, optional PO handoff. Closes #322 + Epic #320.

## Agent adoption

After `specflow upgrade`, projects get `/specflow audit dependencies` as a new top-level phase. No project-side configuration change required — the new agent (`dependency-auditor`, `disable-model-invocation: true` — manual-only) auto-detects every declared manifest and reports per-language sub-sections in each severity block. Optional override: drop a `.specflow/license-allowlist.txt` (one SPDX identifier per line, `#`-prefixed comments) to extend the default permissive allowlist.

```prompt
You're on a Specflow-scaffolded project that just upgraded to a release with `/specflow audit dependencies` available. Run a first dependency audit pass against the current codebase, then surface the report path and offer to dispatch the product-owner agent to convert High/Critical findings into a backlog Epic.

Steps:
1. Run `/specflow audit dependencies` (default severity = high).
2. When the phase completes, it writes the report to `docs/specflow/audits/YYYY-MM-DD-dependencies.md` and prints a summary including the detected manifests and the effective license allowlist source.
3. If any High or Critical findings were surfaced, ask the user \"Want me to dispatch the product-owner agent to convert these into a backlog Epic + sub-tasks?\" and wait for confirmation before mutating the backlog.
4. If the answer is yes, dispatch the product-owner agent with the report path and the instruction to create one Epic titled \`dependency audit findings YYYY-MM-DD\` with one sub-task per High/Critical finding.
5. If the report contains a Critical typosquat or license-violation finding, surface it to the user IMMEDIATELY — those classes warrant a same-day fix, not a backlog ticket.
6. If your project needs to allow non-permissive licenses (e.g., an internal GPL-licensed mirror you intentionally depend on), drop a \`.specflow/license-allowlist.txt\` with the additional SPDX identifiers — the agent will merge it with the default permissive allowlist on the next run.
7. For live CVE / advisory data, run your ecosystem's native tool separately (\`npm audit\` / \`cargo audit\` / \`pip-audit\` / \`bundle audit\` / \`osv-scanner\`) — the audit-dependencies phase intentionally excludes these to keep the read-only contract reproducible across runs.
```

## Manifest auto-detection

| Manifest | Lockfile | Ecosystem |
|---|---|---|
| `package.json` | `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` | npm / Node |
| `pyproject.toml` | `poetry.lock` / `uv.lock` / `requirements*.txt` | Python |
| `Cargo.toml` | `Cargo.lock` | Rust |
| `composer.json` | `composer.lock` | PHP |
| `Gemfile` | `Gemfile.lock` | Ruby |
| `go.mod` | `go.sum` | Go |
| `deno.json` / `deno.jsonc` | `deno.lock` | Deno |

Absent manifests are skipped silently. Zero recognised manifests = abort with a single-line \"skipped — no dependency manifest detected\" (escape hatch mirroring the FE-gate from #305).

## Checklist axes (Mode 2 — full audit)

| # | Axis | Default severity |
|---|---|---|
| 1 | Version pin discipline (`*`, `latest`, bare `>=`, untagged URL imports) | HIGH direct / MEDIUM dev |
| 2 | Lockfile presence + freshness | HIGH missing / MEDIUM stale |
| 3 | Unused declared deps (excluding build-tool conventions) | MEDIUM |
| 4 | License violations (vs SPDX allowlist + optional project override) | CRITICAL copyleft / HIGH unknown / MEDIUM missing-metadata |
| 5 | Outdated by major (git-age heuristic, no live registry) | LOW |
| 6 | Typosquat / suspicious-name heuristics | CRITICAL |
| 7 | Peer-dep conflicts | MEDIUM |
| 8 | Duplicate deps at different versions in same dep tree | LOW |

## What's explicitly out of scope

Live advisory / CVE cross-reference is **NOT** invoked — `npm audit`, `cargo audit`, `pip-audit`, `pnpm audit`, `yarn audit`, `bundle audit`, `osv-scanner`, `snyk` are all explicitly banned from the agent's Bash allow-list. The boundary mirrors the \"no third-party scanners\" rule from Epic #302; the audit recommends running the ecosystem's native tool separately, and surfaces this in the report's `Out of scope` section. Rationale: live CVE DBs drift between runs, breaking reproducibility — and they add cost/latency Specflow shouldn't own.

## Test deltas

- `plugin_coverage`: 35 → 37
- `init_test` agentMdCount: 14 → 15
- `init_codex_test` codexAgentsCount: 14 → 15
- `init_gemini_test` agentsCount: 14 → 15
- `init_copilot_test` instructionsCount: 43 → 45 (+1 phase +1 agent)
- `init_windsurf_test` workflowsCount: 43 → 45 (+1 phase +1 agent)
- `plugin_sync_test` SYNC_PAIRS: +1 phase pair + 1 agent pair
- `smoke-features.sh`: +10 assertions
- `docs/llms.md`: phase + agent counts bumped (18→19 / 14→15)

All 678 unit/integration tests pass locally. Pre-commit hook ran fmt/lint/bundle/check (green). docs/llms.md proactively bumped to avoid the docs-drift re-run from #323.

## Compound-form routing

The `audit <axis>` two-token form in the specflow router SKILL.md now accepts `dependencies` alongside `security`/`performance`/`accessibility`/`architecture`. Both `audit dependencies` and `audit-dependencies` resolve to the same phase doc.

## Epic #320 status

After this PR merges, the phase-2 audit family is complete: 5 axes wired (`security`, `performance`, `accessibility`, `architecture`, `dependencies`). Suggested follow-up: bump v1.10.0 + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)