### PR TITLE
ci: guard against src/templates_bundle.ts drifting from templates/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,21 @@ jobs:
         run: deno task lint
       - name: Bundle templates
         run: deno task bundle
+      - name: Verify bundle is in sync with templates/
+        # deno task bundle (above) regenerates src/templates_bundle.ts.
+        # If the committed copy was stale, the regeneration leaves a
+        # diff — fail the build so the drift can't land on main. CI
+        # otherwise silently masks this: it always re-bundles before
+        # testing, so a stale committed bundle never trips a test.
+        run: |
+          if ! git diff --quiet -- src/templates_bundle.ts; then
+            echo "::error::src/templates_bundle.ts is stale — it does not match templates/."
+            echo "Run 'deno task bundle' locally and commit the regenerated src/templates_bundle.ts."
+            echo "If this keeps happening, install the pre-commit hook: deno task setup"
+            git diff --stat -- src/templates_bundle.ts
+            exit 1
+          fi
+          echo "Bundle is in sync with templates/."
       - name: Type check
         run: deno task check
       - name: Test


### PR DESCRIPTION
## Why

PR #328 merged with a stale `src/templates_bundle.ts` — the committed generated bundle didn't match its `templates/` source. CI never caught it: every CI job runs `deno task bundle` (which **overwrites** the file) before testing, so a stale *committed* bundle is silently masked and never trips a test. PR #329 fixed that specific drift; this PR closes the structural gap so it can't recur.

## What changed

One new step in the `lint-test` job, right after `Bundle templates`:

```yaml
- name: Verify bundle is in sync with templates/
  run: |
    if ! git diff --quiet -- src/templates_bundle.ts; then
      echo "::error::src/templates_bundle.ts is stale — it does not match templates/."
      ...
      exit 1
    fi
```

`deno task bundle` regenerates the file; if the committed copy was stale, the regeneration leaves a working-tree diff and the step fails with a clear remediation message (`deno task bundle` + commit, and `deno task setup` to install the pre-commit hook).

## Placement rationale

- **After** `Bundle templates` — the regenerated file must exist to diff against.
- **Before** `Type check` / `Test` — those steps legitimately consume the regenerated bundle; a read-only `git diff` doesn't disturb them.
- **Only in `lint-test`** — `cross-smoke` has `needs: lint-test`, so the guard already gates the whole workflow. Duplicating it across the 3-OS matrix would just add noise.
- Runs on **both** `push: main` and `pull_request` triggers — a direct-to-main push with a stale bundle also fails.

## DevOps-SRE advisory

Dispatched `devops-sre` before touching `ci.yml`. Verdict: **PASS** across all six review dimensions (git primitive correctness, inline-step vs job, annotation level, trigger coverage, no `release.yml` interaction, `needs:`-gating sufficiency). The one actionable note — add a pre-commit-hook hint to the error message — is incorporated (`deno task setup`).

## Closes

Closes #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)