### PR TITLE
chore(sync): retarget Codex marketplace from openai/openai-codex-plugins (404) to openai/plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,12 +245,12 @@ jobs:
             scripts/bump-tap-formula.ts
       - name: Sync to Codex marketplace fork (#277 / B1)
         # Mirrors the Specflow plugin content into
-        # `mkrlabs/openai-codex-plugins:plugins/specflow/`. A human
-        # rebases that fork's PR into upstream `openai/openai-codex-plugins`
-        # for the actual marketplace publish. If CODEX_SYNC_TOKEN is
-        # unset, the script emits a workflow ::warning and exits 0 —
-        # the release itself ships unaffected (same pattern as
-        # HOMEBREW_TAP_TOKEN and WIKI_SSH_KEY).
+        # `mkrlabs/plugins:plugins/specflow/`. A human rebases that
+        # fork's PR into upstream `openai/plugins` for the actual
+        # marketplace publish. If CODEX_SYNC_TOKEN is unset, the
+        # script emits a workflow ::warning and exits 0 — the release
+        # itself ships unaffected (same pattern as HOMEBREW_TAP_TOKEN
+        # and WIKI_SSH_KEY).
         env:
           GH_TOKEN: ${{ secrets.CODEX_SYNC_TOKEN }}
           SPECFLOW_VERSION: ${{ github.ref_name }}

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -105,9 +105,9 @@ that need a one-time human setup before the marketplace listings are live:
 
 - **Codex CLI** — `.codex-plugin/plugin.json` ships in this repo; the
   `scripts/sync-to-codex-plugin.sh` script (fires on every release tag) mirrors the Specflow plugin
-  content into a fork of `openai/openai-codex-plugins`. Until that fork + the `CODEX_SYNC_TOKEN` PAT
-  are provisioned (see issues #298–#300), the sync emits a workflow warning and skips — same
-  fail-safe pattern as the Homebrew tap bump.
+  content into `mkrlabs/plugins` (a fork of `openai/plugins`). Until that fork is rebased into
+  upstream and the `CODEX_SYNC_TOKEN` PAT is provisioned (see issues #298–#300), the sync emits a
+  workflow warning and skips — same fail-safe pattern as the Homebrew tap bump.
 - **Copilot CLI + shared marketplace** — `.claude-plugin/marketplace.json` lives in
   `mkrlabs/specflow-marketplace` (a separate repo). `scripts/sync-to-marketplace.sh` bumps the
   version on every release. Until the marketplace repo + `MARKETPLACE_SYNC_TOKEN` are provisioned

--- a/scripts/lib/sync-helpers.sh
+++ b/scripts/lib/sync-helpers.sh
@@ -87,7 +87,7 @@ git_bot_identity() {
 # (an earlier run already pushed the same content; nothing to do).
 #
 # Arguments:
-#   $1 — repo (e.g. mkrlabs/openai-codex-plugins)
+#   $1 — repo (e.g. mkrlabs/plugins)
 #   $2 — branch (e.g. specflow-sync/v1.8.0)
 #   $3 — PR title
 #   $4 — PR body (multi-line OK)

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-# Sync Specflow → mkrlabs/openai-codex-plugins fork.
+# Sync Specflow → mkrlabs/plugins fork (of openai/plugins).
 #
 # Triggered from .github/workflows/release.yml on every `v*` tag push,
 # after the binary build + Homebrew tap bump. Mirrors the upstream
 # pattern from obra/superpowers (scripts/sync-to-codex-plugin.sh,
 # MIT-licensed) — deterministic rsync into a fork, then `gh pr create`
 # against that fork's main. A human (Kevin) later merges that fork
-# into the upstream openai-codex-plugins marketplace.
+# into the upstream openai/plugins marketplace.
 #
 # Required environment:
 #   GH_TOKEN     — fine-grained PAT with Contents:write + Pull
-#                  requests:write on mkrlabs/openai-codex-plugins.
+#                  requests:write on mkrlabs/plugins.
 #                  Set via the CODEX_SYNC_TOKEN repo secret in
 #                  release.yml (parallel to HOMEBREW_TAP_TOKEN).
 #
@@ -35,8 +35,8 @@ set -euo pipefail
 . "$(dirname "$0")/lib/sync-helpers.sh"
 
 # Configuration — change FORK / DEST_REL if the marketplace topology shifts.
-FORK="mkrlabs/openai-codex-plugins"
-UPSTREAM="openai/openai-codex-plugins"
+FORK="mkrlabs/plugins"
+UPSTREAM="openai/plugins"
 DEST_REL="plugins/specflow"
 BRANCH_PREFIX="specflow-sync"
 


### PR DESCRIPTION
## Why

The repo `openai/openai-codex-plugins` referenced in `scripts/sync-to-codex-plugin.sh` does not exist (HTTP 404). The actual OpenAI Codex CLI plugin marketplace is **`openai/plugins`** (active, last pushed 2026-05-18, same `plugins/<name>/.codex-plugin/plugin.json` shape we target).

This was discovered while driving Epic #270's remaining prereq #299 — the `gh fork` call against the wrong upstream returned 404, so I went looking for the real marketplace and confirmed `openai/plugins` is canonical.

## What changed

- `scripts/sync-to-codex-plugin.sh` — `FORK="mkrlabs/plugins"` and `UPSTREAM="openai/plugins"`; header docs (lines 2, 9, 13) updated to match. The inline PR-body template uses `$UPSTREAM` so it renders correctly without an additional edit.
- `scripts/lib/sync-helpers.sh` — single doc-comment example (`create_pr_idempotent $1`) updated for consistency.
- `.github/workflows/release.yml` — the Codex-sync step's narrative comments updated. No `with:` / `env:` / `secrets:` key changes — `CODEX_SYNC_TOKEN` stays.
- `docs/llms.md` — single narrative mention of the marketplace target updated.

## What did NOT change

- `CODEX_SYNC_TOKEN` secret name stays as-is — no functional coupling to the fork name; renaming would force a coordinated PAT rotation for zero benefit.
- PAT scope guidance stays at `Contents: Read and write` + `Pull requests: Read and write`, just scoped to `mkrlabs/plugins` now.
- `DEST_REL="plugins/specflow"` stays — verified that `openai/plugins` uses the same `plugins/<name>/` layout (124 plugins under that path; `plugins/figma/.codex-plugin/plugin.json` confirmed as a canonical example).

## Fork already created

`mkrlabs/plugins` exists as a fork of `openai/plugins` — created via `gh api -X POST /repos/openai/plugins/forks -f organization=mkrlabs` ahead of this PR.

## DevOps-SRE advisory

Dispatched the `devops-sre` agent before patching. Verdict: **PASS** — plan complete, no missed occurrences across `.github/workflows/*.yml`, `scripts/`, `docs/`, `.codex-plugin/plugin.json`, `assets/*.svg`. The full grep audit + scope verification is in the agent's report.

## Follow-up

Closes #299 once merged. Issue #300 (`CODEX_SYNC_TOKEN` provisioning) needs its body retargeted from `mkrlabs/openai-codex-plugins` → `mkrlabs/plugins` — the PO will land that comment after this PR merges. The Codex sync chain becomes fully operational once Kevin generates the PAT.

## Agent adoption

If your project also drives a Codex CLI plugin sync pattern, update your `UPSTREAM` constant to `openai/plugins` — `openai/openai-codex-plugins` does not exist. The `plugins/<name>/.codex-plugin/plugin.json` shape is canonical and unchanged.

```prompt
If your repository ships a Codex CLI plugin via a sync script that targets `openai/openai-codex-plugins`, retarget it to `openai/plugins` — the former does not exist on GitHub (404). The destination subdir convention `plugins/<your-plugin-name>/.codex-plugin/plugin.json` is unchanged. Rename your fork accordingly (e.g. `<your-org>/plugins`) and update both `UPSTREAM` and `FORK` constants in your sync script in lockstep. Secret names like `CODEX_SYNC_TOKEN` have no functional coupling to the fork name and should NOT be rotated as part of this change.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)