### PR TITLE
feat(init,upgrade): parent-managed detection — suppress .claude/ provisioning in workspace sub-repos (#371)

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specflow/specs/008-cloud-keychain",
-  "linked_issue": 360,
+  "feature_directory": ".specflow/specs/009-parent-managed-init",
+  "linked_issue": 371,
   "workflow_shape": "full"
 }

--- a/.specflow/specs/009-parent-managed-init/checklists/requirements.md
+++ b/.specflow/specs/009-parent-managed-init/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: Parent-managed detection for init/upgrade
+
+**Purpose**: Validate specification completeness before planning **Created**: 2026-06-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable and technology-agnostic
+- [x] All acceptance scenarios defined; edge cases identified
+- [x] Scope clearly bounded; dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details in specification
+
+## Notes
+
+Spec is derived from issue #371, which carries a complete pre-authored behavioural contract (C1–C5)
+and the source contract file at
+`mkrlabs/specflow-monorepo:.specflow/specs/002-centralize-skills-agents/contracts/parent-managed-detection.md`.
+That removed the usual ambiguity — no `[NEEDS CLARIFICATION]` markers were needed. Every FR maps to
+an acceptance scenario and at least one SC; every SC maps back to a contract item (C1–C5) or FR.
+Ready for `/specflow plan`.

--- a/.specflow/specs/009-parent-managed-init/contracts/parent-managed-detection.md
+++ b/.specflow/specs/009-parent-managed-init/contracts/parent-managed-detection.md
@@ -1,0 +1,85 @@
+# Contract — Parent-managed detection for init/upgrade
+
+CLI-internal contract (no wire/HTTP surface). Mirrors the source contract in
+`mkrlabs/specflow-monorepo:.specflow/specs/002-centralize-skills-agents/contracts/parent-managed-detection.md`
+(C1–C5) and binds it to concrete `apps/specflow` seams.
+
+## 1. Detection port — `ParentWorkspaceReader`
+
+```ts
+interface ParentWorkspaceReader {
+  findProvidingAncestor(targetDir: string): Promise<string | null>;
+  hasStandaloneOverride(targetDir: string): Promise<boolean>;
+}
+```
+
+**`findProvidingAncestor` contract**
+
+- Walks `dirname(targetDir)` upward to filesystem root.
+- Returns the canonical path of the **first** ancestor `A` such that:
+  - `A/.specflow/` exists (directory), **and**
+  - `A/deno.json` exists and its `workspace` array contains ≥1 member whose path, resolved relative
+    to `A` and canonicalised (`Deno.realPath`), equals the canonicalised `targetDir`.
+- Returns `null` if no such ancestor exists or the root is reached.
+- Tolerates missing/unparseable `deno.json` at an ancestor (treat as non-match, keep walking).
+
+**`hasStandaloneOverride` contract**
+
+- Returns `true` iff `targetDir/.specflow/standalone.yml` exists. Contents ignored.
+
+## 2. Decision function (pure)
+
+```ts
+isParentManaged(providingAncestor: string | null, standaloneOverride: boolean): boolean
+```
+
+- `standaloneOverride === true` ⇒ `false` (override always wins).
+- else ⇒ `providingAncestor !== null`.
+
+## 3. Bundle filter
+
+```ts
+isAgenticPath(dest: string): boolean   // .claude/skills|agents|commands prefixes
+```
+
+- **init** (`InitProjectUseCase.execute`): after `harness.mapBundle(...)`, if `input.parentManaged`,
+  drop every entry whose `dest` satisfies `isAgenticPath`. Build `writeBundle` input AND lock
+  entries from the filtered bundle.
+- **upgrade** (`UpgradeProjectUseCase.execute`): after `fullBundle` is built, if the target is
+  parent-managed (per lock), drop agentic entries before computing `destPaths`/`bundle`. Never plan,
+  write, or "restore" a suppressed path.
+
+## 4. Lock-schema change
+
+- `InstalledLock` gains `parentManaged?: true`; YAML key `parent_managed`, emitted only when set.
+- For a parent-managed target the `entries` map contains **no** agentic keys.
+- Legacy locks (no key) parse to `undefined`; upgrade re-derives once via the port and persists the
+  result.
+
+## 5. Handler wiring
+
+- `init_handler.runInit`: call the reader, compute the decision, set
+  `InitProjectInput.parentManaged`. On `true`, print exactly once:
+  `parent-managed workspace detected — skills/agents inherited from parent`.
+- `upgrade_handler.runUpgrade`: take `lock.parentManaged` if present; else re-derive via the reader
+  and persist into the rewritten lock.
+
+## 6. Acceptance mapping (C1–C5 ⇄ tests ⇄ SC/FR)
+
+| Contract                                           | Test                                                                                                                 | Asserts                                                                                               | Spec               |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------ |
+| **C1** member target ⇒ init writes 0 agentic files | `tests/integration/init_parent_managed_test.ts::parent-managed suppresses agentic`                                   | 0 files under `target/.claude/skills` & `target/.claude/agents`; `.specflow/` present; notice printed | SC-001, FR-005/006 |
+| **C2** standalone ⇒ unchanged provisioning         | `…::standalone provisions normally`                                                                                  | skills/agents written; parity with baseline                                                           | SC-002, FR-009/010 |
+| **C3** upgrade on parent-managed ⇒ no resurrection | `tests/integration/upgrade_parent_managed_test.ts::no agentic resurrection`                                          | upgrade updates `.specflow/`; 0 agentic files; no `.claude/` recreated                                | SC-003, FR-007     |
+| **C4** `standalone.yml` ⇒ forced full provisioning | `tests/integration/init_parent_managed_test.ts::override forces full`                                                | skills/agents written despite enclosing workspace                                                     | SC-004, FR-008     |
+| **C5** manifest has no agentic entries             | `tests/integration/upgrade_parent_managed_test.ts::lock has no agentic entries` (+ unit in `installed_lock_test.ts`) | `installed.lock` entries exclude `.claude/skills`/`.claude/agents`; `parent_managed: true` present    | SC-005, FR-012     |
+
+Unit coverage backing the above:
+
+- `tests/domain/parent_managed_test.ts` — `isParentManaged` truth table (override wins; null ⇒
+  false; ancestor ⇒ true) + `isAgenticPath` prefix matrix.
+- `tests/application/init_project_test.ts` — fake reader → filtered `written` set + filtered lock
+  entries.
+- `tests/application/upgrade_project_test.ts` — `lock.parentManaged=true` → filtered bundle; legacy
+  lock → re-derive path.
+- `tests/domain/installed_lock_test.ts` — `parent_managed` round-trips; absence ⇒ `undefined`.

--- a/.specflow/specs/009-parent-managed-init/data-model.md
+++ b/.specflow/specs/009-parent-managed-init/data-model.md
@@ -1,0 +1,96 @@
+# Phase 1 Data Model — Parent-managed detection
+
+Bounded context: **CLI provisioning**. All types are CLI-internal; nothing crosses the OSS/Cloud
+HTTP boundary.
+
+## Domain types (pure — `src/domain/parent_managed.ts`)
+
+### `ParentManagedDecision` (value object)
+
+| Field                | Type             | Meaning                                                   |
+| -------------------- | ---------------- | --------------------------------------------------------- |
+| `isParentManaged`    | `boolean`        | Final decision: suppress agentic files?                   |
+| `providingWorkspace` | `string \| null` | Canonical path of the first providing ancestor, or `null` |
+
+Computed by the pure function:
+
+```
+isParentManaged(providingAncestor: string | null, standaloneOverride: boolean): boolean
+  = standaloneOverride ? false : providingAncestor !== null
+```
+
+- **Invariant**: `standaloneOverride === true` ⇒ result is always `false` (override wins — FR-008).
+- **Invariant**: pure — no `Deno.*`; all filesystem facts are passed in as arguments.
+
+### Agentic-path predicate
+
+```
+isAgenticPath(dest: string): boolean
+  = dest.startsWith(".claude/skills/")
+ || dest.startsWith(".claude/agents/")
+ || dest.startsWith(".claude/commands/")
+```
+
+- Operates on **harness-mapped destination strings**, not `CoreCategory`.
+- Non-matches (always provisioned): every `.specflow/**` path, `AGENTS.md`, `.gitignore`,
+  `.claude/settings.json`, and any non-`.claude` harness target.
+- **Invariant**: the predicate never depends on repo identity (FR-010/FR-011).
+
+## Application port (`src/application/ports.ts`)
+
+### `ParentWorkspaceReader`
+
+```
+interface ParentWorkspaceReader {
+  // Walk parents of targetDir to filesystem root; return the canonical path of
+  // the first ancestor that has .specflow/ AND a deno.json whose `workspace`
+  // member list resolves (canonically) to targetDir. null if none.
+  findProvidingAncestor(targetDir: string): Promise<string | null>;
+
+  // True iff targetDir/.specflow/standalone.yml exists.
+  hasStandaloneOverride(targetDir: string): Promise<boolean>;
+}
+```
+
+- The **only** abstraction that touches the filesystem for detection.
+- Concrete adapter: `FsParentWorkspaceReader` (`src/infrastructure/`).
+- Fakeable in unit tests by returning canned ancestor / override values.
+
+## Manifest extension (`src/domain/installed_lock.ts`)
+
+`InstalledLock` gains one optional field:
+
+| Field           | Type                | YAML key         | When written                                              |
+| --------------- | ------------------- | ---------------- | --------------------------------------------------------- |
+| `parentManaged` | `true \| undefined` | `parent_managed` | only when the target is parent-managed; omitted otherwise |
+
+- `serializeLock`: emit `parent_managed: true` only when set.
+- `parseLock`: missing key ⇒ `undefined` (legacy locks parse cleanly).
+- `entries` map is **unchanged in shape** but, for a parent-managed target, contains **no**
+  `.claude/skills`/`.claude/agents`/`.claude/commands` keys (they were filtered before lock
+  construction) — this is the FR-012 guarantee.
+- `LockStore` port signatures unchanged.
+
+## State / flow
+
+```
+init:
+  handler → reader.hasStandaloneOverride(target)         \
+          → reader.findProvidingAncestor(target)          >── isParentManaged() → decision
+          → InitProjectInput{ parentManaged: decision }   /
+  use case → bundle = mapBundle(...); if parentManaged: bundle = filter(bundle, !isAgenticPath)
+           → writeBundle(bundle); lock.entries = from(bundle); lock.parentManaged = decision||undefined
+
+upgrade:
+  handler → lock = read()
+          → parentManaged = lock.parentManaged ?? (legacy: re-derive via reader, persist)
+  use case → if parentManaged: fullBundle = filter(fullBundle, !isAgenticPath)
+           → never recreates .claude/ for suppressed paths
+```
+
+## Validation rules
+
+- Member-path comparison uses canonical absolute paths on both sides (FR-004).
+- Detection resolves on the **first** providing ancestor; ancestors above are not consulted.
+- An ancestor with `.specflow/` but no matching member, or with a matching member but no
+  `.specflow/`, does **not** qualify.

--- a/.specflow/specs/009-parent-managed-init/plan.md
+++ b/.specflow/specs/009-parent-managed-init/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Parent-managed detection for init/upgrade
+
+**Branch**: `009-parent-managed-init` | **Date**: 2026-06-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `.specflow/specs/009-parent-managed-init/spec.md`
+
+## Summary
+
+Add a `isParentManaged(targetDir) → boolean` detection to `specflow init` and `specflow upgrade`.
+When the target sits inside a **providing Specflow workspace** (an ancestor with `.specflow/` whose
+`deno.json` `workspace` list resolves to the target), provision the `.specflow/` toolkit as normal
+but write **zero** agentic files (`.claude/skills/`, `.claude/agents/`, `.claude/commands/`). A
+`target/.specflow/standalone.yml` marker overrides detection to force full provisioning. The CLI is
+never special-cased; standalone clones are unchanged.
+
+**Technical approach** (grounded in the current hexagonal code, per architect pass):
+
+- New **pure domain** functions `isParentManaged()` + `isAgenticPath()` in
+  `src/domain/parent_managed.ts`.
+- New **port** `ParentWorkspaceReader` in `src/application/ports.ts` + adapter
+  `FsParentWorkspaceReader` in `src/infrastructure/fs_parent_workspace_reader.ts` (the only place
+  that walks the filesystem / parses ancestor `deno.json`).
+- Thread a `parentManaged: boolean` through `InitProjectInput`; **filter the mapped bundle** in
+  `InitProjectUseCase.execute()` before `writeBundle` and before lock-entry construction (so
+  suppressed files never enter the lock).
+- Persist `parentManaged?: true` on `InstalledLock`; `UpgradeProjectUseCase` reads it (re-deriving
+  via the port on legacy locks) and applies the same filter.
+- Handlers (`init_handler`, `upgrade_handler`) resolve detection and emit the one-line notice.
+
+## Technical Context
+
+**Language/Version**: Deno / TypeScript (per `apps/specflow/deno.json`, currently v1.13.1)\
+**Primary Dependencies**: Deno std (`@std/path`), no new third-party deps\
+**Storage**: filesystem; `.specflow/installed.lock` (YAML) is the install manifest\
+**Testing**: `deno task test` — unit (in-memory port fakes) + integration (`Deno.makeTempDir` +
+`runSpecflow`)\
+**Target Platform**: cross-platform CLI binary (macOS / Linux / Windows)\
+**Project Type**: single-project CLI (hexagonal: domain / application / infrastructure / cli)\
+**Performance Goals**: detection adds one bounded upward directory walk (≤ depth-to-root
+`Deno.stat`/`readTextFile`); negligible vs init/upgrade runtime\
+**Constraints**: must not special-case the CLI repo (FR-010); suppressed files must not appear in
+the lock (FR-012); upgrade must never resurrect deleted `.claude/` (FR-007)\
+**Scale/Scope**: ~3 new source files, 2 use-case edits, 2 handler edits, 1 lock-schema field; 7 task
+groups
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+The CLI repo has no runtime `.specflow/memory/constitution.md`; the binding principles are in
+`apps/specflow/AGENTS.md` § "Design principles" (l.172-173) and the monorepo constitution § I
+(OSS/private boundary). Gates evaluated:
+
+| Principle                                                                                               | Status  | Justification                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Hexagonal layering** (domain pure, application owns ports, infrastructure adapters, cli presentation) | ✅ PASS | New logic split exactly: pure predicates → `domain/`; port → `application/ports.ts`; FS walk → `infrastructure/`; wiring + notice → `cli/handlers/`. No Deno.* in domain/application. |
+| **Ports for all I/O** (testability)                                                                     | ✅ PASS | Filesystem walk + ancestor `deno.json` parse routed through new `ParentWorkspaceReader` port; use cases stay FS-free and unit-testable with fakes.                                    |
+| **TDD / tests mirror src**                                                                              | ✅ PASS | Each task lands tests beside it: `tests/domain/`, `tests/application/`, `tests/integration/` mirror the `src/` tree (architect-confirmed pattern). C1–C5 become integration fixtures. |
+| **OSS/private boundary** (constitution § I)                                                             | ✅ PASS | CLI-only change; no Cloud/Mobile identifier, no private-half reference. "Providing workspace" is a generic Deno-workspace concept, not a Specflow-monorepo-specific name.             |
+| **No CLI special-casing** (FR-010)                                                                      | ✅ PASS | Decision inputs are only enclosing-workspace structure + override marker; repo identity is never read.                                                                                |
+| **Backward compatibility**                                                                              | ✅ PASS | Legacy `installed.lock` without `parent_managed` → upgrade re-derives once via the port, then caches; standalone path byte-for-byte unchanged.                                        |
+
+No violations. No complexity-tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specflow/specs/009-parent-managed-init/
+├── spec.md              # /specflow specify output (done)
+├── plan.md              # this file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── parent-managed-detection.md   # port + filter + lock contract
+├── checklists/
+│   └── requirements.md  # spec quality checklist (done)
+└── tasks.md             # /specflow tasks output (next phase)
+```
+
+### Source Code (repository root = apps/specflow/)
+
+```text
+src/
+├── domain/
+│   ├── parent_managed.ts            # NEW — isParentManaged(), isAgenticPath() (pure)
+│   └── installed_lock.ts            # EDIT — add parentManaged?: true to InstalledLock + (de)serialize
+├── application/
+│   ├── ports.ts                     # EDIT — add ParentWorkspaceReader port
+│   ├── init_project.ts              # EDIT — InitProjectInput.parentManaged + bundle filter
+│   └── upgrade_project.ts           # EDIT — read lock.parentManaged (re-derive on legacy) + bundle filter
+├── infrastructure/
+│   └── fs_parent_workspace_reader.ts # NEW — FsParentWorkspaceReader adapter (upward walk + deno.json)
+└── cli/handlers/
+    ├── init_handler.ts              # EDIT — resolve detection, pass parentManaged, emit notice
+    └── upgrade_handler.ts           # EDIT — resolve/migrate detection for upgrade
+
+tests/
+├── domain/
+│   ├── parent_managed_test.ts       # NEW — unit: predicates
+│   └── installed_lock_test.ts       # EDIT — round-trip parent_managed field
+├── application/
+│   ├── init_project_test.ts         # EDIT — parent-managed suppression cases
+│   └── upgrade_project_test.ts      # EDIT — lock.parentManaged suppression cases
+└── integration/
+    ├── init_parent_managed_test.ts  # NEW — C1, C2, C4 (override)
+    └── upgrade_parent_managed_test.ts # NEW — C3, C5
+```
+
+## Phase 0: Outline & Research
+
+See [research.md](./research.md). All Technical Context items resolved — no `NEEDS CLARIFICATION`
+remained after the architect pass over the current code. Key decisions: handler-side detection (not
+a use-case dep); predicate over mapped bundle `dest` strings (not `CoreCategory`); lock field caches
+the decision; legacy-lock migration re-derives once.
+
+## Phase 1: Design & Contracts
+
+- **Data model**: [data-model.md](./data-model.md) — `ParentManagedDecision`, `StandaloneOverride`,
+  the `InstalledLock.parentManaged` extension, and the agentic-path predicate domain.
+- **Contracts**: [contracts/parent-managed-detection.md](./contracts/parent-managed-detection.md) —
+  the `ParentWorkspaceReader` port signature, the bundle-filter behaviour, the lock-schema change,
+  and the C1–C5 acceptance mapping.
+- **Quickstart**: [quickstart.md](./quickstart.md) — how to verify the feature by hand and which
+  tests cover each contract item.
+- **Agent context**: no `<!-- SPECFLOW START/END -->` markers present in this repo's context file;
+  nothing to update.
+
+### Post-design Constitution re-check
+
+Re-evaluated after design: all gates still PASS. The port keeps the use cases pure; the filter lives
+in the use case (not the adapter) so the lock and the written set stay in lock-step (FR-012). No new
+dependencies, no boundary crossings, no CLI special-casing.
+
+## Phases summary (for /specflow tasks)
+
+1. Domain predicates `parent_managed.ts` + unit tests.
+2. `ParentWorkspaceReader` port + `FsParentWorkspaceReader` adapter + adapter tests.
+3. `InstalledLock.parentManaged` field + (de)serialize + round-trip tests.
+4. `InitProjectInput.parentManaged` + use-case bundle filter + unit tests.
+5. `UpgradeProjectUseCase` lock-driven filter (+ legacy re-derive) + unit tests.
+6. Handler wiring (`init`, `upgrade`) + one-line notice.
+7. Integration tests C1–C5.
+
+## Key rules
+
+- Absolute paths for filesystem ops; project-relative paths in docs/references.
+- ERROR on any gate failure (none expected).
+- Domain stays pure: no `Deno.*` in `domain/` or `application/`.

--- a/.specflow/specs/009-parent-managed-init/quickstart.md
+++ b/.specflow/specs/009-parent-managed-init/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart — Parent-managed detection
+
+How to verify #371 by hand and where the automated coverage lives.
+
+## Manual smoke (parent-managed case → C1)
+
+```bash
+# 1. Build a providing workspace fixture
+mkdir -p /tmp/ws/child
+printf '{ "workspace": ["./child"] }\n' > /tmp/ws/deno.json
+mkdir -p /tmp/ws/.specflow            # makes /tmp/ws a *providing* workspace
+
+# 2. Init inside the member
+cd /tmp/ws/child
+specflow init --harness claude --yes
+
+# Expect:
+#  • notice: "parent-managed workspace detected — skills/agents inherited from parent"
+#  • /tmp/ws/child/.specflow/        present (toolkit provisioned)
+#  • /tmp/ws/child/.claude/skills/   ABSENT
+#  • /tmp/ws/child/.claude/agents/   ABSENT
+find /tmp/ws/child/.claude -type d 2>/dev/null   # → no skills/ or agents/
+```
+
+## Standalone case (→ C2)
+
+```bash
+mkdir -p /tmp/solo && cd /tmp/solo
+specflow init --harness claude --yes
+# Expect: .claude/skills/ and .claude/agents/ provisioned as today; no notice.
+```
+
+## Override case (→ C4)
+
+```bash
+mkdir -p /tmp/ws/child2 && mkdir -p /tmp/ws/child2/.specflow
+: > /tmp/ws/child2/.specflow/standalone.yml      # force full provisioning
+# (add ./child2 to /tmp/ws/deno.json workspace list)
+cd /tmp/ws/child2 && specflow init --harness claude --yes
+# Expect: full provisioning despite the enclosing workspace.
+```
+
+## Upgrade case (→ C3, C5)
+
+```bash
+cd /tmp/ws/child                 # parent-managed, already inited, no .claude/skills
+specflow upgrade --yes
+# Expect:
+#  • .specflow/ toolkit refreshed
+#  • .claude/skills/ and .claude/agents/ still ABSENT (not resurrected)
+grep -c 'claude/skills\|claude/agents' .specflow/installed.lock   # → 0
+grep -c 'parent_managed: true' .specflow/installed.lock           # → 1
+```
+
+## Automated coverage
+
+```bash
+cd apps/specflow
+deno task test                                   # full suite
+deno test tests/domain/parent_managed_test.ts    # predicates
+deno test tests/integration/init_parent_managed_test.ts
+deno test tests/integration/upgrade_parent_managed_test.ts
+```
+
+| Contract                            | Where                                              |
+| ----------------------------------- | -------------------------------------------------- |
+| C1 / C2 / C4                        | `tests/integration/init_parent_managed_test.ts`    |
+| C3 / C5                             | `tests/integration/upgrade_parent_managed_test.ts` |
+| `isParentManaged` / `isAgenticPath` | `tests/domain/parent_managed_test.ts`              |
+| lock `parent_managed` round-trip    | `tests/domain/installed_lock_test.ts`              |
+| use-case filtering                  | `tests/application/{init,upgrade}_project_test.ts` |

--- a/.specflow/specs/009-parent-managed-init/research.md
+++ b/.specflow/specs/009-parent-managed-init/research.md
@@ -1,0 +1,91 @@
+# Phase 0 Research — Parent-managed detection
+
+All unknowns were resolved by an `architect`-agent pass over the current `apps/specflow` source. No
+`NEEDS CLARIFICATION` markers remain.
+
+## D1 — Where detection injects into `init`
+
+- **Decision**: Resolve detection in the **handler** (`cli/handlers/init_handler.ts` `runInit()`)
+  and pass a new `parentManaged: boolean` on `InitProjectInput`; the use case applies a bundle
+  filter.
+- **Rationale**: `InitProjectUseCase` already follows "handler resolves all inputs (harness,
+  backlogBackend), use case executes". Detection is one more resolve-before-call. Keeps the use-case
+  constructor stable (no new dep every test must stub) and mirrors upgrade, which reads the decision
+  from the lock.
+- **Alternatives considered**: Injecting `ParentWorkspaceReader` directly into the use case —
+  rejected: forces every existing use-case test to stub a new dep and spreads FS concerns into the
+  application layer's call graph for no benefit.
+- **Seam**: filter runs in `InitProjectUseCase.execute()` immediately after
+  `harness.mapBundle(...)`, before `writer.writeBundle(...)` and before lock-entry construction (so
+  the lock is built from the filtered set — FR-012).
+
+## D2 — Where detection injects into `upgrade`
+
+- **Decision**: `UpgradeProjectUseCase` reads a new `lock.parentManaged` field and filters
+  `fullBundle` before computing `destPaths`/`bundle`. On a **legacy lock** lacking the field, the
+  upgrade handler re-runs detection via the port and persists the result into the rewritten lock.
+- **Rationale**: The lock is read first in upgrade anyway; caching the decision there avoids a
+  filesystem walk on every upgrade and makes the suppression deterministic regardless of whether
+  `.claude/` happens to exist on disk. Re-deriving from "is `.claude/` absent?" would be fragile
+  (could be coincidental).
+- **Alternatives considered**: Always re-walk the FS on upgrade — rejected: wasteful and couples
+  upgrade to live workspace layout that may have moved.
+
+## D3 — How to identify "agentic" paths to suppress
+
+- **Decision**: A pure predicate `isAgenticPath(dest)` over the **already-harness-mapped bundle
+  keys** (the destination strings), matching prefixes `.claude/skills/`, `.claude/agents/`,
+  `.claude/commands/`.
+- **Rationale**: `CoreCategory` (`agent`/`skill`/`phase`/…) only maps to `.claude/` paths inside
+  `claude_harness.ts`; other harnesses map the same categories elsewhere. The destination string is
+  the stable, harness-resolved truth. `plugin_coverage.ts` is the in-repo precedent for path-prefix
+  predicates over the `.claude/` space.
+- **Alternatives considered**: Filtering on `CoreCategory` before mapping — rejected: leaks
+  harness-mapping knowledge into the filter and would wrongly suppress non-`.claude` harness
+  targets. Note `.claude/settings.json`, `AGENTS.md`, `.gitignore`, all `.specflow/` paths do
+  **not** match → always provisioned.
+
+## D4 — Install manifest shape & FR-012
+
+- **Decision**: `.specflow/installed.lock` (YAML), type `InstalledLock` in
+  `src/domain/installed_lock.ts` (`parseLock`/`serializeLock`;
+  `entries: dest → {sha256, installedAt, templatesVersion}`). Add `readonly parentManaged?: true`,
+  serialized as `parent_managed: true`, key omitted when false/absent.
+- **Rationale**: Because the use case builds `lockEntries` from the **filtered** bundle, agentic
+  dests never enter `entries` — FR-012 satisfied with no extra bookkeeping. The boolean field only
+  caches the decision for upgrade. `LockStore` read/write signatures unchanged.
+- **Alternatives considered**: A separate "suppressed paths" list in the lock — rejected: redundant;
+  absence from `entries` already encodes it, and a cached boolean is enough for upgrade.
+
+## D5 — Reading `deno.json` workspace members & the upward walk
+
+- **Decision**: New `ParentWorkspaceReader` port; adapter walks `dirname` upward to root, and at
+  each ancestor checks `.specflow/` exists AND `deno.json` `workspace: string[]` has a member that,
+  resolved relative to the ancestor and `Deno.realPath`-canonicalised, equals the canonicalised
+  `targetDir`.
+- **Rationale**: No existing code parses workspace members or walks parents for this purpose (the
+  only upward walk, in `fs_staging_store.ts`, is for empty-dir cleanup — not reusable). A dedicated
+  port keeps the walk testable and the use cases pure. `Deno.realPath` on both sides handles
+  relative paths and symlinks (FR-004).
+- **Alternatives considered**: Inline `Deno.*` in the handler — rejected: unit-untestable, violates
+  ports discipline. Supporting `package.json`/Cargo workspaces — out of scope; spec pins the
+  Deno-workspace mechanism.
+
+## D6 — Override marker semantics
+
+- **Decision**: Presence of `target/.specflow/standalone.yml` short-circuits detection to `false`
+  (full provisioning). Contents are irrelevant.
+- **Rationale**: Spec FR-008 + edge case: a mere marker is the signal; requiring a schema would add
+  friction for an escape hatch. The port exposes `hasStandaloneOverride()` so the domain decision
+  function stays pure.
+
+## D7 — Test strategy
+
+- **Decision**: Pure predicates → `tests/domain/parent_managed_test.ts`. Use-case suppression →
+  extend `tests/application/{init,upgrade}_project_test.ts` with a fake reader / lock field. C1–C5 →
+  `tests/integration/{init,upgrade}_parent_managed_test.ts` building parent fixtures
+  programmatically in `Deno.makeTempDir` (a parent dir with `.specflow/` + `deno.json`
+  `workspace: ["./child"]`), per the existing `init_test.ts` / `upgrade_test.ts` precedent.
+- **Rationale**: Mirrors the established two-tier test pattern (in-memory fakes for units, temp
+  dirs + `runSpecflow` for integration). Fixtures are built in-test, not stored statically — matches
+  upgrade test precedent.

--- a/.specflow/specs/009-parent-managed-init/spec.md
+++ b/.specflow/specs/009-parent-managed-init/spec.md
@@ -1,0 +1,269 @@
+# Feature Specification: Parent-managed detection for init/upgrade
+
+**Feature Branch**: `009-parent-managed-init`\
+**Created**: 2026-06-09\
+**Status**: Draft\
+**Input**: User description: "specify #371 — parent-managed detection for init/upgrade (suppress
+.claude/ provisioning in a monorepo sub-repo)"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Initialise a sub-repo without re-introducing agentic files (Priority: P1)
+
+A maintainer working inside a Specflow workspace (a parent repo that declares its sub-repos as
+workspace members and centralises all skills/agents at its own root) runs `specflow init` inside one
+of those sub-repos. They expect the spec-driven toolkit (`.specflow/`) to be provisioned so the
+sub-repo can run the workflow, but they do **not** want a `.claude/skills/` or `.claude/agents/`
+directory written into the sub-repo — those are owned by the parent and any local copy is drift that
+the workspace deliberately eliminated.
+
+**Why this priority**: This is the core regression the feature exists to prevent. Without it, a
+single `specflow init` undoes the centralisation a workspace has invested in, silently re-scattering
+agentic files across sub-repos. It is the reason the issue was filed.
+
+**Independent Test**: In a fixture where the target directory is a declared workspace member of an
+enclosing Specflow workspace, run `init` and assert that zero files are written under
+`target/.claude/skills/` and `target/.claude/agents/`, while `.specflow/` is still fully provisioned
+and a one-line notice is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** a target directory that is a workspace member of an enclosing providing Specflow
+   workspace, **When** `specflow init` runs in that directory, **Then** `.specflow/` is provisioned
+   normally and **zero** files are written under `.claude/skills/` or `.claude/agents/`.
+2. **Given** the same parent-managed target, **When** `init` completes, **Then** a single notice
+   line is shown: "parent-managed workspace detected — skills/agents inherited from parent".
+
+---
+
+### User Story 2 - Standalone OSS clone is unaffected (Priority: P1)
+
+A community contributor clones the public Specflow CLI on its own — not nested inside any enclosing
+Specflow workspace — and runs `specflow init` in a fresh project. They expect the full toolkit,
+including `.claude/skills/` and `.claude/agents/`, exactly as today. The new detection must not
+special-case the CLI or change anything for the overwhelmingly common standalone case.
+
+**Why this priority**: Equal-criticality guardrail to US1. The feature is only acceptable if it is
+invisible to the standalone path. A detection that mis-fires on a plain clone would break every
+ordinary user and the OSS funnel.
+
+**Independent Test**: In a fixture with no enclosing workspace, run `init` and assert skills/agents
+are provisioned exactly as in the current behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** a target directory with no enclosing providing Specflow workspace, **When**
+   `specflow init` runs, **Then** provisioning is unchanged — skills and agents are written as
+   today.
+2. **Given** a target nested inside an enclosing Deno workspace that is **not** a providing Specflow
+   workspace (no `.specflow/` at the ancestor), **When** `init` runs, **Then** detection returns
+   negative and provisioning is unchanged.
+
+---
+
+### User Story 3 - Explicit standalone override (Priority: P2)
+
+A user keeps their standalone Specflow project inside a parent Deno workspace for unrelated reasons
+(e.g. a personal monorepo of Deno projects) and genuinely wants the full local toolkit. They place a
+`standalone.yml` marker in the target's `.specflow/` to force full provisioning regardless of any
+enclosing workspace.
+
+**Why this priority**: An escape hatch that prevents the detection from silently surprising users
+whose directory layout coincidentally resembles a managed workspace. Important for trust, but
+secondary to the two P1 default behaviours.
+
+**Independent Test**: In a parent-managed fixture, add `target/.specflow/standalone.yml`, run
+`init`, and assert full provisioning occurs despite the enclosing workspace.
+
+**Acceptance Scenarios**:
+
+1. **Given** a target that would otherwise be detected as parent-managed, **When**
+   `target/.specflow/standalone.yml` is present and `init` runs, **Then** the toolkit is fully
+   provisioned including `.claude/skills/` and `.claude/agents/`.
+
+---
+
+### User Story 4 - Upgrade never resurrects deleted agentic files (Priority: P1)
+
+A maintainer runs `specflow upgrade` inside a parent-managed sub-repo to refresh the `.specflow/`
+toolkit to a newer CLI version. The sub-repo has no `.claude/` (it was deliberately removed). They
+expect the upgrade to update `.specflow/` only and to **not** recreate any `.claude/skills/` or
+`.claude/agents/` — the deletion must survive the upgrade.
+
+**Why this priority**: Upgrade runs far more often than init over a repo's life. If upgrade
+re-creates agentic files, the regression returns on the next routine version bump even after a
+correct init — so this is as critical as US1.
+
+**Independent Test**: In a parent-managed fixture with no `.claude/`, run `upgrade` and assert
+`.specflow/` is updated while zero agentic files are (re)created and no `.claude/` directory is
+resurrected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a parent-managed target with no `.claude/`, **When** `specflow upgrade` runs, **Then**
+   `.specflow/` toolkit files are updated and **no** `.claude/` skills/agents are created.
+2. **Given** a standalone target, **When** `upgrade` runs, **Then** behaviour is unchanged from
+   today.
+
+---
+
+### Edge Cases
+
+- **Detection stops at the first providing ancestor**: walking upward, the first ancestor that is a
+  providing Specflow workspace decides the result; ancestors above it are not consulted.
+- **Ancestor has `.specflow/` but does not list the target as a member**: detection returns negative
+  — proximity alone is not enough; the target must be a declared workspace member that resolves to
+  the target path.
+- **Ancestor lists members but has no `.specflow/`**: not a _providing_ workspace → detection
+  returns negative.
+- **Symlinked or relative member paths in the ancestor manifest**: member paths are resolved to
+  absolute, canonical paths before comparison so that an equivalent-but-differently-spelled path
+  still matches the target.
+- **Filesystem root reached with no providing ancestor**: detection returns negative (standalone
+  path).
+- **`standalone.yml` present but malformed/empty**: presence of the marker file is sufficient to
+  force provisioning; its contents are not required for the override to take effect.
+- **`init` in an already-initialised parent-managed target**: same suppression applies; no agentic
+  files are added on re-run.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST determine, for a given target directory, whether that directory is
+  _parent-managed_ — i.e. nested inside an enclosing **providing Specflow workspace** that declares
+  the target as one of its members.
+- **FR-002**: A _providing Specflow workspace_ MUST be defined as an ancestor directory that BOTH
+  contains a `.specflow/` toolkit AND declares a workspace member list in which at least one member
+  resolves to the target directory's path.
+- **FR-003**: Detection MUST walk parent directories upward from the target to the filesystem root
+  and resolve on the **first** ancestor that satisfies FR-002; if none is found, detection MUST
+  return negative.
+- **FR-004**: Member-path comparison MUST resolve both the declared member path and the target path
+  to absolute canonical paths before comparing, so equivalent paths expressed differently still
+  match.
+- **FR-005**: When the target is parent-managed, `specflow init` MUST provision the `.specflow/`
+  toolkit as normal AND MUST write **zero** files under the target's `.claude/skills/`,
+  `.claude/agents/`, or any orchestration `.claude/` agentic files.
+- **FR-006**: When the target is parent-managed, `specflow init` MUST emit exactly one
+  human-readable notice indicating that a parent-managed workspace was detected and skills/agents
+  are inherited from the parent.
+- **FR-007**: When the target is parent-managed, `specflow upgrade` MUST update the `.specflow/`
+  toolkit only and MUST NOT create or resurrect any `.claude/` skills/agents, even if the target
+  currently has no `.claude/` directory.
+- **FR-008**: A `standalone.yml` marker file in the target's `.specflow/` MUST override detection
+  and force full provisioning (the standalone path) regardless of any enclosing workspace.
+- **FR-009**: When the target is NOT parent-managed (and no override applies), both `init` and
+  `upgrade` MUST behave exactly as today, with no change to the files written.
+- **FR-010**: The detection MUST NOT special-case the Specflow CLI repository itself; a standalone
+  clone of the CLI MUST take the unchanged full-provisioning path. The only inputs to the decision
+  are the enclosing-workspace structure and the override marker.
+- **FR-011**: The feature MUST NOT alter the content or behaviour of any provisioned skill or agent;
+  it changes only **whether** agentic files are written into a given target.
+- **FR-012**: The install manifest (the record of what was provisioned) for a parent-managed target
+  MUST NOT list any `.claude/skills` or `.claude/agents` entries, so a later upgrade/check
+  reconciles against the suppressed set rather than expecting files that were intentionally not
+  written.
+
+### Key Entities _(see Domain Model section below for full structure)_
+
+- **Target repository**: the directory `init`/`upgrade` is operating on; the subject of the
+  parent-managed decision.
+- **Providing Specflow workspace**: an ancestor directory that owns the centralised skills/agents
+  and declares the target as a workspace member.
+- **Standalone override marker**: a file in the target that forces full provisioning.
+- **Install manifest**: the persisted record of which toolkit files were provisioned into the
+  target.
+
+## Domain Model _(mandatory)_
+
+**Bounded context:** CLI provisioning (the `init` / `upgrade` / `check` lifecycle that writes the
+Specflow toolkit into a target repository).
+
+**Vocabulary (Ubiquitous language):**
+
+- **Target repository** — the directory the provisioning command operates on.
+- **Providing Specflow workspace** — an ancestor that contains `.specflow/` and declares the target
+  as a workspace member; it owns the centralised skills/agents the target would otherwise duplicate.
+- **Parent-managed** — the state of a target that sits inside a providing workspace; in this state
+  agentic files are inherited, not written locally.
+- **Agentic files** — files under `.claude/skills/` and `.claude/agents/` (plus orchestration
+  `.claude/` files) that make a repo independently drive the workflow.
+- **Toolkit (`.specflow/`)** — the spec-driven assets (templates, memory, scripts) that are
+  provisioned regardless of parent-managed state.
+- **Standalone override** — an explicit marker in the target that forces full provisioning even
+  under a providing workspace.
+- **Install manifest** — the persisted record of provisioned files used by later upgrade/check runs.
+
+**Entities (have identity):**
+
+- **Target repository** [aggregate root] — identified by its absolute canonical path; carries the
+  toolkit and, when not suppressed, the agentic files; owns its install manifest and any override
+  marker.
+- **Providing Specflow workspace** — identified by its directory path; declares a member list and
+  contains a toolkit; the ancestor that makes a target parent-managed.
+
+**Value objects (no identity, immutable):**
+
+- **ParentManagedDecision(isParentManaged, providingWorkspacePath?)** — the computed outcome of
+  detection for one target; pure function of the filesystem state at evaluation time.
+- **StandaloneOverride(present: boolean)** — derived from the existence of the marker file in the
+  target's toolkit directory.
+
+**Invariants (rules the domain must never break):**
+
+- A parent-managed target never has agentic files written into it by `init` or `upgrade` — why: any
+  local copy is the drift the centralised workspace eliminated.
+- The standalone override always wins over a positive detection — why: users must be able to opt out
+  of a coincidental layout without surprise.
+- Detection never reads or depends on the identity of the target repo (e.g. "is this the CLI") —
+  why: FR-010, the CLI must not be special-cased.
+- The toolkit (`.specflow/`) is always provisioned regardless of the decision — why: a
+  parent-managed sub-repo still needs to run the workflow.
+- The install manifest reflects exactly what was written — why: upgrade/check must reconcile against
+  reality, not an assumed full set.
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- **Skills/agents content** — what each skill or agent does is unchanged; this feature only gates
+  whether they are written.
+- **Per-project customisation preservation (#367)** — the orthogonal `--force` manifest-preservation
+  feature is not part of this work.
+- **Cloud / Mobile halves** — this is a CLI-only change; it does not touch the proprietary halves
+  directly.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: In a fixture where the target is a declared member of an enclosing providing
+  workspace, `specflow init` writes **0** files under `target/.claude/skills/` and
+  `target/.claude/agents/`. (maps C1)
+- **SC-002**: In a standalone fixture (no enclosing providing workspace), `specflow init` provisions
+  skills and agents identically to the current behaviour — verified by file-count/content parity
+  against the pre-feature baseline. (maps C2, FR-010)
+- **SC-003**: In a parent-managed fixture with no `.claude/`, `specflow upgrade` re-creates **0**
+  agentic files and resurrects no `.claude/` directory. (maps C3)
+- **SC-004**: With `target/.specflow/standalone.yml` present under an enclosing workspace,
+  `specflow init` performs full provisioning (skills and agents written). (maps C4)
+- **SC-005**: For a parent-managed target, the install manifest records **0** `.claude/skills` and
+  **0** `.claude/agents` entries. (maps C5)
+- **SC-006**: The notice "parent-managed workspace detected — skills/agents inherited from parent"
+  appears exactly once on a parent-managed `init` and never on a standalone `init`.
+
+## Assumptions
+
+- The enclosing-workspace relationship is expressed via the parent's Deno workspace member
+  declaration (the existing `deno.json` `workspace` mechanism); no new configuration format is
+  introduced for the parent.
+- "Orchestration `.claude/` files" means agentic provisioning under `.claude/` (skills, agents, and
+  any command/loop scaffolding the CLI writes); non-agentic, user-authored `.claude/` content the
+  CLI never manages is irrelevant because the CLI does not touch it.
+- The override marker lives at `target/.specflow/standalone.yml`; its mere presence is the signal —
+  no schema is required for this feature.
+- The existing install-manifest mechanism already records provisioned paths, so suppression is
+  reflected simply by not recording the suppressed entries.
+- Detection cost (walking ancestors and reading at most one manifest per level) is negligible
+  relative to overall `init`/`upgrade` runtime; no performance budget concern.
+- This is a CLI-only change tracked on `mkrlabs/specflow`; the contract was authored under the
+  centralisation epic and is the authority for acceptance (C1–C5).

--- a/.specflow/specs/009-parent-managed-init/tasks.md
+++ b/.specflow/specs/009-parent-managed-init/tasks.md
@@ -1,0 +1,207 @@
+---
+description: "Task list for parent-managed detection (init/upgrade)"
+---
+
+# Tasks: Parent-managed detection for init/upgrade
+
+**Input**: Design documents from `.specflow/specs/009-parent-managed-init/` **Prerequisites**:
+plan.md, spec.md, research.md, data-model.md, contracts/parent-managed-detection.md **Linked
+issue**: mkrlabs/specflow#371
+
+**Tests**: INCLUDED — the behavioural contract C1–C5 and the unit truth-tables are themselves
+acceptance criteria (SC-001…SC-006). TDD: write the test, watch it fail, implement, watch it pass.
+
+**Organization**: grouped by user story. US1 (suppress on init) + US2 (standalone unchanged) are the
+MVP; US4 (upgrade no-resurrect) and US3 (override) layer on top.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete-task dependency)
+- **[Story]**: US1/US2/US3/US4 — Setup/Foundational/Polish carry no story label
+- Paths are relative to `apps/specflow/`
+
+## Path Conventions
+
+Single project: `src/` and `tests/` at `apps/specflow/` root, hexagonal layers `domain/` →
+`application/` → `infrastructure/` → `cli/`; tests mirror `src/`.
+
+---
+
+## Phase 1: Setup
+
+- [x] T001 Confirm branch `009-parent-managed-init` is checked out in `apps/specflow/` and
+      `deno task test` is green on a clean tree (baseline for SC-002 parity).
+
+---
+
+## Phase 2: Foundational (blocking prerequisites for all stories)
+
+**These are the pure/port primitives every story depends on. Complete before Phase 3.**
+
+- [x] T002 [P] Write failing unit tests for the domain predicates in
+      `tests/domain/parent_managed_test.ts`: `isParentManaged` truth table (standaloneOverride=true
+      ⇒ false; ancestor=null ⇒ false; ancestor set & no override ⇒ true) and `isAgenticPath` prefix
+      matrix (`.claude/skills/…`, `.claude/agents/…`, `.claude/commands/…` ⇒ true; `.specflow/…`,
+      `AGENTS.md`, `.claude/settings.json` ⇒ false).
+- [x] T003 Implement `src/domain/parent_managed.ts` with pure
+      `isParentManaged(providingAncestor, standaloneOverride)` and `isAgenticPath(dest)` until T002
+      passes. No `Deno.*` imports.
+- [x] T004 [P] Add the `ParentWorkspaceReader` port interface to `src/application/ports.ts`
+      (`findProvidingAncestor(targetDir): Promise<string|null>`,
+      `hasStandaloneOverride(targetDir): Promise<boolean>`) per contracts §1.
+- [x] T005 Write failing adapter tests in `tests/infrastructure/fs_parent_workspace_reader_test.ts`
+      using `Deno.makeTempDir`: providing ancestor matched (has `.specflow/` + `deno.json` workspace
+      member resolving to target); ancestor with `.specflow/` but non-matching member ⇒ null;
+      ancestor with matching member but no `.specflow/` ⇒ null; relative/symlinked member path
+      canonicalised (FR-004); `standalone.yml` present ⇒ `hasStandaloneOverride` true; walk stops at
+      filesystem root ⇒ null.
+- [x] T006 Implement `src/infrastructure/fs_parent_workspace_reader.ts` (`FsParentWorkspaceReader`)
+      — upward `dirname` walk, per-ancestor `.specflow/` stat + `deno.json` parse, `@std/path`
+      resolve + `Deno.realPath` canonicalisation, tolerate missing/unparseable `deno.json` — until
+      T005 passes.
+- [x] T007 [P] Extend `tests/domain/installed_lock_test.ts`: `parent_managed: true` round-trips
+      through `serializeLock`/`parseLock`; absent key ⇒ `parentManaged` undefined; legacy lock (no
+      key) parses cleanly.
+- [x] T008 Add `readonly parentManaged?: true` to `InstalledLock` in `src/domain/installed_lock.ts`;
+      emit `parent_managed: true` only when set in `serializeLock`; default to `undefined` in
+      `parseLock` — until T007 passes.
+
+---
+
+## Phase 3: US1 — Suppress agentic files on init (Priority: P1) 🎯 MVP
+
+**Goal**: `specflow init` inside a providing-workspace member provisions `.specflow/` but writes
+zero `.claude/skills|agents|commands` files, and prints the notice once.
+
+**Independent test**: integration fixture with a parent dir (`.specflow/` + `deno.json`
+`workspace:["./child"]`) → `init` in child → assert 0 agentic files, `.specflow/` present, notice
+shown.
+
+- [x] T009 [US1] Write failing unit cases in `tests/application/init_project_test.ts` with a fake
+      `ParentWorkspaceReader`/`parentManaged` input: assert `writer.written` and the built lock
+      `entries` both exclude `isAgenticPath` dests when parent-managed; include all dests when not.
+- [x] T010 [US1] Add `parentManaged: boolean` to `InitProjectInput` and apply the bundle filter in
+      `InitProjectUseCase.execute()` immediately after `harness.mapBundle(...)` — build both
+      `writeBundle` input and lock entries from the filtered bundle; set `lock.parentManaged` from
+      the input — until T009 passes.
+- [x] T011 [US1] Write failing integration test
+      `tests/integration/init_parent_managed_test.ts::parent-managed suppresses agentic` (C1): build
+      temp providing-workspace fixture, run `init` in the member, assert 0 files under
+      `target/.claude/skills` & `target/.claude/agents`, `.specflow/` provisioned, notice line
+      emitted.
+- [x] T012 [US1] Wire detection into `cli/handlers/init_handler.ts` `runInit`: call
+      `hasStandaloneOverride` + `findProvidingAncestor`, compute `isParentManaged`, pass
+      `parentManaged` into `InitProjectInput`, and print exactly once
+      `parent-managed workspace detected — skills/agents inherited from parent` when true — until
+      T011 passes.
+
+**Checkpoint**: US1 done — the core regression is closed. SC-001, SC-006 green.
+
+---
+
+## Phase 4: US2 — Standalone clone unaffected (Priority: P1)
+
+**Goal**: no enclosing providing workspace (or a non-providing Deno workspace) ⇒ provisioning
+byte-for-byte unchanged; CLI never special-cased.
+
+**Independent test**: standalone temp dir → `init` → skills/agents written exactly as baseline.
+
+- [x] T013 [US2] Add integration cases to `tests/integration/init_parent_managed_test.ts`:
+      `standalone provisions normally` (C2 — no enclosing workspace ⇒ agentic files written, no
+      notice) and `non-providing ancestor` (enclosing Deno workspace with no `.specflow/` ⇒
+      detection false). Assert parity against the standalone baseline file set.
+- [x] T014 [US2] Verify (and adjust handler/use-case only if a test fails) that the
+      not-parent-managed path is unchanged — no new branches taken, no notice, full bundle written.
+      No CLI-identity check anywhere (FR-010).
+
+**Checkpoint**: US1+US2 = shippable MVP. SC-002 green.
+
+---
+
+## Phase 5: US4 — Upgrade never resurrects agentic files (Priority: P1)
+
+**Goal**: `specflow upgrade` on a parent-managed target updates `.specflow/` only; never recreates
+`.claude/`; lock keeps zero agentic entries.
+
+**Independent test**: parent-managed fixture with no `.claude/` → `upgrade` → assert 0 agentic
+files, `.specflow/` refreshed, lock has `parent_managed: true` and no agentic entries.
+
+- [x] T015 [US4] Write failing unit cases in `tests/application/upgrade_project_test.ts`:
+      `lock.parentManaged=true` ⇒ `fullBundle` filtered (no agentic dests in plan/`writer.written`);
+      legacy lock (no field) ⇒ re-derive via fake reader then filter + persist field.
+- [x] T016 [US4] In `UpgradeProjectUseCase.execute()` apply the agentic filter to `fullBundle`
+      (before `destPaths`/`bundle` split) when the target is parent-managed; ensure suppressed paths
+      are never planned, written, or restored — until T015 passes.
+- [x] T017 [US4] In `cli/handlers/upgrade_handler.ts` `runUpgrade`: take `lock.parentManaged` when
+      present; else re-derive via the reader and persist into the rewritten lock — until the
+      migration case in T015 passes.
+- [x] T018 [US4] Write failing integration tests `tests/integration/upgrade_parent_managed_test.ts`:
+      `no agentic resurrection` (C3 — upgrade on parent-managed target leaves
+      `.claude/skills|agents` absent, `.specflow/` updated) and `lock has no agentic entries` (C5 —
+      `installed.lock` excludes agentic keys and carries `parent_managed: true`).
+
+**Checkpoint**: routine upgrades can no longer reintroduce the drift. SC-003, SC-005 green.
+
+---
+
+## Phase 6: US3 — Explicit standalone override (Priority: P2)
+
+**Goal**: `target/.specflow/standalone.yml` forces full provisioning under a providing workspace.
+
+**Independent test**: parent-managed fixture + `standalone.yml` → `init` → skills/agents written.
+
+- [x] T019 [US3] Add integration case `override forces full` (C4) to
+      `tests/integration/init_parent_managed_test.ts`: providing-workspace member with
+      `target/.specflow/standalone.yml` present ⇒ `init` writes skills/agents fully, no suppression,
+      no notice.
+- [x] T020 [US3] Confirm the override short-circuit is honoured end-to-end (handler passes
+      `hasStandaloneOverride` into the decision; `isParentManaged` returns false when override true)
+      — adjust only if T019 fails. SC-004 green.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [x] T021 [P] Run `deno task fmt` and `deno task lint` across the new/edited files; fix any
+      findings.
+- [x] T022 [P] Run the full `deno task test` suite; confirm green and that SC-002 standalone parity
+      holds (no unintended diff in the standalone file set).
+- [x] T023 Update CLI docs if `init`/`upgrade` behaviour is user-documented (e.g. `docs/llms.md` or
+      command help) with a one-line note on parent-managed detection + the `standalone.yml`
+      override; skip if no such surface documents provisioning.
+- [x] T024 Self-review against `contracts/parent-managed-detection.md` §6 — confirm every C1–C5 row
+      maps to a passing test and every FR/SC is covered; note any deviation in the PR description.
+
+---
+
+## Dependencies & order
+
+- **Setup (T001)** → **Foundational (T002–T008)** → stories.
+- Foundational blocks everything: T003 (predicates), T006 (adapter), T008 (lock field) are
+  prerequisites for all use-case/handler wiring.
+- **US1 (T009–T012)** is the MVP and depends only on Foundational.
+- **US2 (T013–T014)** depends on US1's handler wiring (shares `init_handler`).
+- **US4 (T015–T018)** depends on Foundational (lock field, filter predicate, reader) — independent
+  of US1/US2 source-wise but shares the filter helper.
+- **US3 (T019–T020)** depends on US1 (override flows through the same init path).
+- **Polish (T021–T024)** last.
+
+## Parallel opportunities
+
+- Within Foundational: T002, T004, T007 are `[P]` (different files) and can be drafted together;
+  their implementations T003/T006/T008 follow each.
+- Across stories after Foundational: US1 and US4 touch different use cases (`init_project` vs
+  `upgrade_project`) and different test files — their _implementation_ can proceed in parallel; only
+  the shared `init_handler` (US1/US2/US3) serialises.
+- Polish T021/T022 are `[P]`.
+
+## Implementation strategy
+
+1. **MVP** = Phase 1 + 2 + US1 (T001–T012): closes the headline regression and is independently
+   demoable (init in a member writes no agentic files).
+2. Add **US2** (T013–T014) to guarantee standalone safety — required before shipping.
+3. Add **US4** (T015–T018): protects the far-more-frequent upgrade path.
+4. Add **US3** (T019–T020): the override escape hatch.
+5. **Polish** (T021–T024): fmt/lint/test/docs/self-review.
+
+**Total: 24 tasks** — Setup 1 · Foundational 7 · US1 4 · US2 2 · US4 4 · US3 2 · Polish 4.

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -173,6 +173,13 @@ Pass `--dry-run` to preview the plan without touching disk — combined with `--
 files would be overwritten and which would be merged, but writes nothing. `--dry-run` is the trump
 card: it wins over `--force`.
 
+**Inside a monorepo workspace?** When the target sits inside an enclosing Specflow workspace (an
+ancestor with `.specflow/` whose `deno.json` `workspace` list declares the target as a member),
+`specflow init` and `specflow upgrade` provision `.specflow/` as usual but skip the agentic files
+(`.claude/skills`, `.claude/agents`, `.claude/commands`) — those are inherited from the parent, so
+no copy is scattered into the sub-repo. To force full provisioning anyway, drop an empty
+`.specflow/standalone.yml` marker in the target.
+
 ### What's in `.specflow/installed.lock` and should I commit it?
 
 `specflow init` writes a small YAML file at `.specflow/installed.lock`. It records the harness you

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -8,8 +8,10 @@ import type {
   VersionScheme,
 } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
+import type { Bundle } from "../domain/template.ts";
 import { TEMPLATES_VERSION } from "../templates_bundle.ts";
 import { canonicalBlockBody } from "../domain/merge_block.ts";
+import { isAgenticPath } from "../domain/parent_managed.ts";
 
 export type InitResult =
   | {
@@ -56,6 +58,15 @@ export type InitProjectInput = {
    * backups, no lock written, no git init. Used by `--dry-run`.
    */
   dryRun: boolean;
+  /**
+   * When true, the target is a member of a providing Specflow workspace
+   * (009-parent-managed-init): the toolkit (`.specflow/`) is still provisioned
+   * but agentic files (`.claude/skills|agents|commands`) are suppressed — they
+   * are inherited from the parent. The decision is resolved handler-side via
+   * the `ParentWorkspaceReader`; the use case only applies the bundle filter.
+   * Absent ⇒ treated as `false` (standalone, full provisioning).
+   */
+  parentManaged?: boolean;
 };
 
 export class InitProjectUseCase {
@@ -81,7 +92,16 @@ export class InitProjectUseCase {
       await ensureDir(input.targetDir);
     }
 
-    const bundle = harness.mapBundle(core, { backlogBackend, versionScheme });
+    const mappedBundle = harness.mapBundle(core, { backlogBackend, versionScheme });
+    // Parent-managed targets inherit agentic files from the providing
+    // workspace: filter them out of the bundle here — after harness mapping,
+    // before BOTH writeBundle and lock-entry construction — so suppressed
+    // paths are never written and never enter the lock (FR-005 / FR-012).
+    const bundle: Bundle = input.parentManaged
+      ? Object.fromEntries(
+        Object.entries(mappedBundle).filter(([dest]) => !isAgenticPath(dest)),
+      )
+      : mappedBundle;
 
     if (!input.force) {
       const conflicts = await writer.detectConflicts(bundle, input.targetDir);
@@ -156,6 +176,9 @@ export class InitProjectUseCase {
       versionScheme,
       templatesVersion: TEMPLATES_VERSION,
       entries: lockEntries,
+      // Cache the decision so a later upgrade suppresses agentic files
+      // deterministically without re-walking the filesystem.
+      ...(input.parentManaged ? { parentManaged: true as const } : {}),
     };
     await lockStore.write(input.targetDir, lock);
 

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -88,6 +88,32 @@ export interface FsReader {
 }
 
 /**
+ * Resolves the enclosing-workspace facts that drive parent-managed
+ * detection. The **only** abstraction that touches the filesystem for
+ * detection — keeps the use cases pure and unit-testable with fakes.
+ *
+ * See `docs`/the 009-parent-managed-init spec: a *providing Specflow
+ * workspace* is an ancestor that owns the centralised skills/agents and
+ * declares the target as a workspace member.
+ */
+export interface ParentWorkspaceReader {
+  /**
+   * Walks `dirname(targetDir)` upward to the filesystem root and returns the
+   * canonical path of the **first** ancestor `A` such that `A/.specflow/`
+   * exists AND `A/deno.json` declares a `workspace` member that, resolved
+   * relative to `A` and canonicalised, equals the canonicalised `targetDir`.
+   * Returns `null` if no such ancestor exists or the root is reached.
+   */
+  findProvidingAncestor(targetDir: string): Promise<string | null>;
+
+  /**
+   * True iff `targetDir/.specflow/standalone.yml` exists. Contents ignored —
+   * the marker's mere presence forces the full standalone provisioning path.
+   */
+  hasStandaloneOverride(targetDir: string): Promise<boolean>;
+}
+
+/**
  * Detects whether a Claude Code plugin is currently installed.
  *
  * The default implementation probes

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -6,6 +6,7 @@ import type { CoreBundle } from "../domain/core_bundle.ts";
 import { computeUpgradePlan, type UpgradePlan } from "../domain/upgrade_plan.ts";
 import { canonicalBlockBody, extractBlock } from "../domain/merge_block.ts";
 import { isPluginCoveredPath } from "../domain/plugin_coverage.ts";
+import { isAgenticPath } from "../domain/parent_managed.ts";
 
 /** The plugin name used for both the install probe and the cache directory. */
 export const PLUGIN_NAME = "specflow-plugin";
@@ -23,6 +24,15 @@ export type UpgradeProjectInput = {
    * never edited the affected files.
    */
   resetBaseline?: boolean;
+  /**
+   * Parent-managed decision re-derived by the handler when the lock predates
+   * the `parent_managed` field (009-parent-managed-init). When provided it
+   * takes precedence over `lock.parentManaged`, and the value is persisted into
+   * the rewritten lock so subsequent upgrades read it directly. Absent ⇒ the
+   * decision is read from `lock.parentManaged` (already cached) or treated as
+   * `false`.
+   */
+  parentManagedOverride?: boolean;
 };
 
 export type UpgradeProjectResult =
@@ -76,10 +86,22 @@ export class UpgradeProjectUseCase {
     if (!harness) {
       throw new Error(`unknown harness in lock: ${lock.harness}`);
     }
-    const fullBundle = harness.mapBundle(core, {
+    const mappedBundle = harness.mapBundle(core, {
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
     });
+
+    // Parent-managed targets inherit agentic files from the providing
+    // workspace. Drop agentic dests from the full bundle *before* the plan is
+    // computed so suppressed paths are never planned, written, or "restored"
+    // (FR-007). The decision comes from the handler's re-derivation override
+    // (legacy lock) or the cached `lock.parentManaged`.
+    const parentManaged = input.parentManagedOverride ?? lock.parentManaged ?? false;
+    const fullBundle: Bundle = parentManaged
+      ? Object.fromEntries(
+        Object.entries(mappedBundle).filter(([dest]) => !isAgenticPath(dest)),
+      )
+      : mappedBundle;
 
     // JSON-merged files (e.g. `.claude/settings.json`) are user-owned: we
     // never overwrite them, only graft our entries in. They live outside
@@ -145,6 +167,26 @@ export class UpgradeProjectUseCase {
       (a.kind === "remove" && (!a.wasCustomized || input.force))
     );
     if (!hasActualWork && plan.every((a) => a.kind === "unchanged")) {
+      // No file work to do. But a legacy lock (or any lock whose recorded
+      // `parent_managed` differs from the decision we just computed) still
+      // needs the corrected field persisted — otherwise a handler-derived
+      // override never reaches disk until an unrelated file change triggers
+      // a rewrite (009-parent-managed-init / FR-007). This is a metadata-only
+      // write: no file operations, just the lock. The common case (lock
+      // already carries the right value) keeps the no-op fast path.
+      const lockParentManaged = lock.parentManaged ?? false;
+      if (parentManaged !== lockParentManaged) {
+        const correctedLock: InstalledLock = {
+          version: 2,
+          harness: lock.harness,
+          backlogBackend: lock.backlogBackend,
+          versionScheme: lock.versionScheme,
+          templatesVersion: lock.templatesVersion,
+          entries: lock.entries,
+          ...(parentManaged ? { parentManaged: true as const } : {}),
+        };
+        await lockStore.write(input.projectDir, correctedLock);
+      }
       return { status: "up-to-date", currentVersion: lock.templatesVersion };
     }
 
@@ -274,6 +316,9 @@ export class UpgradeProjectUseCase {
       versionScheme: lock.versionScheme,
       templatesVersion,
       entries: updatedEntries,
+      // Persist the (possibly re-derived) decision so future upgrades read it
+      // directly without re-walking the filesystem.
+      ...(parentManaged ? { parentManaged: true as const } : {}),
     };
     await lockStore.write(input.projectDir, newLock);
 

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -25,6 +25,8 @@ import { ClaudeSettingsParseError } from "../../domain/claude_settings_merge.ts"
 import { DenoFsWriter } from "../../infrastructure/deno_fs_writer.ts";
 import { DenoGit } from "../../infrastructure/deno_git.ts";
 import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
+import { FsParentWorkspaceReader } from "../../infrastructure/fs_parent_workspace_reader.ts";
+import { isParentManaged } from "../../domain/parent_managed.ts";
 import { CORE_BUNDLE } from "../../templates_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 
@@ -406,6 +408,20 @@ export async function runInit(intent: InitIntent): Promise<number> {
 
   console.log(`Initializing into ${bold(targetDir)}`);
 
+  // Parent-managed detection (009-parent-managed-init): when the target is a
+  // member of a providing Specflow workspace, agentic files are inherited from
+  // the parent and suppressed locally. A `standalone.yml` override forces the
+  // full standalone path. The use case applies the bundle filter.
+  const parentReader = new FsParentWorkspaceReader();
+  const standaloneOverride = await parentReader.hasStandaloneOverride(targetDir);
+  const providingAncestor = await parentReader.findProvidingAncestor(targetDir);
+  const parentManaged = isParentManaged(providingAncestor, standaloneOverride);
+  if (parentManaged) {
+    console.log(
+      dim("parent-managed workspace detected — skills/agents inherited from parent"),
+    );
+  }
+
   const useCase = new InitProjectUseCase({
     writer: new DenoFsWriter(),
     git: new DenoGit(),
@@ -424,6 +440,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
       initGit: !intent.noGit,
       force: intent.force,
       dryRun: intent.dryRun,
+      parentManaged,
     });
   } catch (err) {
     // Surface the actionable first-line message for known structured

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -8,6 +8,8 @@ import { DenoFsReader } from "../../infrastructure/fs_reader.ts";
 import { DenoFsWriter } from "../../infrastructure/deno_fs_writer.ts";
 import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
 import { FsPluginDetector } from "../../infrastructure/fs_plugin_detector.ts";
+import { FsParentWorkspaceReader } from "../../infrastructure/fs_parent_workspace_reader.ts";
+import { isAgenticPath, isParentManaged } from "../../domain/parent_managed.ts";
 import { CORE_BUNDLE, TEMPLATES_VERSION } from "../../templates_bundle.ts";
 import { renderUnifiedDiff } from "../../domain/diff.ts";
 import type { UpgradePlan } from "../../domain/upgrade_plan.ts";
@@ -46,14 +48,23 @@ export async function switchBacklogBackend(
   const harness = findHarness(lock.harness);
   if (!harness) throw new Error(`unknown harness in lock: ${lock.harness}`);
 
-  const newBundle = harness.mapBundle(CORE_BUNDLE, {
+  // A parent-managed target inherits agentic files (incl. the backlog skill)
+  // from the providing workspace — they were never written locally (FR-012).
+  // Drop agentic dests from both bundles so a backend switch neither writes
+  // nor re-tracks them in the lock. Mirrors UpgradeProjectUseCase's filtering.
+  const dropAgentic = (b: Record<string, { content: string; executable: boolean }>) =>
+    lock.parentManaged
+      ? Object.fromEntries(Object.entries(b).filter(([dest]) => !isAgenticPath(dest)))
+      : b;
+
+  const newBundle = dropAgentic(harness.mapBundle(CORE_BUNDLE, {
     backlogBackend: newBackend,
     versionScheme: lock.versionScheme,
-  });
-  const oldBundle = harness.mapBundle(CORE_BUNDLE, {
+  }));
+  const oldBundle = dropAgentic(harness.mapBundle(CORE_BUNDLE, {
     backlogBackend: from,
     versionScheme: lock.versionScheme,
-  });
+  }));
 
   const writer = new DenoFsWriter();
   const reader = new DenoFsReader();
@@ -119,6 +130,11 @@ export async function switchBacklogBackend(
     versionScheme: lock.versionScheme,
     templatesVersion: lock.templatesVersion,
     entries: updatedEntries,
+    // Preserve the parent-managed decision across a backend switch — dropping
+    // it would silently re-enable agentic provisioning on the next upgrade
+    // (009-parent-managed-init / FR-012). Mirrors upgrade_project.ts:301 and
+    // init_project.ts:181.
+    ...(lock.parentManaged ? { parentManaged: true as const } : {}),
   };
   await lockStore.write(projectDir, newLock);
   void report;
@@ -222,6 +238,20 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     }
   }
 
+  // Parent-managed decision for the upgrade path. The use case reads
+  // `lock.parentManaged` directly; only when the lock predates the field (a
+  // legacy lock) do we re-derive once via the reader and pass an override so
+  // suppression is deterministic — and the use case persists it into the
+  // rewritten lock (009-parent-managed-init / FR-007).
+  let parentManagedOverride: boolean | undefined;
+  const lockForDetection = await new FsLockStore().read(projectDir);
+  if (lockForDetection !== null && lockForDetection.parentManaged === undefined) {
+    const parentReader = new FsParentWorkspaceReader();
+    const standaloneOverride = await parentReader.hasStandaloneOverride(projectDir);
+    const providingAncestor = await parentReader.findProvidingAncestor(projectDir);
+    parentManagedOverride = isParentManaged(providingAncestor, standaloneOverride);
+  }
+
   const useCase = new UpgradeProjectUseCase({
     reader: new DenoFsReader(),
     writer: new DenoFsWriter(),
@@ -239,6 +269,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
       dryRun: intent.dryRun,
       force: intent.force,
       resetBaseline: intent.resetBaseline,
+      ...(parentManagedOverride !== undefined ? { parentManagedOverride } : {}),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/domain/installed_lock.ts
+++ b/src/domain/installed_lock.ts
@@ -43,6 +43,15 @@ export type InstalledLock = {
   readonly versionScheme: VersionScheme;
   readonly templatesVersion: string;
   readonly entries: ReadonlyMap<string, LockEntry>;
+  /**
+   * Caches the parent-managed decision (009-parent-managed-init). When `true`,
+   * the target is a member of a providing Specflow workspace and agentic files
+   * (`.claude/skills|agents|commands`) were intentionally suppressed — `entries`
+   * therefore contains no agentic keys (FR-012). Serialized as `parent_managed:
+   * true` and emitted only when set; a legacy lock without the key parses to
+   * `undefined`, prompting upgrade to re-derive it once via the reader.
+   */
+  readonly parentManaged?: true;
 };
 
 function asObject(v: unknown, name: string): Record<string, unknown> {
@@ -113,6 +122,10 @@ export function parseLock(yaml: string): InstalledLock {
     }
     entries.set(path, { sha256, installedAt, templatesVersion: ver });
   }
+  // `parent_managed` only ever stores the truthy decision; any other value
+  // (absent, false, garbage) means "not parent-managed" ⇒ undefined.
+  const parentManaged = root.parent_managed === true ? true : undefined;
+
   return {
     version: 2,
     harness,
@@ -120,6 +133,7 @@ export function parseLock(yaml: string): InstalledLock {
     versionScheme,
     templatesVersion,
     entries,
+    ...(parentManaged ? { parentManaged } : {}),
   };
 }
 
@@ -139,6 +153,9 @@ export function serializeLock(lock: InstalledLock): string {
     harness: lock.harness,
     backlog_backend: lock.backlogBackend,
     version_scheme: lock.versionScheme,
+    // Emit `parent_managed` only when set so legacy/standalone locks stay
+    // byte-for-byte identical to before this feature.
+    ...(lock.parentManaged ? { parent_managed: true } : {}),
     templates_version: lock.templatesVersion,
     entries: entriesObj,
   });

--- a/src/domain/parent_managed.ts
+++ b/src/domain/parent_managed.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure domain predicates for parent-managed detection.
+ *
+ * A *parent-managed* target is a sub-repo nested inside a providing Specflow
+ * workspace (an ancestor that owns the centralised skills/agents and declares
+ * the target as a workspace member). In that state the toolkit (`.specflow/`)
+ * is still provisioned, but the agentic files (`.claude/skills|agents|commands`)
+ * are inherited from the parent rather than written locally — any local copy is
+ * the drift the centralised workspace deliberately eliminated.
+ *
+ * These functions are pure: all filesystem facts are passed in as arguments so
+ * the domain layer never touches `Deno.*`.
+ */
+
+/**
+ * Final detection decision for one target.
+ *
+ * The standalone override always wins over a positive detection (FR-008): a
+ * user must be able to opt out of a coincidental directory layout without
+ * surprise. Otherwise the target is parent-managed iff a providing ancestor
+ * was found.
+ *
+ * @param providingAncestor canonical path of the first providing ancestor, or
+ *   `null` when none exists.
+ * @param standaloneOverride whether a `standalone.yml` marker forces the
+ *   full standalone provisioning path.
+ */
+export function isParentManaged(
+  providingAncestor: string | null,
+  standaloneOverride: boolean,
+): boolean {
+  if (standaloneOverride) return false;
+  return providingAncestor !== null;
+}
+
+/**
+ * Whether a harness-mapped destination path is an *agentic* file — the set
+ * suppressed for a parent-managed target.
+ *
+ * Operates on the already-harness-mapped destination string (not `CoreCategory`)
+ * because the destination is the stable, harness-resolved truth: the same core
+ * category maps to different paths under different harnesses. The predicate
+ * never depends on repo identity (FR-010/FR-011).
+ *
+ * The prefix set is **claude-harness-only by design for this feature**: the
+ * whole centralisation effort that motivates parent-managed detection is scoped
+ * to `.claude/` (skills/agents/commands inherited from the providing
+ * workspace). It does NOT match equivalent paths under other harnesses
+ * (`.cursor/`, `.codex/`, `.opencode/`, …) — those are out of scope here and a
+ * future reader should not assume they are suppressed. Within `.claude/`,
+ * notably `.claude/settings.json`, `.claude/CLAUDE.md`, `AGENTS.md`,
+ * `.gitignore`, and every `.specflow/**` path are NOT agentic and are always
+ * provisioned.
+ */
+export function isAgenticPath(dest: string): boolean {
+  return dest.startsWith(".claude/skills/") ||
+    dest.startsWith(".claude/agents/") ||
+    dest.startsWith(".claude/commands/");
+}

--- a/src/infrastructure/fs_parent_workspace_reader.ts
+++ b/src/infrastructure/fs_parent_workspace_reader.ts
@@ -1,0 +1,126 @@
+import { dirname, isAbsolute, join, resolve } from "@std/path";
+import type { ParentWorkspaceReader } from "../application/ports.ts";
+
+/**
+ * Filesystem-backed `ParentWorkspaceReader`.
+ *
+ * The only place that walks the filesystem and parses an ancestor `deno.json`
+ * for parent-managed detection. Keeps the FS walk testable and the use cases
+ * pure.
+ */
+export class FsParentWorkspaceReader implements ParentWorkspaceReader {
+  /**
+   * Walks ancestors of `targetDir` upward to the filesystem root and returns
+   * the canonical path of the first *providing* Specflow workspace — an
+   * ancestor with `.specflow/` AND a `deno.json` whose `workspace` array has a
+   * member resolving (canonically) to `targetDir`.
+   *
+   * Member paths and the target are both canonicalised via `Deno.realPath` so
+   * relative or symlinked spellings still match (FR-004). A missing or
+   * unparseable `deno.json` is treated as a non-match and the walk continues.
+   */
+  async findProvidingAncestor(targetDir: string): Promise<string | null> {
+    const canonicalTarget = await tryRealPath(targetDir);
+    if (canonicalTarget === null) return null;
+
+    // Walk dirname upward; stop when `dirname` no longer changes (root).
+    let current = dirname(canonicalTarget);
+    let parent = dirname(current);
+    while (parent !== current) {
+      if (await this.isProvidingWorkspace(current, canonicalTarget)) {
+        // `current` is already canonical (derived from a canonical target via
+        // repeated dirname), but normalise via realPath to be safe.
+        return await tryRealPath(current) ?? current;
+      }
+      current = parent;
+      parent = dirname(current);
+    }
+    // `current` is now the filesystem root — check it too before giving up.
+    if (await this.isProvidingWorkspace(current, canonicalTarget)) {
+      return await tryRealPath(current) ?? current;
+    }
+    return null;
+  }
+
+  /**
+   * True iff `ancestor/.specflow/` exists AND `ancestor/deno.json` declares a
+   * workspace member canonically equal to `canonicalTarget`.
+   */
+  private async isProvidingWorkspace(
+    ancestor: string,
+    canonicalTarget: string,
+  ): Promise<boolean> {
+    if (!(await isDir(join(ancestor, ".specflow")))) return false;
+
+    const members = await readWorkspaceMembers(join(ancestor, "deno.json"));
+    if (members === null) return false;
+
+    for (const member of members) {
+      const memberPath = isAbsolute(member) ? member : resolve(ancestor, member);
+      const canonicalMember = await tryRealPath(memberPath);
+      if (canonicalMember !== null && canonicalMember === canonicalTarget) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async hasStandaloneOverride(targetDir: string): Promise<boolean> {
+    return await fileExists(join(targetDir, ".specflow", "standalone.yml"));
+  }
+}
+
+/** `Deno.realPath` that yields `null` for a missing path rather than throwing. */
+async function tryRealPath(path: string): Promise<string | null> {
+  try {
+    return await Deno.realPath(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return null;
+    throw err;
+  }
+}
+
+async function isDir(path: string): Promise<boolean> {
+  try {
+    return (await Deno.stat(path)).isDirectory;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}
+
+/**
+ * Reads the `workspace` member array from a `deno.json`. Returns `null` when
+ * the file is missing, unparseable, or has no string `workspace` array —
+ * every such case is a non-match the caller keeps walking past.
+ */
+async function readWorkspaceMembers(denoJsonPath: string): Promise<string[] | null> {
+  let raw: string;
+  try {
+    raw = await Deno.readTextFile(denoJsonPath);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return null;
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // A malformed deno.json is tolerated: treat as non-match, keep walking.
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object") return null;
+  const workspace = (parsed as Record<string, unknown>).workspace;
+  if (!Array.isArray(workspace)) return null;
+  return workspace.filter((m): m is string => typeof m === "string");
+}

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -64,6 +64,23 @@ function fakeClaudeHarness(): Harness {
   };
 }
 
+// A core bundle whose mapped dests mix agentic (.claude/skills|agents|commands)
+// and non-agentic (.specflow, AGENTS.md, .claude/settings.json) paths.
+const MIXED_CORE: CoreBundle = [
+  ".specflow/memory/constitution.md",
+  "AGENTS.md",
+  ".claude/settings.json",
+  ".claude/skills/specflow/SKILL.md",
+  ".claude/agents/developer.md",
+  ".claude/commands/specflow.md",
+].map((dest) => ({
+  category: "project-root" as const,
+  name: "root",
+  suffix: dest,
+  content: `# ${dest}\n`,
+  executable: false,
+})) as CoreBundle;
+
 const SAMPLE_CORE: CoreBundle = [
   {
     category: "project-root",
@@ -352,6 +369,78 @@ Deno.test("InitProjectUseCase records harness.key in the installed lock", async 
   });
   await uc.execute({ targetDir: "/tmp/demo", initGit: false, force: false, dryRun: false });
   assertEquals(lockStore.lastWritten?.harness, "claude");
+});
+
+Deno.test("InitProjectUseCase suppresses agentic dests from writes AND lock when parentManaged=true", async () => {
+  const writer = fakeFsWriter();
+  const lockStore = fakeLockStore();
+  const uc = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore,
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: MIXED_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: false,
+    dryRun: false,
+    parentManaged: true,
+  });
+
+  const writtenDests = writer.written.map((w) => w.replace("/tmp/demo:", ""));
+  // Agentic dests are filtered out of the written set.
+  assert(!writtenDests.includes(".claude/skills/specflow/SKILL.md"));
+  assert(!writtenDests.includes(".claude/agents/developer.md"));
+  assert(!writtenDests.includes(".claude/commands/specflow.md"));
+  // Non-agentic dests still provisioned.
+  assert(writtenDests.includes(".specflow/memory/constitution.md"));
+  assert(writtenDests.includes("AGENTS.md"));
+  assert(writtenDests.includes(".claude/settings.json"));
+
+  // FR-012: the lock excludes agentic entries and records parentManaged.
+  const lock = lockStore.lastWritten!;
+  assert(!lock.entries.has(".claude/skills/specflow/SKILL.md"));
+  assert(!lock.entries.has(".claude/agents/developer.md"));
+  assert(!lock.entries.has(".claude/commands/specflow.md"));
+  assert(lock.entries.has(".specflow/memory/constitution.md"));
+  assert(lock.entries.has("AGENTS.md"));
+  assertEquals(lock.parentManaged, true);
+});
+
+Deno.test("InitProjectUseCase writes all dests and sets no parentManaged when not parent-managed", async () => {
+  const writer = fakeFsWriter();
+  const lockStore = fakeLockStore();
+  const uc = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore,
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: MIXED_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: false,
+    dryRun: false,
+    parentManaged: false,
+  });
+
+  const writtenDests = writer.written.map((w) => w.replace("/tmp/demo:", ""));
+  assert(writtenDests.includes(".claude/skills/specflow/SKILL.md"));
+  assert(writtenDests.includes(".claude/agents/developer.md"));
+  assert(writtenDests.includes(".claude/commands/specflow.md"));
+
+  const lock = lockStore.lastWritten!;
+  assert(lock.entries.has(".claude/skills/specflow/SKILL.md"));
+  assertEquals(lock.parentManaged, undefined);
 });
 
 Deno.test("InitProjectUseCase uses harness.mapBundle output as the file tree", async () => {

--- a/tests/application/upgrade_project_test.ts
+++ b/tests/application/upgrade_project_test.ts
@@ -606,3 +606,139 @@ Deno.test("UpgradeProjectUseCase: does NOT write staging for auto-update files",
     throw new Error("auto-update should not stage upstream content");
   }
 });
+
+// ── Parent-managed upgrade suppression (009-parent-managed-init) ─────────────
+
+Deno.test("UpgradeProjectUseCase: lock.parentManaged=true filters agentic dests from the plan and writes", async () => {
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    templatesVersion: "0.7.0",
+    entries: new Map(), // parent-managed lock never had agentic entries (FR-012)
+    parentManaged: true,
+  };
+  const writer = fakeWriter();
+  const lockStore = fakeLockStore(lock);
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({}), // no .claude/ on disk — it was deliberately removed
+    writer,
+    lockStore,
+    core: coreFromBundle({
+      ".specflow/memory/constitution.md": { content: "toolkit\n", executable: false },
+      ".claude/skills/specflow/SKILL.md": { content: "skill\n", executable: false },
+      ".claude/agents/developer.md": { content: "agent\n", executable: false },
+      ".claude/commands/specflow.md": { content: "cmd\n", executable: false },
+    }),
+    templatesVersion: "0.8.0",
+    findHarness: findFakeHarness,
+  });
+  const result = await uc.execute({ projectDir: "/p", dryRun: false, force: false });
+  assertEquals(result.status, "applied");
+  if (result.status === "applied") {
+    // No agentic dest appears anywhere in the plan.
+    for (const action of result.plan) {
+      assert(
+        !action.dest.startsWith(".claude/skills/") &&
+          !action.dest.startsWith(".claude/agents/") &&
+          !action.dest.startsWith(".claude/commands/"),
+        `agentic dest leaked into plan: ${action.dest}`,
+      );
+    }
+  }
+  // Toolkit file added; agentic files never written / resurrected.
+  assertEquals(writer.written.get(".specflow/memory/constitution.md"), "toolkit\n");
+  assertEquals(writer.written.has(".claude/skills/specflow/SKILL.md"), false);
+  assertEquals(writer.written.has(".claude/agents/developer.md"), false);
+  assertEquals(writer.written.has(".claude/commands/specflow.md"), false);
+  // Lock keeps parentManaged and no agentic entries (FR-012).
+  assertEquals(lockStore.last?.parentManaged, true);
+  assertEquals(lockStore.last?.entries.has(".claude/skills/specflow/SKILL.md"), false);
+});
+
+Deno.test("UpgradeProjectUseCase: parentManagedOverride re-derives + persists on a legacy lock without the field", async () => {
+  // Legacy lock — no parent_managed field — but the handler re-derived
+  // parent-managed=true and passes it as an override.
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    templatesVersion: "0.7.0",
+    entries: new Map(),
+  };
+  const writer = fakeWriter();
+  const lockStore = fakeLockStore(lock);
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({}),
+    writer,
+    lockStore,
+    core: coreFromBundle({
+      ".specflow/memory/constitution.md": { content: "toolkit\n", executable: false },
+      ".claude/agents/developer.md": { content: "agent\n", executable: false },
+    }),
+    templatesVersion: "0.8.0",
+    findHarness: findFakeHarness,
+  });
+  const result = await uc.execute({
+    projectDir: "/p",
+    dryRun: false,
+    force: false,
+    parentManagedOverride: true,
+  });
+  assertEquals(result.status, "applied");
+  assertEquals(writer.written.has(".claude/agents/developer.md"), false);
+  assertEquals(writer.written.get(".specflow/memory/constitution.md"), "toolkit\n");
+  // The re-derived decision is persisted into the rewritten lock.
+  assertEquals(lockStore.last?.parentManaged, true);
+});
+
+Deno.test("UpgradeProjectUseCase: legacy lock + parentManagedOverride persists parent_managed even when up-to-date", async () => {
+  // Up-to-date case: disk + lock + bundle all match (no file work). A legacy
+  // lock (no parent_managed field) plus a handler-derived override of `true`
+  // must still rewrite the lock with the corrected field — otherwise the
+  // decision never reaches disk until an unrelated file change occurs
+  // (009-parent-managed-init / FR-007).
+  const content = "toolkit\n";
+  const sha = await sha256Hex(content);
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    templatesVersion: "0.8.0",
+    // Only a non-agentic toolkit entry; agentic dests are suppressed by the
+    // override so they never enter the plan.
+    entries: new Map([[".specflow/memory/constitution.md", {
+      sha256: sha,
+      installedAt: "2026-05-01T00:00:00Z",
+      templatesVersion: "0.8.0",
+    }]]),
+  };
+  const writer = fakeWriter();
+  const lockStore = fakeLockStore(lock);
+  const uc = new UpgradeProjectUseCase({
+    reader: fakeReader({ ".specflow/memory/constitution.md": content }),
+    writer,
+    lockStore,
+    core: coreFromBundle({
+      ".specflow/memory/constitution.md": { content, executable: false },
+      ".claude/agents/developer.md": { content: "agent\n", executable: false },
+    }),
+    templatesVersion: "0.8.0",
+    findHarness: findFakeHarness,
+  });
+  const result = await uc.execute({
+    projectDir: "/p",
+    dryRun: false,
+    force: false,
+    parentManagedOverride: true,
+  });
+  // No file work (the only non-suppressed file is unchanged).
+  assertEquals(result.status, "up-to-date");
+  // But the lock was still rewritten with the corrected field.
+  assertEquals(lockStore.last?.parentManaged, true);
+  // Metadata-only: no files written.
+  assertEquals(writer.written.size, 0);
+});

--- a/tests/cli/handlers/upgrade_handler_test.ts
+++ b/tests/cli/handlers/upgrade_handler_test.ts
@@ -1,0 +1,85 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { switchBacklogBackend } from "../../../src/cli/handlers/upgrade_handler.ts";
+import { parseLock } from "../../../src/domain/installed_lock.ts";
+
+const MAIN = fromFileUrl(new URL("../../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+/**
+ * Init a parent-managed child so it carries a `parent_managed: true` lock with
+ * no agentic entries — the realistic precondition for a backend switch.
+ */
+async function initializedParentManagedChild(): Promise<{ root: string; child: string }> {
+  const root = await Deno.makeTempDir({ prefix: "specflow-switch-pm-" });
+  const parent = join(root, "parent");
+  const child = join(parent, "child");
+  await Deno.mkdir(join(parent, ".specflow"), { recursive: true });
+  await Deno.mkdir(child, { recursive: true });
+  await Deno.writeTextFile(
+    join(parent, "deno.json"),
+    JSON.stringify({ workspace: ["./child"] }, null, 2),
+  );
+  const { code, stderr } = await runSpecflow(["init", "--here", "--no-git"], { cwd: child });
+  assertEquals(code, 0, `init precondition failed: ${stderr}`);
+  return { root, child };
+}
+
+// HIGH — switching backlog backend on a parent-managed lock must preserve the
+// parent-managed decision (FR-012). Dropping it silently re-enables agentic
+// provisioning on the next upgrade.
+Deno.test("switchBacklogBackend preserves parent_managed and excludes agentic entries", async () => {
+  const { root, child } = await initializedParentManagedChild();
+  try {
+    const lockPath = join(child, ".specflow/installed.lock");
+    const before = parseLock(await Deno.readTextFile(lockPath));
+    assertEquals(before.parentManaged, true, "precondition: lock must be parent-managed");
+    assertEquals(before.backlogBackend, "local", "precondition: starts on local backend");
+
+    const { switched, from } = await switchBacklogBackend(child, "github");
+    assertEquals(switched, true);
+    assertEquals(from, "local");
+
+    const after = parseLock(await Deno.readTextFile(lockPath));
+    // Backend switched...
+    assertEquals(after.backlogBackend, "github");
+    // ...but the parent-managed decision survived.
+    assertEquals(after.parentManaged, true);
+    // ...and no agentic entry was re-introduced.
+    for (const dest of after.entries.keys()) {
+      assert(
+        !dest.startsWith(".claude/skills/") &&
+          !dest.startsWith(".claude/agents/") &&
+          !dest.startsWith(".claude/commands/"),
+        `agentic entry leaked into lock after switch: ${dest}`,
+      );
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/tests/domain/installed_lock_test.ts
+++ b/tests/domain/installed_lock_test.ts
@@ -206,6 +206,56 @@ entries:
   assertEquals(lock.harness, "copilot");
 });
 
+Deno.test("serializeLock emits parent_managed: true when set, round-trips through parseLock", () => {
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    templatesVersion: "1.0.0",
+    entries: new Map(),
+    parentManaged: true,
+  };
+  const yaml = serializeLock(lock);
+  assertEquals(yaml.includes("parent_managed: true"), true);
+  const roundtrip = parseLock(yaml);
+  assertEquals(roundtrip.parentManaged, true);
+});
+
+Deno.test("serializeLock omits parent_managed when not set", () => {
+  const lock: InstalledLock = {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    templatesVersion: "1.0.0",
+    entries: new Map(),
+  };
+  const yaml = serializeLock(lock);
+  assertEquals(yaml.includes("parent_managed"), false);
+});
+
+Deno.test("parseLock defaults parentManaged to undefined when key absent (legacy lock)", () => {
+  const v2 = `version: 2
+harness: claude
+templates_version: 0.7.0
+entries: {}
+`;
+  const lock = parseLock(v2);
+  assertEquals(lock.parentManaged, undefined);
+});
+
+Deno.test("parseLock reads parent_managed: true", () => {
+  const v2 = `version: 2
+harness: claude
+parent_managed: true
+templates_version: 0.7.0
+entries: {}
+`;
+  const lock = parseLock(v2);
+  assertEquals(lock.parentManaged, true);
+});
+
 Deno.test("parseLock accepts v2 lock with harness=opencode", () => {
   const v2 = `version: 2
 harness: opencode

--- a/tests/domain/parent_managed_test.ts
+++ b/tests/domain/parent_managed_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "@std/assert";
+import { isAgenticPath, isParentManaged } from "../../src/domain/parent_managed.ts";
+
+Deno.test("isParentManaged: standalone override wins over a providing ancestor", () => {
+  assertEquals(isParentManaged("/some/parent", true), false);
+});
+
+Deno.test("isParentManaged: null ancestor with no override is not parent-managed", () => {
+  assertEquals(isParentManaged(null, false), false);
+});
+
+Deno.test("isParentManaged: ancestor set and no override is parent-managed", () => {
+  assertEquals(isParentManaged("/some/parent", false), true);
+});
+
+Deno.test("isParentManaged: override wins even when ancestor is null", () => {
+  assertEquals(isParentManaged(null, true), false);
+});
+
+Deno.test("isAgenticPath: .claude/skills/ paths are agentic", () => {
+  assertEquals(isAgenticPath(".claude/skills/specflow/SKILL.md"), true);
+});
+
+Deno.test("isAgenticPath: .claude/agents/ paths are agentic", () => {
+  assertEquals(isAgenticPath(".claude/agents/developer.md"), true);
+});
+
+Deno.test("isAgenticPath: .claude/commands/ paths are agentic", () => {
+  assertEquals(isAgenticPath(".claude/commands/specflow.md"), true);
+});
+
+Deno.test("isAgenticPath: .specflow/ paths are not agentic", () => {
+  assertEquals(isAgenticPath(".specflow/memory/constitution.md"), false);
+  assertEquals(isAgenticPath(".specflow/templates/spec-template.md"), false);
+});
+
+Deno.test("isAgenticPath: AGENTS.md is not agentic", () => {
+  assertEquals(isAgenticPath("AGENTS.md"), false);
+});
+
+Deno.test("isAgenticPath: .gitignore is not agentic", () => {
+  assertEquals(isAgenticPath(".gitignore"), false);
+});
+
+Deno.test("isAgenticPath: .claude/settings.json is not agentic", () => {
+  assertEquals(isAgenticPath(".claude/settings.json"), false);
+});
+
+Deno.test("isAgenticPath: .claude/CLAUDE.md is not agentic", () => {
+  assertEquals(isAgenticPath(".claude/CLAUDE.md"), false);
+});

--- a/tests/infrastructure/fs_parent_workspace_reader_test.ts
+++ b/tests/infrastructure/fs_parent_workspace_reader_test.ts
@@ -1,0 +1,160 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { FsParentWorkspaceReader } from "../../src/infrastructure/fs_parent_workspace_reader.ts";
+
+/**
+ * Builds a parent/child fixture under a fresh temp dir.
+ *
+ * Returns the canonical (`realPath`) parent and child paths — macOS temp dirs
+ * live under a symlinked `/var` → `/private/var`, so tests must compare against
+ * the canonicalised parent path the reader returns.
+ */
+async function fixture(
+  opts: {
+    parentHasSpecflow?: boolean;
+    member?: string | null; // value placed in the parent deno.json workspace array
+    denoJson?: string; // raw override (e.g. malformed)
+    childStandalone?: boolean;
+  },
+): Promise<{ root: string; parent: string; child: string }> {
+  const root = await Deno.makeTempDir({ prefix: "specflow-pwr-" });
+  const parent = join(root, "parent");
+  const child = join(parent, "child");
+  await Deno.mkdir(child, { recursive: true });
+
+  if (opts.parentHasSpecflow ?? true) {
+    await Deno.mkdir(join(parent, ".specflow"), { recursive: true });
+  }
+  if (opts.denoJson !== undefined) {
+    await Deno.writeTextFile(join(parent, "deno.json"), opts.denoJson);
+  } else if (opts.member !== null && opts.member !== undefined) {
+    await Deno.writeTextFile(
+      join(parent, "deno.json"),
+      JSON.stringify({ workspace: [opts.member] }, null, 2),
+    );
+  }
+  if (opts.childStandalone) {
+    await Deno.mkdir(join(child, ".specflow"), { recursive: true });
+    await Deno.writeTextFile(join(child, ".specflow", "standalone.yml"), "");
+  }
+
+  const realParent = await Deno.realPath(parent);
+  const realChild = await Deno.realPath(child);
+  return { root, parent: realParent, child: realChild };
+}
+
+Deno.test("findProvidingAncestor: matches a providing ancestor (.specflow + member resolves to target)", async () => {
+  const { root, parent, child } = await fixture({ member: "./child" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(child), parent);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: ancestor with .specflow but non-matching member ⇒ null", async () => {
+  const { root, child } = await fixture({ member: "./other" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(child), null);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: matching member but no .specflow ⇒ null", async () => {
+  const { root, child } = await fixture({ parentHasSpecflow: false, member: "./child" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(child), null);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: relative member path is canonicalised (FR-004)", async () => {
+  // Member declared as "child" (no leading ./) still resolves to the target.
+  const { root, parent, child } = await fixture({ member: "child" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(child), parent);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: symlinked workspace member is canonicalised (FR-004)", async () => {
+  // The member is declared as a symlink that points at the real child dir.
+  // Detection must canonicalise the member path (`tryRealPath(memberPath)`)
+  // so the symlinked spelling still resolves to the target.
+  const root = await Deno.makeTempDir({ prefix: "specflow-pwr-symlink-" });
+  const parent = join(root, "parent");
+  const realChildDir = join(parent, "child");
+  await Deno.mkdir(realChildDir, { recursive: true });
+  await Deno.mkdir(join(parent, ".specflow"), { recursive: true });
+  await Deno.symlink(realChildDir, join(parent, "link"));
+  await Deno.writeTextFile(
+    join(parent, "deno.json"),
+    JSON.stringify({ workspace: ["link"] }, null, 2),
+  );
+  const realParent = await Deno.realPath(parent);
+  const realChild = await Deno.realPath(realChildDir);
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(realChild), realParent);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: tolerates a malformed deno.json (treat as non-match)", async () => {
+  const { root, child } = await fixture({ denoJson: "{ this is : not json" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(child), null);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: missing deno.json ⇒ null", async () => {
+  const { root, child } = await fixture({ member: null });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(child), null);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("findProvidingAncestor: walk to filesystem root with no provider ⇒ null", async () => {
+  // A lone temp dir with no enclosing provider.
+  const dir = await Deno.makeTempDir({ prefix: "specflow-pwr-solo-" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.findProvidingAncestor(await Deno.realPath(dir)), null);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("hasStandaloneOverride: true when standalone.yml present", async () => {
+  const { root, child } = await fixture({ member: "./child", childStandalone: true });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.hasStandaloneOverride(child), true);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("hasStandaloneOverride: false when marker absent", async () => {
+  const { root, child } = await fixture({ member: "./child" });
+  try {
+    const reader = new FsParentWorkspaceReader();
+    assertEquals(await reader.hasStandaloneOverride(child), false);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/tests/integration/init_parent_managed_test.ts
+++ b/tests/integration/init_parent_managed_test.ts
@@ -1,0 +1,167 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+import { parseLock } from "../../src/domain/installed_lock.ts";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+/**
+ * Builds a providing-workspace fixture: a parent dir with `.specflow/` and a
+ * `deno.json` declaring `workspace: ["./child"]`, plus an (empty) child dir.
+ * Returns canonical paths (macOS temp dirs symlink `/var`).
+ */
+async function providingFixture(
+  opts: { childStandalone?: boolean } = {},
+): Promise<{ root: string; parent: string; child: string }> {
+  const root = await Deno.makeTempDir({ prefix: "specflow-pm-" });
+  const parent = join(root, "parent");
+  const child = join(parent, "child");
+  await Deno.mkdir(join(parent, ".specflow"), { recursive: true });
+  await Deno.mkdir(child, { recursive: true });
+  await Deno.writeTextFile(
+    join(parent, "deno.json"),
+    JSON.stringify({ workspace: ["./child"] }, null, 2),
+  );
+  if (opts.childStandalone) {
+    await Deno.mkdir(join(child, ".specflow"), { recursive: true });
+    await Deno.writeTextFile(join(child, ".specflow", "standalone.yml"), "");
+  }
+  return { root, parent, child };
+}
+
+const NOTICE = "parent-managed workspace detected — skills/agents inherited from parent";
+
+// C1 — SC-001, SC-006, FR-005/FR-006
+Deno.test("parent-managed suppresses agentic", async () => {
+  const { root, child } = await providingFixture();
+  try {
+    const { code, stdout, stderr } = await runSpecflow(
+      ["init", "--here", "--no-git"],
+      { cwd: child },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+
+    // Zero agentic files written.
+    assertEquals(await exists(join(child, ".claude/skills")), false);
+    assertEquals(await exists(join(child, ".claude/agents")), false);
+    assertEquals(await exists(join(child, ".claude/commands")), false);
+
+    // Toolkit still provisioned.
+    assertEquals(await exists(join(child, ".specflow/memory/constitution.md")), true);
+    assertEquals(await exists(join(child, "AGENTS.md")), true);
+
+    // Notice printed exactly once.
+    assertStringIncludes(stdout, NOTICE);
+    assertEquals(stdout.split(NOTICE).length - 1, 1);
+
+    // Lock records the parent-managed decision and carries zero agentic
+    // entries (FR-012) — close the invariant at the init integration layer.
+    const lock = parseLock(await Deno.readTextFile(join(child, ".specflow/installed.lock")));
+    assertEquals(lock.parentManaged, true);
+    for (const dest of lock.entries.keys()) {
+      assert(
+        !dest.startsWith(".claude/skills") &&
+          !dest.startsWith(".claude/agents") &&
+          !dest.startsWith(".claude/commands"),
+        `agentic entry leaked into lock: ${dest}`,
+      );
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+// C2 — SC-002, FR-009/FR-010
+Deno.test("standalone provisions normally", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-pm-standalone-" });
+  try {
+    const { code, stdout, stderr } = await runSpecflow(
+      ["init", "--here", "--no-git"],
+      { cwd: dir },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+
+    // Full agentic provisioning.
+    assertEquals(await exists(join(dir, ".claude/skills/specflow/SKILL.md")), true);
+    assertEquals(await exists(join(dir, ".claude/agents/developer.md")), true);
+    assertEquals(await exists(join(dir, ".claude/commands/specflow.md")), true);
+    assertEquals(await exists(join(dir, ".specflow/memory/constitution.md")), true);
+
+    // No notice on the standalone path.
+    assert(!stdout.includes(NOTICE), "standalone init must not print the notice");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// C2 variant — enclosing Deno workspace that is NOT a providing Specflow
+// workspace (no .specflow/ at the ancestor) ⇒ detection negative.
+Deno.test("non-providing ancestor", async () => {
+  const root = await Deno.makeTempDir({ prefix: "specflow-pm-nonprov-" });
+  const parent = join(root, "parent");
+  const child = join(parent, "child");
+  await Deno.mkdir(child, { recursive: true });
+  // Parent declares the member but has NO .specflow/ → not a provider.
+  await Deno.writeTextFile(
+    join(parent, "deno.json"),
+    JSON.stringify({ workspace: ["./child"] }, null, 2),
+  );
+  try {
+    const { code, stdout, stderr } = await runSpecflow(
+      ["init", "--here", "--no-git"],
+      { cwd: child },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+    // Detection negative ⇒ full provisioning, no notice.
+    assertEquals(await exists(join(child, ".claude/skills/specflow/SKILL.md")), true);
+    assertEquals(await exists(join(child, ".claude/agents/developer.md")), true);
+    assert(!stdout.includes(NOTICE));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+// C4 — SC-004, FR-008
+Deno.test("override forces full", async () => {
+  const { root, child } = await providingFixture({ childStandalone: true });
+  try {
+    const { code, stdout, stderr } = await runSpecflow(
+      ["init", "--here", "--no-git"],
+      { cwd: child },
+    );
+    assertEquals(code, 0, `init failed: ${stderr}`);
+    // standalone.yml override ⇒ full provisioning despite the providing parent.
+    assertEquals(await exists(join(child, ".claude/skills/specflow/SKILL.md")), true);
+    assertEquals(await exists(join(child, ".claude/agents/developer.md")), true);
+    assertEquals(await exists(join(child, ".claude/commands/specflow.md")), true);
+    assert(!stdout.includes(NOTICE), "override path must not print the notice");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/tests/integration/upgrade_parent_managed_test.ts
+++ b/tests/integration/upgrade_parent_managed_test.ts
@@ -1,0 +1,94 @@
+import { assert, assertEquals } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+import { parseLock } from "../../src/domain/installed_lock.ts";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd?: string } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+/**
+ * Builds a providing-workspace fixture and runs `init --here` in the child so
+ * the child carries a parent-managed `installed.lock` with no agentic files —
+ * the realistic precondition for an upgrade.
+ */
+async function initializedParentManagedChild(): Promise<{ root: string; child: string }> {
+  const root = await Deno.makeTempDir({ prefix: "specflow-up-pm-" });
+  const parent = join(root, "parent");
+  const child = join(parent, "child");
+  await Deno.mkdir(join(parent, ".specflow"), { recursive: true });
+  await Deno.mkdir(child, { recursive: true });
+  await Deno.writeTextFile(
+    join(parent, "deno.json"),
+    JSON.stringify({ workspace: ["./child"] }, null, 2),
+  );
+  const { code, stderr } = await runSpecflow(["init", "--here", "--no-git"], { cwd: child });
+  assertEquals(code, 0, `init precondition failed: ${stderr}`);
+  // Sanity: init left no agentic files and a parent-managed lock.
+  assertEquals(await exists(join(child, ".claude/skills")), false);
+  return { root, child };
+}
+
+// C3 — SC-003, FR-007
+Deno.test("no agentic resurrection", async () => {
+  const { root, child } = await initializedParentManagedChild();
+  try {
+    const { code, stderr } = await runSpecflow(["upgrade"], { cwd: child });
+    assertEquals(code, 0, `upgrade failed: ${stderr}`);
+
+    // Upgrade refreshed the toolkit but resurrected nothing under .claude/.
+    assertEquals(await exists(join(child, ".specflow/installed.lock")), true);
+    assertEquals(await exists(join(child, ".claude/skills")), false);
+    assertEquals(await exists(join(child, ".claude/agents")), false);
+    assertEquals(await exists(join(child, ".claude/commands")), false);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+// C5 — SC-005, FR-012
+Deno.test("lock has no agentic entries", async () => {
+  const { root, child } = await initializedParentManagedChild();
+  try {
+    const { code, stderr } = await runSpecflow(["upgrade"], { cwd: child });
+    assertEquals(code, 0, `upgrade failed: ${stderr}`);
+
+    const lockYaml = await Deno.readTextFile(join(child, ".specflow/installed.lock"));
+    const lock = parseLock(lockYaml);
+    assertEquals(lock.parentManaged, true);
+    for (const dest of lock.entries.keys()) {
+      assert(
+        !dest.startsWith(".claude/skills/") &&
+          !dest.startsWith(".claude/agents/") &&
+          !dest.startsWith(".claude/commands/"),
+        `agentic entry leaked into lock: ${dest}`,
+      );
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds `isParentManaged(targetDir)` detection to `specflow init` and `specflow upgrade`. When the target repo is nested inside a **providing Specflow workspace** — an ancestor that has `.specflow/` AND a `deno.json` whose `workspace` member list resolves (canonically) to the target — the commands provision the `.specflow/` toolkit as normal but write **zero** agentic files (`.claude/skills|agents|commands`). A `target/.specflow/standalone.yml` marker overrides detection to force full provisioning. Standalone clones are byte-for-byte unaffected and the CLI is never special-cased.

This makes the monorepo-root skill/agent centralisation (#7 / #370) self-enforcing: re-running the CLI inside a managed sub-repo can no longer re-scatter `.claude/` tooling. Closes #371.

Hexagonal split: pure predicates in `domain/parent_managed.ts`; the `ParentWorkspaceReader` port in `application/ports.ts`; all filesystem I/O isolated in `infrastructure/fs_parent_workspace_reader.ts`; bundle-filtering in the init/upgrade use cases (before the install-lock is built, so a managed target's lock records no agentic entries — FR-012); detection wiring + the one-line notice in the CLI handlers. The decision is cached on `installed.lock` (`parent_managed: true`); legacy locks re-derive once and persist, and the decision survives a `--backlog` backend switch.

Contract C1–C5 covered end-to-end. **+38 tests, full suite 808 green** (fmt / lint / typecheck / test all pass).

## Agent adoption

Maintainers of monorepo-style Specflow workspaces (a parent repo that declares its sub-repos as Deno `workspace` members and centralises skills/agents at its own root) can now safely run `specflow init` / `specflow upgrade` inside a sub-repo: the toolkit updates but no `.claude/` skills/agents are written, so a routine CLI run no longer re-introduces the drift that root-centralisation removed. No action is required to benefit — detection is automatic. If you intentionally keep a standalone Specflow project inside an unrelated parent Deno workspace and want the full local toolkit, drop an empty `.specflow/standalone.yml` in that project to force full provisioning. Standalone (non-nested) projects are completely unaffected.

```prompt
If this project lives as a sub-repo inside a parent Deno workspace that centralises its Claude Code skills/agents at the workspace root, you can now run `specflow upgrade` here without it recreating a local `.claude/skills` or `.claude/agents` directory — Specflow detects the providing workspace and suppresses agentic-file provisioning automatically. Verify after upgrading that no `.claude/skills` or `.claude/agents` directory reappeared in this sub-repo. If instead you WANT the full local toolkit despite the enclosing workspace, create an empty file at `.specflow/standalone.yml` and re-run `specflow init`.
```