### PR TITLE
feat(specflow): add /specflow brainstorm phase — optional step-0 spec discovery (#351)

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -434,6 +434,18 @@ The chain is invoked through the bundled `/specflow` skill:
 /specflow specify "<feature description>"
 ```
 
+When the idea is still fuzzy and you can't yet write that one-line description, start one phase
+earlier with the optional **step 0**:
+
+```
+/specflow brainstorm "<rough idea>"
+```
+
+`brainstorm` runs a discovery dialogue (one question at a time, 2–3 approaches, design approval),
+then chains into `specify` with the agreed brief — so `brainstorm → specify → clarify → …` flows in
+one session. It reuses the bundled `brainstorming` skill for the dialogue; when your brief is
+already clear, skip it and start at `specify`.
+
 Two checkpoints inside the chain:
 
 - **STOP #1 — clarify** runs after `clarify`. If `spec.md` still has `[NEEDS CLARIFICATION]`

--- a/plugin/skills/specflow/SKILL.md
+++ b/plugin/skills/specflow/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (brainstorm, specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). `/specflow` with no args prints the workflow overview.
+argument-hint: <brainstorm|specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
 when_to_use: |
   Trigger phrases that should route here:
+  - brainstorm: "I have a rough idea", "help me figure out what to build", "let's brainstorm a feature", "I don't know exactly what I want yet"
   - specify: "spec out a feature", "write a spec", "create a specification"
   - clarify: "clarify requirements", "fill in gaps in the spec"
   - plan: "plan a feature", "build a technical plan"
@@ -80,6 +81,7 @@ when_to_use: |
 
 | Phase | Reference | One-liner |
 |-------|-----------|-----------|
+| `brainstorm` | `phases/brainstorm.md` | Optional step 0 — discover a fuzzy idea through dialogue, then hand the agreed brief to `specify`. |
 | `specify` | `phases/specify.md` | Create or update the feature spec from a natural-language description. |
 | `clarify` | `phases/clarify.md` | Resolve ambiguities in the spec via structured questioning. |
 | `plan` | `phases/plan.md` | Generate the technical plan, research, data model, contracts, quickstart. |
@@ -100,8 +102,8 @@ when_to_use: |
 | `audit architecture` | `phases/audit-architecture.md` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
 | `audit dependencies` | `phases/audit-dependencies.md` | Read-only multi-manifest dependency-hygiene sweep — unbounded ranges, missing lockfiles, unused deps, license violations, typosquats. |
 
-Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
-`implement`, `review`. The others (`merge`, `constitution`,
+Chainable phases are: `brainstorm`, `specify`, `clarify`, `plan`, `tasks`,
+`analyze`, `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
 `audit security`, `audit performance`, `audit accessibility`,
 `audit architecture`, `audit dependencies`) are one-shot regardless
@@ -139,16 +141,16 @@ After the phase procedure completes successfully:
 - `CHAIN_MODE == continue` → read `phases/auto-chain.md` and chain
   through the remaining phases regardless of downstream-artefact state.
 - `CHAIN_MODE == auto` (the default) → read `phases/auto-chain.md`. For
-  `specify`, the chain always continues. For any other chainable phase,
-  apply the artefact-detection table in that file — chain if downstream
-  artefacts are absent, one-shot if present.
+  `brainstorm` and `specify`, the chain always continues. For any other
+  chainable phase, apply the artefact-detection table in that file — chain
+  if downstream artefacts are absent, one-shot if present.
 
 ## Workflow overview
 
 ```
-specify → clarify → plan → tasks → analyze → implement → review → merge
-                                                                    ▲
-                                                          STOP for pre-merge validation
+(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
+    ▲                                                                              ▲
+    optional step 0 — only when the idea is still fuzzy            STOP for pre-merge validation
 ```
 
 Default behavior: `/specflow specify "..."` runs the entire chain in one
@@ -156,9 +158,25 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
+`brainstorm` is an **optional front-end**: when the user doesn't yet have a
+clear enough idea to spec, `/specflow brainstorm "<rough idea>"` runs a
+discovery dialogue (one question at a time, 2–3 approaches, design approval)
+and then chains into `specify` with the agreed brief. When the brief is
+already clear, start at `/specflow specify` and skip it.
+
 `constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`, `dependencies`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
+
+When the idea is still fuzzy, start one phase earlier:
+
+```
+/specflow brainstorm "let users monitor agent runs from their phone"
+  → discovery dialogue (one question at a time, 2–3 approaches, design approval)
+  → on approval, auto-chains into /specflow specify with the agreed brief
+```
+
+When the brief is already clear, start at `specify`:
 
 ```
 /specflow specify "Add OAuth2 login"

--- a/plugin/skills/specflow/phases/auto-chain.md
+++ b/plugin/skills/specflow/phases/auto-chain.md
@@ -2,17 +2,22 @@
 
 This file carries the chain mechanics that the `/specflow` router follows
 when chain mode is engaged. The router reads it after a chainable phase
-(`specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`)
-completes — unless `--manual` or `--once` was passed, or downstream
+(`brainstorm`, `specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`,
+`review`) completes — unless `--manual` or `--once` was passed, or downstream
 artefacts indicate one-shot intent.
 
 ## Default flow
 
 ```
-specify → clarify → plan → tasks → analyze → implement → review → merge
-          ▲                                                        ▲
-          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
+                         ▲                                                        ▲
+                         STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
 ```
+
+`brainstorm` is the optional step 0 (see `phases/brainstorm.md`). It runs
+only when the user invokes `/specflow brainstorm` because the idea is still
+fuzzy; on design approval it always chains into `specify`, which then drives
+the rest of the flow. Entering at `specify` skips it.
 
 ## Lite chain
 
@@ -58,6 +63,7 @@ The **next phase** depends on the chain shape recorded in
 
 | Current phase | Next (full) | Next (lite) |
 |---|---|---|
+| `brainstorm` | `specify`   | `specify`   |
 | `specify`   | `clarify`   | `plan`      |
 | `clarify`   | `plan`      | n/a (lite never runs clarify) |
 | `plan`      | `tasks`     | `analyze`   |

--- a/plugin/skills/specflow/phases/brainstorm.md
+++ b/plugin/skills/specflow/phases/brainstorm.md
@@ -1,0 +1,85 @@
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+`$ARGUMENTS` is the rough idea to brainstorm. It may be vague ("something to
+let users monitor agent runs from their phone"), a bare issue title, or
+**empty** — if empty, open with a single question: "What do you want to
+build? Describe it in a sentence or two, even roughly." Do not pick a topic
+yourself.
+
+## Purpose
+
+`brainstorm` is the optional **step 0** of the spec-driven pipeline: the
+entry point for when the user does NOT yet have a clear enough idea to write
+a spec. It runs a collaborative discovery dialogue, turns the fuzzy idea into
+an approved design brief, then hands that brief to `/specflow specify` — which
+owns writing the formal `.specflow/specs/<feature>/spec.md`.
+
+Use this phase when the idea needs *discovery* before it can be specified.
+When the user already has a clear brief, they invoke `/specflow specify`
+directly and skip this phase.
+
+## Procedure
+
+The discovery dialogue is already defined, in full, by the bundled
+**`brainstorming` skill**. Do not duplicate it here.
+
+1. **Run the `brainstorming` skill's discovery process.** Read the
+   `brainstorming` skill (via the `Skill` tool, or read its `SKILL.md` if the
+   platform cannot invoke it) and follow its **Steps 1–6**:
+   - Step 1 — explore project context (`git log`, `AGENTS.md`,
+     `.specflow/memory/constitution.md`, the relevant directory structure).
+   - Step 2 — assess scope; if the idea spans multiple independent
+     subsystems, propose splitting it into one brainstorm per subsystem
+     (a multi-subsystem idea is an Epic, not one feature).
+   - Step 3 — ask clarifying questions **one at a time**, multiple-choice
+     where possible (purpose, success criteria, constraints, out of scope).
+   - Step 4 — propose 2–3 approaches with trade-offs; lead with a
+     recommendation.
+   - Step 5 — present the design section by section, confirming each.
+   - Step 6 — design for isolation and clarity.
+
+2. **Get explicit design approval.** Honour the skill's hard rule: no
+   handoff until the user has approved the design. The design may be short
+   for small ideas, but it MUST be presented and approved.
+
+## Terminal handoff — overridden for the spec-kit chain
+
+The standalone `brainstorming` skill ends (its Steps 7–10) by writing its own
+markdown design doc and forking to `writing-plans` **or** `/specflow specify`.
+Inside the `/specflow` router this phase **overrides that ending**:
+
+- **Do NOT** write a separate design doc and do **NOT** hand off to
+  `writing-plans`. `/specflow specify` is the next phase and it owns writing
+  `.specflow/specs/<feature>/spec.md`, so a brainstorm-authored doc would only
+  double up.
+- Instead, distill the approved design into a concise **feature brief**
+  (2–6 sentences capturing goal, the chosen approach, key constraints, and
+  explicit out-of-scope items) and carry it forward as the input to
+  `/specflow specify`.
+
+## Chain decision
+
+`brainstorm` is a **chainable** phase. Its next phase is always `specify`
+(in both the full and lite chain shapes).
+
+- `CHAIN_MODE == auto` (default) or `continue` → after design approval,
+  immediately invoke `/specflow specify` with the distilled feature brief as
+  its `$ARGUMENTS`. Emit `✓ brainstorm complete — proceeding to specify`.
+  The chain then continues normally from `specify` (which applies its own
+  lite/full shape heuristic).
+- `CHAIN_MODE == off` (`--manual`) or `once` → stop after design approval.
+  Print the approved feature brief and tell the user they can run
+  `/specflow specify "<brief>"` when ready. Do not auto-invoke `specify`.
+
+## Notes
+
+- This phase is design-only: it asks questions and produces a brief. It
+  writes no spec, no plan, and no code — those belong to `specify` and the
+  phases after it.
+- Backlog mutations (e.g. refining a vague issue body into the agreed brief)
+  go through the `product-owner` agent, never inline — consistent with the
+  rest of the pipeline.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11,10 +11,11 @@ export const CORE_BUNDLE: CoreBundle = [
     suffix: null,
     content: `---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). \`/specflow\` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. \`/specflow <phase> [args]\` dispatches to a single phase (brainstorm, specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). \`/specflow\` with no args prints the workflow overview.
+argument-hint: <brainstorm|specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
 when_to_use: |
   Trigger phrases that should route here:
+  - brainstorm: "I have a rough idea", "help me figure out what to build", "let's brainstorm a feature", "I don't know exactly what I want yet"
   - specify: "spec out a feature", "write a spec", "create a specification"
   - clarify: "clarify requirements", "fill in gaps in the spec"
   - plan: "plan a feature", "build a technical plan"
@@ -91,6 +92,7 @@ when_to_use: |
 
 | Phase | Reference | One-liner |
 |-------|-----------|-----------|
+| \`brainstorm\` | \`phases/brainstorm.md\` | Optional step 0 — discover a fuzzy idea through dialogue, then hand the agreed brief to \`specify\`. |
 | \`specify\` | \`phases/specify.md\` | Create or update the feature spec from a natural-language description. |
 | \`clarify\` | \`phases/clarify.md\` | Resolve ambiguities in the spec via structured questioning. |
 | \`plan\` | \`phases/plan.md\` | Generate the technical plan, research, data model, contracts, quickstart. |
@@ -111,8 +113,8 @@ when_to_use: |
 | \`audit architecture\` | \`phases/audit-architecture.md\` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
 | \`audit dependencies\` | \`phases/audit-dependencies.md\` | Read-only multi-manifest dependency-hygiene sweep — unbounded ranges, missing lockfiles, unused deps, license violations, typosquats. |
 
-Chainable phases are: \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`,
-\`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
+Chainable phases are: \`brainstorm\`, \`specify\`, \`clarify\`, \`plan\`, \`tasks\`,
+\`analyze\`, \`implement\`, \`review\`. The others (\`merge\`, \`constitution\`,
 \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`,
 \`audit security\`, \`audit performance\`, \`audit accessibility\`,
 \`audit architecture\`, \`audit dependencies\`) are one-shot regardless
@@ -150,16 +152,16 @@ After the phase procedure completes successfully:
 - \`CHAIN_MODE == continue\` → read \`phases/auto-chain.md\` and chain
   through the remaining phases regardless of downstream-artefact state.
 - \`CHAIN_MODE == auto\` (the default) → read \`phases/auto-chain.md\`. For
-  \`specify\`, the chain always continues. For any other chainable phase,
-  apply the artefact-detection table in that file — chain if downstream
-  artefacts are absent, one-shot if present.
+  \`brainstorm\` and \`specify\`, the chain always continues. For any other
+  chainable phase, apply the artefact-detection table in that file — chain
+  if downstream artefacts are absent, one-shot if present.
 
 ## Workflow overview
 
 \`\`\`
-specify → clarify → plan → tasks → analyze → implement → review → merge
-                                                                    ▲
-                                                          STOP for pre-merge validation
+(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
+    ▲                                                                              ▲
+    optional step 0 — only when the idea is still fuzzy            STOP for pre-merge validation
 \`\`\`
 
 Default behavior: \`/specflow specify "..."\` runs the entire chain in one
@@ -167,9 +169,25 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See \`phases/auto-chain.md\` for the
 chain mechanics.
 
+\`brainstorm\` is an **optional front-end**: when the user doesn't yet have a
+clear enough idea to spec, \`/specflow brainstorm "<rough idea>"\` runs a
+discovery dialogue (one question at a time, 2–3 approaches, design approval)
+and then chains into \`specify\` with the agreed brief. When the brief is
+already clear, start at \`/specflow specify\` and skip it.
+
 \`constitution\`, \`checklist\`, \`groom\`, \`tag-version\`, \`release-version\`, \`list-skills\`, and \`audit <axis>\` (any of \`security\`, \`performance\`, \`accessibility\`, \`architecture\`, \`dependencies\`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
+
+When the idea is still fuzzy, start one phase earlier:
+
+\`\`\`
+/specflow brainstorm "let users monitor agent runs from their phone"
+  → discovery dialogue (one question at a time, 2–3 approaches, design approval)
+  → on approval, auto-chains into /specflow specify with the agreed brief
+\`\`\`
+
+When the brief is already clear, start at \`specify\`:
 
 \`\`\`
 /specflow specify "Add OAuth2 login"
@@ -210,6 +228,100 @@ Without an explicit flag, \`phases/specify.md\` scores the brief
 against \`phases/lite-heuristic.md\` and either prompts the user once or
 commits to a shape silently. See \`phases/auto-chain.md\` for how the
 chain sequence adapts to the chosen shape.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "phase",
+    name: "brainstorm",
+    suffix: "brainstorm.md",
+    content: `## User Input
+
+\`\`\`text
+\$ARGUMENTS
+\`\`\`
+
+\`\$ARGUMENTS\` is the rough idea to brainstorm. It may be vague ("something to
+let users monitor agent runs from their phone"), a bare issue title, or
+**empty** — if empty, open with a single question: "What do you want to
+build? Describe it in a sentence or two, even roughly." Do not pick a topic
+yourself.
+
+## Purpose
+
+\`brainstorm\` is the optional **step 0** of the spec-driven pipeline: the
+entry point for when the user does NOT yet have a clear enough idea to write
+a spec. It runs a collaborative discovery dialogue, turns the fuzzy idea into
+an approved design brief, then hands that brief to \`/specflow specify\` — which
+owns writing the formal \`.specflow/specs/<feature>/spec.md\`.
+
+Use this phase when the idea needs *discovery* before it can be specified.
+When the user already has a clear brief, they invoke \`/specflow specify\`
+directly and skip this phase.
+
+## Procedure
+
+The discovery dialogue is already defined, in full, by the bundled
+**\`brainstorming\` skill**. Do not duplicate it here.
+
+1. **Run the \`brainstorming\` skill's discovery process.** Read the
+   \`brainstorming\` skill (via the \`Skill\` tool, or read its \`SKILL.md\` if the
+   platform cannot invoke it) and follow its **Steps 1–6**:
+   - Step 1 — explore project context (\`git log\`, \`AGENTS.md\`,
+     \`.specflow/memory/constitution.md\`, the relevant directory structure).
+   - Step 2 — assess scope; if the idea spans multiple independent
+     subsystems, propose splitting it into one brainstorm per subsystem
+     (a multi-subsystem idea is an Epic, not one feature).
+   - Step 3 — ask clarifying questions **one at a time**, multiple-choice
+     where possible (purpose, success criteria, constraints, out of scope).
+   - Step 4 — propose 2–3 approaches with trade-offs; lead with a
+     recommendation.
+   - Step 5 — present the design section by section, confirming each.
+   - Step 6 — design for isolation and clarity.
+
+2. **Get explicit design approval.** Honour the skill's hard rule: no
+   handoff until the user has approved the design. The design may be short
+   for small ideas, but it MUST be presented and approved.
+
+## Terminal handoff — overridden for the spec-kit chain
+
+The standalone \`brainstorming\` skill ends (its Steps 7–10) by writing its own
+markdown design doc and forking to \`writing-plans\` **or** \`/specflow specify\`.
+Inside the \`/specflow\` router this phase **overrides that ending**:
+
+- **Do NOT** write a separate design doc and do **NOT** hand off to
+  \`writing-plans\`. \`/specflow specify\` is the next phase and it owns writing
+  \`.specflow/specs/<feature>/spec.md\`, so a brainstorm-authored doc would only
+  double up.
+- Instead, distill the approved design into a concise **feature brief**
+  (2–6 sentences capturing goal, the chosen approach, key constraints, and
+  explicit out-of-scope items) and carry it forward as the input to
+  \`/specflow specify\`.
+
+## Chain decision
+
+\`brainstorm\` is a **chainable** phase. Its next phase is always \`specify\`
+(in both the full and lite chain shapes).
+
+- \`CHAIN_MODE == auto\` (default) or \`continue\` → after design approval,
+  immediately invoke \`/specflow specify\` with the distilled feature brief as
+  its \`\$ARGUMENTS\`. Emit \`✓ brainstorm complete — proceeding to specify\`.
+  The chain then continues normally from \`specify\` (which applies its own
+  lite/full shape heuristic).
+- \`CHAIN_MODE == off\` (\`--manual\`) or \`once\` → stop after design approval.
+  Print the approved feature brief and tell the user they can run
+  \`/specflow specify "<brief>"\` when ready. Do not auto-invoke \`specify\`.
+
+## Notes
+
+- This phase is design-only: it asks questions and produces a brief. It
+  writes no spec, no plan, and no code — those belong to \`specify\` and the
+  phases after it.
+- Backlog mutations (e.g. refining a vague issue body into the agreed brief)
+  go through the \`product-owner\` agent, never inline — consistent with the
+  rest of the pipeline.
 `,
     executable: false,
     backend: null,
@@ -2403,17 +2515,22 @@ The script emits the body verbatim. Do NOT:
 
 This file carries the chain mechanics that the \`/specflow\` router follows
 when chain mode is engaged. The router reads it after a chainable phase
-(\`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`, \`implement\`, \`review\`)
-completes — unless \`--manual\` or \`--once\` was passed, or downstream
+(\`brainstorm\`, \`specify\`, \`clarify\`, \`plan\`, \`tasks\`, \`analyze\`, \`implement\`,
+\`review\`) completes — unless \`--manual\` or \`--once\` was passed, or downstream
 artefacts indicate one-shot intent.
 
 ## Default flow
 
 \`\`\`
-specify → clarify → plan → tasks → analyze → implement → review → merge
-          ▲                                                        ▲
-          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
+                         ▲                                                        ▲
+                         STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
 \`\`\`
+
+\`brainstorm\` is the optional step 0 (see \`phases/brainstorm.md\`). It runs
+only when the user invokes \`/specflow brainstorm\` because the idea is still
+fuzzy; on design approval it always chains into \`specify\`, which then drives
+the rest of the flow. Entering at \`specify\` skips it.
 
 ## Lite chain
 
@@ -2459,6 +2576,7 @@ The **next phase** depends on the chain shape recorded in
 
 | Current phase | Next (full) | Next (lite) |
 |---|---|---|
+| \`brainstorm\` | \`specify\`   | \`specify\`   |
 | \`specify\`   | \`clarify\`   | \`plan\`      |
 | \`clarify\`   | \`plan\`      | n/a (lite never runs clarify) |
 | \`plan\`      | \`tasks\`     | \`analyze\`   |

--- a/templates/core/skills/specflow/SKILL.md
+++ b/templates/core/skills/specflow/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: specflow
-description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). `/specflow` with no args prints the workflow overview.
-argument-hint: <specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
+description: Specflow workflow router — entry point for the spec-driven pipeline. `/specflow <phase> [args]` dispatches to a single phase (brainstorm, specify, clarify, plan, tasks, analyze, implement, review, merge, constitution, checklist, groom, tag-version, release-version, list-skills, audit). `/specflow` with no args prints the workflow overview.
+argument-hint: <brainstorm|specify|clarify|plan|tasks|analyze|implement|review|merge|constitution|checklist|groom|tag-version|release-version|list-skills|audit> [args]
 when_to_use: |
   Trigger phrases that should route here:
+  - brainstorm: "I have a rough idea", "help me figure out what to build", "let's brainstorm a feature", "I don't know exactly what I want yet"
   - specify: "spec out a feature", "write a spec", "create a specification"
   - clarify: "clarify requirements", "fill in gaps in the spec"
   - plan: "plan a feature", "build a technical plan"
@@ -80,6 +81,7 @@ when_to_use: |
 
 | Phase | Reference | One-liner |
 |-------|-----------|-----------|
+| `brainstorm` | `phases/brainstorm.md` | Optional step 0 — discover a fuzzy idea through dialogue, then hand the agreed brief to `specify`. |
 | `specify` | `phases/specify.md` | Create or update the feature spec from a natural-language description. |
 | `clarify` | `phases/clarify.md` | Resolve ambiguities in the spec via structured questioning. |
 | `plan` | `phases/plan.md` | Generate the technical plan, research, data model, contracts, quickstart. |
@@ -100,8 +102,8 @@ when_to_use: |
 | `audit architecture` | `phases/audit-architecture.md` | Read-only project-wide architectural sweep — hex-layer violations, circular deps, god files, bounded-context leaks. |
 | `audit dependencies` | `phases/audit-dependencies.md` | Read-only multi-manifest dependency-hygiene sweep — unbounded ranges, missing lockfiles, unused deps, license violations, typosquats. |
 
-Chainable phases are: `specify`, `clarify`, `plan`, `tasks`, `analyze`,
-`implement`, `review`. The others (`merge`, `constitution`,
+Chainable phases are: `brainstorm`, `specify`, `clarify`, `plan`, `tasks`,
+`analyze`, `implement`, `review`. The others (`merge`, `constitution`,
 `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`,
 `audit security`, `audit performance`, `audit accessibility`,
 `audit architecture`, `audit dependencies`) are one-shot regardless
@@ -139,16 +141,16 @@ After the phase procedure completes successfully:
 - `CHAIN_MODE == continue` → read `phases/auto-chain.md` and chain
   through the remaining phases regardless of downstream-artefact state.
 - `CHAIN_MODE == auto` (the default) → read `phases/auto-chain.md`. For
-  `specify`, the chain always continues. For any other chainable phase,
-  apply the artefact-detection table in that file — chain if downstream
-  artefacts are absent, one-shot if present.
+  `brainstorm` and `specify`, the chain always continues. For any other
+  chainable phase, apply the artefact-detection table in that file — chain
+  if downstream artefacts are absent, one-shot if present.
 
 ## Workflow overview
 
 ```
-specify → clarify → plan → tasks → analyze → implement → review → merge
-                                                                    ▲
-                                                          STOP for pre-merge validation
+(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
+    ▲                                                                              ▲
+    optional step 0 — only when the idea is still fuzzy            STOP for pre-merge validation
 ```
 
 Default behavior: `/specflow specify "..."` runs the entire chain in one
@@ -156,9 +158,25 @@ session, pausing only at STOP #1 (if clarifications are needed) and
 STOP #2 (pre-merge confirmation). See `phases/auto-chain.md` for the
 chain mechanics.
 
+`brainstorm` is an **optional front-end**: when the user doesn't yet have a
+clear enough idea to spec, `/specflow brainstorm "<rough idea>"` runs a
+discovery dialogue (one question at a time, 2–3 approaches, design approval)
+and then chains into `specify` with the agreed brief. When the brief is
+already clear, start at `/specflow specify` and skip it.
+
 `constitution`, `checklist`, `groom`, `tag-version`, `release-version`, `list-skills`, and `audit <axis>` (any of `security`, `performance`, `accessibility`, `architecture`, `dependencies`) are out-of-band utilities, not part of the linear flow.
 
 ## Typical flow
+
+When the idea is still fuzzy, start one phase earlier:
+
+```
+/specflow brainstorm "let users monitor agent runs from their phone"
+  → discovery dialogue (one question at a time, 2–3 approaches, design approval)
+  → on approval, auto-chains into /specflow specify with the agreed brief
+```
+
+When the brief is already clear, start at `specify`:
 
 ```
 /specflow specify "Add OAuth2 login"

--- a/templates/core/skills/specflow/phases/auto-chain.md
+++ b/templates/core/skills/specflow/phases/auto-chain.md
@@ -2,17 +2,22 @@
 
 This file carries the chain mechanics that the `/specflow` router follows
 when chain mode is engaged. The router reads it after a chainable phase
-(`specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`, `review`)
-completes — unless `--manual` or `--once` was passed, or downstream
+(`brainstorm`, `specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`,
+`review`) completes — unless `--manual` or `--once` was passed, or downstream
 artefacts indicate one-shot intent.
 
 ## Default flow
 
 ```
-specify → clarify → plan → tasks → analyze → implement → review → merge
-          ▲                                                        ▲
-          STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
+                         ▲                                                        ▲
+                         STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
 ```
+
+`brainstorm` is the optional step 0 (see `phases/brainstorm.md`). It runs
+only when the user invokes `/specflow brainstorm` because the idea is still
+fuzzy; on design approval it always chains into `specify`, which then drives
+the rest of the flow. Entering at `specify` skips it.
 
 ## Lite chain
 
@@ -58,6 +63,7 @@ The **next phase** depends on the chain shape recorded in
 
 | Current phase | Next (full) | Next (lite) |
 |---|---|---|
+| `brainstorm` | `specify`   | `specify`   |
 | `specify`   | `clarify`   | `plan`      |
 | `clarify`   | `plan`      | n/a (lite never runs clarify) |
 | `plan`      | `tasks`     | `analyze`   |

--- a/templates/core/skills/specflow/phases/brainstorm.md
+++ b/templates/core/skills/specflow/phases/brainstorm.md
@@ -1,0 +1,85 @@
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+`$ARGUMENTS` is the rough idea to brainstorm. It may be vague ("something to
+let users monitor agent runs from their phone"), a bare issue title, or
+**empty** — if empty, open with a single question: "What do you want to
+build? Describe it in a sentence or two, even roughly." Do not pick a topic
+yourself.
+
+## Purpose
+
+`brainstorm` is the optional **step 0** of the spec-driven pipeline: the
+entry point for when the user does NOT yet have a clear enough idea to write
+a spec. It runs a collaborative discovery dialogue, turns the fuzzy idea into
+an approved design brief, then hands that brief to `/specflow specify` — which
+owns writing the formal `.specflow/specs/<feature>/spec.md`.
+
+Use this phase when the idea needs *discovery* before it can be specified.
+When the user already has a clear brief, they invoke `/specflow specify`
+directly and skip this phase.
+
+## Procedure
+
+The discovery dialogue is already defined, in full, by the bundled
+**`brainstorming` skill**. Do not duplicate it here.
+
+1. **Run the `brainstorming` skill's discovery process.** Read the
+   `brainstorming` skill (via the `Skill` tool, or read its `SKILL.md` if the
+   platform cannot invoke it) and follow its **Steps 1–6**:
+   - Step 1 — explore project context (`git log`, `AGENTS.md`,
+     `.specflow/memory/constitution.md`, the relevant directory structure).
+   - Step 2 — assess scope; if the idea spans multiple independent
+     subsystems, propose splitting it into one brainstorm per subsystem
+     (a multi-subsystem idea is an Epic, not one feature).
+   - Step 3 — ask clarifying questions **one at a time**, multiple-choice
+     where possible (purpose, success criteria, constraints, out of scope).
+   - Step 4 — propose 2–3 approaches with trade-offs; lead with a
+     recommendation.
+   - Step 5 — present the design section by section, confirming each.
+   - Step 6 — design for isolation and clarity.
+
+2. **Get explicit design approval.** Honour the skill's hard rule: no
+   handoff until the user has approved the design. The design may be short
+   for small ideas, but it MUST be presented and approved.
+
+## Terminal handoff — overridden for the spec-kit chain
+
+The standalone `brainstorming` skill ends (its Steps 7–10) by writing its own
+markdown design doc and forking to `writing-plans` **or** `/specflow specify`.
+Inside the `/specflow` router this phase **overrides that ending**:
+
+- **Do NOT** write a separate design doc and do **NOT** hand off to
+  `writing-plans`. `/specflow specify` is the next phase and it owns writing
+  `.specflow/specs/<feature>/spec.md`, so a brainstorm-authored doc would only
+  double up.
+- Instead, distill the approved design into a concise **feature brief**
+  (2–6 sentences capturing goal, the chosen approach, key constraints, and
+  explicit out-of-scope items) and carry it forward as the input to
+  `/specflow specify`.
+
+## Chain decision
+
+`brainstorm` is a **chainable** phase. Its next phase is always `specify`
+(in both the full and lite chain shapes).
+
+- `CHAIN_MODE == auto` (default) or `continue` → after design approval,
+  immediately invoke `/specflow specify` with the distilled feature brief as
+  its `$ARGUMENTS`. Emit `✓ brainstorm complete — proceeding to specify`.
+  The chain then continues normally from `specify` (which applies its own
+  lite/full shape heuristic).
+- `CHAIN_MODE == off` (`--manual`) or `once` → stop after design approval.
+  Print the approved feature brief and tell the user they can run
+  `/specflow specify "<brief>"` when ready. Do not auto-invoke `specify`.
+
+## Notes
+
+- This phase is design-only: it asks questions and produces a brief. It
+  writes no spec, no plan, and no code — those belong to `specify` and the
+  phases after it.
+- Backlog mutations (e.g. refining a vague issue body into the agreed brief)
+  go through the `product-owner` agent, never inline — consistent with the
+  rest of the pipeline.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -2,6 +2,7 @@
   "version": "1.12.0",
   "core": [
     { "category": "skill", "name": "specflow", "source": "core/skills/specflow/SKILL.md" },
+    { "category": "phase", "name": "brainstorm", "suffix": "brainstorm.md", "source": "core/skills/specflow/phases/brainstorm.md" },
     { "category": "phase", "name": "specify", "suffix": "specify.md", "source": "core/skills/specflow/phases/specify.md" },
     { "category": "phase", "name": "clarify", "suffix": "clarify.md", "source": "core/skills/specflow/phases/clarify.md" },
     { "category": "phase", "name": "plan", "suffix": "plan.md", "source": "core/skills/specflow/phases/plan.md" },

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -82,20 +82,21 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     assertEquals(cmdContent.includes("model: opus"), false);
     assertEquals(cmdContent.includes("tools:"), false);
 
-    // Router + 21 phases (11 original + tag-version + release-version +
+    // Router + 22 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
     // #304 + audit-accessibility #305 + audit-architecture #321 +
-    // audit-dependencies #322 + lite-heuristic #346) + specflow-auto +
-    // specflow-review + writing-plans (#271) + requesting-code-review
-    // (#273) + using-specflow (#282) + subagent-driven-development (#272)
-    // + executing-plans (#274) + verification-before-completion (#275) +
-    // brainstorming (#276) + backlog + 15 agents (11 original +
-    // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321 + dependency-auditor #322) = 46.
+    // audit-dependencies #322 + lite-heuristic #346 + brainstorm #351) +
+    // specflow-auto + specflow-review + writing-plans (#271) +
+    // requesting-code-review (#273) + using-specflow (#282) +
+    // subagent-driven-development (#272) + executing-plans (#274) +
+    // verification-before-completion (#275) + brainstorming (#276) +
+    // backlog + 15 agents (11 original + performance-auditor #304 +
+    // a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
+    // #322) = 47.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 46);
+    assertEquals(instructionsCount, 47);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -437,6 +437,7 @@ Deno.test("specflow init scaffolds the consolidated router skill + 11 phase docs
     );
     for (
       const name of [
+        "brainstorm",
         "specify",
         "plan",
         "tasks",

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -74,20 +74,21 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
       true,
     );
 
-    // Router + 21 phases (11 original + tag-version + release-version +
+    // Router + 22 phases (11 original + tag-version + release-version +
     // auto-chain + list-skills + audit-security #303 + audit-performance
     // #304 + audit-accessibility #305 + audit-architecture #321 +
-    // audit-dependencies #322 + lite-heuristic #346) + specflow-auto +
-    // specflow-review alias + writing-plans (#271) + requesting-code-review
-    // (#273) + using-specflow (#282) + subagent-driven-development (#272)
-    // + executing-plans (#274) + verification-before-completion (#275) +
-    // brainstorming (#276) + backlog + 15 agent workflows (11 original +
-    // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321 + dependency-auditor #322) = 46.
+    // audit-dependencies #322 + lite-heuristic #346 + brainstorm #351) +
+    // specflow-auto + specflow-review alias + writing-plans (#271) +
+    // requesting-code-review (#273) + using-specflow (#282) +
+    // subagent-driven-development (#272) + executing-plans (#274) +
+    // verification-before-completion (#275) + brainstorming (#276) +
+    // backlog + 15 agent workflows (11 original + performance-auditor #304
+    // + a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
+    // #322) = 47.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 46);
+    assertEquals(workflowsCount, 47);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -17,14 +17,16 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/specflow/SKILL.md",
     source: "templates/core/skills/specflow/SKILL.md",
   },
-  // 20 phase reference docs, loaded by the router on demand. The
+  // 21 phase reference docs, loaded by the router on demand. The
   // phase-1 audit trio (`audit-security` #303, `audit-performance` #304,
   // `audit-accessibility` #305) shipped in v1.9.0; the phase-2 pair
   // (`audit-architecture` #321 + `audit-dependencies` #322) closes
   // Epic #320. `lite-heuristic` (#346) is a contract doc consulted by
   // `phases/specify.md` when CHAIN_SHAPE == auto — not a phase itself,
-  // but synced through the same byte-identical channel.
+  // but synced through the same byte-identical channel. `brainstorm`
+  // (#351) is the optional step-0 spec-discovery front-end.
   ...[
+    "brainstorm",
     "specify",
     "clarify",
     "plan",


### PR DESCRIPTION
Closes #351.

## Why

Specflow already bundles a `brainstorming` skill (`templates/core/skills/brainstorming/SKILL.md`) — a re-implementation of obra/superpowers brainstorming that turns a vague idea into an approved design via one-question-at-a-time dialogue. But it was only **model-auto-triggered** by phrases ("I want to build X"); there was no **explicit, discoverable command** in the `/specflow` router. The pipeline's documented entry point, `/specflow specify`, assumes the user already has a brief. A user who doesn't yet have a clear vision had no first-class "step 0" to type.

## What

Adds `/specflow brainstorm` as the optional **step-0** front-end to the spec-kit chain:

- **`phases/brainstorm.md`** (new) — reuses the bundled `brainstorming` skill for the discovery dialogue (no duplicated process text) and overrides only its terminal handoff: instead of writing its own design doc / forking to `writing-plans`, it distills the agreed design into a concise brief and chains into `/specflow specify`. `--manual` stops after design approval.
- **Router `SKILL.md`** — phase-index row, `brainstorm` added to the chainable list, frontmatter (`argument-hint` + `when_to_use`), and the workflow overview / typical flow now show `(brainstorm) → specify → …` as an optional step 0.
- **`phases/auto-chain.md`** — `brainstorm → specify` transition documented for both full and lite chain shapes.
- **`templates/manifest.json`** — registered as a `phase`, so it bundles across all harnesses. Plugin mirror (`plugin/skills/specflow/phases/brainstorm.md`) kept byte-identical; bundle regenerated (104 core entries).
- **`docs/llms.md`** — documents the optional step-0 entry point.

## Design note

This phase is deliberately thin: the dialogue mechanics stay owned by the one `brainstorming` skill (DRY). The standalone skill keeps its existing lighter handoff to `writing-plans`; the new phase is specifically the **spec-kit pipeline's** discovery front-end and always targets `specify`.

## Testing

- `deno task test` → **674 passed / 0 failed**.
- Updated phase-enumerating tests: `init_test.ts` phase-exists loop + `plugin_sync_test.ts` list include `brainstorm`; windsurf/copilot flat per-phase workflow counts bumped 46 → 47.
- fmt / lint / bundle / check all green (pre-commit).

## Agent adoption

A new optional first step joins the spec-driven pipeline: when an idea is too fuzzy to spec, `/specflow brainstorm "<rough idea>"` runs a discovery dialogue and then chains straight into `/specflow specify` with the agreed brief. If your brief is already clear, nothing changes — keep starting at `specify`. Reach for brainstorm whenever you're tempted to guess at a spec from a one-line idea.

```prompt
When the user hands you a vague feature idea and you don't yet have enough to write a spec, run `/specflow brainstorm "<their rough idea>"` instead of guessing. It asks one question at a time, proposes 2–3 approaches, gets design approval, then auto-chains into `/specflow specify`. Only start at `/specflow specify` directly when the brief is already concrete.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)