### PR TITLE
chore(bundle): regenerate templates_bundle.ts to include #328

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -8880,9 +8880,15 @@ HEADER
     content: `#!/usr/bin/env bash
 # Post-move hook with two propagation rules:
 #
-#   - #260: when a sub-task moves OUT of Backlog, auto-advance its
-#     parent Epic to In Progress (only if the Epic is currently in
-#     Backlog or Ready). Manual In Review / Done states are preserved.
+#   - #260: when a sub-task moves to In Progress or In Review,
+#     auto-advance its parent Epic to In Progress (only if the Epic is
+#     currently in Backlog or Ready). Manual In Review / Done states
+#     are preserved. A child moving to **Ready** does NOT trigger
+#     promotion — Ready means "groomed and waiting", not "active work";
+#     the parent stays put until a child actually starts. This matches
+#     #260 AC(a) which enumerates only "In Progress, In Review, or
+#     Done" as the promoting transitions — the prior \`*)\` glob
+#     accidentally also matched Ready.
 #
 #   - #263: when the LAST open direct child of an Epic reaches Done,
 #     auto-advance the parent Epic to Done (only if it is currently
@@ -9011,9 +9017,12 @@ case "\$NEW_STATUS" in
       esac
     fi
     ;;
-  *)
-    # Existing #260 behaviour: child moved out of Backlog into Ready /
-    # In progress / In review — promote a stalled parent.
+  "In progress"|"In review")
+    # #260 AC(a) (tightened): child moved into In progress or In review
+    # — promote a stalled parent. Done is handled by its own arm above
+    # (all-children-Done rollup). Moves to Ready are explicitly NOT
+    # promoting — see header. Moves into Backlog were already filtered
+    # at the top of this script.
     case "\$PARENT_STATUS" in
       "Backlog"|"Ready")
         if [ -x "\$SCRIPT_DIR/move.sh" ]; then
@@ -9035,6 +9044,11 @@ case "\$NEW_STATUS" in
         # Idempotency + regression guard branch.
         ;;
     esac
+    ;;
+  *)
+    # Ready (or any unknown / future status) — explicit no-op. Ready
+    # means the child is groomed and waiting for a developer to pick
+    # it up; that's not active work and should not promote the parent.
     ;;
 esac
 
@@ -9720,9 +9734,15 @@ exit 0
     content: `#!/usr/bin/env bash
 # Post-move hook with two propagation rules:
 #
-#   - #260: when a sub-issue moves OUT of Backlog, auto-advance its
-#     parent Epic to In Progress (only if the Epic is currently in
-#     Backlog or Ready). Manual In Review / Done states are preserved.
+#   - #260: when a sub-issue moves to In Progress or In Review,
+#     auto-advance its parent Epic to In Progress (only if the Epic is
+#     currently in Backlog or Ready). Manual In Review / Done states
+#     are preserved. A child moving to **Ready** does NOT trigger
+#     promotion — Ready means "groomed and waiting", not "active work";
+#     the parent stays put until a child actually starts. This matches
+#     #260 AC(a) which enumerates only "In Progress, In Review, or
+#     Done" as the promoting transitions — the prior \`*)\` glob
+#     accidentally also matched Ready.
 #
 #   - #263: when the LAST open direct child of an Epic reaches Done,
 #     auto-advance the parent Epic to Done (only if it is currently
@@ -9903,9 +9923,12 @@ case "\$NEW_STATUS" in
       esac
     fi
     ;;
-  *)
-    # Existing #260 behaviour: child moved out of Backlog into Ready /
-    # In progress / In review — promote a stalled parent.
+  "In progress"|"In review")
+    # #260 AC(a) (tightened): child moved into In progress or In review
+    # — promote a stalled parent. Done is handled by its own arm above
+    # (all-children-Done rollup). Moves to Ready are explicitly NOT
+    # promoting — see header. Moves into Backlog were already filtered
+    # at the top of this script.
     case "\$PARENT_STATUS" in
       "Backlog"|"Ready")
         if [ -x "\$SCRIPT_DIR/move.sh" ]; then
@@ -9926,6 +9949,11 @@ case "\$NEW_STATUS" in
         # Idempotency + regression guard branch.
         ;;
     esac
+    ;;
+  *)
+    # Ready (or any unknown / future status) — explicit no-op. Ready
+    # means the child is groomed and waiting for a developer to pick
+    # it up; that's not active work and should not promote the parent.
     ;;
 esac
 


### PR DESCRIPTION
## Why

PR #328 changed `templates/core/skills/backlog/scripts/{github,local}/propagate-parent-status.sh` but merged without regenerating `src/templates_bundle.ts`. The source of truth (`templates/`) and the bundled copy had drifted — the committed bundle still carried the pre-#328 propagate-parent-status script with the buggy `*)` glob.

## Impact

Limited but real:
- ✅ Release binaries unaffected — `release.yml` runs `deno task bundle` before cross-compiling, so shipped artifacts always bundle fresh.
- ⚠️ `deno run src/main.ts` from a fresh checkout (without a prior `deno task bundle`) would embed the stale script.
- ⚠️ A committed generated artifact should always match its source, full stop.

## What changed

Pure `deno task bundle` output regenerated against current `templates/` — no hand edits. Diff is 40 insertions / 12 deletions, all inside the two `propagate-parent-status.sh` bundle entries.

## Root cause / follow-up

CI runs `deno task bundle` (overwriting the file in the workspace) and *then* tests — so CI never detects that the **committed** bundle was stale; it silently regenerates and tests the fresh copy. The pre-commit hook regenerates locally, but a PR author can still commit before the hook fires, `git add` selectively, or `--no-verify`.

A proper guard — `deno task bundle && git diff --exit-code src/templates_bundle.ts` as a CI step — would catch this class of drift. Filing that as a separate backlog item via the PO (it's a CI-pipeline change, out of scope for this mechanical fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)