### PR TITLE
fix(release): preflight CI polling + postflight soft-warn diff status + gh retry

### DIFF
--- a/.specflow/release/postflight.sh
+++ b/.specflow/release/postflight.sh
@@ -10,10 +10,13 @@ REPO="mkrlabs/specflow"
 echo "▶ finding release.yml run for $TAG"
 # release.yml is push-tag-triggered; the GitHub Actions API can take 5-30s to
 # register a new run, so poll with retries before giving up. Search up to 20
-# entries so back-to-back releases don't push our run off the page.
+# entries so back-to-back releases don't push our run off the page. The
+# substitution is wrapped with `|| true` so transient gh failures (auth
+# blip, rate limit during the post-release surge) don't kill the loop —
+# they just count as "not found yet" and we retry.
 run_id=""
 for i in 1 2 3 4 5 6 7 8 9 10; do
-  run_id="$(gh run list --workflow release.yml --limit 20 --json databaseId,headBranch --jq ".[] | select(.headBranch == \"$TAG\") | .databaseId" | head -1)"
+  run_id="$(gh run list --workflow release.yml --limit 20 --json databaseId,headBranch --jq ".[] | select(.headBranch == \"$TAG\") | .databaseId" 2>/dev/null | head -1 || true)"
   [ -n "$run_id" ] && break
   echo "  waiting for release.yml run to appear ($i/10)…"
   sleep 15
@@ -32,14 +35,23 @@ echo "▶ verifying Homebrew tap formula bumped to ${TAG#v}"
 # Match the exact commit-message template used by scripts/bump-tap-formula.ts
 # instead of a bare version glob — catches both message-template drift and
 # tag-not-bumped cases. Soft-warn (don't exit), since the bump can land slightly
-# after the release.yml run completes.
+# after the release.yml run completes. We track the soft-warn so the final
+# status differentiates "all green" from "release shipped but tap unverified".
+homebrew_warned=0
 formula_msg="$(gh api repos/mkrlabs/homebrew-tap/commits/main --jq '.commit.message' | head -1)"
 expected_prefix="chore: bump specflow to ${TAG#v}"
-[[ "$formula_msg" == "$expected_prefix"* ]] || { echo "⚠ Homebrew formula tip message != '$expected_prefix*': '$formula_msg'"; }
+if [[ "$formula_msg" != "$expected_prefix"* ]]; then
+  echo "⚠ Homebrew formula tip message != '$expected_prefix*': '$formula_msg'"
+  homebrew_warned=1
+fi
 
 echo "▶ refreshing local binary"
 specflow self-update
 local_version="$(specflow --version | awk '{print $2}')"
 [ "v$local_version" = "$TAG" ] || { echo "❌ local binary at v$local_version, expected $TAG"; exit 1; }
 
-echo "✅ postflight passed — $TAG is live"
+if [ "$homebrew_warned" -eq 1 ]; then
+  echo "✅ release shipped — $TAG is live (⚠ tap bump unverified, re-check in ~60s)"
+else
+  echo "✅ postflight passed — $TAG is live"
+fi

--- a/.specflow/release/preflight.sh
+++ b/.specflow/release/preflight.sh
@@ -18,11 +18,19 @@ git fetch origin main --quiet
 
 echo "▶ CI green on HEAD"
 sha="$(git rev-parse HEAD)"
-# The headSha filter is critical — a bare `--limit 1` would happily return the
-# previous commit's green run while the current commit's CI is still pending.
-# Search up to 20 recent runs to handle PRs landing rapidly back-to-back.
-conclusion="$(gh run list --workflow ci --branch main --limit 20 --json headSha,conclusion,status --jq "[.[] | select(.headSha == \"$sha\" and .status == \"completed\")] | .[0].conclusion")"
-[ "$conclusion" = "success" ] || { echo "❌ CI not green on $sha (got: ${conclusion:-no-completed-run})"; exit 1; }
+# The headSha filter avoids racing on the previous commit's green run. The
+# polling loop tolerates a fresh push where CI hasn't completed yet —
+# symmetric to postflight's release.yml polling. 10 × 30s = up to 5 min;
+# the preflight's `deno task test` runs for ~10-25 s on its own so this
+# rarely fires.
+conclusion=""
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  conclusion="$(gh run list --workflow ci --branch main --limit 20 --json headSha,conclusion,status --jq "[.[] | select(.headSha == \"$sha\" and .status == \"completed\")] | .[0].conclusion")"
+  [ -n "$conclusion" ] && [ "$conclusion" != "null" ] && break
+  echo "  waiting for ci run on $sha to complete ($i/10)…"
+  sleep 30
+done
+[ "$conclusion" = "success" ] || { echo "❌ CI not green on $sha (got: ${conclusion:-no-completed-run-after-5min})"; exit 1; }
 
 echo "▶ smoke audit"
 # audit.sh prints `0 coverage gap(s)` / `0 stale assertion(s)` but does NOT exit


### PR DESCRIPTION
## Summary

Three small follow-ups to PR #364 that were flagged as non-blocking by the code-quality reviewer. The v26.6.8a Cloud release validation surfaced the **preflight CI race** as a real problem (it bit us on the first attempt) so we're not deferring any longer — same fix lands here for CLI symmetry.

### 1. Preflight CI-green polling loop

The bare check fail-closed when the release ran right after a push (the natural case — fix lands, release is next). Postflight already polls for its workflow lookup; preflight now mirrors that. 10×30s window. The existing \`deno task test\` step absorbs the wait on its own most of the time anyway.

### 2. Postflight differentiated final status

Before: postflight printed \`✅ postflight passed\` even when the Homebrew formula soft-warn fired. Masks a real gap. Now tracks a \`homebrew_warned\` flag and prints \`✅ release shipped — <tag> is live (⚠ tap bump unverified, re-check in ~60s)\` so a human can act.

### 3. Postflight \`gh\` retry on transient errors

The polling loop only retried on empty results. A transient \`gh\` error (auth blip, post-release rate-limit surge) would kill the script via \`set -euo pipefail\`. Wrapped the substitution in \`2>/dev/null | head -1 || true\` — transients now count as "not found yet" and the loop retries.

## Test plan

- [x] \`bash -n\` clean on both scripts
- [x] Pre-commit hook (fmt + lint + bundle + check) clean
- [ ] CI green on this PR
- [ ] Next CLI release exercises preflight polling + postflight differentiated status

🤖 Generated with [Claude Code](https://claude.com/claude-code)