### PR TITLE
fix(sync): wire GH_TOKEN into git push for marketplace sync scripts

### DIFF
--- a/scripts/lib/sync-helpers.sh
+++ b/scripts/lib/sync-helpers.sh
@@ -80,6 +80,28 @@ git_bot_identity() {
   git config user.name "Specflow Sync Bot"
 }
 
+# wire_gh_token_to_remote
+#
+# Rewrite the `origin` remote URL to embed GH_TOKEN as a URL credential
+# so a bare `git push` works on a headless CI runner. `gh repo clone`
+# authenticates the clone itself but writes a plain
+# `https://github.com/...` remote, so the subsequent `git push` has no
+# credentials and fails with exit 128 ("could not read Username for
+# 'https://github.com'"). Call from inside the destination clone, after
+# `git_bot_identity` and before any `git push`. No-op in DRY_RUN and
+# when the remote already carries credentials (re-run, or a non-HTTPS
+# remote) so the helper is safe to call unconditionally.
+wire_gh_token_to_remote() {
+  [ -n "${DRY_RUN:-}" ] && return 0
+  local current_url
+  current_url="$(git remote get-url origin)"
+  if [[ "$current_url" == *"@github.com"* ]]; then
+    return 0
+  fi
+  git remote set-url origin \
+    "${current_url/https:\/\/github.com/https:\/\/x-access-token:${GH_TOKEN}@github.com}"
+}
+
 # create_pr_idempotent <repo> <branch> <title> <body>
 #
 # Open a PR on <repo> from <branch> against main. If a PR with the

--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -67,6 +67,7 @@ fi
 cd "$CLONE_TARGET"
 
 git_bot_identity
+wire_gh_token_to_remote
 
 # rsync EXCLUDES — what NOT to ship into the Codex marketplace.
 # Inspired by superpowers' EXCLUDES array. We ship:

--- a/scripts/sync-to-marketplace.sh
+++ b/scripts/sync-to-marketplace.sh
@@ -84,6 +84,7 @@ fi
 cd "$CLONE_TARGET"
 
 git_bot_identity
+wire_gh_token_to_remote
 
 # Update the specflow entry's version in the catalog. The catalog
 # JSON shape is canonical Claude Code marketplace format


### PR DESCRIPTION
## Summary

The Codex marketplace sync step failed in the v1.11.0 release with exit code 128 (`fatal: could not read Username for 'https://github.com'`), and the marketplace-catalog sync step was skipped as a consequence. Root cause: `gh repo clone` authenticates the clone itself but writes a plain `https://github.com/...` origin remote, so the subsequent bare `git push` has no credentials on a headless CI runner. `GH_TOKEN` is set as an env var but git's credential path was never wired to it.

This was never caught before because v1.11.0 is the **first release where the step ran past the token check** — pre-retarget the fork 404'd (`openai/openai-codex-plugins`), and the `CODEX_SYNC_TOKEN` / `MARKETPLACE_SYNC_TOKEN` secrets only landed the same day.

This PR adds a shared `wire_gh_token_to_remote` helper to `scripts/lib/sync-helpers.sh` that rewrites the origin URL to embed `GH_TOKEN` as an `x-access-token` URL credential, and calls it after `git_bot_identity` in both `sync-to-codex-plugin.sh` and `sync-to-marketplace.sh`. The helper is a no-op in `DRY_RUN` and when the remote already carries credentials, so it is safe to call unconditionally.

Advisory pass by the `devops-sre` agent confirmed both scripts share the bug and the fix belongs in the shared library.

The v1.11.0 sync gap will be backfilled by running both scripts locally with `SPECFLOW_VERSION=1.11.0` once this merges (the v1.11.0 tag points at the pre-fix commit, so re-running the release workflow would re-run the broken script).