### PR TITLE
docs(AGENTS): drop stale version/test/binary pins from Repository state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,20 +160,12 @@ the artefacts. The agent-file template is repopulated on every feature to give c
 - No "mega-spec": ship via an **incremental roadmap**, each brick has its own spec → plan →
   implementation cycle.
 
-## Repository state (v0.1.0-alpha.1 shipped)
+## Repository state
 
-First public alpha released as `v0.1.0-alpha.1` with the full CLI surface:
-
-- `specflow init [<name>] [--here] [--no-git] [--force]` — scaffold a Claude Code project
-- `specflow check [--project]` — env + project diagnostic
-- `specflow upgrade [--dry-run] [--force]` — update templates in an existing project
-- `specflow self-update [--check]` — update the binary itself
-- `specflow backlog configure` + `specflow backlog sync [--id NNN] [--dry-run] [--allow-secrets]`
-- `specflow --version` / `--help`
-
-Five binaries published on GitHub Releases (macOS arm64/x64, Linux arm64/x64, Windows x64) +
-`.sha256` checksums. 196 tests green. Install via `curl -fsSL … | bash`, Homebrew tap, or manual
-download.
+Shipping public releases via the Homebrew tap, the `install.sh` one-liner, and GitHub Releases. For
+the current CLI surface, run `specflow --help` or read `src/cli/help.ts`; for the current version
+and what changed, see `gh release list -R mkrlabs/specflow` or `CHANGELOG.md`. The cross-platform
+build matrix lives in `.github/workflows/release.yml`; each binary ships with a `.sha256` checksum.
 
 ## Conventions for AI agents working on this repo
 


### PR DESCRIPTION
## What

Cleans up the `Repository state` section in `AGENTS.md`, which had pinned three numbers that drifted silently across releases:

- `v0.1.0-alpha.1` shipped — current is **v1.11.1** (~10 majors stale)
- `196 tests green` — outdated as soon as the suite grew
- `Five binaries published` — would break if the matrix ever changed

Plus the enumerated CLI surface (`init`, `check`, `upgrade`, `self-update`, `backlog`, …) — same anti-pattern; `specflow --help` is the source of truth.

## How

Replaced ~14 lines with ~5 lines pointing to live sources:

| Was pinned | Now points to |
|---|---|
| Version | `gh release list -R mkrlabs/specflow`, `CHANGELOG.md` |
| CLI surface | `specflow --help`, `src/cli/help.ts` |
| Build matrix | `.github/workflows/release.yml` |
| Test count | dropped entirely |

No code touched. Pre-commit hook (fmt + lint + bundle + check) passed locally.

## Why now

This is the root cause of the same drift that propagated up into `specflow-monorepo/AGENTS.md` — fixed there in commit `3e67583` on `mkrlabs/specflow-monorepo`, which also codified a no-version-pinning convention in its `CLAUDE.md`. This PR closes the loop on the source.

Refs #338