### PR TITLE
fix(init): honour --dry-run (#366)

### DIFF
--- a/docs/llms.md
+++ b/docs/llms.md
@@ -169,6 +169,10 @@ Specflow merges its `.gitignore` block into your existing file (non-destructivel
 `# --- Specflow: gitignore ---` markers). Other specflow-managed files use upgrade-aware semantics:
 if you customize a generated file, `specflow upgrade` will preserve it unless you pass `--force`.
 
+Pass `--dry-run` to preview the plan without touching disk — combined with `--force` it shows which
+files would be overwritten and which would be merged, but writes nothing. `--dry-run` is the trump
+card: it wins over `--force`.
+
 ### What's in `.specflow/installed.lock` and should I commit it?
 
 `specflow init` writes a small YAML file at `.specflow/installed.lock`. It records the harness you

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -50,6 +50,12 @@ export type InitProjectInput = {
   targetDir: string;
   initGit: boolean;
   force: boolean;
+  /**
+   * When true, compute the plan and return a synthetic "initialized"
+   * result without touching disk. Trumps `force`: no overwrites, no
+   * backups, no lock written, no git init. Used by `--dry-run`.
+   */
+  dryRun: boolean;
 };
 
 export class InitProjectUseCase {
@@ -68,7 +74,12 @@ export class InitProjectUseCase {
     } = this.deps;
     const warnings: string[] = [];
 
-    await ensureDir(input.targetDir);
+    // `--dry-run` skips creating the target dir entirely (no side
+    // effects). Everything else below is a no-op for dry-run except
+    // the read-only conflict detection.
+    if (!input.dryRun) {
+      await ensureDir(input.targetDir);
+    }
 
     const bundle = harness.mapBundle(core, { backlogBackend, versionScheme });
 
@@ -82,6 +93,29 @@ export class InitProjectUseCase {
           lockExists: existingLock !== null,
         };
       }
+    }
+
+    // Dry-run short-circuit: no writes, no lock, no git init. Synthesize
+    // an InitResult from the bundle so the caller can print the same
+    // "would write N files" summary as a real run.
+    if (input.dryRun) {
+      const mergedPaths: string[] = [];
+      let writtenCount = 0;
+      for (const [dest, file] of Object.entries(bundle)) {
+        if (file.mergeBlock !== undefined || file.mergeJson !== undefined) {
+          mergedPaths.push(dest);
+        } else {
+          writtenCount++;
+        }
+      }
+      return {
+        status: "initialized",
+        filesWritten: writtenCount,
+        filesMerged: mergedPaths,
+        warnings,
+        backups: [],
+        lockWritten: false,
+      };
     }
 
     const report = await writer.writeBundle(bundle, input.targetDir, {

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -42,6 +42,11 @@ export type InitIntent = {
   /** Explicit `--scheme` value (`semver` | `date`). Null = ask/detect. */
   scheme: VersionScheme | null;
   force: boolean;
+  /**
+   * `--dry-run`. Compute the plan and print it without writing anywhere
+   * on disk — trumps `--force` (no overwrites, no backups, no lock).
+   */
+  dryRun: boolean;
 };
 
 async function resolveHarnessKey(
@@ -418,6 +423,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
       targetDir,
       initGit: !intent.noGit,
       force: intent.force,
+      dryRun: intent.dryRun,
     });
   } catch (err) {
     // Surface the actionable first-line message for known structured
@@ -452,6 +458,13 @@ export async function runInit(intent: InitIntent): Promise<number> {
   const mergedSuffix = result.filesMerged.length > 0
     ? ` (+ merged: ${result.filesMerged.join(", ")})`
     : "";
+  if (intent.dryRun) {
+    console.log(
+      green(`✓ would write ${result.filesWritten} files${mergedSuffix}`),
+    );
+    console.log(dim("(dry-run — no files written)"));
+    return 0;
+  }
   console.log(green(`✓ wrote ${result.filesWritten} files${mergedSuffix}`));
 
   await writeBacklogConfigStub(targetDir, backlogBackend, kanbanUrl, githubRepo);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -35,6 +35,8 @@ ${bold("Flags (for init):")}
                       Cargo.toml [lib], composer.json type=library), semver-shaped git tags
                       (v1.2.3), or a CHANGELOG.md with Keep-a-Changelog headers. Falls back to
                       "date" when no signal is found.
+  --force             Overwrite locally-customized files (existing content backed up to *.specflow.bak)
+  --dry-run           Show the plan without writing — trumps --force
 
 ${bold("Flags (for upgrade):")}
   --dry-run           Show the plan without writing

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -78,6 +78,12 @@ export type Intent =
      */
     scheme: "semver" | "date" | null;
     force: boolean;
+    /**
+     * `--dry-run`. Compute the plan (conflicts + would-write counts) and
+     * print it without touching disk. Trumps `--force` — when both are
+     * set, no writes happen. See issue #366.
+     */
+    dryRun: boolean;
   }
   | { kind: "self-update"; checkOnly: boolean }
   | { kind: "check"; projectMode: boolean }
@@ -206,6 +212,7 @@ export function parseArgs(argv: string[]): Intent {
       backlogRepo: backlogRepoRaw,
       scheme: schemeResult.value,
       force: Boolean(parsed.force),
+      dryRun: Boolean(parsed["dry-run"]),
     };
   }
 

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -90,6 +90,7 @@ Deno.test("InitProjectUseCase writes the bundle to the target dir (happy path)",
     targetDir: "/tmp/demo",
     initGit: true,
     force: false,
+    dryRun: false,
   });
   assertEquals(result.status, "initialized");
   if (result.status === "initialized") {
@@ -114,6 +115,7 @@ Deno.test("InitProjectUseCase fails with 'conflicts' when target already has spe
     targetDir: "/tmp/demo",
     initGit: true,
     force: false,
+    dryRun: false,
   });
   assertEquals(result.status, "conflicts");
   if (result.status === "conflicts") {
@@ -146,6 +148,7 @@ Deno.test("InitProjectUseCase reports lockExists=true when conflicts hit a previ
     targetDir: "/tmp/demo",
     initGit: true,
     force: false,
+    dryRun: false,
   });
   assertEquals(result.status, "conflicts");
   if (result.status === "conflicts") {
@@ -165,7 +168,7 @@ Deno.test("InitProjectUseCase calls git.init when repo not initialized and initG
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
-  await useCase.execute({ targetDir: "/tmp/demo", initGit: true, force: false });
+  await useCase.execute({ targetDir: "/tmp/demo", initGit: true, force: false, dryRun: false });
   assert(initCalled.value, "git.init should have been called");
 });
 
@@ -181,7 +184,7 @@ Deno.test("InitProjectUseCase skips git.init when initGit=false", async () => {
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
-  await useCase.execute({ targetDir: "/tmp/demo", initGit: false, force: false });
+  await useCase.execute({ targetDir: "/tmp/demo", initGit: false, force: false, dryRun: false });
   assertEquals(initCalled.value, false);
 });
 
@@ -197,7 +200,12 @@ Deno.test("InitProjectUseCase skips git.init when git not available", async () =
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
-  const result = await useCase.execute({ targetDir: "/tmp/demo", initGit: true, force: false });
+  const result = await useCase.execute({
+    targetDir: "/tmp/demo",
+    initGit: true,
+    force: false,
+    dryRun: false,
+  });
   assertEquals(initCalled.value, false);
   assertEquals(result.status, "initialized");
   // Warning about missing git should be in warnings
@@ -218,7 +226,7 @@ Deno.test("InitProjectUseCase skips git.init when repo already initialized", asy
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
-  await useCase.execute({ targetDir: "/tmp/demo", initGit: true, force: false });
+  await useCase.execute({ targetDir: "/tmp/demo", initGit: true, force: false, dryRun: false });
   assertEquals(initCalled.value, false);
 });
 
@@ -248,6 +256,7 @@ Deno.test("InitProjectUseCase with force=true skips conflict detection and reque
     targetDir: "/tmp/demo",
     initGit: false,
     force: true,
+    dryRun: false,
   });
   assertEquals(result.status, "initialized");
   assertEquals(passedBackupExisting, true);
@@ -279,6 +288,7 @@ Deno.test("InitProjectUseCase returns backups array from writer report", async (
     targetDir: "/tmp/demo",
     initGit: false,
     force: true,
+    dryRun: false,
   });
   if (result.status === "initialized") {
     assertEquals(result.backups, [".claude/x.md"]);
@@ -317,6 +327,7 @@ Deno.test("InitProjectUseCase persists an installed.lock with SHA256 of every fi
     targetDir: "/tmp/demo",
     initGit: false,
     force: false,
+    dryRun: false,
   });
   const written = lockStore.lastWritten;
   assert(written !== null, "lock not written");
@@ -339,7 +350,7 @@ Deno.test("InitProjectUseCase records harness.key in the installed lock", async 
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
-  await uc.execute({ targetDir: "/tmp/demo", initGit: false, force: false });
+  await uc.execute({ targetDir: "/tmp/demo", initGit: false, force: false, dryRun: false });
   assertEquals(lockStore.lastWritten?.harness, "claude");
 });
 
@@ -355,7 +366,7 @@ Deno.test("InitProjectUseCase uses harness.mapBundle output as the file tree", a
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
-  await uc.execute({ targetDir: "/tmp/demo", initGit: false, force: false });
+  await uc.execute({ targetDir: "/tmp/demo", initGit: false, force: false, dryRun: false });
   // The fake harness maps project-root suffix → flat dest.
   assert(writer.written.includes("/tmp/demo:CLAUDE.md"));
 });

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -24,6 +24,7 @@ Deno.test("parseArgs returns init intent with a project name", () => {
     backlogRepo: null,
     scheme: null,
     force: false,
+    dryRun: false,
   });
 });
 
@@ -39,6 +40,7 @@ Deno.test("parseArgs returns init intent with --here", () => {
     backlogRepo: null,
     scheme: null,
     force: false,
+    dryRun: false,
   });
 });
 
@@ -54,6 +56,7 @@ Deno.test("parseArgs returns init intent with --no-git", () => {
     backlogRepo: null,
     scheme: null,
     force: false,
+    dryRun: false,
   });
 });
 
@@ -95,7 +98,32 @@ Deno.test("parseArgs init with --force", () => {
     backlogRepo: null,
     scheme: null,
     force: true,
+    dryRun: false,
   });
+});
+
+Deno.test("parseArgs init with --dry-run", () => {
+  assertEquals(parseArgs(["init", "demo", "--dry-run"]), {
+    kind: "init",
+    projectName: "demo",
+    here: false,
+    noGit: false,
+    ai: null,
+    backlog: null,
+    backlogUrl: null,
+    backlogRepo: null,
+    scheme: null,
+    force: false,
+    dryRun: true,
+  });
+});
+
+Deno.test("parseArgs init with --force --dry-run captures both flags", () => {
+  const r = parseArgs(["init", "--here", "--force", "--dry-run"]);
+  if (r.kind === "init") {
+    assertEquals(r.force, true);
+    assertEquals(r.dryRun, true);
+  }
 });
 
 Deno.test("parseArgs init without --force defaults to false", () => {

--- a/tests/integration/init_dry_run_test.ts
+++ b/tests/integration/init_dry_run_test.ts
@@ -1,0 +1,137 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-init-dry-run-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test(
+  "init --dry-run on a fresh dir exits 0 without writing anything",
+  async () => {
+    await withTempDir(async (dir) => {
+      const result = await runSpecflow(
+        ["init", "demo", "--no-git", "--dry-run"],
+        { cwd: dir },
+      );
+      assertEquals(result.code, 0, `stderr: ${result.stderr}`);
+      assertStringIncludes(result.stdout, "dry-run");
+
+      // Nothing should have been written to disk.
+      assertEquals(await exists(join(dir, "demo/.claude")), false);
+      assertEquals(await exists(join(dir, "demo/.specflow")), false);
+      assertEquals(await exists(join(dir, "demo/AGENTS.md")), false);
+    });
+  },
+);
+
+Deno.test(
+  "init --force --dry-run honours dry-run (does not overwrite existing files)",
+  async () => {
+    await withTempDir(async (dir) => {
+      // Pre-seed a project: real init landed a router skill, the user
+      // customised it.
+      const skillPath = join(dir, "demo/.claude/skills/specflow/SKILL.md");
+      await Deno.mkdir(join(dir, "demo/.claude/skills/specflow"), {
+        recursive: true,
+      });
+      const ORIGINAL = "CUSTOM CONTENT FROM USER";
+      await Deno.writeTextFile(skillPath, ORIGINAL);
+
+      // Dry-run + force must NOT touch the file, NOT create a .specflow.bak,
+      // and NOT write the lock.
+      const result = await runSpecflow(
+        ["init", "demo", "--no-git", "--force", "--dry-run"],
+        { cwd: dir },
+      );
+      assertEquals(result.code, 0, `stderr: ${result.stderr}`);
+      assertStringIncludes(result.stdout, "dry-run");
+
+      // Original file is untouched.
+      const content = await Deno.readTextFile(skillPath);
+      assertEquals(content, ORIGINAL);
+
+      // No backup created.
+      assertEquals(await exists(`${skillPath}.specflow.bak`), false);
+
+      // No lock file written.
+      assertEquals(
+        await exists(join(dir, "demo/.specflow/installed.lock")),
+        false,
+      );
+    });
+  },
+);
+
+Deno.test(
+  "init --here --force --dry-run inside an existing project does not write",
+  async () => {
+    await withTempDir(async (dir) => {
+      // Simulate the Cloud-scaffold reproduction: existing AGENTS.md the user
+      // tweaked, run init --here --force --dry-run — content must survive.
+      const agentsPath = join(dir, "AGENTS.md");
+      const ORIGINAL_AGENTS = "# Project AGENTS\n\nProject-specific notes.\n";
+      await Deno.writeTextFile(agentsPath, ORIGINAL_AGENTS);
+
+      const result = await runSpecflow(
+        [
+          "init",
+          "--here",
+          "--no-git",
+          "--force",
+          "--dry-run",
+          "--ai",
+          "claude",
+          "--backlog",
+          "local",
+        ],
+        { cwd: dir },
+      );
+      assertEquals(result.code, 0, `stderr: ${result.stderr}`);
+
+      // AGENTS.md content survives — this is the regression we're guarding.
+      const content = await Deno.readTextFile(agentsPath);
+      assertEquals(content, ORIGINAL_AGENTS);
+
+      // No .specflow.bak siblings.
+      assertEquals(await exists(`${agentsPath}.specflow.bak`), false);
+
+      // No managed dirs created.
+      assertEquals(await exists(join(dir, ".claude")), false);
+      assertEquals(await exists(join(dir, ".specflow")), false);
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- `specflow init` was silently dropping `--dry-run`; the parser captured the flag globally but the `init` branch never read it (only `upgrade` did)
- Result: `init --here --force --dry-run` wrote to disk, clobbering project files (caught during the Cloud release scaffold)
- Wire `--dry-run` through parser → `InitIntent` → `InitProjectInput` → `InitProjectUseCase.execute()`
- Use case skips `ensureDir`, `writeBundle`, `lockStore.write`, `git.init`; handler skips `writeBacklogConfigStub` and emits `✓ would write N files` + `(dry-run — no files written)`
- `--dry-run` is now the trump card: when both `--force` and `--dry-run` are passed, **no writes happen**

## Files changed
- `src/cli/parser.ts` — accept `dryRun` on init Intent
- `src/cli/handlers/init_handler.ts` — plumb through + dry-run output
- `src/application/init_project.ts` — gate writes, return synthetic counts
- `src/cli/help.ts` — document `--force` / `--dry-run` for init
- `tests/integration/init_dry_run_test.ts` — 3 regression tests
- `tests/cli/parser_test.ts` — 2 new parser fixtures (`--dry-run`, `--force --dry-run`)
- `tests/application/init_project_test.ts` — fixture rows updated for new field

## Test plan
- [x] `deno task test` — 770 passed / 0 failed locally
- [x] `deno fmt --check` — clean
- [ ] CI green
- [ ] Smoke: `specflow init demo --no-git --dry-run` exits 0 with no `demo/` writes
- [ ] Smoke: `specflow init --here --force --dry-run` in an init'd project leaves existing files untouched

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)