### PR TITLE
feat(codex): carry agent model tier into sub-agent TOML reasoning effort

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,0 +1,4 @@
+{
+  "feature_directory": ".specflow/specs/001-codex-subagent-model",
+  "linked_issue": 340
+}

--- a/.specflow/specs/001-codex-subagent-model/checklists/requirements.md
+++ b/.specflow/specs/001-codex-subagent-model/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: Carry agent model assignment into Codex sub-agent TOML
+
+**Purpose**: Validate specification completeness before planning **Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable and technology-agnostic
+- [x] All acceptance scenarios defined; edge cases identified
+- [x] Scope clearly bounded; dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details in specification
+
+## Notes
+
+- **Resolved (clarify, 2026-05-29)**: FR-002 maps a declared tier to Codex's
+  `model_reasoning_effort` field (NOT `model`) — `opus` → `high`, `sonnet` → `medium`. Effort is
+  tier-shaped and stable; `model` would pin drifting OpenAI model identifiers.
+- All checklist items pass. Spec is implementation-ready.

--- a/.specflow/specs/001-codex-subagent-model/spec.md
+++ b/.specflow/specs/001-codex-subagent-model/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Carry agent model assignment into Codex sub-agent TOML
+
+**Feature Branch**: `feat/codex-subagent-model-mapping` **Created**: 2026-05-29 **Status**: Draft
+**Linked issue**: mkrlabs/specflow#340 (axis 1, re-scoped) **Input**: User description: "Extend
+CodexHarness — carry the per-agent model assignment into the generated `.codex/agents/*.toml` so
+Codex sub-agents run at the capability tier the Specflow agent declares, instead of all silently
+inheriting the session default."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Codex sub-agents run at their declared capability tier (Priority: P1)
+
+A user runs `specflow init --ai codex` on a project. Specflow's bundled agents each declare a
+deliberate capability tier (e.g. the heavy `qa-tester` is meant to run on a high-capability model;
+the lighter `code-reviewer` on a mid tier). After init, when the user's Codex CLI spawns one of
+those sub-agents, it runs at a tier that reflects what the agent author intended — not a flat
+session default applied uniformly to every agent.
+
+**Why this priority**: This is the entire feature. Without it, `--ai codex` produces sub-agents that
+have lost the model intent the Claude harness preserves, making the Codex experience a
+lower-fidelity copy. It is the only axis of issue #340 that is both unbuilt and unblocked.
+
+**Independent Test**: Generate the Codex bundle for a project whose agents declare differing tiers,
+inspect the emitted `.codex/agents/*.toml`, and confirm each file carries a capability signal
+derived from its source agent's declared tier — a heavy agent and a light agent produce different
+signals.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bundled agent that declares the higher capability tier, **When** the Codex bundle is
+   generated, **Then** its `.codex/agents/<name>.toml` carries the capability signal corresponding
+   to that tier.
+2. **Given** a bundled agent that declares the mid capability tier, **When** the Codex bundle is
+   generated, **Then** its `.codex/agents/<name>.toml` carries the mid-tier signal — distinct from
+   the higher tier.
+3. **Given** an agent whose frontmatter declares no model, **When** the Codex bundle is generated,
+   **Then** its TOML omits the capability signal entirely so the agent inherits the parent Codex
+   session default (today's behaviour, preserved).
+4. **Given** the existing `name` / `description` / `developer_instructions` fields, **When** the
+   capability signal is added, **Then** those three fields are emitted unchanged and the TOML
+   remains valid and discoverable by Codex.
+
+### Edge Cases
+
+- **Unrecognised model value** — an agent declares a tier Specflow does not map (a typo, or a future
+  tier). The emitter must not produce an invalid TOML file; it omits the capability signal (falls
+  back to session-default inheritance) rather than emitting a guessed or malformed value.
+- **`model: inherit`** (or an explicit "use the session default" sentinel) — treated the same as "no
+  model declared": the signal is omitted.
+- **Empty / whitespace model value** — treated as "no model declared".
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The Codex sub-agent TOML emitter MUST read the source agent's declared capability tier
+  from its frontmatter when generating each `.codex/agents/<name>.toml`.
+- **FR-002**: The emitter MUST translate a recognised declared tier into the Codex
+  `model_reasoning_effort` field (NOT the `model` field — resolved in clarify: effort is tier-shaped
+  and stable, whereas `model` would hard-code drifting OpenAI model identifiers). Mapping: `opus` →
+  `high`, `sonnet` → `medium`.
+- **FR-003**: When the source agent declares no recognised tier (absent, empty, `inherit`, or an
+  unmapped value), the emitter MUST omit the capability signal so the sub-agent inherits the parent
+  Codex session default.
+- **FR-004**: The emitter MUST continue to emit the existing `name`, `description`, and
+  `developer_instructions` fields unchanged, and the output MUST remain valid TOML that Codex CLI
+  discovers without further configuration.
+- **FR-005**: The tier→signal translation MUST live in one place so the supported tiers and their
+  mapping are auditable and extendable from a single location.
+- **FR-006**: The behaviour MUST be covered by automated tests asserting the emitted signal for a
+  high-tier agent, a mid-tier agent, and a no-model agent.
+
+### Key Entities _(see Domain Model section below for full structure)_
+
+- **Source agent**: a bundled Specflow agent definition carrying a `model` tier in its frontmatter
+  (today: `opus` or `sonnet`).
+- **Codex sub-agent file**: the generated `.codex/agents/<name>.toml` Codex reads to discover and
+  configure a sub-agent.
+- **Capability signal**: the Codex `model_reasoning_effort` value through which a declared tier is
+  expressed (resolved in clarify).
+
+## Domain Model _(mandatory)_
+
+**Bounded context:** Harness bundling — translating the harness-agnostic core bundle into Codex's
+on-disk conventions.
+
+**Vocabulary (Ubiquitous language):**
+
+- **Core agent** — a harness-agnostic agent definition in the core bundle, authored in the Claude
+  frontmatter shape.
+- **Capability tier** — the model intent an agent author declares (`opus` = higher, `sonnet` = mid
+  today); harness-agnostic, expresses "how much model this agent needs", not a vendor model id.
+- **Capability signal** — the Codex-side expression of a tier in the generated TOML.
+- **Session default** — the model/effort the parent Codex session runs with, inherited by any
+  sub-agent that declares nothing.
+
+**Entities (have identity):**
+
+- **Codex sub-agent file** [aggregate root] — one `.codex/agents/<name>.toml` per core agent;
+  identified by agent name.
+
+**Value objects (no identity, immutable):**
+
+- **Tier mapping(tier → signal)** — the pure, total function from a declared tier to a capability
+  signal (or "omit"); the single source of truth for what Specflow supports.
+
+**Invariants (rules the domain must never break):**
+
+- A generated TOML file is always valid and discoverable — an unmapped or absent tier never yields a
+  malformed or guessed field.
+- The three existing fields (`name`, `description`, `developer_instructions`) are never altered by
+  this feature.
+- Boundary: this is public-CLI-only work; no private-half (Cloud / Mobile) identifier is involved.
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- **Claude harness** — owns its own model handling; untouched.
+- **Codex Agents SDK integration** (#340 axis 2) — blocked on an upstream TypeScript SDK release;
+  tracked separately.
+- **`/goal` scaffolding** (#340 axis 3) — already delivered
+  (`templates/harness-specific/codex/goal.md`); not part of this feature.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: For every bundled agent that declares a recognised tier, the generated Codex TOML
+  carries a capability signal — measured as 100% of tier-declaring agents (today 15 of 15) emitting
+  a non-empty signal.
+- **SC-002**: A higher-tier agent and a mid-tier agent emit _different_ capability signals — the
+  tier distinction survives the translation.
+- **SC-003**: An agent declaring no recognised tier emits a TOML file with no capability signal —
+  byte-identical, for the agent body, to today's output.
+- **SC-004**: 100% of generated Codex sub-agent TOML files parse as valid TOML and are discovered by
+  Codex CLI without manual edits.
+
+## Assumptions
+
+- Codex sub-agent TOML supports an optional capability field (`model` and/or
+  `model_reasoning_effort`) that, when omitted, inherits from the parent session — per the current
+  OpenAI Codex sub-agents documentation.
+- Bundled Specflow agents declare their tier via a `model:` frontmatter key (verified: values are
+  `opus` and `sonnet` today).
+- The set of tiers Specflow uses is small and stable; new tiers are added by extending the single
+  mapping, not by changing call sites.
+- This change is confined to the Codex harness mapping and its tests — no change to the core bundle,
+  the agent frontmatter shape, or any other harness.

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -8,20 +8,46 @@ import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 
-function parseAgentFrontmatter(content: string): { description: string; body: string } {
+function parseAgentFrontmatter(
+  content: string,
+): { description: string; model: string | null; body: string } {
   const split = splitFrontmatter(content);
-  if (!split) return { description: "", body: content };
+  if (!split) return { description: "", model: null, body: content };
   return {
     description: frontmatterField(split.fmBody, "description") ?? "",
+    model: frontmatterField(split.fmBody, "model"),
     body: split.rest.replace(/^\n+/, ""),
   };
 }
 
+/**
+ * Translates a Specflow agent's declared capability tier (a Claude model name)
+ * into a Codex `model_reasoning_effort` level. Codex models are OpenAI-specific,
+ * so we map the *tier* rather than copy the vendor model id — keeping the
+ * mapping stable across OpenAI model releases. An absent, empty, or
+ * unrecognised tier (including `inherit`) returns null so the sub-agent
+ * inherits the parent Codex session default instead of getting a guessed value.
+ */
+function tierToReasoningEffort(model: string | null): string | null {
+  switch (model?.trim().toLowerCase()) {
+    case "opus":
+      return "high";
+    case "sonnet":
+      return "medium";
+    case "haiku":
+      return "low";
+    default:
+      return null;
+  }
+}
+
 function toCodexSubagentToml(entry: CoreEntry): string {
-  const { description, body } = parseAgentFrontmatter(entry.content);
+  const { description, model, body } = parseAgentFrontmatter(entry.content);
+  const effort = tierToReasoningEffort(model);
   return stringifyToml({
     name: entry.name,
     description: description || `Specflow ${entry.name} agent`,
+    ...(effort ? { model_reasoning_effort: effort } : {}),
     developer_instructions: body,
   });
 }

--- a/tests/infrastructure/harness/codex_harness_test.ts
+++ b/tests/infrastructure/harness/codex_harness_test.ts
@@ -99,9 +99,52 @@ Deno.test("CodexHarness maps agent to .codex/agents/<name>.toml with valid TOML"
     (parsed.developer_instructions as string).includes("You are the PO"),
     "agent body should end up in developer_instructions",
   );
-  // Claude-only frontmatter fields must be stripped.
+  // The Claude `model` tier is translated to Codex `model_reasoning_effort`,
+  // never copied verbatim; `tools` is dropped entirely.
   assertEquals("model" in parsed, false);
+  assertEquals(parsed.model_reasoning_effort, "high"); // opus → high
   assertEquals("tools" in parsed, false);
+});
+
+Deno.test("CodexHarness maps agent model tiers to model_reasoning_effort", () => {
+  const agent = (name: string, model: string | null): CoreBundle[number] => ({
+    category: "agent",
+    name,
+    suffix: null,
+    content: `---\nname: ${name}\ndescription: ${name} role\n${
+      model === null ? "" : `model: ${model}\n`
+    }tools: Read\n---\n\n# Body\n`,
+    executable: false,
+  });
+  const core: CoreBundle = [
+    agent("heavy", "opus"), // → high
+    agent("mid", "sonnet"), // → medium
+    agent("light", "haiku"), // → low
+    agent("none", null), // → omitted (inherit session default)
+    agent("inherit", "inherit"), // → omitted
+    agent("weird", "gpt-9-ultra"), // → omitted (unrecognised, no guess)
+  ];
+  const h = new CodexHarness();
+  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver" });
+
+  const effortOf = (name: string) => {
+    const file = mapped[`.codex/agents/${name}.toml`];
+    assert(file, `${name} TOML not emitted`);
+    return parseToml(file.content).model_reasoning_effort;
+  };
+
+  assertEquals(effortOf("heavy"), "high");
+  assertEquals(effortOf("mid"), "medium");
+  assertEquals(effortOf("light"), "low");
+  // A higher tier and a mid tier emit distinct signals (SC-002).
+  assert(effortOf("heavy") !== effortOf("mid"));
+  // Absent / inherit / unrecognised tiers omit the field so Codex inherits
+  // the parent session default (FR-003) — and the file stays valid TOML.
+  for (const name of ["none", "inherit", "weird"]) {
+    const parsed = parseToml(mapped[`.codex/agents/${name}.toml`]!.content);
+    assertEquals("model_reasoning_effort" in parsed, false, `${name} should omit effort`);
+    assertEquals(parsed.name, name); // file is still valid & discoverable
+  }
 });
 
 Deno.test("CodexHarness maps spec-root to .specflow/<suffix> and project-root to <suffix>", () => {

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -73,6 +73,9 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     assertEquals(parsed.name, "product-owner");
     assertEquals(typeof parsed.description, "string");
     assertEquals(typeof parsed.developer_instructions, "string");
+    // The bundled product-owner declares `model: opus`, which maps to the
+    // Codex reasoning-effort tier "high" (not a copied vendor model id).
+    assertEquals(parsed.model_reasoning_effort, "high");
 
     // Codex harness reference doc + /goal prompt template
     assertEquals(await exists(join(root, ".codex/AGENTS.md")), true);


### PR DESCRIPTION
## Why

`specflow init --ai codex` generated `.codex/agents/<name>.toml` files that **dropped each agent's declared `model` tier** — so every Codex sub-agent silently inherited the parent session default, losing the capability intent the Claude harness preserves. A `qa-tester` meant to run heavy and a light `code-reviewer` came out identical.

This is **axis 1 of #340**, re-scoped to the only work that's both unbuilt and unblocked:
- **Axis 3 (`/goal` scaffold)** was already shipped (`templates/harness-specific/codex/goal.md`).
- **Axis 2 (Agents SDK)** is blocked on the Codex Agents SDK's TypeScript bindings (Python-only GA today) → split to #349.

## What

`toCodexSubagentToml` now reads the agent's `model` frontmatter and maps the **tier** to Codex's `model_reasoning_effort` field:

| Declared tier | Codex effort |
|---|---|
| `opus` | `high` |
| `sonnet` | `medium` |
| `haiku` | `low` |
| absent / `inherit` / unrecognised | *(omitted — inherits session default)* |

We map the **tier**, not the vendor model id: `model_reasoning_effort` is stable across OpenAI model releases, whereas writing a concrete `model` name would pin identifiers that drift. Unmapped/absent tiers omit the field so the TOML stays valid and the sub-agent inherits the session default (today's behaviour, preserved). The mapping lives in one function (`tierToReasoningEffort`) so supported tiers are auditable in one place.

## Tests

- Unit: all three tiers + the three omit cases (absent / `inherit` / unrecognised), and that a higher and a mid tier emit *distinct* signals.
- Integration: the real bundled `product-owner` (`model: opus`) emits `model_reasoning_effort = "high"` end-to-end through `init --ai codex`.
- Full suite green (673 passed), fmt + lint + bundle + check clean via pre-commit.

## Spec

`.specflow/specs/001-codex-subagent-model/` (the first feature spec dogfooded in this repo).

## Agent adoption

Projects initialised with `--ai codex` now get a `model_reasoning_effort` line in each generated `.codex/agents/*.toml` (opus→high, sonnet→medium, haiku→low), so Codex sub-agents run at the tier the agent declares instead of a flat session default. After `specflow upgrade`, regenerate the Codex agent files so the tiers land; agents with no `model` (or `inherit`) keep inheriting the session default.

```prompt
Regenerate this project's Codex sub-agent files so they carry the new capability tier.
For each `.codex/agents/*.toml`, confirm it now includes a `model_reasoning_effort`
line when the source agent declares a `model` (opus→high, sonnet→medium, haiku→low),
and omits it otherwise. If the files are stale, re-run `specflow upgrade` (or
`specflow init --ai codex` on a fresh checkout), then open a PR with the regenerated files.
```

Refs #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)