### PR TITLE
fix(backlog): add.sh rejects --help and unknown flags instead of creating junk issues

### DIFF
--- a/.claude/skills/backlog/scripts/add.sh
+++ b/.claude/skills/backlog/scripts/add.sh
@@ -6,6 +6,19 @@
 #   add.sh "<title>" "<body>" "<label1,label2,...>"
 set -euo pipefail
 
+# Guard --help / unknown flags before they reach `gh issue create` as a
+# positional title (#333) — otherwise `add.sh --help` creates a junk issue.
+case "${1:-}" in
+  -h|--help)
+    echo 'usage: add.sh "<title>" [<body>] [<labels-csv>]'
+    exit 0
+    ;;
+  --*)
+    echo "add.sh: unknown flag '$1'" >&2
+    exit 2
+    ;;
+esac
+
 TITLE="${1:?usage: add.sh \"<title>\" [<body>] [<labels-csv>]}"
 BODY="${2:-}"
 LABELS="${3:-}"

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -8551,6 +8551,10 @@ PARENT=""
 ARGS=()
 while [ \$# -gt 0 ]; do
   case "\$1" in
+    -h|--help)
+      echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]'
+      exit 0
+      ;;
     --parent)
       if [ \$# -lt 2 ]; then
         echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
@@ -8558,6 +8562,11 @@ while [ \$# -gt 0 ]; do
       fi
       PARENT="\$2"
       shift 2
+      ;;
+    --*)
+      echo "add.sh: unknown flag '\$1'" >&2
+      echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
+      exit 2
       ;;
     *)
       ARGS+=("\$1")
@@ -9177,13 +9186,16 @@ gh issue view "\$1" --repo "\$REPO" --comments
 #   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
-# shellcheck source=./_config.sh
-. "\$(dirname "\$0")/_config.sh"
-
+# Parse arguments before sourcing _config.sh so \`--help\` and unknown-flag
+# handling work regardless of whether the backlog backend is configured.
 PARENT=""
 ARGS=()
 while [ \$# -gt 0 ]; do
   case "\$1" in
+    -h|--help)
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]'
+      exit 0
+      ;;
     --parent)
       if [ \$# -lt 2 ]; then
         echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
@@ -9191,6 +9203,11 @@ while [ \$# -gt 0 ]; do
       fi
       PARENT="\$2"
       shift 2
+      ;;
+    --*)
+      echo "add.sh: unknown flag '\$1'" >&2
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+      exit 2
       ;;
     *)
       ARGS+=("\$1")
@@ -9206,6 +9223,9 @@ fi
 TITLE="\${ARGS[0]}"
 BODY="\${ARGS[1]:-}"
 LABELS="\${ARGS[2]:-}"
+
+# shellcheck source=./_config.sh
+. "\$(dirname "\$0")/_config.sh"
 
 # When --parent is set, fail fast if the parent issue doesn't exist —
 # GitHub's sub_issues POST returns a confusing 404 otherwise.
@@ -10080,13 +10100,16 @@ glab issue view "\$1" --repo "\$PROJECT_ID" --comments
 #   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
-# shellcheck source=./_config.sh
-. "\$(dirname "\$0")/_config.sh"
-
+# Parse arguments before sourcing _config.sh so \`--help\` and unknown-flag
+# handling work regardless of whether the backlog backend is configured.
 PARENT=""
 ARGS=()
 while [ \$# -gt 0 ]; do
   case "\$1" in
+    -h|--help)
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]'
+      exit 0
+      ;;
     --parent)
       if [ \$# -lt 2 ]; then
         echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
@@ -10094,6 +10117,11 @@ while [ \$# -gt 0 ]; do
       fi
       PARENT="\$2"
       shift 2
+      ;;
+    --*)
+      echo "add.sh: unknown flag '\$1'" >&2
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+      exit 2
       ;;
     *)
       ARGS+=("\$1")
@@ -10109,6 +10137,9 @@ fi
 TITLE="\${ARGS[0]}"
 BODY="\${ARGS[1]:-}"
 EXTRA_LABELS="\${ARGS[2]:-}"
+
+# shellcheck source=./_config.sh
+. "\$(dirname "\$0")/_config.sh"
 
 LABELS="Status::Backlog"
 if [ -n "\$EXTRA_LABELS" ]; then

--- a/templates/core/skills/backlog/scripts/github/add.sh
+++ b/templates/core/skills/backlog/scripts/github/add.sh
@@ -7,13 +7,16 @@
 #   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
-# shellcheck source=./_config.sh
-. "$(dirname "$0")/_config.sh"
-
+# Parse arguments before sourcing _config.sh so `--help` and unknown-flag
+# handling work regardless of whether the backlog backend is configured.
 PARENT=""
 ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
+    -h|--help)
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]'
+      exit 0
+      ;;
     --parent)
       if [ $# -lt 2 ]; then
         echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
@@ -21,6 +24,11 @@ while [ $# -gt 0 ]; do
       fi
       PARENT="$2"
       shift 2
+      ;;
+    --*)
+      echo "add.sh: unknown flag '$1'" >&2
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+      exit 2
       ;;
     *)
       ARGS+=("$1")
@@ -36,6 +44,9 @@ fi
 TITLE="${ARGS[0]}"
 BODY="${ARGS[1]:-}"
 LABELS="${ARGS[2]:-}"
+
+# shellcheck source=./_config.sh
+. "$(dirname "$0")/_config.sh"
 
 # When --parent is set, fail fast if the parent issue doesn't exist —
 # GitHub's sub_issues POST returns a confusing 404 otherwise.

--- a/templates/core/skills/backlog/scripts/gitlab/add.sh
+++ b/templates/core/skills/backlog/scripts/gitlab/add.sh
@@ -9,13 +9,16 @@
 #   add.sh "<title>" [body] [labels-csv] [--parent <num>]
 set -euo pipefail
 
-# shellcheck source=./_config.sh
-. "$(dirname "$0")/_config.sh"
-
+# Parse arguments before sourcing _config.sh so `--help` and unknown-flag
+# handling work regardless of whether the backlog backend is configured.
 PARENT=""
 ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
+    -h|--help)
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]'
+      exit 0
+      ;;
     --parent)
       if [ $# -lt 2 ]; then
         echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
@@ -23,6 +26,11 @@ while [ $# -gt 0 ]; do
       fi
       PARENT="$2"
       shift 2
+      ;;
+    --*)
+      echo "add.sh: unknown flag '$1'" >&2
+      echo 'usage: add.sh "<title>" [body] [labels-csv] [--parent <num>]' >&2
+      exit 2
       ;;
     *)
       ARGS+=("$1")
@@ -38,6 +46,9 @@ fi
 TITLE="${ARGS[0]}"
 BODY="${ARGS[1]:-}"
 EXTRA_LABELS="${ARGS[2]:-}"
+
+# shellcheck source=./_config.sh
+. "$(dirname "$0")/_config.sh"
 
 LABELS="Status::Backlog"
 if [ -n "$EXTRA_LABELS" ]; then

--- a/templates/core/skills/backlog/scripts/local/add.sh
+++ b/templates/core/skills/backlog/scripts/local/add.sh
@@ -12,6 +12,10 @@ PARENT=""
 ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
+    -h|--help)
+      echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]'
+      exit 0
+      ;;
     --parent)
       if [ $# -lt 2 ]; then
         echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
@@ -19,6 +23,11 @@ while [ $# -gt 0 ]; do
       fi
       PARENT="$2"
       shift 2
+      ;;
+    --*)
+      echo "add.sh: unknown flag '$1'" >&2
+      echo 'usage: add.sh "<title>" [body] [labels] [--parent <num>]' >&2
+      exit 2
       ;;
     *)
       ARGS+=("$1")

--- a/tests/scripts/backlog_add_flag_test.ts
+++ b/tests/scripts/backlog_add_flag_test.ts
@@ -1,0 +1,77 @@
+// Regression tests for `add.sh` flag handling across the backlog backends.
+//
+// Before #333 the argument loop only special-cased `--parent`; the `*)`
+// catch-all swallowed `--help` and any unknown `--flag` as a positional
+// argument, so `add.sh --help` created a real issue titled `--help`
+// instead of printing usage. These tests pin the corrected contract:
+//
+//   - `--help` / `-h` print usage to stdout and exit 0, creating nothing.
+//   - an unrecognised `--flag` is rejected (exit 2, error on stderr).
+//
+// The github/gitlab scripts source `_config.sh` (which exits 2 on a
+// missing backlog-config.yml), so the scripts are run from an empty temp
+// dir on purpose: flag handling must work *before* — and independently
+// of — the backend config check.
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+const BACKENDS = [
+  { name: "github", rel: "../../templates/core/skills/backlog/scripts/github/add.sh" },
+  { name: "gitlab", rel: "../../templates/core/skills/backlog/scripts/gitlab/add.sh" },
+  { name: "local", rel: "../../templates/core/skills/backlog/scripts/local/add.sh" },
+];
+
+function scriptPath(rel: string): string {
+  return fromFileUrl(new URL(rel, import.meta.url));
+}
+
+async function run(
+  script: string,
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cwd = await Deno.makeTempDir({ prefix: "backlog-add-flag-" });
+  try {
+    const { code, stdout, stderr } = await new Deno.Command("bash", {
+      args: [script, ...args],
+      cwd,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    return {
+      code,
+      stdout: new TextDecoder().decode(stdout),
+      stderr: new TextDecoder().decode(stderr),
+    };
+  } finally {
+    await Deno.remove(cwd, { recursive: true });
+  }
+}
+
+for (const backend of BACKENDS) {
+  const script = scriptPath(backend.rel);
+
+  Deno.test(`add.sh (${backend.name}): --help prints usage and exits 0`, async () => {
+    const { code, stdout } = await run(script, ["--help"]);
+    assertEquals(code, 0, `--help must exit 0, got ${code}`);
+    assert(
+      stdout.includes("usage:"),
+      `--help must print usage to stdout, got: ${JSON.stringify(stdout)}`,
+    );
+  });
+
+  Deno.test(`add.sh (${backend.name}): -h prints usage and exits 0`, async () => {
+    const { code, stdout } = await run(script, ["-h"]);
+    assertEquals(code, 0, `-h must exit 0, got ${code}`);
+    assert(stdout.includes("usage:"), `-h must print usage, got: ${JSON.stringify(stdout)}`);
+  });
+
+  Deno.test(`add.sh (${backend.name}): unknown --flag is rejected with exit 2`, async () => {
+    const { code, stderr } = await run(script, ["--bogus"]);
+    assertEquals(code, 2, `unknown flag must exit 2, got ${code}`);
+    assert(
+      stderr.includes("unknown flag"),
+      `unknown flag must explain itself on stderr, got: ${JSON.stringify(stderr)}`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #333.

`add.sh`'s argument loop only special-cased `--parent`; the `*)` catch-all swallowed `--help` and any unrecognised `--flag` as a positional argument. The result: `add.sh --help` created a real GitHub issue / backlog item **titled `--help`** that then had to be cleaned up. Any mistaken `--flag` did the same.

This PR adds explicit cases across **all three scaffolded backends** (`github`, `gitlab`, `local`) and the repo's own product-owner `add.sh`:

- `-h` / `--help` → print usage to stdout, exit 0, create nothing.
- unknown `--flag` → error to stderr, exit 2.

For the `github` and `gitlab` backends the argument parse now runs **before** sourcing `_config.sh`, so `--help` prints usage regardless of whether the backlog backend is configured (`_config.sh` exits 2 on a missing `backlog-config.yml`).

## Tests

New `tests/scripts/backlog_add_flag_test.ts` — each backend's `add.sh` is run from an empty temp dir and asserted to print usage + exit 0 on `--help`/`-h`, and exit 2 with an error on an unknown flag. 9 new tests; full suite 678 → 687 green.

`docs:not-needed` — pure bug fix, the documented `add.sh "<title>" [body] [labels] [--parent <num>]` usage contract is unchanged.