### PR TITLE
chore(ci): bump GitHub Actions to Node 24-ready versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -48,7 +48,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,15 +41,15 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -18,7 +18,7 @@ jobs:
   docs-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # actions/checkout's default shallow clone (depth 1) doesn't
           # include the PR base commit, so `git diff <base>...<head>`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
       # post-release).
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history + tags so `git describe` and `git log <prev>..HEAD`
           # can produce the changelog.
@@ -214,7 +214,7 @@ jobs:
       - name: Generate release notes
         run: deno run --allow-read --allow-write --allow-run scripts/gen-changelog.ts
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/specflow-macos-x64

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -42,13 +42,13 @@ jobs:
         run: deno task docs:build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "docs-dist"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -48,7 +48,7 @@ jobs:
             exit 0
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up SSH agent with the wiki deploy key
         env:


### PR DESCRIPTION
## Summary

GitHub Actions forces Node.js 24 as the default runtime on **2026-06-02** (~6 days). The current workflows pin actions whose latest published majors still run on Node 20 — annotations were emitted on every release run starting with v1.12.0.

This PR bumps every action to its latest Node-24-ready major in a single atomic change.

## Bumps

| Action                              | Before | After  | Workflows                                        |
| ----------------------------------- | ------ | ------ | ------------------------------------------------ |
| `actions/checkout`                  | `@v4`  | `@v6`  | ci, codeql, docs-check, release, static, wiki   |
| `softprops/action-gh-release`       | `@v2`  | `@v3`  | release                                          |
| `actions/configure-pages`           | `@v5`  | `@v6`  | static                                           |
| `actions/upload-pages-artifact`     | `@v3`  | `@v5`  | static                                           |
| `actions/deploy-pages`              | `@v4`  | `@v5`  | static                                           |
| `github/codeql-action/init`         | `@v3`  | `@v4`  | codeql                                           |
| `github/codeql-action/analyze`      | `@v3`  | `@v4`  | codeql                                           |

Skipped: `denoland/setup-deno@v2` — the `@v2` floating branch already resolves to `v2.0.4` (Node 24), no edit needed.

## Risk analysis

- **`actions/checkout@v6`** — `persist-credentials` default remains `true` (verified upstream `action.yml`); the only behavior change vs v4 is that credentials are persisted to a separate file (PR #2286 on upstream). Specflow's git operations in `release.yml` (changelog `git log`, tap bump via explicit token) are unaffected.
- **`softprops/action-gh-release@v3`** — pure Node 24 runtime bump per upstream release notes; no input/behavior changes (`files`, `body_path`, `tag_name` all unchanged).
- **Pages + CodeQL** — straightforward major bumps; upstream Node 24 confirmed via direct `action.yml` inspection.

## Test plan

CI will validate. If `chore/bump-actions-node24` passes all checks (ci, codeql, docs-check, lint, lint-test, cross-smoke, Analyze, comment-on-linked-issues), the merge to main is safe. The next release tag will exercise the bumped `release.yml` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)