### PR TITLE
fix(backlog): don't auto-promote parent Epic on child→Ready

### DIFF
--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-github.sh
@@ -167,6 +167,8 @@ check "propagator promotes only Backlog/Ready parents" \
   'grep -qE "\"Backlog\"\|\"Ready\"" .specflow/scripts/backlog/propagate-parent-status.sh'
 check "propagator carries the SPECFLOW_INTERNAL_PROPAGATION recursion guard" \
   'grep -q "SPECFLOW_INTERNAL_PROPAGATION" .specflow/scripts/backlog/propagate-parent-status.sh'
+check "propagator triggers on In-progress/In-review only, not Ready (AC a fidelity)" \
+  'grep -qE "\"In progress\"\|\"In review\"\)" .specflow/scripts/backlog/propagate-parent-status.sh'
 
 echo
 echo "═══ #263  Auto-Done propagation in github propagator (static-grep) ═══"

--- a/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
+++ b/.claude/skills/test-sandbox/scripts/smoke-backlog-local.sh
@@ -146,7 +146,16 @@ bash .specflow/scripts/backlog/add.sh "Second sibling of 1" "" --parent 1 >/dev/
 bash .specflow/scripts/backlog/move.sh 1 Backlog >/dev/null
 bash .specflow/scripts/backlog/move.sh 3 Backlog >/dev/null
 
-# Move child OUT of Backlog → parent should auto-promote to In progress.
+# Move child to Ready → parent must stay in Backlog (#260 AC a tightened: Ready
+# means "groomed, waiting", not "active work" — only In progress / In review
+# / Done promote the parent).
+bash .specflow/scripts/backlog/move.sh 3 "Ready" >/dev/null
+parent_status=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' .specflow/backlog/001-first-item.md)
+[ "$parent_status" = "Backlog" ] \
+  && pass "parent stays Backlog when child moves to Ready (AC a fidelity)" \
+  || fail "parent unexpectedly promoted on child→Ready" "expected 'Backlog', got '$parent_status'"
+
+# Move child to In progress → parent should auto-promote.
 bash .specflow/scripts/backlog/move.sh 3 "In progress" >/dev/null
 parent_status=$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); print; exit}' .specflow/backlog/001-first-item.md)
 [ "$parent_status" = "In progress" ] \

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -621,6 +621,12 @@ callers don't issue a redundant `close` and 422, exits 3 when the parent doesn't
 all children are closed. The PO runs it before `gh issue close` / `glab issue close`. The local
 backend uses an inline `grep` equivalent.
 
+A companion `propagate-parent-status.sh` keeps the parent's board column honest as children move: a
+child entering **In progress** or **In review** promotes a stalled parent (Backlog or Ready → In
+progress), and once every child reaches **Done** the parent rolls up to Done. A child moving to
+**Ready** is deliberately a no-op — Ready means groomed-and-waiting, not active work, so it must not
+promote the parent.
+
 The Product Owner agent **proactively** proposes epic decomposition during `/backlog add` and during
 grooming whenever a request crosses ≥2 subsystems, has more than 5 acceptance-criteria bullets, or
 carries trigger phrases like "break down", "phased", "rewrite", "end-to-end". Obvious splits get

--- a/templates/core/skills/backlog/scripts/github/propagate-parent-status.sh
+++ b/templates/core/skills/backlog/scripts/github/propagate-parent-status.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Post-move hook with two propagation rules:
 #
-#   - #260: when a sub-issue moves OUT of Backlog, auto-advance its
-#     parent Epic to In Progress (only if the Epic is currently in
-#     Backlog or Ready). Manual In Review / Done states are preserved.
+#   - #260: when a sub-issue moves to In Progress or In Review,
+#     auto-advance its parent Epic to In Progress (only if the Epic is
+#     currently in Backlog or Ready). Manual In Review / Done states
+#     are preserved. A child moving to **Ready** does NOT trigger
+#     promotion — Ready means "groomed and waiting", not "active work";
+#     the parent stays put until a child actually starts. This matches
+#     #260 AC(a) which enumerates only "In Progress, In Review, or
+#     Done" as the promoting transitions — the prior `*)` glob
+#     accidentally also matched Ready.
 #
 #   - #263: when the LAST open direct child of an Epic reaches Done,
 #     auto-advance the parent Epic to Done (only if it is currently
@@ -184,9 +190,12 @@ case "$NEW_STATUS" in
       esac
     fi
     ;;
-  *)
-    # Existing #260 behaviour: child moved out of Backlog into Ready /
-    # In progress / In review — promote a stalled parent.
+  "In progress"|"In review")
+    # #260 AC(a) (tightened): child moved into In progress or In review
+    # — promote a stalled parent. Done is handled by its own arm above
+    # (all-children-Done rollup). Moves to Ready are explicitly NOT
+    # promoting — see header. Moves into Backlog were already filtered
+    # at the top of this script.
     case "$PARENT_STATUS" in
       "Backlog"|"Ready")
         if [ -x "$SCRIPT_DIR/move.sh" ]; then
@@ -207,6 +216,11 @@ case "$NEW_STATUS" in
         # Idempotency + regression guard branch.
         ;;
     esac
+    ;;
+  *)
+    # Ready (or any unknown / future status) — explicit no-op. Ready
+    # means the child is groomed and waiting for a developer to pick
+    # it up; that's not active work and should not promote the parent.
     ;;
 esac
 

--- a/templates/core/skills/backlog/scripts/local/propagate-parent-status.sh
+++ b/templates/core/skills/backlog/scripts/local/propagate-parent-status.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Post-move hook with two propagation rules:
 #
-#   - #260: when a sub-task moves OUT of Backlog, auto-advance its
-#     parent Epic to In Progress (only if the Epic is currently in
-#     Backlog or Ready). Manual In Review / Done states are preserved.
+#   - #260: when a sub-task moves to In Progress or In Review,
+#     auto-advance its parent Epic to In Progress (only if the Epic is
+#     currently in Backlog or Ready). Manual In Review / Done states
+#     are preserved. A child moving to **Ready** does NOT trigger
+#     promotion — Ready means "groomed and waiting", not "active work";
+#     the parent stays put until a child actually starts. This matches
+#     #260 AC(a) which enumerates only "In Progress, In Review, or
+#     Done" as the promoting transitions — the prior `*)` glob
+#     accidentally also matched Ready.
 #
 #   - #263: when the LAST open direct child of an Epic reaches Done,
 #     auto-advance the parent Epic to Done (only if it is currently
@@ -132,9 +138,12 @@ case "$NEW_STATUS" in
       esac
     fi
     ;;
-  *)
-    # Existing #260 behaviour: child moved out of Backlog into Ready /
-    # In progress / In review — promote a stalled parent.
+  "In progress"|"In review")
+    # #260 AC(a) (tightened): child moved into In progress or In review
+    # — promote a stalled parent. Done is handled by its own arm above
+    # (all-children-Done rollup). Moves to Ready are explicitly NOT
+    # promoting — see header. Moves into Backlog were already filtered
+    # at the top of this script.
     case "$PARENT_STATUS" in
       "Backlog"|"Ready")
         if [ -x "$SCRIPT_DIR/move.sh" ]; then
@@ -156,6 +165,11 @@ case "$NEW_STATUS" in
         # Idempotency + regression guard branch.
         ;;
     esac
+    ;;
+  *)
+    # Ready (or any unknown / future status) — explicit no-op. Ready
+    # means the child is groomed and waiting for a developer to pick
+    # it up; that's not active work and should not promote the parent.
     ;;
 esac
 


### PR DESCRIPTION
## Summary

The propagate-parent-status.sh `*)` glob currently matches any non-Backlog, non-Done child status — including **Ready** — and auto-promotes the parent Epic to In Progress. That accidentally fires the moment a Backlog child gets groomed.

Issue #260 AC(a) explicitly enumerates the promoting transitions as **"In Progress, In Review, or Done"** — Ready is conspicuously absent. The design intent is "promote when active work starts", and Ready means "groomed and waiting", not "active work". The current `*)` is a fidelity-vs-intent bug.

## What changes

Both backend variants (`github/propagate-parent-status.sh`, `local/propagate-parent-status.sh`):

```diff
-  *)
-    # Existing #260 behaviour: child moved out of Backlog into Ready /
-    # In progress / In review — promote a stalled parent.
+  "In progress"|"In review")
+    # #260 AC(a) (tightened): child moved into In progress or In review
+    # — promote a stalled parent. ...
     case "$PARENT_STATUS" in
       "Backlog"|"Ready")
         ...promote...
       ...
     esac
     ;;
+  *)
+    # Ready (or any unknown / future status) — explicit no-op. Ready
+    # means the child is groomed and waiting for a developer to pick
+    # it up; that's not active work and should not promote the parent.
+    ;;
 esac
```

Done continues to be handled by its own arm above (the all-children-Done rollup from #263). Moves into Backlog were already filtered at the top of the script.

## Test coverage

- `smoke-backlog-local.sh`: **new behavioural test** — move a child to Ready and assert the parent stays in Backlog. (Was missing — only In progress was previously exercised.)
- `smoke-backlog-github.sh`: **new structural grep** — assert the case pattern is `"In progress"|"In review")`, not `*)`.
- The existing tests at lines 167 (`"Backlog"|"Ready"` parent guard), 185 (`"Ready"|"In progress"|"In review"` parent guard for the Done arm), and the structural Done branch test continue to pass — none of those patterns moved.

## Concrete drift this fixes

Real-world reproduction from a project I'm grooming: I ran a single groom pass that promoted ~50 sub-issues from Backlog → Ready in one batch. **All 9 epics ended up in "In Progress"** even though zero actual work had started on any of them — they were just children that had been groomed. The board no longer signals what's actually in flight vs what's just been planned.

After this fix the same pass leaves the epics in Ready/Backlog where they belong, and they only flip to In Progress when a child is genuinely picked up.

## Why fix instead of just remove?

Promotion-on-In-progress is still genuinely useful (it's what #260 was designed to solve). The fix is to honour AC(a) literally rather than the broader glob the implementation accidentally landed.

## Backwards compatibility

- Behavioural delta only fires on child→Ready (previously: promote, now: no-op). Child→In progress, child→In review, child→Done all behave identically to before.
- Projects that depended on "any child move promotes the parent" (i.e. relied on Ready triggering) are extremely unlikely — Ready is supposed to be a planning state, not a workflow trigger.