### PR TITLE
fix(install-hooks): resolve hooks dir via git rev-parse so submodule checkouts work

### DIFF
--- a/scripts/install-hooks.ts
+++ b/scripts/install-hooks.ts
@@ -1,11 +1,10 @@
-// Installs hooks/pre-commit into .git/hooks/pre-commit as a symlink.
-// Run via `deno task setup`. Idempotent.
+// Installs hooks/pre-commit into the repository's hooks directory as a
+// symlink. Run via `deno task setup`. Idempotent.
 
 import { resolve } from "@std/path";
 
 const ROOT = new URL("..", import.meta.url).pathname;
 const SOURCE = resolve(ROOT, "hooks/pre-commit");
-const TARGET = resolve(ROOT, ".git/hooks/pre-commit");
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -17,11 +16,38 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+// Resolve the real hooks directory via `git rev-parse --git-path hooks`.
+// We can't hardcode `<repo>/.git/hooks` because that path is wrong when the
+// repo is checked out as a git submodule — there `.git` is a *gitdir file*
+// (`gitdir: ../../.git/modules/<name>`) pointing at the parent repo's
+// `.git/modules/<name>/`, and the real hooks live there (#335). Letting
+// git answer keeps the script correct in both layouts.
+export async function resolveHooksDir(cwd: string): Promise<string> {
+  const out = await new Deno.Command("git", {
+    args: ["rev-parse", "--git-path", "hooks"],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (!out.success) {
+    throw new Error(
+      `error: not a git repository (\`git rev-parse\` failed in ${cwd}): ${
+        new TextDecoder().decode(out.stderr).trim()
+      }`,
+    );
+  }
+  return resolve(cwd, new TextDecoder().decode(out.stdout).trim());
+}
+
 async function main() {
-  if (!(await exists(`${ROOT}/.git`))) {
-    console.error("error: not a git repository");
+  let hooksDir: string;
+  try {
+    hooksDir = await resolveHooksDir(ROOT);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
     Deno.exit(1);
   }
+  const TARGET = resolve(hooksDir, "pre-commit");
 
   if (await exists(TARGET)) {
     const info = await Deno.lstat(TARGET);

--- a/tests/scripts/install_hooks_test.ts
+++ b/tests/scripts/install_hooks_test.ts
@@ -1,0 +1,58 @@
+// Regression test for #335: `deno task setup` must work when Specflow
+// is checked out as a git submodule (where `.git` is a *gitdir file*
+// pointing at the parent repo's `.git/modules/<name>/`, not a directory).
+//
+// Before #335 the install script hardcoded `<cwd>/.git/hooks/pre-commit`
+// and crashed with `NotADirectory: lstat '...'` because `.git` was a
+// file. The fix routes the hooks-dir lookup through
+// `git rev-parse --git-path hooks`, which returns the correct path in
+// both layouts. This test pins the contract by exercising both.
+
+import { assert, assertEquals } from "@std/assert";
+import { resolveHooksDir } from "../../scripts/install-hooks.ts";
+
+Deno.test("resolveHooksDir: plain checkout (.git is a directory)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "install-hooks-plain-" });
+  try {
+    const init = await new Deno.Command("git", {
+      args: ["init", "-q"],
+      cwd: dir,
+    }).output();
+    assert(init.success, "git init failed");
+
+    const got = await Deno.realPath(await resolveHooksDir(dir));
+    const want = await Deno.realPath(`${dir}/.git/hooks`);
+    assertEquals(got, want);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("resolveHooksDir: submodule checkout (.git is a gitdir file)", async () => {
+  // Reproduce the submodule layout that surfaced #335: the working copy
+  // lives at `host/child/` and its `.git` is a file pointing at the
+  // separate gitdir under `host/.git/modules/child/`. `git init
+  // --separate-git-dir=...` produces exactly this shape.
+  const host = await Deno.makeTempDir({ prefix: "install-hooks-submodule-" });
+  try {
+    const childDir = `${host}/child`;
+    const gitDir = `${host}/.git/modules/child`;
+    await Deno.mkdir(childDir, { recursive: true });
+    await Deno.mkdir(`${host}/.git/modules`, { recursive: true });
+
+    const init = await new Deno.Command("git", {
+      args: ["init", "-q", `--separate-git-dir=${gitDir}`],
+      cwd: childDir,
+    }).output();
+    assert(
+      init.success,
+      `git init --separate-git-dir failed: ${new TextDecoder().decode(init.stderr)}`,
+    );
+
+    const got = await Deno.realPath(await resolveHooksDir(childDir));
+    const want = await Deno.realPath(`${gitDir}/hooks`);
+    assertEquals(got, want);
+  } finally {
+    await Deno.remove(host, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #335.

`scripts/install-hooks.ts` hardcoded `<repo>/.git/hooks/pre-commit` and crashed with `NotADirectory: lstat '...'` whenever Specflow was checked out as a git submodule — there `.git` is a *gitdir file* (`gitdir: ../../.git/modules/<name>`) pointing at the parent repo's `.git/modules/<name>/`, not a directory, so the hardcoded path was wrong.

This PR routes the hooks-dir lookup through `git rev-parse --git-path hooks`, which returns the correct path in both layouts:

- Plain checkout (`.git` is a directory) → `<repo>/.git/hooks`
- Submodule checkout (`.git` is a gitdir file) → `<parent>/.git/modules/<name>/hooks`

The existing redundant `exists('.git')` check is dropped — `git rev-parse` itself errors clearly when the cwd isn't a git repo.

Surfaced while migrating my local Specflow checkout into a private monorepo as a submodule (`mkrlabs/specflow-monorepo`). On that path, `deno task setup` was the first thing to break.

## Tests

New `tests/scripts/install_hooks_test.ts` — two cases, both running real `git` against real temp dirs:

- Plain checkout: `git init` in a temp dir, assert `resolveHooksDir` returns `<tmp>/.git/hooks`.
- Submodule checkout: `git init --separate-git-dir=<tmp>/.git/modules/child` (which produces exactly the gitdir-file layout that caused #335), assert `resolveHooksDir` returns the parent's `modules/child/hooks`.

Full suite: 687 → 689 green.

Manual verification: removed the manual symlink I'd installed in the monorepo submodule earlier, re-ran `deno task setup` from the fixed branch → installed cleanly to the correct path.