### PR TITLE
feat: add lite chain mode (skip clarify + tasks for small features) [#346]

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -488,6 +488,35 @@ the default guesses wrong:
 - `/specflow <phase> N --continue` — force the chain regardless of artefact state.
 - `/specflow <phase> N --once` — force one-shot regardless.
 
+#### Lite chain (small-feature shortcut)
+
+For small, single-file features (markdown documentation, agent definitions, README / AGENTS / CLAUDE
+/ CHANGELOG tweaks), the chain runs in a lighter shape that skips `clarify` and `tasks`:
+
+```
+specify → plan → analyze → implement → review → merge
+```
+
+Selection happens once, in `phases/specify.md`:
+
+- The router's `--lite` / `--full` flag forces the shape and skips the heuristic.
+- Otherwise the brief is scored against `phases/lite-heuristic.md` (file-path hints like `.md` /
+  `AGENTS.md`, verb hints like `write` / `document`, subject hints like `doc` / `paragraph`, brief
+  length, suppressors like `API` / `migration` / `auth`). On a positive score the user is prompted
+  once: `This brief looks small — run the lite chain? [Y/n]`.
+- The chosen shape persists to `.specflow/feature.json` as `workflow_shape: "lite" | "full"`.
+  Downstream phases consult it at every chain transition. Backward-compat: absent field treated as
+  `"full"`.
+
+In lite mode STOP #1 is n/a (no `clarify` phase runs) — `specify` makes informed guesses for
+ambiguities and records them in the spec's Assumptions section. STOP #2 (pre-merge) behaves
+identically to the full chain.
+
+```
+/specflow specify --lite "Document the OSS/proprio boundary in AGENTS.md"
+/specflow specify --full "Add OAuth2 login"   # opt out of auto-detected lite
+```
+
 The `/specflow-auto` slash command is kept for one release as a deprecation alias and will be
 removed in the next major version.
 

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -35,6 +35,22 @@ when_to_use: |
 
    Strip the matched flag from the token list before going further.
 
+   **Chain shape parsing** — additionally scan the tokens for at most
+   one of `--lite`, `--full`. They are mutually exclusive with each
+   other; if both are present, report `error: --lite and --full are mutually exclusive`
+   and stop. They **compose** with the pace flags above (e.g. `--once --lite`
+   is valid).
+   - `--lite` → CHAIN_SHAPE = `lite` (force the lite chain — `specify
+     → plan → analyze → implement → review`, skipping `clarify` and
+     `tasks`; see `phases/lite-heuristic.md` and the "Lite chain"
+     section in `phases/auto-chain.md`)
+   - `--full` → CHAIN_SHAPE = `full` (force the full chain even when
+     the specify-phase heuristic would otherwise propose lite)
+   - none → CHAIN_SHAPE = `auto` (the default; `phases/specify.md`
+     applies the heuristic and may prompt the user once)
+
+   Strip the matched flag from the token list before going further.
+
 2. **Phase extraction** — the first remaining token is the phase name.
    Everything after the first whitespace is the argument string for
    that phase.
@@ -169,3 +185,17 @@ To force or skip the chain mid-flow:
 /specflow plan 042 --once       # regenerate plan.md only, do not cascade
 /specflow plan 042 --continue   # regenerate plan.md AND cascade tasks → review
 ```
+
+To opt in or out of the **lite chain** (skip `clarify` and `tasks` —
+calibrated for small single-file features like markdown docs, README
+tweaks, agent definitions):
+
+```
+/specflow specify --lite "Document the OSS/proprio boundary in AGENTS.md"
+/specflow specify --full "Add OAuth2 login"   # opt out of auto-detected lite
+```
+
+Without an explicit flag, `phases/specify.md` scores the brief
+against `phases/lite-heuristic.md` and either prompts the user once or
+commits to a shape silently. See `phases/auto-chain.md` for how the
+chain sequence adapts to the chosen shape.

--- a/plugin/skills/specflow/phases/auto-chain.md
+++ b/plugin/skills/specflow/phases/auto-chain.md
@@ -14,6 +14,38 @@ specify → clarify → plan → tasks → analyze → implement → review → 
           STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
 ```
 
+## Lite chain
+
+For small, single-file features (markdown documentation, agent
+definitions, README/AGENTS/CLAUDE/CHANGELOG tweaks), the chain runs in
+a lighter shape that skips `clarify` and `tasks`:
+
+```
+specify → plan → analyze → implement → review → merge
+                                                  ▲
+                                                  STOP #2 (pre-merge validation)
+```
+
+STOP #1 (clarification checkpoint) is **n/a in lite mode** — no
+`clarify` phase runs, so there are no `[NEEDS CLARIFICATION]` markers
+to resolve mid-chain. The `phases/specify.md` procedure makes informed
+guesses for ambiguities and notes them in the spec's Assumptions
+section rather than blocking on user questions. STOP #2 behaves
+identically to the full chain.
+
+**Shape selection** happens once, in `phases/specify.md`:
+- The router's `--lite` / `--full` flag (parsed in `SKILL.md` step 1)
+  forces the shape and skips any heuristic / prompt.
+- Otherwise, `phases/specify.md` scores the brief against
+  `phases/lite-heuristic.md`. If the score crosses the threshold, the
+  user is prompted once; if not, full chain runs silently.
+- The chosen shape is persisted to `.specflow/feature.json` as
+  `workflow_shape: "lite" | "full"`.
+
+At every chain transition below, read `workflow_shape` from
+`.specflow/feature.json`. When the field is absent (legacy
+`feature.json`), treat as `"full"`.
+
 ## Per-phase behavior
 
 After each phase completes successfully, immediately invoke the next phase via
@@ -21,7 +53,25 @@ the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
 for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
 log is sufficient.
 
+The **next phase** depends on the chain shape recorded in
+`.specflow/feature.json` (`workflow_shape`):
+
+| Current phase | Next (full) | Next (lite) |
+|---|---|---|
+| `specify`   | `clarify`   | `plan`      |
+| `clarify`   | `plan`      | n/a (lite never runs clarify) |
+| `plan`      | `tasks`     | `analyze`   |
+| `tasks`     | `analyze`   | n/a (lite never runs tasks)   |
+| `analyze`   | `implement` | `implement` |
+| `implement` | `review`    | `review`    |
+| `review`    | STOP #2 → `merge` | STOP #2 → `merge` |
+
+When `workflow_shape` is absent from `feature.json`, treat as `"full"`.
+
 ## STOP #1 — Clarification checkpoint
+
+Applies only when `workflow_shape == "full"`. Lite mode does not run
+`clarify`, so there is no STOP #1 in lite chains.
 
 After `/specflow clarify` finishes:
 

--- a/plugin/skills/specflow/phases/lite-heuristic.md
+++ b/plugin/skills/specflow/phases/lite-heuristic.md
@@ -1,0 +1,115 @@
+# Lite-chain heuristic
+
+The lite chain (`specify → plan → analyze → implement → review`, skipping
+`clarify` and `tasks`) is calibrated for **small, single-file features**:
+markdown documentation, agent definitions, README tweaks, AGENTS.md edits,
+CLAUDE.md updates, changelog notes. For these, the full chain's spec /
+clarify / tasks / analyze / implement / review ceremony produces a
+doc/code ratio that's wildly off (concrete prior signal: ~1500 lines of
+spec+plan+research+data-model+contracts+quickstart+tasks for ~155 lines
+of agent markdown — roughly 10:1).
+
+This file is the **pattern bag** consulted by `phases/specify.md` when
+`CHAIN_SHAPE == auto`. Edit the signal lists below to tune detection
+without touching `specify.md` logic.
+
+## Scoring
+
+The heuristic runs against the user's feature brief — the text typed
+after `/specflow specify` (after flag-stripping by the router). It
+produces a score:
+
+```
+score = (signal hits) − (suppressor hits × 2)
+```
+
+- **score ≥ 2** → propose the lite chain to the user via the prompt
+  below. The user's answer (Y/n) decides.
+- **score < 2** → silently keep the full chain.
+
+Suppressors weigh **double** because a single private/system keyword is
+strong evidence the work is non-trivial regardless of how the brief is
+worded.
+
+## User prompt (when heuristic fires)
+
+```
+This brief looks small — run the lite chain?
+  Lite chain = specify → plan → analyze → implement → review
+               (skips clarify and tasks)
+  Full chain = specify → clarify → plan → tasks → analyze → implement → review
+
+Proceed in lite mode? [Y/n]
+```
+
+Default to **full** chain on an empty or unclear answer. The prompt
+appears exactly **once** per `/specflow specify` invocation — there is
+no re-prompting mid-chain.
+
+## Signal lists
+
+Each match (substring, case-insensitive) contributes **+1** to the
+score.
+
+### File-path hints (strongest individual signal — single match = score 1)
+
+- `AGENTS.md`, `README.md`, `CLAUDE.md`, `CHANGELOG.md`
+- Any `.md` path token
+- `docs/...`, `docs/`
+- `.specflow/...` (the workspace docs surface)
+
+### Verb hints
+
+- `write`, `document`, `draft`, `note down`, `add a note`
+- `rephrase`, `tweak`, `polish`, `clarify wording`
+- `rename`, `update wording`, `fix wording`
+- `clean up`, `tidy`, `format`
+
+### Subject hints
+
+- `doc`, `documentation`, `docs`, `guide`
+- `section`, `paragraph`, `wording`, `phrasing`
+- `comment`, `comments` (when the brief is about comment text, not
+  code-level comment cleanup)
+- `agent definition`, `agent markdown`, `agent file`
+- `prompt`, `system prompt`, `instruction`
+
+### Length hint
+
+- Brief length ≤ 150 characters → **+1** (weak signal — small briefs
+  often describe small work).
+
+## Suppressors (each hit subtracts 2)
+
+These keywords reliably indicate non-trivial scope. A single suppressor
+is usually enough to keep the full chain.
+
+- `system`, `service`, `subsystem`
+- `API`, `endpoint`, `HTTP`, `webhook`, `RPC`
+- `schema`, `migration`, `database`, `data model`
+- `test suite`, `test harness`, `integration test`
+- `feature flag`, `feature toggle`, `experiment`
+- `auth`, `authentication`, `authorization`, `OAuth`, `OIDC`, `SSO`
+- `pipeline`, `CI`, `release pipeline`, `Homebrew`, `binary`
+- `agent` *(when paired with `pipeline` / `orchestrator` / `multi-agent`
+  — a single "agent definition" mention is a subject hint, not a
+  suppressor)*
+
+## Canonical smoke inputs
+
+Used by `tests/plugin/plugin_sync_test.ts` and any future smoke
+validation. The expected routing for each:
+
+| Brief | Expected | Why |
+|---|---|---|
+| `document the OSS/proprio boundary in AGENTS.md` | **lite** | path hint (`AGENTS.md`), verb (`document`), subject (`boundary` neutral); score ≥ 2 |
+| `write a new agent definition for orchestrating backlog routing` | **lite** | verb (`write`), subject (`agent definition`); score ≥ 2, "orchestrating" is not a suppressor in isolation |
+| `add OAuth2 login with GitHub and Google providers` | **full** | suppressor `OAuth` (×2) overwhelms any positive signal; score < 2 |
+
+## Explicit overrides
+
+The router's `--lite` and `--full` flags force the shape directly and
+**skip this heuristic entirely**. See `SKILL.md` step 1 "Chain shape
+parsing". When forced, no prompt is emitted; the chosen shape is
+persisted to `.specflow/feature.json` (`workflow_shape`) and the
+spec.md frontmatter (`workflow:`).

--- a/plugin/skills/specflow/phases/specify.md
+++ b/plugin/skills/specflow/phases/specify.md
@@ -20,6 +20,43 @@ Skip silently if the file is absent or unparseable. For each enabled entry
 
 Hooks with non-empty `condition` are deferred to the HookExecutor.
 
+## Chain shape selection
+
+Before running the outline below, determine the **chain shape** that
+will apply to this `/specflow specify` invocation (and the rest of
+the chain after it):
+
+1. **Read `CHAIN_SHAPE` from the router context** (set by `SKILL.md`
+   step 1 chain-shape parsing).
+   - `CHAIN_SHAPE == lite` → use lite, no prompt. Skip step 2.
+   - `CHAIN_SHAPE == full` → use full, no prompt. Skip step 2.
+   - `CHAIN_SHAPE == auto` → proceed to step 2.
+
+2. **Apply the lite heuristic.** Read `phases/lite-heuristic.md`,
+   score the feature brief (the original user input from
+   `/specflow specify`, before flag stripping is irrelevant — use the
+   substantive brief), and:
+   - If `score < 2`: silently set `CHAIN_SHAPE = full`. No prompt.
+   - If `score ≥ 2`: emit the prompt from `phases/lite-heuristic.md`
+     ("This brief looks small — run the lite chain? [Y/n]") **exactly
+     once**, wait for the user's answer:
+     - `Y` / `yes` / empty (default-Y if you treated the prompt as a
+       Y/n with capital Y) → `CHAIN_SHAPE = lite`.
+     - `n` / `no` / anything else interpreted as no → `CHAIN_SHAPE =
+       full`.
+
+3. **Persist the chosen shape** to `.specflow/feature.json` (when
+   step 3 of the Outline below writes that file, include
+   `"workflow_shape": "lite"` or `"workflow_shape": "full"` alongside
+   `feature_directory` and `linked_issue`).
+
+4. **Log line on phase transition** (used by the chain when invoking
+   the next phase): emit `✓ specify (lite) complete — proceeding to
+   plan` when `CHAIN_SHAPE == lite`, or the unchanged `✓ specify
+   complete — proceeding to clarify` when `CHAIN_SHAPE == full`.
+   `phases/auto-chain.md` reads `workflow_shape` from `feature.json`
+   to decide which phase to chain to next.
+
 ## Outline
 
 The text the user typed after `/specflow specify` is the feature description. Do not ask the user to repeat it unless they provided an empty command.
@@ -55,7 +92,7 @@ Given that feature description, do this:
    - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
    - Persist to `.specflow/feature.json`:
      ```json
-     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null> }
+     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null>, "workflow_shape": "<lite|full>" }
      ```
      Write the actual resolved path (e.g., `.specflow/specs/003-user-auth`), not the literal string.
      This lets downstream commands (`/specflow plan`, `/specflow tasks`, etc.) locate the feature directory.
@@ -65,6 +102,11 @@ Given that feature description, do this:
      Otherwise persist `null`. The merge phase reads this field to auto-close the linked
      backlog item on the project board after a successful fast-forward + push. Backward-compat
      with existing `feature.json` files: absent or null is a no-op everywhere downstream.
+
+     **`workflow_shape`**: the chain shape chosen during "Chain shape selection" above —
+     `"lite"` or `"full"`. `phases/auto-chain.md` reads this field at every chain transition
+     to decide which phase comes next (lite skips `clarify` and `tasks`). Backward-compat
+     with existing `feature.json` files: absent → treat as `"full"` everywhere downstream.
 
    **IMPORTANT**:
    - Create only one feature per `/specflow specify` invocation.

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -67,8 +67,8 @@ export function isPluginCoveredPath(
  * (either re-install the plugin or run `specflow upgrade` to restore
  * the bundled snapshot).
  *
- * Kept in sync with `isPluginCoveredPath` above. Total: 37 paths
- * (15 agents excluding architect + 1 router skill + 19 phase docs +
+ * Kept in sync with `isPluginCoveredPath` above. Total: 38 paths
+ * (15 agents excluding architect + 1 router skill + 20 phase docs +
  * specflow-review alias + specflow-auto).
  *
  * Phase docs include hyphenated names — the regex was widened in #303
@@ -76,7 +76,10 @@ export function isPluginCoveredPath(
  * `list-skills`. The phase-1 audit family (`audit-security` #303,
  * `audit-performance` #304, `audit-accessibility` #305) shipped in
  * v1.9.0; the phase-2 family added `audit-architecture` (#321) and
- * now `audit-dependencies` (#322) closes Epic #320.
+ * `audit-dependencies` (#322) closing Epic #320. The lite-chain
+ * heuristic (`lite-heuristic`, #346) ships under the same
+ * `phases/` directory because it's bundled and synced through the
+ * same channel, even though it's a contract doc rather than a phase.
  * `ui-ux-designer` was added alongside `architecture-auditor` in #321
  * to close a long-standing drift bug; this array continues to mirror
  * the bundled Claude scaffold exactly.
@@ -120,6 +123,7 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
     "audit-accessibility",
     "audit-architecture",
     "audit-dependencies",
+    "lite-heuristic",
   ].map((name) => `.claude/skills/specflow/phases/${name}.md`),
   ".claude/skills/specflow-review/SKILL.md",
   ".claude/skills/specflow-auto/SKILL.md",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -46,6 +46,22 @@ when_to_use: |
 
    Strip the matched flag from the token list before going further.
 
+   **Chain shape parsing** — additionally scan the tokens for at most
+   one of \`--lite\`, \`--full\`. They are mutually exclusive with each
+   other; if both are present, report \`error: --lite and --full are mutually exclusive\`
+   and stop. They **compose** with the pace flags above (e.g. \`--once --lite\`
+   is valid).
+   - \`--lite\` → CHAIN_SHAPE = \`lite\` (force the lite chain — \`specify
+     → plan → analyze → implement → review\`, skipping \`clarify\` and
+     \`tasks\`; see \`phases/lite-heuristic.md\` and the "Lite chain"
+     section in \`phases/auto-chain.md\`)
+   - \`--full\` → CHAIN_SHAPE = \`full\` (force the full chain even when
+     the specify-phase heuristic would otherwise propose lite)
+   - none → CHAIN_SHAPE = \`auto\` (the default; \`phases/specify.md\`
+     applies the heuristic and may prompt the user once)
+
+   Strip the matched flag from the token list before going further.
+
 2. **Phase extraction** — the first remaining token is the phase name.
    Everything after the first whitespace is the argument string for
    that phase.
@@ -180,6 +196,20 @@ To force or skip the chain mid-flow:
 /specflow plan 042 --once       # regenerate plan.md only, do not cascade
 /specflow plan 042 --continue   # regenerate plan.md AND cascade tasks → review
 \`\`\`
+
+To opt in or out of the **lite chain** (skip \`clarify\` and \`tasks\` —
+calibrated for small single-file features like markdown docs, README
+tweaks, agent definitions):
+
+\`\`\`
+/specflow specify --lite "Document the OSS/proprio boundary in AGENTS.md"
+/specflow specify --full "Add OAuth2 login"   # opt out of auto-detected lite
+\`\`\`
+
+Without an explicit flag, \`phases/specify.md\` scores the brief
+against \`phases/lite-heuristic.md\` and either prompts the user once or
+commits to a shape silently. See \`phases/auto-chain.md\` for how the
+chain sequence adapts to the chosen shape.
 `,
     executable: false,
     backend: null,
@@ -210,6 +240,43 @@ Skip silently if the file is absent or unparseable. For each enabled entry
   \`EXECUTE_COMMAND: {command}\`, and wait for the result before proceeding.
 
 Hooks with non-empty \`condition\` are deferred to the HookExecutor.
+
+## Chain shape selection
+
+Before running the outline below, determine the **chain shape** that
+will apply to this \`/specflow specify\` invocation (and the rest of
+the chain after it):
+
+1. **Read \`CHAIN_SHAPE\` from the router context** (set by \`SKILL.md\`
+   step 1 chain-shape parsing).
+   - \`CHAIN_SHAPE == lite\` → use lite, no prompt. Skip step 2.
+   - \`CHAIN_SHAPE == full\` → use full, no prompt. Skip step 2.
+   - \`CHAIN_SHAPE == auto\` → proceed to step 2.
+
+2. **Apply the lite heuristic.** Read \`phases/lite-heuristic.md\`,
+   score the feature brief (the original user input from
+   \`/specflow specify\`, before flag stripping is irrelevant — use the
+   substantive brief), and:
+   - If \`score < 2\`: silently set \`CHAIN_SHAPE = full\`. No prompt.
+   - If \`score ≥ 2\`: emit the prompt from \`phases/lite-heuristic.md\`
+     ("This brief looks small — run the lite chain? [Y/n]") **exactly
+     once**, wait for the user's answer:
+     - \`Y\` / \`yes\` / empty (default-Y if you treated the prompt as a
+       Y/n with capital Y) → \`CHAIN_SHAPE = lite\`.
+     - \`n\` / \`no\` / anything else interpreted as no → \`CHAIN_SHAPE =
+       full\`.
+
+3. **Persist the chosen shape** to \`.specflow/feature.json\` (when
+   step 3 of the Outline below writes that file, include
+   \`"workflow_shape": "lite"\` or \`"workflow_shape": "full"\` alongside
+   \`feature_directory\` and \`linked_issue\`).
+
+4. **Log line on phase transition** (used by the chain when invoking
+   the next phase): emit \`✓ specify (lite) complete — proceeding to
+   plan\` when \`CHAIN_SHAPE == lite\`, or the unchanged \`✓ specify
+   complete — proceeding to clarify\` when \`CHAIN_SHAPE == full\`.
+   \`phases/auto-chain.md\` reads \`workflow_shape\` from \`feature.json\`
+   to decide which phase to chain to next.
 
 ## Outline
 
@@ -246,7 +313,7 @@ Given that feature description, do this:
    - Set \`SPEC_FILE\` to \`SPECIFY_FEATURE_DIRECTORY/spec.md\`
    - Persist to \`.specflow/feature.json\`:
      \`\`\`json
-     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null> }
+     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null>, "workflow_shape": "<lite|full>" }
      \`\`\`
      Write the actual resolved path (e.g., \`.specflow/specs/003-user-auth\`), not the literal string.
      This lets downstream commands (\`/specflow plan\`, \`/specflow tasks\`, etc.) locate the feature directory.
@@ -256,6 +323,11 @@ Given that feature description, do this:
      Otherwise persist \`null\`. The merge phase reads this field to auto-close the linked
      backlog item on the project board after a successful fast-forward + push. Backward-compat
      with existing \`feature.json\` files: absent or null is a no-op everywhere downstream.
+
+     **\`workflow_shape\`**: the chain shape chosen during "Chain shape selection" above —
+     \`"lite"\` or \`"full"\`. \`phases/auto-chain.md\` reads this field at every chain transition
+     to decide which phase comes next (lite skips \`clarify\` and \`tasks\`). Backward-compat
+     with existing \`feature.json\` files: absent → treat as \`"full"\` everywhere downstream.
 
    **IMPORTANT**:
    - Create only one feature per \`/specflow specify\` invocation.
@@ -2343,6 +2415,38 @@ specify → clarify → plan → tasks → analyze → implement → review → 
           STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
 \`\`\`
 
+## Lite chain
+
+For small, single-file features (markdown documentation, agent
+definitions, README/AGENTS/CLAUDE/CHANGELOG tweaks), the chain runs in
+a lighter shape that skips \`clarify\` and \`tasks\`:
+
+\`\`\`
+specify → plan → analyze → implement → review → merge
+                                                  ▲
+                                                  STOP #2 (pre-merge validation)
+\`\`\`
+
+STOP #1 (clarification checkpoint) is **n/a in lite mode** — no
+\`clarify\` phase runs, so there are no \`[NEEDS CLARIFICATION]\` markers
+to resolve mid-chain. The \`phases/specify.md\` procedure makes informed
+guesses for ambiguities and notes them in the spec's Assumptions
+section rather than blocking on user questions. STOP #2 behaves
+identically to the full chain.
+
+**Shape selection** happens once, in \`phases/specify.md\`:
+- The router's \`--lite\` / \`--full\` flag (parsed in \`SKILL.md\` step 1)
+  forces the shape and skips any heuristic / prompt.
+- Otherwise, \`phases/specify.md\` scores the brief against
+  \`phases/lite-heuristic.md\`. If the score crosses the threshold, the
+  user is prompted once; if not, full chain runs silently.
+- The chosen shape is persisted to \`.specflow/feature.json\` as
+  \`workflow_shape: "lite" | "full"\`.
+
+At every chain transition below, read \`workflow_shape\` from
+\`.specflow/feature.json\`. When the field is absent (legacy
+\`feature.json\`), treat as \`"full"\`.
+
 ## Per-phase behavior
 
 After each phase completes successfully, immediately invoke the next phase via
@@ -2350,7 +2454,25 @@ the \`Skill\` tool (or the platform equivalent). Do not emit a user-facing "read
 for next step?" prompt. A one-line \`✓ <phase> complete — proceeding to <next>\`
 log is sufficient.
 
+The **next phase** depends on the chain shape recorded in
+\`.specflow/feature.json\` (\`workflow_shape\`):
+
+| Current phase | Next (full) | Next (lite) |
+|---|---|---|
+| \`specify\`   | \`clarify\`   | \`plan\`      |
+| \`clarify\`   | \`plan\`      | n/a (lite never runs clarify) |
+| \`plan\`      | \`tasks\`     | \`analyze\`   |
+| \`tasks\`     | \`analyze\`   | n/a (lite never runs tasks)   |
+| \`analyze\`   | \`implement\` | \`implement\` |
+| \`implement\` | \`review\`    | \`review\`    |
+| \`review\`    | STOP #2 → \`merge\` | STOP #2 → \`merge\` |
+
+When \`workflow_shape\` is absent from \`feature.json\`, treat as \`"full"\`.
+
 ## STOP #1 — Clarification checkpoint
+
+Applies only when \`workflow_shape == "full"\`. Lite mode does not run
+\`clarify\`, so there is no STOP #1 in lite chains.
 
 After \`/specflow clarify\` finishes:
 
@@ -3356,6 +3478,130 @@ Next step: dispatch product-owner to convert findings into a backlog Epic? (y/N)
 Inspired by the discipline of \`obra/superpowers\` v5.1.0 (MIT, Jesse Vincent),
 adapted to Specflow's bundled agent + backlog conventions. The
 \`dependency-auditor\` agent itself is Specflow-native (no upstream sibling).
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "lite-heuristic",
+    suffix: "lite-heuristic.md",
+    content: `# Lite-chain heuristic
+
+The lite chain (\`specify → plan → analyze → implement → review\`, skipping
+\`clarify\` and \`tasks\`) is calibrated for **small, single-file features**:
+markdown documentation, agent definitions, README tweaks, AGENTS.md edits,
+CLAUDE.md updates, changelog notes. For these, the full chain's spec /
+clarify / tasks / analyze / implement / review ceremony produces a
+doc/code ratio that's wildly off (concrete prior signal: ~1500 lines of
+spec+plan+research+data-model+contracts+quickstart+tasks for ~155 lines
+of agent markdown — roughly 10:1).
+
+This file is the **pattern bag** consulted by \`phases/specify.md\` when
+\`CHAIN_SHAPE == auto\`. Edit the signal lists below to tune detection
+without touching \`specify.md\` logic.
+
+## Scoring
+
+The heuristic runs against the user's feature brief — the text typed
+after \`/specflow specify\` (after flag-stripping by the router). It
+produces a score:
+
+\`\`\`
+score = (signal hits) − (suppressor hits × 2)
+\`\`\`
+
+- **score ≥ 2** → propose the lite chain to the user via the prompt
+  below. The user's answer (Y/n) decides.
+- **score < 2** → silently keep the full chain.
+
+Suppressors weigh **double** because a single private/system keyword is
+strong evidence the work is non-trivial regardless of how the brief is
+worded.
+
+## User prompt (when heuristic fires)
+
+\`\`\`
+This brief looks small — run the lite chain?
+  Lite chain = specify → plan → analyze → implement → review
+               (skips clarify and tasks)
+  Full chain = specify → clarify → plan → tasks → analyze → implement → review
+
+Proceed in lite mode? [Y/n]
+\`\`\`
+
+Default to **full** chain on an empty or unclear answer. The prompt
+appears exactly **once** per \`/specflow specify\` invocation — there is
+no re-prompting mid-chain.
+
+## Signal lists
+
+Each match (substring, case-insensitive) contributes **+1** to the
+score.
+
+### File-path hints (strongest individual signal — single match = score 1)
+
+- \`AGENTS.md\`, \`README.md\`, \`CLAUDE.md\`, \`CHANGELOG.md\`
+- Any \`.md\` path token
+- \`docs/...\`, \`docs/\`
+- \`.specflow/...\` (the workspace docs surface)
+
+### Verb hints
+
+- \`write\`, \`document\`, \`draft\`, \`note down\`, \`add a note\`
+- \`rephrase\`, \`tweak\`, \`polish\`, \`clarify wording\`
+- \`rename\`, \`update wording\`, \`fix wording\`
+- \`clean up\`, \`tidy\`, \`format\`
+
+### Subject hints
+
+- \`doc\`, \`documentation\`, \`docs\`, \`guide\`
+- \`section\`, \`paragraph\`, \`wording\`, \`phrasing\`
+- \`comment\`, \`comments\` (when the brief is about comment text, not
+  code-level comment cleanup)
+- \`agent definition\`, \`agent markdown\`, \`agent file\`
+- \`prompt\`, \`system prompt\`, \`instruction\`
+
+### Length hint
+
+- Brief length ≤ 150 characters → **+1** (weak signal — small briefs
+  often describe small work).
+
+## Suppressors (each hit subtracts 2)
+
+These keywords reliably indicate non-trivial scope. A single suppressor
+is usually enough to keep the full chain.
+
+- \`system\`, \`service\`, \`subsystem\`
+- \`API\`, \`endpoint\`, \`HTTP\`, \`webhook\`, \`RPC\`
+- \`schema\`, \`migration\`, \`database\`, \`data model\`
+- \`test suite\`, \`test harness\`, \`integration test\`
+- \`feature flag\`, \`feature toggle\`, \`experiment\`
+- \`auth\`, \`authentication\`, \`authorization\`, \`OAuth\`, \`OIDC\`, \`SSO\`
+- \`pipeline\`, \`CI\`, \`release pipeline\`, \`Homebrew\`, \`binary\`
+- \`agent\` *(when paired with \`pipeline\` / \`orchestrator\` / \`multi-agent\`
+  — a single "agent definition" mention is a subject hint, not a
+  suppressor)*
+
+## Canonical smoke inputs
+
+Used by \`tests/plugin/plugin_sync_test.ts\` and any future smoke
+validation. The expected routing for each:
+
+| Brief | Expected | Why |
+|---|---|---|
+| \`document the OSS/proprio boundary in AGENTS.md\` | **lite** | path hint (\`AGENTS.md\`), verb (\`document\`), subject (\`boundary\` neutral); score ≥ 2 |
+| \`write a new agent definition for orchestrating backlog routing\` | **lite** | verb (\`write\`), subject (\`agent definition\`); score ≥ 2, "orchestrating" is not a suppressor in isolation |
+| \`add OAuth2 login with GitHub and Google providers\` | **full** | suppressor \`OAuth\` (×2) overwhelms any positive signal; score < 2 |
+
+## Explicit overrides
+
+The router's \`--lite\` and \`--full\` flags force the shape directly and
+**skip this heuristic entirely**. See \`SKILL.md\` step 1 "Chain shape
+parsing". When forced, no prompt is emitted; the chosen shape is
+persisted to \`.specflow/feature.json\` (\`workflow_shape\`) and the
+spec.md frontmatter (\`workflow:\`).
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -35,6 +35,22 @@ when_to_use: |
 
    Strip the matched flag from the token list before going further.
 
+   **Chain shape parsing** — additionally scan the tokens for at most
+   one of `--lite`, `--full`. They are mutually exclusive with each
+   other; if both are present, report `error: --lite and --full are mutually exclusive`
+   and stop. They **compose** with the pace flags above (e.g. `--once --lite`
+   is valid).
+   - `--lite` → CHAIN_SHAPE = `lite` (force the lite chain — `specify
+     → plan → analyze → implement → review`, skipping `clarify` and
+     `tasks`; see `phases/lite-heuristic.md` and the "Lite chain"
+     section in `phases/auto-chain.md`)
+   - `--full` → CHAIN_SHAPE = `full` (force the full chain even when
+     the specify-phase heuristic would otherwise propose lite)
+   - none → CHAIN_SHAPE = `auto` (the default; `phases/specify.md`
+     applies the heuristic and may prompt the user once)
+
+   Strip the matched flag from the token list before going further.
+
 2. **Phase extraction** — the first remaining token is the phase name.
    Everything after the first whitespace is the argument string for
    that phase.
@@ -169,3 +185,17 @@ To force or skip the chain mid-flow:
 /specflow plan 042 --once       # regenerate plan.md only, do not cascade
 /specflow plan 042 --continue   # regenerate plan.md AND cascade tasks → review
 ```
+
+To opt in or out of the **lite chain** (skip `clarify` and `tasks` —
+calibrated for small single-file features like markdown docs, README
+tweaks, agent definitions):
+
+```
+/specflow specify --lite "Document the OSS/proprio boundary in AGENTS.md"
+/specflow specify --full "Add OAuth2 login"   # opt out of auto-detected lite
+```
+
+Without an explicit flag, `phases/specify.md` scores the brief
+against `phases/lite-heuristic.md` and either prompts the user once or
+commits to a shape silently. See `phases/auto-chain.md` for how the
+chain sequence adapts to the chosen shape.

--- a/templates/core/skills/specflow/phases/auto-chain.md
+++ b/templates/core/skills/specflow/phases/auto-chain.md
@@ -14,6 +14,38 @@ specify → clarify → plan → tasks → analyze → implement → review → 
           STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
 ```
 
+## Lite chain
+
+For small, single-file features (markdown documentation, agent
+definitions, README/AGENTS/CLAUDE/CHANGELOG tweaks), the chain runs in
+a lighter shape that skips `clarify` and `tasks`:
+
+```
+specify → plan → analyze → implement → review → merge
+                                                  ▲
+                                                  STOP #2 (pre-merge validation)
+```
+
+STOP #1 (clarification checkpoint) is **n/a in lite mode** — no
+`clarify` phase runs, so there are no `[NEEDS CLARIFICATION]` markers
+to resolve mid-chain. The `phases/specify.md` procedure makes informed
+guesses for ambiguities and notes them in the spec's Assumptions
+section rather than blocking on user questions. STOP #2 behaves
+identically to the full chain.
+
+**Shape selection** happens once, in `phases/specify.md`:
+- The router's `--lite` / `--full` flag (parsed in `SKILL.md` step 1)
+  forces the shape and skips any heuristic / prompt.
+- Otherwise, `phases/specify.md` scores the brief against
+  `phases/lite-heuristic.md`. If the score crosses the threshold, the
+  user is prompted once; if not, full chain runs silently.
+- The chosen shape is persisted to `.specflow/feature.json` as
+  `workflow_shape: "lite" | "full"`.
+
+At every chain transition below, read `workflow_shape` from
+`.specflow/feature.json`. When the field is absent (legacy
+`feature.json`), treat as `"full"`.
+
 ## Per-phase behavior
 
 After each phase completes successfully, immediately invoke the next phase via
@@ -21,7 +53,25 @@ the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
 for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
 log is sufficient.
 
+The **next phase** depends on the chain shape recorded in
+`.specflow/feature.json` (`workflow_shape`):
+
+| Current phase | Next (full) | Next (lite) |
+|---|---|---|
+| `specify`   | `clarify`   | `plan`      |
+| `clarify`   | `plan`      | n/a (lite never runs clarify) |
+| `plan`      | `tasks`     | `analyze`   |
+| `tasks`     | `analyze`   | n/a (lite never runs tasks)   |
+| `analyze`   | `implement` | `implement` |
+| `implement` | `review`    | `review`    |
+| `review`    | STOP #2 → `merge` | STOP #2 → `merge` |
+
+When `workflow_shape` is absent from `feature.json`, treat as `"full"`.
+
 ## STOP #1 — Clarification checkpoint
+
+Applies only when `workflow_shape == "full"`. Lite mode does not run
+`clarify`, so there is no STOP #1 in lite chains.
 
 After `/specflow clarify` finishes:
 

--- a/templates/core/skills/specflow/phases/lite-heuristic.md
+++ b/templates/core/skills/specflow/phases/lite-heuristic.md
@@ -1,0 +1,115 @@
+# Lite-chain heuristic
+
+The lite chain (`specify → plan → analyze → implement → review`, skipping
+`clarify` and `tasks`) is calibrated for **small, single-file features**:
+markdown documentation, agent definitions, README tweaks, AGENTS.md edits,
+CLAUDE.md updates, changelog notes. For these, the full chain's spec /
+clarify / tasks / analyze / implement / review ceremony produces a
+doc/code ratio that's wildly off (concrete prior signal: ~1500 lines of
+spec+plan+research+data-model+contracts+quickstart+tasks for ~155 lines
+of agent markdown — roughly 10:1).
+
+This file is the **pattern bag** consulted by `phases/specify.md` when
+`CHAIN_SHAPE == auto`. Edit the signal lists below to tune detection
+without touching `specify.md` logic.
+
+## Scoring
+
+The heuristic runs against the user's feature brief — the text typed
+after `/specflow specify` (after flag-stripping by the router). It
+produces a score:
+
+```
+score = (signal hits) − (suppressor hits × 2)
+```
+
+- **score ≥ 2** → propose the lite chain to the user via the prompt
+  below. The user's answer (Y/n) decides.
+- **score < 2** → silently keep the full chain.
+
+Suppressors weigh **double** because a single private/system keyword is
+strong evidence the work is non-trivial regardless of how the brief is
+worded.
+
+## User prompt (when heuristic fires)
+
+```
+This brief looks small — run the lite chain?
+  Lite chain = specify → plan → analyze → implement → review
+               (skips clarify and tasks)
+  Full chain = specify → clarify → plan → tasks → analyze → implement → review
+
+Proceed in lite mode? [Y/n]
+```
+
+Default to **full** chain on an empty or unclear answer. The prompt
+appears exactly **once** per `/specflow specify` invocation — there is
+no re-prompting mid-chain.
+
+## Signal lists
+
+Each match (substring, case-insensitive) contributes **+1** to the
+score.
+
+### File-path hints (strongest individual signal — single match = score 1)
+
+- `AGENTS.md`, `README.md`, `CLAUDE.md`, `CHANGELOG.md`
+- Any `.md` path token
+- `docs/...`, `docs/`
+- `.specflow/...` (the workspace docs surface)
+
+### Verb hints
+
+- `write`, `document`, `draft`, `note down`, `add a note`
+- `rephrase`, `tweak`, `polish`, `clarify wording`
+- `rename`, `update wording`, `fix wording`
+- `clean up`, `tidy`, `format`
+
+### Subject hints
+
+- `doc`, `documentation`, `docs`, `guide`
+- `section`, `paragraph`, `wording`, `phrasing`
+- `comment`, `comments` (when the brief is about comment text, not
+  code-level comment cleanup)
+- `agent definition`, `agent markdown`, `agent file`
+- `prompt`, `system prompt`, `instruction`
+
+### Length hint
+
+- Brief length ≤ 150 characters → **+1** (weak signal — small briefs
+  often describe small work).
+
+## Suppressors (each hit subtracts 2)
+
+These keywords reliably indicate non-trivial scope. A single suppressor
+is usually enough to keep the full chain.
+
+- `system`, `service`, `subsystem`
+- `API`, `endpoint`, `HTTP`, `webhook`, `RPC`
+- `schema`, `migration`, `database`, `data model`
+- `test suite`, `test harness`, `integration test`
+- `feature flag`, `feature toggle`, `experiment`
+- `auth`, `authentication`, `authorization`, `OAuth`, `OIDC`, `SSO`
+- `pipeline`, `CI`, `release pipeline`, `Homebrew`, `binary`
+- `agent` *(when paired with `pipeline` / `orchestrator` / `multi-agent`
+  — a single "agent definition" mention is a subject hint, not a
+  suppressor)*
+
+## Canonical smoke inputs
+
+Used by `tests/plugin/plugin_sync_test.ts` and any future smoke
+validation. The expected routing for each:
+
+| Brief | Expected | Why |
+|---|---|---|
+| `document the OSS/proprio boundary in AGENTS.md` | **lite** | path hint (`AGENTS.md`), verb (`document`), subject (`boundary` neutral); score ≥ 2 |
+| `write a new agent definition for orchestrating backlog routing` | **lite** | verb (`write`), subject (`agent definition`); score ≥ 2, "orchestrating" is not a suppressor in isolation |
+| `add OAuth2 login with GitHub and Google providers` | **full** | suppressor `OAuth` (×2) overwhelms any positive signal; score < 2 |
+
+## Explicit overrides
+
+The router's `--lite` and `--full` flags force the shape directly and
+**skip this heuristic entirely**. See `SKILL.md` step 1 "Chain shape
+parsing". When forced, no prompt is emitted; the chosen shape is
+persisted to `.specflow/feature.json` (`workflow_shape`) and the
+spec.md frontmatter (`workflow:`).

--- a/templates/core/skills/specflow/phases/specify.md
+++ b/templates/core/skills/specflow/phases/specify.md
@@ -20,6 +20,43 @@ Skip silently if the file is absent or unparseable. For each enabled entry
 
 Hooks with non-empty `condition` are deferred to the HookExecutor.
 
+## Chain shape selection
+
+Before running the outline below, determine the **chain shape** that
+will apply to this `/specflow specify` invocation (and the rest of
+the chain after it):
+
+1. **Read `CHAIN_SHAPE` from the router context** (set by `SKILL.md`
+   step 1 chain-shape parsing).
+   - `CHAIN_SHAPE == lite` → use lite, no prompt. Skip step 2.
+   - `CHAIN_SHAPE == full` → use full, no prompt. Skip step 2.
+   - `CHAIN_SHAPE == auto` → proceed to step 2.
+
+2. **Apply the lite heuristic.** Read `phases/lite-heuristic.md`,
+   score the feature brief (the original user input from
+   `/specflow specify`, before flag stripping is irrelevant — use the
+   substantive brief), and:
+   - If `score < 2`: silently set `CHAIN_SHAPE = full`. No prompt.
+   - If `score ≥ 2`: emit the prompt from `phases/lite-heuristic.md`
+     ("This brief looks small — run the lite chain? [Y/n]") **exactly
+     once**, wait for the user's answer:
+     - `Y` / `yes` / empty (default-Y if you treated the prompt as a
+       Y/n with capital Y) → `CHAIN_SHAPE = lite`.
+     - `n` / `no` / anything else interpreted as no → `CHAIN_SHAPE =
+       full`.
+
+3. **Persist the chosen shape** to `.specflow/feature.json` (when
+   step 3 of the Outline below writes that file, include
+   `"workflow_shape": "lite"` or `"workflow_shape": "full"` alongside
+   `feature_directory` and `linked_issue`).
+
+4. **Log line on phase transition** (used by the chain when invoking
+   the next phase): emit `✓ specify (lite) complete — proceeding to
+   plan` when `CHAIN_SHAPE == lite`, or the unchanged `✓ specify
+   complete — proceeding to clarify` when `CHAIN_SHAPE == full`.
+   `phases/auto-chain.md` reads `workflow_shape` from `feature.json`
+   to decide which phase to chain to next.
+
 ## Outline
 
 The text the user typed after `/specflow specify` is the feature description. Do not ask the user to repeat it unless they provided an empty command.
@@ -55,7 +92,7 @@ Given that feature description, do this:
    - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
    - Persist to `.specflow/feature.json`:
      ```json
-     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null> }
+     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null>, "workflow_shape": "<lite|full>" }
      ```
      Write the actual resolved path (e.g., `.specflow/specs/003-user-auth`), not the literal string.
      This lets downstream commands (`/specflow plan`, `/specflow tasks`, etc.) locate the feature directory.
@@ -65,6 +102,11 @@ Given that feature description, do this:
      Otherwise persist `null`. The merge phase reads this field to auto-close the linked
      backlog item on the project board after a successful fast-forward + push. Backward-compat
      with existing `feature.json` files: absent or null is a no-op everywhere downstream.
+
+     **`workflow_shape`**: the chain shape chosen during "Chain shape selection" above —
+     `"lite"` or `"full"`. `phases/auto-chain.md` reads this field at every chain transition
+     to decide which phase comes next (lite skips `clarify` and `tasks`). Backward-compat
+     with existing `feature.json` files: absent → treat as `"full"` everywhere downstream.
 
    **IMPORTANT**:
    - Create only one feature per `/specflow specify` invocation.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -22,6 +22,7 @@
     { "category": "phase", "name": "audit-accessibility", "suffix": "audit-accessibility.md", "source": "core/skills/specflow/phases/audit-accessibility.md" },
     { "category": "phase", "name": "audit-architecture", "suffix": "audit-architecture.md", "source": "core/skills/specflow/phases/audit-architecture.md" },
     { "category": "phase", "name": "audit-dependencies", "suffix": "audit-dependencies.md", "source": "core/skills/specflow/phases/audit-dependencies.md" },
+    { "category": "phase", "name": "lite-heuristic", "suffix": "lite-heuristic.md", "source": "core/skills/specflow/phases/lite-heuristic.md" },
     { "category": "phase-script", "name": "tag", "suffix": "tag.sh", "source": "core/skills/specflow/scripts/tag.sh", "executable": true },
     { "category": "phase-script", "name": "release", "suffix": "release.sh", "source": "core/skills/specflow/scripts/release.sh", "executable": true },
     { "category": "phase-script", "name": "release-github", "suffix": "release-github.sh", "source": "core/skills/specflow/scripts/release-github.sh", "executable": true },

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -839,12 +839,13 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
     );
     // 15 agents (10 original + ui-ux-designer drift fix #321 +
     // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321 + dependency-auditor #322) + 1 router skill + 19 phase docs
+    // #321 + dependency-auditor #322) + 1 router skill + 20 phase docs
     // (the 11 original + tag-version + release-version + list-skills +
     // audit-security #303 + audit-performance #304 + audit-accessibility
-    // #305 + audit-architecture #321 + audit-dependencies #322) +
-    // specflow-review alias + specflow-auto = 37 covered paths.
-    assertEquals(gapOutcomes.length, 37);
+    // #305 + audit-architecture #321 + audit-dependencies #322 +
+    // lite-heuristic #346) + specflow-review alias + specflow-auto = 38
+    // covered paths.
+    assertEquals(gapOutcomes.length, 38);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specflow upgrade"), true);

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,20 +82,20 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 20 phases (11 original + tag-version + release-version +
+    // Router + 21 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
     // #304 + audit-accessibility #305 + audit-architecture #321 +
-    // audit-dependencies #322) + specflow-auto + specflow-review +
-    // writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + subagent-driven-development (#272) +
-    // executing-plans (#274) + verification-before-completion (#275) +
+    // audit-dependencies #322 + lite-heuristic #346) + specflow-auto +
+    // specflow-review + writing-plans (#271) + requesting-code-review
+    // (#273) + using-specflow (#282) + subagent-driven-development (#272)
+    // + executing-plans (#274) + verification-before-completion (#275) +
     // brainstorming (#276) + backlog + 15 agents (11 original +
     // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321 + dependency-auditor #322) = 45.
+    // #321 + dependency-auditor #322) = 46.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 45);
+    assertEquals(instructionsCount, 46);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,20 +74,20 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 20 phases (11 original + tag-version + release-version +
+    // Router + 21 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
     // #304 + audit-accessibility #305 + audit-architecture #321 +
-    // audit-dependencies #322) + specflow-auto + specflow-review alias +
-    // writing-plans (#271) + requesting-code-review (#273) +
-    // using-specflow (#282) + subagent-driven-development (#272) +
-    // executing-plans (#274) + verification-before-completion (#275) +
+    // audit-dependencies #322 + lite-heuristic #346) + specflow-auto +
+    // specflow-review alias + writing-plans (#271) + requesting-code-review
+    // (#273) + using-specflow (#282) + subagent-driven-development (#272)
+    // + executing-plans (#274) + verification-before-completion (#275) +
     // brainstorming (#276) + backlog + 15 agent workflows (11 original +
     // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321 + dependency-auditor #322) = 45.
+    // #321 + dependency-auditor #322) = 46.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 45);
+    assertEquals(workflowsCount, 46);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -17,11 +17,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow/SKILL.md",
     source: "templates/core/skills/specflow/SKILL.md",
   },
-  // 19 phase reference docs, loaded by the router on demand. The
+  // 20 phase reference docs, loaded by the router on demand. The
   // phase-1 audit trio (`audit-security` #303, `audit-performance` #304,
   // `audit-accessibility` #305) shipped in v1.9.0; the phase-2 pair
   // (`audit-architecture` #321 + `audit-dependencies` #322) closes
-  // Epic #320.
+  // Epic #320. `lite-heuristic` (#346) is a contract doc consulted by
+  // `phases/specify.md` when CHAIN_SHAPE == auto — not a phase itself,
+  // but synced through the same byte-identical channel.
   ...[
     "specify",
     "clarify",
@@ -42,6 +44,7 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     "audit-accessibility",
     "audit-architecture",
     "audit-dependencies",
+    "lite-heuristic",
   ].map((name) => ({
     plugin: `plugin/skills/specflow/phases/${name}.md`,
     source: `templates/core/skills/specflow/phases/${name}.md`,


### PR DESCRIPTION
## Summary

Adds an opt-in **lite chain shape** for the `/specflow specify` flow that skips `clarify` and `tasks`, calibrated for small single-file features (markdown docs, agent definitions, README/AGENTS/CLAUDE tweaks). Closes #346.

Chain shapes:

```
full: specify → clarify → plan → tasks → analyze → implement → review → merge
lite: specify ───────────→ plan ─────────→ analyze → implement → review → merge
```

Selection happens once, in `phases/specify.md`:

1. Router flag (`--lite` / `--full`) forces the shape and skips the heuristic.
2. Otherwise the brief is scored against `phases/lite-heuristic.md`; on hit, the user is prompted once.
3. Chosen shape persists to `.specflow/feature.json` (`workflow_shape: lite | full`); downstream phases consult it on every chain transition.

## Why now

Concrete dogfood signal during the close of `mkrlabs/specflow-monorepo#3`: the cross-repo product-manager agent feature produced ~1500 lines of spec / plan / research / data-model / contracts / quickstart / tasks for ~155 lines of agent markdown — doc/code ratio ≈ 10:1. Calibrated for medium features, heavy for single-file deliverables. The lite shape addresses that ratio directly without sacrificing the `analyze` cross-artifact gate.

## What changed

- **Router (`SKILL.md`)** — new shape-flag parser; `--lite` / `--full` compose with `--manual` / `--once` / `--continue`.
- **`phases/lite-heuristic.md`** (new contract doc) — signal patterns (file paths, verbs, subjects, length), suppressors, scoring, threshold, three canonical smoke inputs. Editable as the pattern source without touching code.
- **`phases/specify.md`** — new "Chain shape selection" section + `workflow_shape` field in `feature.json`. Backward-compat: absent → `full`.
- **`phases/auto-chain.md`** — "Lite chain" section + next-phase decision table consulting `workflow_shape`. STOP #1 n/a in lite mode; STOP #2 unchanged.
- **`templates/manifest.json`** — register `lite-heuristic.md` so `specflow init` includes it.
- **`src/domain/plugin_coverage.ts`** — covered-paths list 37 → 38.
- **`docs/llms.md`** — new "Lite chain (small-feature shortcut)" subsection documenting the shape, trigger, and persistence.
- **Tests** — `plugin_sync_test`, `init_copilot_test`, `init_windsurf_test`, `fs_project_inspector_test` bumped to reflect the new file.

`plugin/` and `templates/core/` stay byte-identical (sync test enforces). `src/templates_bundle.ts` regenerated by `deno task bundle`.

## Agent adoption

`/specflow specify` now proposes a **lite chain** shape for small, single-file features (skips `clarify` and `tasks`, runs specify → plan → analyze → implement → review). Triggered by a heuristic on the brief, or forced via `--lite` / `--full` flags. Projects with agent rules or documentation explaining the Specflow workflow should mention the new shape and the override flags.

```prompt
Add a short paragraph to my project's `.claude/agents/specflow-expert.md`
(and any equivalent for other harnesses — `.cursor/rules/specflow.mdc`,
`AGENTS.md`, `GEMINI.md`) explaining the new lite chain mode:

  - `/specflow specify` auto-detects small features (markdown docs,
    agent definitions, README / AGENTS tweaks) via a heuristic and
    prompts once: "This brief looks small — run the lite chain? [Y/n]"
  - Lite chain skips `clarify` and `tasks`:
      specify → plan → analyze → implement → review
  - `--lite` and `--full` flags force the shape (skip the heuristic).
  - Chosen shape persists to `.specflow/feature.json` as
    `workflow_shape: lite | full` so downstream phases consult it.

Open a PR with the additions.
```

## Test plan

- [x] `deno task test` → 690 passed, 0 failed
- [x] `deno task fmt:check`, `deno task lint`, `deno task check` all pass
- [ ] Manual smoke (after merge): three canonical inputs from `lite-heuristic.md` produce expected routing (lite / lite / full)

## Out of scope

- Lighter spec/plan **templates** for small features (`--shape=docs`) — different concern from chain shape.
- LLM classifier fallback for ambiguous briefs (Haiku sub-call). Heuristic-first chosen.
- Extending the lite shape to `/specflow audit <axis>` or non-`specify` entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)