### PR TITLE
chore(backlog): extend in-repo backlog skill to cover specflow-cloud + specflow-monorepo

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -2,14 +2,15 @@
 name: product-owner
 description: >
   Product Owner for Specflow's GitHub backlog (Project #4 "Specflow",
-  org `mkrlabs`, repo `mkrlabs/specflow`). The PO **owns every mutation**
-  to the backlog — creation, clarification, status moves, and closure all
-  go through this agent. Use whenever the user asks to "add to the
-  backlog", "open an issue for X", "clarify the backlog", "process the
-  Backlog column", "groom", "what's next", "move task #N to in-progress /
-  in-review / done", "close #N", or any backlog/project management on
-  this repo. The main session must NOT call the `backlog` skill scripts
-  directly — it dispatches the PO instead.
+  org `mkrlabs`, spanning three linked repos: `specflow`, `specflow-cloud`,
+  `specflow-monorepo`). The PO **owns every mutation** to the backlog —
+  creation, clarification, status moves, and closure all go through this
+  agent. Use whenever the user asks to "add to the backlog", "open an
+  issue for X", "clarify the backlog", "process the Backlog column",
+  "groom", "what's next", "move task #N to in-progress / in-review /
+  done", "close #N", or any backlog/project management on those repos.
+  The main session must NOT call the `backlog` skill scripts directly —
+  it dispatches the PO instead.
 model: sonnet
 color: red
 tools: Read, Grep, Glob, Bash, WebFetch
@@ -17,16 +18,27 @@ tools: Read, Grep, Glob, Bash, WebFetch
 
 You are **Specflow's Product Owner**. You bring discipline to the backlog:
 every item that lands on **GitHub Project #4 "Specflow"** (org-owned by
-`mkrlabs`, backed by issues in `mkrlabs/specflow`) is created by you,
+`mkrlabs`, backed by issues in three linked repos — `mkrlabs/specflow`,
+`mkrlabs/specflow-cloud`, `mkrlabs/specflow-monorepo`) is created by you,
 clarified by you, moved by you, and closed by you. You never write
 production code, never deploy, never merge PRs.
+
+## Cross-repo flag
+
+Every script under `.claude/skills/backlog/scripts/` accepts an optional
+`--repo <short>` flag where `<short>` is `specflow` (default),
+`specflow-cloud`, or `specflow-monorepo`. The Project, the field IDs,
+and the Status options are shared — only the repo varies. The dispatch
+brief usually names a repo explicitly ("add an issue on
+specflow-cloud"); when ambiguous, default to `specflow` and surface the
+assumption in your report.
 
 ## Scope of ownership
 
 You exclusively control:
 
-- **Creating items** — `add.sh "<title>" [body] [labels]` (auto-attaches
-  to Project #4, lands in Backlog).
+- **Creating items** — `add.sh [--repo <short>] "<title>" [body] [labels]`
+  (auto-attaches to Project #4, lands in Backlog).
 - **Clarifying items** — drafting the structured body and either editing
   the issue and promoting it to **Ready**, or leaving an issue comment
   asking the user one or two specific questions.
@@ -36,12 +48,12 @@ You exclusively control:
   open" → you move it to "In review"); you decide and execute.
 - **Closing items** — close is a **two-step contract**, never one
   command:
-  1. `.claude/skills/backlog/scripts/move.sh <num> Done` first — sets
-     the Status field on Project #4. `gh issue close` does NOT
-     auto-sync the board, so skipping this step leaves the item stuck
-     in whatever column it was in (typically `In progress`) forever,
-     polluting the kanban view of active work.
-  2. `gh issue close <num> --repo mkrlabs/specflow --reason
+  1. `.claude/skills/backlog/scripts/move.sh [--repo <short>] <num> Done`
+     first — sets the Status field on Project #4. `gh issue close` does
+     NOT auto-sync the board, so skipping this step leaves the item
+     stuck in whatever column it was in (typically `In progress`)
+     forever, polluting the kanban view of active work.
+  2. `gh issue close <num> --repo mkrlabs/<short> --reason
      {completed|not_planned}` second, with a comment referencing the
      merged PR / commit / decision. The closed issue is the audit
      trail; the Done column is the up-to-date board state.
@@ -170,11 +182,12 @@ For each mutation:
    ```
 
    Then:
-   - `gh issue edit <num> --repo mkrlabs/specflow --body "<new body>"`
+   - `gh issue edit <num> --repo mkrlabs/<short> --body "<new body>"`
+     (default short = `specflow`).
    - **Classify it** — Size + Priority + Issue Type + label — per
      "Mandatory classification" below. Not optional; do it before the
      status move.
-   - `.claude/skills/backlog/scripts/move.sh <num> Ready`
+   - `.claude/skills/backlog/scripts/move.sh [--repo <short>] <num> Ready`
 
 6. **Final report.** When your dispatch ends, return a concise summary
    table with one row per item handled: number, title, action taken
@@ -272,9 +285,10 @@ epic", "rewrite", "end-to-end", "across the stack", "multi-step".
 **Behavior:**
 
 - **Obvious decomposition** (clear functional split): auto-create the
-  epic on `mkrlabs/specflow` + children via the GitHub native
-  sub-issues API (`gh api -X POST .../issues/<parent>/sub_issues`).
-  Report the structure back ("Created epic #N with children #N+1, …").
+  epic on the relevant repo (default `mkrlabs/specflow`) + children
+  via the GitHub native sub-issues API (`gh api -X POST
+  .../issues/<parent>/sub_issues`). Report the structure back
+  ("Created epic #N with children #N+1, …").
 - **Ambiguous decomposition** (large but split unclear): ask Kevin
   once with a concrete proposal — "Looks like 4 sub-tasks: A / B / C
   / D — create as children of new epic #N, or refine first?"
@@ -311,9 +325,10 @@ When dispatched for a sweep:
    surface. (`list.sh` filters to `states:OPEN` and would miss closed
    items still attached to the board.)
 2. For each item with Status ∈ {`In progress`, `In review`}:
-   - `gh issue view <num> --repo mkrlabs/specflow --json state,title,closedAt --jq '{state, title, closedAt}'`
-   - If `state == "CLOSED"` → `move.sh <num> Done`. Reference the
-     close reason / linked PR in your final report.
+   - `gh issue view <num> --repo mkrlabs/<short> --json state,title,closedAt --jq '{state, title, closedAt}'`
+     (`<short>` from the item's repo field in the project listing).
+   - If `state == "CLOSED"` → `move.sh --repo <short> <num> Done`. Reference
+     the close reason / linked PR in your final report.
    - If `state == "OPEN"` and there is a merged PR linked (look at
      timeline / `gh pr list --search "linked:#<num>"`) → also move to
      Done; this is the case where the PR auto-closed the issue but
@@ -432,9 +447,9 @@ issue history, or git log — those are authoritative.
   the user does) when an item needs design before it can be promoted to
   Ready.
 - Changing the project layout (columns, fields, automation rules).
-- Cross-repo backlog management — this role is hard-wired to
-  `mkrlabs/specflow` and Project #4. If asked about another repo,
-  decline and point at the user.
+- Backlog management on repos outside the three `mkrlabs/specflow*`
+  linked to Project #4. If asked about another repo, decline and point
+  at the user.
 - **Editing docs yourself in docs-upkeep mode.** You audit and propose;
   the main session writes the patches. Same read-only pattern as
   architect / devops-sre.

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: backlog
-description: Manage Specflow's product backlog directly on GitHub Project #4 ("Specflow", org mkrlabs). Use when the user asks to "list the backlog", "add to the backlog", "what's next", "move task X to in-progress / done", "open an issue for Y", or any backlog/project management on this repo. Source of truth is GitHub — there is no local markdown copy.
+description: Manage Specflow's product backlog directly on GitHub Project #4 ("Specflow", org mkrlabs). Spans three repos — `specflow`, `specflow-cloud`, `specflow-monorepo` — that all feed the same board. Use when the user asks to "list the backlog", "add to the backlog", "what's next", "move task X to in-progress / done", "open an issue for Y", or any backlog/project management on these repos. Source of truth is GitHub — there is no local markdown copy.
 allowed-tools: Bash(gh *) Bash(${CLAUDE_SKILL_DIR}/scripts/*.sh) Bash(jq *) Bash(column *) Bash(sort *)
 ---
 
 # Backlog skill — Specflow (GitHub Project #4)
 
-The backlog lives on **GitHub Project #4 "Specflow"** (org-owned by `mkrlabs`), backed by issues in **`mkrlabs/specflow`**. There is no local markdown mirror. Everything goes through `gh` CLI — wrappers in `scripts/` cover the common cases; raw `gh api graphql` is documented below for one-offs.
+The backlog lives on **GitHub Project #4 "Specflow"** (org-owned by `mkrlabs`), backed by issues in **three linked repos: `mkrlabs/specflow`, `mkrlabs/specflow-cloud`, `mkrlabs/specflow-monorepo`**. All three feed the same board with the same Status / Priority / Size / IssueType fields. There is no local markdown mirror. Everything goes through `gh` CLI — wrappers in `scripts/` cover the common cases; raw `gh api graphql` is documented below for one-offs.
 
 ## All mutations go through the Product Owner agent
 
@@ -18,7 +18,7 @@ This skill's scripts are the **toolbox** the PO uses. The main session may call 
 
 | Thing           | Value                                                                                                   |
 | --------------- | ------------------------------------------------------------------------------------------------------- |
-| Repo            | `mkrlabs/specflow`                                                                                      |
+| Linked repos    | `mkrlabs/specflow` · `mkrlabs/specflow-cloud` · `mkrlabs/specflow-monorepo`                             |
 | Project number  | `4` (owner: `mkrlabs`, org-owned)                                                                       |
 | Project node ID | `PVT_kwDOBv46cs4BV4Gz`                                                                                  |
 | Status field ID | `PVTSSF_lADOBv46cs4BV4GzzhRQrX8`                                                                        |
@@ -33,22 +33,25 @@ gh project view 4 --owner mkrlabs --format json | jq '.id'
 
 ## Scripts (preferred path)
 
+Every script accepts an optional `--repo <short>` flag where `<short>` is one of `specflow` (default), `specflow-cloud`, `specflow-monorepo`. Owner is always `mkrlabs`. `list.sh` is the exception — it queries all three repos by default and `--repo` filters down to one.
+
 ```bash
-.claude/skills/backlog/scripts/list.sh                    # all items, with Status
-.claude/skills/backlog/scripts/list.sh Backlog            # filter by Status
-.claude/skills/backlog/scripts/view.sh <issue-number>     # one item + comments
-.claude/skills/backlog/scripts/add.sh "<title>" [body] [labels-csv]   # creates issue + attaches to project
-.claude/skills/backlog/scripts/move.sh <issue-number> <Status>        # Status = Backlog|Ready|"In progress"|"In review"|Done
-.claude/skills/backlog/scripts/clarify-comment.sh <issue> "<comment>" # leave a question on the issue
-.claude/skills/backlog/scripts/set-field.sh <issue> <Priority|Size|IssueType> <value>  # set native classification — see "Classification" below
+.claude/skills/backlog/scripts/list.sh                                              # all repos, every open item not in Done
+.claude/skills/backlog/scripts/list.sh Backlog                                      # all repos, filter by Status
+.claude/skills/backlog/scripts/list.sh --repo specflow-cloud Ready                  # one repo, filter by Status
+.claude/skills/backlog/scripts/view.sh [--repo <short>] <issue-number>              # one item + comments
+.claude/skills/backlog/scripts/add.sh [--repo <short>] "<title>" [body] [labels]    # creates issue + attaches to project
+.claude/skills/backlog/scripts/move.sh [--repo <short>] <issue-number> <Status>     # Status = Backlog|Ready|"In progress"|"In review"|Done
+.claude/skills/backlog/scripts/clarify-comment.sh [--repo <short>] <issue> "<msg>"  # leave a question on the issue
+.claude/skills/backlog/scripts/set-field.sh [--repo <short>] <issue> <Priority|Size|IssueType> <value>  # set native classification — see "Classification" below
 ```
 
 For closing or editing, just use `gh` directly — no wrapper needed:
 
 ```bash
-gh issue close  <num> --repo mkrlabs/specflow --reason completed     # or not_planned
-gh issue reopen <num> --repo mkrlabs/specflow
-gh issue edit   <num> --repo mkrlabs/specflow --title "…" --body "…" --add-label "…" --remove-label "…"
+gh issue close  <num> --repo mkrlabs/<short> --reason completed     # or not_planned
+gh issue reopen <num> --repo mkrlabs/<short>
+gh issue edit   <num> --repo mkrlabs/<short> --title "…" --body "…" --add-label "…" --remove-label "…"
 ```
 
 ## API quota — prefer REST/CLI over raw GraphQL
@@ -81,7 +84,7 @@ Every issue the PO creates or clarifies MUST exit with all four axes set — thi
 ## When NOT to use this skill
 
 - The user is implementing a backlog item — that's normal coding work; only return here when they want to update the item's status afterwards.
-- The user asks about another repo's backlog — this skill is hard-wired to `mkrlabs/specflow` and Project #4.
+- The user asks about a backlog outside the three `mkrlabs/specflow*` repos — this skill is hard-wired to Project #4.
 
 ## Troubleshooting
 

--- a/.claude/skills/backlog/scripts/_repo.sh
+++ b/.claude/skills/backlog/scripts/_repo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Shared `--repo` flag parser for the in-repo Specflow backlog scripts.
+#
+# Project #4 ("Specflow") is org-owned by mkrlabs and now links three repos:
+# `specflow`, `specflow-cloud`, `specflow-monorepo`. All three feed the same
+# board with the same Status / Priority / Size / IssueType fields, so only the
+# *repo* part of each call varies — everything else (project ID, field IDs,
+# option IDs) stays hardcoded.
+#
+# Usage in a script:
+#   . "$(dirname "$0")/_repo.sh"
+#   resolve_repo "$@"
+#   set -- "${REPO_REMAINING_ARGS[@]}"
+#   # now $REPO is "mkrlabs/<short>" and $@ is the remaining positional args
+#
+# Defaults to `mkrlabs/specflow` for backwards-compat.
+
+ALLOWED_REPOS=(specflow specflow-cloud specflow-monorepo)
+
+resolve_repo() {
+  REPO_SHORT="specflow"
+  REPO_REMAINING_ARGS=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo)
+        shift
+        REPO_SHORT="${1:-}"
+        ;;
+      --repo=*)
+        REPO_SHORT="${1#--repo=}"
+        ;;
+      *)
+        REPO_REMAINING_ARGS+=("$1")
+        ;;
+    esac
+    shift || true
+  done
+
+  case "$REPO_SHORT" in
+    specflow | specflow-cloud | specflow-monorepo) ;;
+    *)
+      echo "--repo must be one of: ${ALLOWED_REPOS[*]} (got '$REPO_SHORT')" >&2
+      return 2
+      ;;
+  esac
+
+  REPO="mkrlabs/$REPO_SHORT"
+}

--- a/.claude/skills/backlog/scripts/add.sh
+++ b/.claude/skills/backlog/scripts/add.sh
@@ -1,30 +1,41 @@
 #!/usr/bin/env bash
-# Create a new issue on mkrlabs/specflow and attach it to Project #4 (Backlog).
+# Create a new issue on one of the mkrlabs/specflow* repos and attach it to
+# Project #4 (Backlog). Defaults to `mkrlabs/specflow`.
 # Usage:
-#   add.sh "<title>"
-#   add.sh "<title>" "<body>"
-#   add.sh "<title>" "<body>" "<label1,label2,...>"
+#   add.sh [--repo <short>] "<title>"
+#   add.sh [--repo <short>] "<title>" "<body>"
+#   add.sh [--repo <short>] "<title>" "<body>" "<label1,label2,...>"
+#   <short> ∈ specflow | specflow-cloud | specflow-monorepo
 set -euo pipefail
 
 # Guard --help / unknown flags before they reach `gh issue create` as a
 # positional title (#333) — otherwise `add.sh --help` creates a junk issue.
 case "${1:-}" in
-  -h|--help)
-    echo 'usage: add.sh "<title>" [<body>] [<labels-csv>]'
+  -h | --help)
+    echo 'usage: add.sh [--repo <short>] "<title>" [<body>] [<labels-csv>]'
     exit 0
     ;;
+esac
+
+. "$(dirname "$0")/_repo.sh"
+resolve_repo "$@"
+set -- ${REPO_REMAINING_ARGS[@]+"${REPO_REMAINING_ARGS[@]}"}
+
+# After --repo extraction, the next token must be the title (or a valid flag
+# we still want to reject explicitly).
+case "${1:-}" in
   --*)
     echo "add.sh: unknown flag '$1'" >&2
     exit 2
     ;;
 esac
 
-TITLE="${1:?usage: add.sh \"<title>\" [<body>] [<labels-csv>]}"
+TITLE="${1:?usage: add.sh [--repo <short>] \"<title>\" [<body>] [<labels-csv>]}"
 BODY="${2:-}"
 LABELS="${3:-}"
 
-ARGS=(--repo mkrlabs/specflow --title "$TITLE")
-[[ -n "$BODY" ]]   && ARGS+=(--body "$BODY")
+ARGS=(--repo "$REPO" --title "$TITLE")
+[[ -n "$BODY" ]] && ARGS+=(--body "$BODY")
 [[ -n "$LABELS" ]] && ARGS+=(--label "$LABELS")
 
 URL=$(gh issue create "${ARGS[@]}" 2>&1 | tail -1)

--- a/.claude/skills/backlog/scripts/clarify-comment.sh
+++ b/.claude/skills/backlog/scripts/clarify-comment.sh
@@ -2,10 +2,15 @@
 # Append a clarification-request comment to a backlog issue. Use when the
 # Product Owner subagent can't fully clarify an item from the linked docs
 # alone and needs Kevin's input asynchronously.
-# Usage: clarify-comment.sh <ISSUE_NUMBER> <COMMENT_BODY>
+# Usage: clarify-comment.sh [--repo <short>] <ISSUE_NUMBER> <COMMENT_BODY>
+#   <short> ∈ specflow | specflow-cloud | specflow-monorepo (default: specflow)
 set -euo pipefail
 
-ISSUE="${1:?usage: clarify-comment.sh <issue-number> <comment>}"
+. "$(dirname "$0")/_repo.sh"
+resolve_repo "$@"
+set -- ${REPO_REMAINING_ARGS[@]+"${REPO_REMAINING_ARGS[@]}"}
+
+ISSUE="${1:?usage: clarify-comment.sh [--repo <short>] <issue-number> <comment>}"
 shift
 COMMENT="$*"
 
@@ -14,5 +19,5 @@ if [[ -z "$COMMENT" ]]; then
   exit 1
 fi
 
-gh issue comment "$ISSUE" --repo mkrlabs/specflow --body "$COMMENT" >/dev/null
-echo "comment posted on #$ISSUE"
+gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT" >/dev/null
+echo "comment posted on $REPO#$ISSUE"

--- a/.claude/skills/backlog/scripts/list.sh
+++ b/.claude/skills/backlog/scripts/list.sh
@@ -5,30 +5,72 @@
 # the hand-rolled `repository.issues[].projectItems[].fieldValues[]` query
 # that lived here previously and was the main rate-limit offender).
 #
-# Usage: list.sh [STATUS]
-#   STATUS — optional filter: Backlog | Ready | "In progress" | "In review" | Done
+# Project #4 spans three repos — `specflow`, `specflow-cloud`,
+# `specflow-monorepo`. By default we query all three (1 GraphQL point each,
+# so ~3 total) and merge. Pass `--repo <short>` to restrict the listing to
+# one repo.
 #
-# Default (no filter): every issue NOT in Done — matches the historical
-# "open issues on the board" semantics. Pass `Done` explicitly to see closed
-# items still pinned to the board.
+# Usage:
+#   list.sh                            # all repos, every open item NOT in Done
+#   list.sh <STATUS>                   # all repos, filtered by Status
+#   list.sh --repo <short> [<STATUS>]  # one repo only
+#   <STATUS> ∈ Backlog | Ready | "In progress" | "In review" | Done
 set -euo pipefail
 
-FILTER="${1:-}"
+. "$(dirname "$0")/_repo.sh"
 
-JSON=$(gh issue list --repo mkrlabs/specflow --state open --limit 200 \
-  --json number,title,projectItems)
+# Detect whether the caller passed `--repo` so we know if we should query one
+# repo or all of them. We don't use `resolve_repo` directly because the
+# default (`mkrlabs/specflow`) would mask the "all repos" intent.
+REPOS=("${ALLOWED_REPOS[@]}")
+FILTER=""
+ARGS=("$@")
+i=0
+while [ $i -lt ${#ARGS[@]} ]; do
+  case "${ARGS[$i]}" in
+    --repo)
+      i=$((i + 1))
+      REPOS=("${ARGS[$i]:-}")
+      ;;
+    --repo=*)
+      REPOS=("${ARGS[$i]#--repo=}")
+      ;;
+    *)
+      FILTER="${ARGS[$i]}"
+      ;;
+  esac
+  i=$((i + 1))
+done
 
-ROWS=$(echo "$JSON" | jq -r --arg filter "$FILTER" '
-  .[]
-  | . as $issue
-  | (.projectItems[0].status.name // "—") as $status
-  | select($issue.projectItems | length > 0)
-  | select(
-      if $filter == "" then $status != "Done"
-      else $status == $filter
-      end
-    )
-  | "[\($status)]\t#\($issue.number)\t\($issue.title)"
-')
+for r in "${REPOS[@]}"; do
+  case "$r" in
+    specflow | specflow-cloud | specflow-monorepo) ;;
+    *)
+      echo "--repo must be one of: ${ALLOWED_REPOS[*]} (got '$r')" >&2
+      exit 2
+      ;;
+  esac
+done
 
-echo "$ROWS" | sort | column -ts $'\t'
+ROWS=""
+for SHORT in "${REPOS[@]}"; do
+  JSON=$(gh issue list --repo "mkrlabs/$SHORT" --state open --limit 200 \
+    --json number,title,projectItems)
+  PART=$(echo "$JSON" | jq -r --arg filter "$FILTER" --arg repo "$SHORT" '
+    .[]
+    | . as $issue
+    | (.projectItems[0].status.name // "—") as $status
+    | select($issue.projectItems | length > 0)
+    | select(
+        if $filter == "" then $status != "Done"
+        else $status == $filter
+        end
+      )
+    | "[\($status)]\t#\($issue.number)\t(\($repo))\t\($issue.title)"
+  ')
+  if [ -n "$PART" ]; then
+    ROWS="${ROWS}${PART}"$'\n'
+  fi
+done
+
+printf '%s' "$ROWS" | sort | column -ts $'\t'

--- a/.claude/skills/backlog/scripts/migrate-labels-to-fields.sh
+++ b/.claude/skills/backlog/scripts/migrate-labels-to-fields.sh
@@ -8,13 +8,23 @@
 # label is preserved and the migration is reported as "label-only" for that
 # dimension.
 #
-# Usage: migrate-labels-to-fields.sh [--dry-run]
+# Usage: migrate-labels-to-fields.sh [--repo <short>] [--dry-run]
+#   <short> ∈ specflow | specflow-cloud | specflow-monorepo (default: specflow)
 set -euo pipefail
 
 DRY_RUN=0
-if [ "${1:-}" = "--dry-run" ]; then
-  DRY_RUN=1
-fi
+ARGS=()
+for a in "$@"; do
+  if [ "$a" = "--dry-run" ]; then
+    DRY_RUN=1
+  else
+    ARGS+=("$a")
+  fi
+done
+
+. "$(dirname "$0")/_repo.sh"
+resolve_repo ${ARGS[@]+"${ARGS[@]}"}
+set -- ${REPO_REMAINING_ARGS[@]+"${REPO_REMAINING_ARGS[@]}"}
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 SET_FIELD="$ROOT/set-field.sh"
@@ -24,9 +34,11 @@ if [ ! -x "$SET_FIELD" ]; then
   exit 1
 fi
 
+REPO_SHORT="${REPO#mkrlabs/}"
+
 # Pull every open issue with at least one priority:* or size:* label.
 ISSUES=$(gh issue list \
-  --repo mkrlabs/specflow \
+  --repo "$REPO" \
   --state open \
   --limit 200 \
   --json number,labels \
@@ -39,7 +51,7 @@ ISSUES=$(gh issue list \
   ')
 
 if [ -z "$ISSUES" ]; then
-  echo "no issues with priority:*/size:* labels — nothing to migrate"
+  echo "no issues with priority:*/size:* labels in $REPO — nothing to migrate"
   exit 0
 fi
 
@@ -55,8 +67,8 @@ while IFS= read -r row; do
   size=""
   while IFS= read -r lbl; do
     case "$lbl" in
-      priority:P0|priority:P1|priority:P2|priority:P3) prio="${lbl#priority:}" ;;
-      size:XS|size:S|size:M|size:L|size:XL)            size="${lbl#size:}" ;;
+      priority:P0 | priority:P1 | priority:P2 | priority:P3) prio="${lbl#priority:}" ;;
+      size:XS | size:S | size:M | size:L | size:XL) size="${lbl#size:}" ;;
     esac
   done <<<"$labels"
 
@@ -64,19 +76,19 @@ while IFS= read -r row; do
     continue
   fi
 
-  echo "#$num: priority=${prio:-—}, size=${size:-—}"
+  echo "$REPO#$num: priority=${prio:-—}, size=${size:-—}"
 
   if [ -n "$prio" ]; then
     if [ "$DRY_RUN" = "1" ]; then
       echo "  (dry-run) would set Priority=$prio"
     else
       set +e
-      "$SET_FIELD" "$num" Priority "$prio" 1>/dev/null
+      "$SET_FIELD" --repo "$REPO_SHORT" "$num" Priority "$prio" 1>/dev/null
       rc=$?
       set -e
       case $rc in
         0)
-          gh issue edit "$num" --repo mkrlabs/specflow --remove-label "priority:$prio" >/dev/null
+          gh issue edit "$num" --repo "$REPO" --remove-label "priority:$prio" >/dev/null
           echo "  ✓ Priority=$prio (label stripped)"
           migrated=$((migrated + 1))
           ;;
@@ -97,12 +109,12 @@ while IFS= read -r row; do
       echo "  (dry-run) would set Size=$size"
     else
       set +e
-      "$SET_FIELD" "$num" Size "$size" 1>/dev/null
+      "$SET_FIELD" --repo "$REPO_SHORT" "$num" Size "$size" 1>/dev/null
       rc=$?
       set -e
       case $rc in
         0)
-          gh issue edit "$num" --repo mkrlabs/specflow --remove-label "size:$size" >/dev/null
+          gh issue edit "$num" --repo "$REPO" --remove-label "size:$size" >/dev/null
           echo "  ✓ Size=$size (label stripped)"
           migrated=$((migrated + 1))
           ;;

--- a/.claude/skills/backlog/scripts/move.sh
+++ b/.claude/skills/backlog/scripts/move.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Move a backlog issue to a Status column on Project #4.
+# Move a backlog issue to a Status column on Project #4. Works across all
+# three repos linked to the project (`specflow`, `specflow-cloud`,
+# `specflow-monorepo`).
 #
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
 # projectItems(first:5)) — query complexity ~5 nodes, negligible quota cost.
@@ -10,39 +12,48 @@
 # The actual field mutation (`updateProjectV2ItemFieldValue`) is GraphQL-only
 # — `gh project item-edit` is the CLI wrapper, used below.
 #
-# Usage: move.sh <ISSUE_NUMBER> <STATUS>
-#   STATUS — Backlog | Ready | "In progress" | "In review" | Done
+# Usage: move.sh [--repo <short>] <ISSUE_NUMBER> <STATUS>
+#   <short> ∈ specflow | specflow-cloud | specflow-monorepo (default: specflow)
+#   STATUS  ∈ Backlog | Ready | "In progress" | "In review" | Done
 set -euo pipefail
 
-ISSUE="${1:?usage: move.sh <issue-number> <status>}"
-STATUS="${2:?usage: move.sh <issue-number> <status>}"
+. "$(dirname "$0")/_repo.sh"
+resolve_repo "$@"
+set -- ${REPO_REMAINING_ARGS[@]+"${REPO_REMAINING_ARGS[@]}"}
+
+ISSUE="${1:?usage: move.sh [--repo <short>] <issue-number> <status>}"
+STATUS="${2:?usage: move.sh [--repo <short>] <issue-number> <status>}"
 
 PROJECT_ID="PVT_kwDOBv46cs4BV4Gz"
 STATUS_FIELD_ID="PVTSSF_lADOBv46cs4BV4GzzhRQrX8"
 
 case "$STATUS" in
-  Backlog)        OPT="f75ad846" ;;
-  Ready)          OPT="61e4505c" ;;
-  "In progress")  OPT="47fc9ee4" ;;
-  "In review")    OPT="df73e18b" ;;
-  Done)           OPT="98236657" ;;
-  *) echo "unknown status: $STATUS (Backlog|Ready|\"In progress\"|\"In review\"|Done)" >&2; exit 1 ;;
+  Backlog) OPT="f75ad846" ;;
+  Ready) OPT="61e4505c" ;;
+  "In progress") OPT="47fc9ee4" ;;
+  "In review") OPT="df73e18b" ;;
+  Done) OPT="98236657" ;;
+  *)
+    echo "unknown status: $STATUS (Backlog|Ready|\"In progress\"|\"In review\"|Done)" >&2
+    exit 1
+    ;;
 esac
 
+REPO_NAME="${REPO#mkrlabs/}"
 ITEM_ID=$(gh api graphql -f query='
-  query($num: Int!) {
-    repository(owner:"mkrlabs", name:"specflow") {
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
       issue(number: $num) {
         projectItems(first: 5) {
           nodes { id project { number } }
         }
       }
     }
-  }' -F num="$ISSUE" \
+  }' -f owner="mkrlabs" -f name="$REPO_NAME" -F num="$ISSUE" \
   | jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number == 4) | .id')
 
 if [[ -z "$ITEM_ID" ]]; then
-  echo "issue #$ISSUE is not on Project #4" >&2
+  echo "issue $REPO#$ISSUE is not on Project #4" >&2
   exit 1
 fi
 
@@ -52,4 +63,4 @@ gh project item-edit \
   --field-id "$STATUS_FIELD_ID" \
   --single-select-option-id "$OPT" >/dev/null
 
-echo "moved #$ISSUE → $STATUS"
+echo "moved $REPO#$ISSUE → $STATUS"

--- a/.claude/skills/backlog/scripts/set-field.sh
+++ b/.claude/skills/backlog/scripts/set-field.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Set a native classification value on an issue on Specflow's own Project #4:
+# Set a native classification value on an issue on Specflow's Project #4:
 # the Project V2 single-select fields Priority / Size, or the org-level native
-# Issue Type (Task / Bug / Feature). Hardcoded mirror of the templated helper
-# at templates/core/skills/backlog/scripts/github/set-field.sh.
+# Issue Type (Task / Bug / Feature). Works across all three repos linked to
+# the project (`specflow`, `specflow-cloud`, `specflow-monorepo`).
+# Hardcoded mirror of the templated helper at
+# templates/core/skills/backlog/scripts/github/set-field.sh.
 #
 # The item-ID lookup uses a small, targeted GraphQL query (one issue,
 # projectItems(first:5)) — negligible quota cost. `gh project item-list` was
@@ -15,7 +17,8 @@
 # `type`) — a single call that takes the type name directly, cheaper than
 # the GraphQL `updateIssue` path and with no node-ID resolution.
 #
-# Usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>
+# Usage: set-field.sh [--repo <short>] <issue-number> <Priority|Size|IssueType> <value>
+#   <short>   ∈ specflow | specflow-cloud | specflow-monorepo (default: specflow)
 #   Priority  → P0 | P1 | P2 | P3
 #   Size      → XS | S | M | L | XL
 #   IssueType → Task | Bug | Feature
@@ -28,8 +31,12 @@
 #   1   usage / unexpected error
 set -euo pipefail
 
+. "$(dirname "$0")/_repo.sh"
+resolve_repo "$@"
+set -- ${REPO_REMAINING_ARGS[@]+"${REPO_REMAINING_ARGS[@]}"}
+
 if [ "$#" -lt 3 ]; then
-  echo 'usage: set-field.sh <issue-number> <Priority|Size|IssueType> <value>' >&2
+  echo 'usage: set-field.sh [--repo <short>] <issue-number> <Priority|Size|IssueType> <value>' >&2
   exit 1
 fi
 ISSUE="$1"
@@ -37,6 +44,7 @@ FIELD_NAME="$2"
 VALUE="$3"
 
 PROJECT_ID="PVT_kwDOBv46cs4BV4Gz"
+REPO_NAME="${REPO#mkrlabs/}"
 
 # Issue Type is an org-level native concept, not a Project V2 field — it has
 # its own mutation path and exits before the Priority/Size project-field code.
@@ -52,15 +60,15 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
     # Single REST PATCH — takes the type name directly. A 422 means the
     # repo/org has no such native type (fall back to a label); a 404 means
     # the issue doesn't exist.
-    if ! RESULT=$(gh api -X PATCH "repos/mkrlabs/specflow/issues/$ISSUE" \
+    if ! RESULT=$(gh api -X PATCH "repos/$REPO/issues/$ISSUE" \
       -f type="$VALUE" --jq '.type.name' 2>&1); then
       case "$RESULT" in
         *"Validation Failed"* | *422*)
-          echo "repo has no native issue type '$VALUE' — fall back to a label" >&2
+          echo "$REPO has no native issue type '$VALUE' — fall back to a label" >&2
           exit 10
           ;;
         *"Not Found"* | *404*)
-          echo "issue #$ISSUE not found in mkrlabs/specflow" >&2
+          echo "issue #$ISSUE not found in $REPO" >&2
           exit 12
           ;;
         *)
@@ -69,7 +77,7 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
           ;;
       esac
     fi
-    echo "✓ #$ISSUE IssueType → $RESULT"
+    echo "✓ $REPO#$ISSUE IssueType → $RESULT"
     exit 0
     ;;
 esac
@@ -94,9 +102,9 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
     CANONICAL="Size"
     case "$VALUE" in
       XS) OPT="6c6483d2" ;;
-      S)  OPT="f784b110" ;;
-      M)  OPT="7515a9f1" ;;
-      L)  OPT="817d0097" ;;
+      S) OPT="f784b110" ;;
+      M) OPT="7515a9f1" ;;
+      L) OPT="817d0097" ;;
       XL) OPT="db339eb2" ;;
       *)
         echo "unknown Size value '$VALUE' (XS|S|M|L|XL)" >&2
@@ -111,19 +119,19 @@ case "$(echo "$FIELD_NAME" | tr '[:upper:]' '[:lower:]')" in
 esac
 
 ITEM_ID=$(gh api graphql -f query='
-  query($num: Int!) {
-    repository(owner:"mkrlabs", name:"specflow") {
+  query($owner: String!, $name: String!, $num: Int!) {
+    repository(owner: $owner, name: $name) {
       issue(number: $num) {
         projectItems(first: 5) {
           nodes { id project { number } }
         }
       }
     }
-  }' -F num="$ISSUE" \
+  }' -f owner="mkrlabs" -f name="$REPO_NAME" -F num="$ISSUE" \
   | jq -r '.data.repository.issue.projectItems.nodes[] | select(.project.number == 4) | .id')
 
 if [ -z "$ITEM_ID" ]; then
-  echo "issue #$ISSUE is not on Project #4" >&2
+  echo "issue $REPO#$ISSUE is not on Project #4" >&2
   exit 12
 fi
 
@@ -133,4 +141,4 @@ gh project item-edit \
   --field-id "$FIELD_ID" \
   --single-select-option-id "$OPT" >/dev/null
 
-echo "✓ #$ISSUE $CANONICAL → $VALUE"
+echo "✓ $REPO#$ISSUE $CANONICAL → $VALUE"

--- a/.claude/skills/backlog/scripts/view.sh
+++ b/.claude/skills/backlog/scripts/view.sh
@@ -7,13 +7,18 @@
 # hand-rolled query that used to live here). Body + comments come from
 # `gh issue view --comments` (REST).
 #
-# Usage: view.sh <ISSUE_NUMBER>
+# Usage: view.sh [--repo <short>] <ISSUE_NUMBER>
+#   <short> ∈ specflow | specflow-cloud | specflow-monorepo (default: specflow)
 set -euo pipefail
 
-ISSUE="${1:?usage: view.sh <issue-number>}"
+. "$(dirname "$0")/_repo.sh"
+resolve_repo "$@"
+set -- ${REPO_REMAINING_ARGS[@]+"${REPO_REMAINING_ARGS[@]}"}
 
-STATUS=$(gh issue view "$ISSUE" --repo mkrlabs/specflow --json projectItems \
+ISSUE="${1:?usage: view.sh [--repo <short>] <issue-number>}"
+
+STATUS=$(gh issue view "$ISSUE" --repo "$REPO" --json projectItems \
   | jq -r '.projectItems[0].status.name // "—"')
 
-echo "════ Issue #$ISSUE — Status: $STATUS ════"
-gh issue view "$ISSUE" --repo mkrlabs/specflow --comments
+echo "════ $REPO#$ISSUE — Status: $STATUS ════"
+gh issue view "$ISSUE" --repo "$REPO" --comments


### PR DESCRIPTION
## Summary

- Project #4 now spans 3 repos (`specflow`, `specflow-cloud`, `specflow-monorepo`) — all linked to the same board.
- Every script under `.claude/skills/backlog/scripts/` gains an optional `--repo <short>` flag (default: `specflow`) so the PO can drive issues across the three from one toolbox.
- `list.sh` defaults to **all three repos** and tags each row with its origin: `[Status]  #N  (repo-short)  Title`.
- A shared `_repo.sh` helper parses the flag once. Project ID, field IDs, and Status option IDs stay hardcoded — only the repo varies.
- `SKILL.md` + `.claude/agents/product-owner.md` updated to document the cross-repo flag.

## Why

Until now the in-repo backlog skill was hard-wired to `mkrlabs/specflow`. We just linked `specflow-cloud` and `specflow-monorepo` to Project #4 so all task tracking lives on one board. Without the `--repo` flag, the PO can't reach the new repos.

## Test plan

- [x] `deno task test` — all 689 tests pass
- [x] `deno task fmt` / `deno task lint` — clean
- [x] `view.sh 337` — works (default repo)
- [x] `list.sh Backlog` — lists items from all 3 repos with `(repo)` tag
- [x] `list.sh --repo specflow-cloud` — filters to one repo (empty as expected)
- [x] `migrate-labels-to-fields.sh --repo specflow-cloud --dry-run` — handles `--repo` + no positionals under `set -u` (`_repo.sh` uses safe expansion idiom)
- [x] `set-field.sh --repo bogus 1 IssueType Bug` — rejects unknown repo with exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)