### PR TITLE
fix(specify): remove permission-asking language from phase doc

### DIFF
--- a/plugin/skills/specflow/phases/specify.md
+++ b/plugin/skills/specflow/phases/specify.md
@@ -169,36 +169,21 @@ Given that feature description, do this:
         1. List failing items and issues; update spec; re-run (max 3 iterations).
         2. After 3 iterations, document remaining issues and warn user.
 
-      - **[NEEDS CLARIFICATION] markers remain**:
-        1. Keep only the 3 most critical; make informed guesses for the rest.
-        2. For each (max 3), present to user:
-
-           ```markdown
-           ## Question [N]: [Topic]
-
-           **Context**: [Quote relevant spec section]
-           **What we need to know**: [Specific question]
-
-           **Suggested Answers**:
-
-           | Option | Answer | Implications |
-           |--------|--------|--------------|
-           | A      | [First answer] | [Implications] |
-           | B      | [Second answer] | [Implications] |
-           | Custom | Provide your own | — |
-
-           **Your choice**: _[Wait for user response]_
-           ```
-
-        3. Number questions Q1–Q3; present all before waiting for responses.
-        4. Update spec with user's answers; re-run validation.
+      - **[NEEDS CLARIFICATION] markers remain**: keep ≤3 most critical,
+        document informed-guess defaults in Assumptions, leave the
+        surviving markers verbatim for `/specflow clarify` to resolve.
+        **Do NOT prompt inline.** In `lite` shape, markers become
+        Assumptions and the chain continues.
 
    d. **Update Checklist** after each validation iteration.
 
-8. **Report completion** with:
-   - `SPECIFY_FEATURE_DIRECTORY` and `SPEC_FILE`
-   - Checklist results summary
-   - Readiness for next phase (`/specflow clarify` or `/specflow plan`)
+8. **Report completion and proceed (no permission ask)**:
+   - Report `SPECIFY_FEATURE_DIRECTORY`, `SPEC_FILE`, and checklist
+     summary in one short block.
+   - Chain unconditionally to the next phase: `full` → `/specflow clarify`,
+     `lite` → `/specflow plan`. Pause only on `--manual` or `--once`.
+     Transition wording is a statement (`✓ specify complete — proceeding
+     to <next>`), never a question.
 
 9. **Check extension hooks (`hooks.after_specify` in `.specflow/extensions.yml`)**:
    Same rules as Pre-Execution Checks. For each executable hook emit:

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -502,34 +502,21 @@ Given that feature description, do this:
         1. List failing items and issues; update spec; re-run (max 3 iterations).
         2. After 3 iterations, document remaining issues and warn user.
 
-      - **[NEEDS CLARIFICATION] markers remain**:
-        1. Keep only the 3 most critical; make informed guesses for the rest
-           and document the guesses in the Assumptions section.
-        2. **Do NOT prompt the user inline during specify.** The remaining
-           markers are handed off to \`/specflow clarify\` (the next phase
-           in \`full\` chain shape), which is the phase responsible for
-           interactive resolution. In \`lite\` chain shape, \`clarify\` is
-           skipped — the markers are converted to Assumptions with the
-           informed-guess defaults and the chain continues.
-        3. Leave the surviving markers in the spec verbatim so \`clarify\`
-           can find them. Never strip a marker silently.
+      - **[NEEDS CLARIFICATION] markers remain**: keep ≤3 most critical,
+        document informed-guess defaults in Assumptions, leave the
+        surviving markers verbatim for \`/specflow clarify\` to resolve.
+        **Do NOT prompt inline.** In \`lite\` shape, markers become
+        Assumptions and the chain continues.
 
    d. **Update Checklist** after each validation iteration.
 
-8. **Report completion and proceed**:
-   - Report \`SPECIFY_FEATURE_DIRECTORY\` and \`SPEC_FILE\` and the checklist
-     results summary in one short block.
-   - **Do not ask the user whether to continue.** The router's
-     chain-decision step takes over from here — specify is in the
-     chainable set and "the chain always continues" for \`specify\`
-     (see \`SKILL.md\` § "Chain decision"). The only legitimate stops
-     after specify are: \`CHAIN_MODE == off\` (the user passed \`--manual\`),
-     or \`CHAIN_MODE == once\` (the user passed \`--once\`). In every other
-     case proceed to the next phase WITHOUT a permission ask:
-       - \`CHAIN_SHAPE == full\` → next phase is \`/specflow clarify\`
-       - \`CHAIN_SHAPE == lite\` → next phase is \`/specflow plan\`
-     Phrase the transition as a one-liner (\`✓ specify complete —
-     proceeding to <next>\`), NOT as a question.
+8. **Report completion and proceed (no permission ask)**:
+   - Report \`SPECIFY_FEATURE_DIRECTORY\`, \`SPEC_FILE\`, and checklist
+     summary in one short block.
+   - Chain unconditionally to the next phase: \`full\` → \`/specflow clarify\`,
+     \`lite\` → \`/specflow plan\`. Pause only on \`--manual\` or \`--once\`.
+     Transition wording is a statement (\`✓ specify complete — proceeding
+     to <next>\`), never a question.
 
 9. **Check extension hooks (\`hooks.after_specify\` in \`.specflow/extensions.yml\`)**:
    Same rules as Pre-Execution Checks. For each executable hook emit:

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -503,35 +503,33 @@ Given that feature description, do this:
         2. After 3 iterations, document remaining issues and warn user.
 
       - **[NEEDS CLARIFICATION] markers remain**:
-        1. Keep only the 3 most critical; make informed guesses for the rest.
-        2. For each (max 3), present to user:
-
-           \`\`\`markdown
-           ## Question [N]: [Topic]
-
-           **Context**: [Quote relevant spec section]
-           **What we need to know**: [Specific question]
-
-           **Suggested Answers**:
-
-           | Option | Answer | Implications |
-           |--------|--------|--------------|
-           | A      | [First answer] | [Implications] |
-           | B      | [Second answer] | [Implications] |
-           | Custom | Provide your own | — |
-
-           **Your choice**: _[Wait for user response]_
-           \`\`\`
-
-        3. Number questions Q1–Q3; present all before waiting for responses.
-        4. Update spec with user's answers; re-run validation.
+        1. Keep only the 3 most critical; make informed guesses for the rest
+           and document the guesses in the Assumptions section.
+        2. **Do NOT prompt the user inline during specify.** The remaining
+           markers are handed off to \`/specflow clarify\` (the next phase
+           in \`full\` chain shape), which is the phase responsible for
+           interactive resolution. In \`lite\` chain shape, \`clarify\` is
+           skipped — the markers are converted to Assumptions with the
+           informed-guess defaults and the chain continues.
+        3. Leave the surviving markers in the spec verbatim so \`clarify\`
+           can find them. Never strip a marker silently.
 
    d. **Update Checklist** after each validation iteration.
 
-8. **Report completion** with:
-   - \`SPECIFY_FEATURE_DIRECTORY\` and \`SPEC_FILE\`
-   - Checklist results summary
-   - Readiness for next phase (\`/specflow clarify\` or \`/specflow plan\`)
+8. **Report completion and proceed**:
+   - Report \`SPECIFY_FEATURE_DIRECTORY\` and \`SPEC_FILE\` and the checklist
+     results summary in one short block.
+   - **Do not ask the user whether to continue.** The router's
+     chain-decision step takes over from here — specify is in the
+     chainable set and "the chain always continues" for \`specify\`
+     (see \`SKILL.md\` § "Chain decision"). The only legitimate stops
+     after specify are: \`CHAIN_MODE == off\` (the user passed \`--manual\`),
+     or \`CHAIN_MODE == once\` (the user passed \`--once\`). In every other
+     case proceed to the next phase WITHOUT a permission ask:
+       - \`CHAIN_SHAPE == full\` → next phase is \`/specflow clarify\`
+       - \`CHAIN_SHAPE == lite\` → next phase is \`/specflow plan\`
+     Phrase the transition as a one-liner (\`✓ specify complete —
+     proceeding to <next>\`), NOT as a question.
 
 9. **Check extension hooks (\`hooks.after_specify\` in \`.specflow/extensions.yml\`)**:
    Same rules as Pre-Execution Checks. For each executable hook emit:

--- a/templates/core/skills/specflow/phases/specify.md
+++ b/templates/core/skills/specflow/phases/specify.md
@@ -170,35 +170,33 @@ Given that feature description, do this:
         2. After 3 iterations, document remaining issues and warn user.
 
       - **[NEEDS CLARIFICATION] markers remain**:
-        1. Keep only the 3 most critical; make informed guesses for the rest.
-        2. For each (max 3), present to user:
-
-           ```markdown
-           ## Question [N]: [Topic]
-
-           **Context**: [Quote relevant spec section]
-           **What we need to know**: [Specific question]
-
-           **Suggested Answers**:
-
-           | Option | Answer | Implications |
-           |--------|--------|--------------|
-           | A      | [First answer] | [Implications] |
-           | B      | [Second answer] | [Implications] |
-           | Custom | Provide your own | — |
-
-           **Your choice**: _[Wait for user response]_
-           ```
-
-        3. Number questions Q1–Q3; present all before waiting for responses.
-        4. Update spec with user's answers; re-run validation.
+        1. Keep only the 3 most critical; make informed guesses for the rest
+           and document the guesses in the Assumptions section.
+        2. **Do NOT prompt the user inline during specify.** The remaining
+           markers are handed off to `/specflow clarify` (the next phase
+           in `full` chain shape), which is the phase responsible for
+           interactive resolution. In `lite` chain shape, `clarify` is
+           skipped — the markers are converted to Assumptions with the
+           informed-guess defaults and the chain continues.
+        3. Leave the surviving markers in the spec verbatim so `clarify`
+           can find them. Never strip a marker silently.
 
    d. **Update Checklist** after each validation iteration.
 
-8. **Report completion** with:
-   - `SPECIFY_FEATURE_DIRECTORY` and `SPEC_FILE`
-   - Checklist results summary
-   - Readiness for next phase (`/specflow clarify` or `/specflow plan`)
+8. **Report completion and proceed**:
+   - Report `SPECIFY_FEATURE_DIRECTORY` and `SPEC_FILE` and the checklist
+     results summary in one short block.
+   - **Do not ask the user whether to continue.** The router's
+     chain-decision step takes over from here — specify is in the
+     chainable set and "the chain always continues" for `specify`
+     (see `SKILL.md` § "Chain decision"). The only legitimate stops
+     after specify are: `CHAIN_MODE == off` (the user passed `--manual`),
+     or `CHAIN_MODE == once` (the user passed `--once`). In every other
+     case proceed to the next phase WITHOUT a permission ask:
+       - `CHAIN_SHAPE == full` → next phase is `/specflow clarify`
+       - `CHAIN_SHAPE == lite` → next phase is `/specflow plan`
+     Phrase the transition as a one-liner (`✓ specify complete —
+     proceeding to <next>`), NOT as a question.
 
 9. **Check extension hooks (`hooks.after_specify` in `.specflow/extensions.yml`)**:
    Same rules as Pre-Execution Checks. For each executable hook emit:

--- a/templates/core/skills/specflow/phases/specify.md
+++ b/templates/core/skills/specflow/phases/specify.md
@@ -169,34 +169,21 @@ Given that feature description, do this:
         1. List failing items and issues; update spec; re-run (max 3 iterations).
         2. After 3 iterations, document remaining issues and warn user.
 
-      - **[NEEDS CLARIFICATION] markers remain**:
-        1. Keep only the 3 most critical; make informed guesses for the rest
-           and document the guesses in the Assumptions section.
-        2. **Do NOT prompt the user inline during specify.** The remaining
-           markers are handed off to `/specflow clarify` (the next phase
-           in `full` chain shape), which is the phase responsible for
-           interactive resolution. In `lite` chain shape, `clarify` is
-           skipped — the markers are converted to Assumptions with the
-           informed-guess defaults and the chain continues.
-        3. Leave the surviving markers in the spec verbatim so `clarify`
-           can find them. Never strip a marker silently.
+      - **[NEEDS CLARIFICATION] markers remain**: keep ≤3 most critical,
+        document informed-guess defaults in Assumptions, leave the
+        surviving markers verbatim for `/specflow clarify` to resolve.
+        **Do NOT prompt inline.** In `lite` shape, markers become
+        Assumptions and the chain continues.
 
    d. **Update Checklist** after each validation iteration.
 
-8. **Report completion and proceed**:
-   - Report `SPECIFY_FEATURE_DIRECTORY` and `SPEC_FILE` and the checklist
-     results summary in one short block.
-   - **Do not ask the user whether to continue.** The router's
-     chain-decision step takes over from here — specify is in the
-     chainable set and "the chain always continues" for `specify`
-     (see `SKILL.md` § "Chain decision"). The only legitimate stops
-     after specify are: `CHAIN_MODE == off` (the user passed `--manual`),
-     or `CHAIN_MODE == once` (the user passed `--once`). In every other
-     case proceed to the next phase WITHOUT a permission ask:
-       - `CHAIN_SHAPE == full` → next phase is `/specflow clarify`
-       - `CHAIN_SHAPE == lite` → next phase is `/specflow plan`
-     Phrase the transition as a one-liner (`✓ specify complete —
-     proceeding to <next>`), NOT as a question.
+8. **Report completion and proceed (no permission ask)**:
+   - Report `SPECIFY_FEATURE_DIRECTORY`, `SPEC_FILE`, and checklist
+     summary in one short block.
+   - Chain unconditionally to the next phase: `full` → `/specflow clarify`,
+     `lite` → `/specflow plan`. Pause only on `--manual` or `--once`.
+     Transition wording is a statement (`✓ specify complete — proceeding
+     to <next>`), never a question.
 
 9. **Check extension hooks (`hooks.after_specify` in `.specflow/extensions.yml`)**:
    Same rules as Pre-Execution Checks. For each executable hook emit:


### PR DESCRIPTION
## Summary
The `/specflow specify` phase template was causing the agent to pause mid-auto-chain to ask permission, undermining the Specflow Auto end-to-end promise.

- Step 7c (NEEDS CLARIFICATION handling): drop the inline Q1–Q3 prompt with "Wait for user response". Markers are deferred to `/specflow clarify` (full shape) or converted to Assumptions with informed defaults (lite shape). No inline pause.
- Step 8 (Report completion): rename to "Report completion and proceed". Make the chain transition explicit and unconditional except for `--manual`, `--once`, and `CHAIN_SHAPE` routing. Phrase as `✓ specify complete — proceeding to <next>`, NOT as a question.
- Bundle regenerated.

## Why
Kevin's feedback (2026-06-08): "Je ne veux plus que tu me demandes de faire des stops constants… Le Workflow Specflow Auto est fait pour que tu te bouges et que tu te dépêches de travailler. Tu modifies Specflow la partie specify pour que quand je te dis qu'on fait une spécification automatique tu ailles jusqu'au bout."

## Test plan
- [x] `deno task bundle` regenerates `src/templates_bundle.ts` (committed)
- [ ] CI green
- [ ] Smoke: an `/specflow specify "..."` invocation with auto-chain mode produces the spec, then proceeds to `/specflow clarify` (or `/specflow plan` in lite) without an interactive permission ask between phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)