### PR TITLE
feat(init): preserve per-project customisations across template refreshes (#367)

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specflow/specs/010-release-adoption-parity",
-  "linked_issue": 363,
+  "feature_directory": ".specflow/specs/011-preserve-customisations",
+  "linked_issue": 367,
   "workflow_shape": "full"
 }

--- a/.specflow/specs/011-preserve-customisations/checklists/requirements.md
+++ b/.specflow/specs/011-preserve-customisations/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Preserve per-project customisations across template refreshes
+
+**Purpose**: Validate specification completeness before planning **Created**: 2026-06-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable and technology-agnostic
+- [x] All acceptance scenarios defined; edge cases identified
+- [x] Scope clearly bounded; dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details in specification
+
+## Notes
+
+Items marked incomplete require spec updates before `/specflow clarify` or `/specflow plan`.
+
+Validation result (2026-06-09): all items pass.
+
+- The declaration mechanism (manifest vs frontmatter vs sidecar) is deliberately left to the plan
+  phase and documented under Assumptions — it is a "how", not a "what", so it is not a [NEEDS
+  CLARIFICATION] blocker.
+- FRs are mechanism-agnostic and each maps to at least one acceptance scenario and a success
+  criterion (SC-001..SC-006).

--- a/.specflow/specs/011-preserve-customisations/contracts/preserve-and-diff.md
+++ b/.specflow/specs/011-preserve-customisations/contracts/preserve-and-diff.md
@@ -1,0 +1,86 @@
+# Contracts — Preserve & Diff
+
+Phase 1 contracts for issue #367. Each contract is paired with the test(s) that prove it and the
+acceptance criteria (SC-/FR-) it satisfies. The C-id ⇄ test ⇄ SC/FR map is the analyze gate's
+checklist.
+
+## 1. Manifest contract — `.specflow/preserve.yml`
+
+- The file is a YAML document with a single `preserved:` key holding a list of project-relative,
+  forward-slash destination paths.
+- Absent file ⇒ `EMPTY_PRESERVE_CONFIG`. Unparseable / malformed ⇒ `EMPTY_PRESERVE_CONFIG` plus a
+  handler `warn:` line. Neither ever aborts a refresh.
+- `parsePreserveConfig` is pure: it trims, de-dupes, drops blanks, strips a leading `./`, and
+  normalises backslashes. It does NOT judge bundle membership.
+- `serializePreserveConfig(parsePreserveConfig(x))` is idempotent on canonical input (round-trip).
+
+## 2. Preserve-plan contract — init filter + upgrade predicate
+
+- **init**: `InitProjectUseCase.execute` MUST write `bundle` minus `input.preservedPaths` and report
+  the removed set as `InitResult.preserved`. With `preservedPaths` absent/empty, the written set is
+  exactly today's `bundle` (no behaviour change).
+- **upgrade**: `computeUpgradePlan` MUST emit `preserve / reason:"declared"` for any `dest` where
+  `isDeclaredPreserved(dest)` is true, regardless of the disk/lock/bundle SHA relationship, and MUST
+  evaluate that check BEFORE the plugin-migration and unchanged/auto-update branches.
+- Neither use case reads any CLI flag; both consume only the predicate / set built by the handler.
+
+## 3. Notice contract — no silent skip, no silent override (FR-004 / FR-005)
+
+- Every file preserved during a refresh MUST produce exactly one notice line naming the path and
+  identifying it as maintainer-declared.
+- Every file overwritten because `--reset-preserved` was passed MUST produce exactly one warning
+  line naming the path and identifying the override.
+- A declared path that is NOT in the bundle MUST produce exactly one `warn:` line (ineffective
+  declaration, FR-008) and MUST NOT appear in either of the above.
+
+## 4. Diff command contract — `specflow diff` (read-only)
+
+- `DiffProjectUseCase` MUST depend on no `FsWriter` and MUST mutate zero files (read-only
+  invariant).
+- It returns `DivergenceResult[]`: `differs` (with both contents), `matches`, or `missing`
+  (declared/ tracked on disk, absent from the new bundle).
+- The handler renders each `differs` via `renderUnifiedDiff`, prints "no divergence" + exit 0 when
+  the result set is empty, and returns non-zero ONLY on error (a present diff is exit 0).
+- `--only-customised` restricts results to paths whose disk SHA ≠ lock SHA; default shows all
+  managed paths.
+
+## 5. Reset contract — `--reset-preserved`
+
+- Off by default. When absent, declared files are preserved on `init --force` and `upgrade`.
+- When present, `init_handler` passes an empty preserved set and `upgrade_handler` passes
+  `isDeclaredPreserved: () => false`; previously-preserved files are overwritten with the bundle and
+  each override is reported (contract §3).
+
+## 6. Backward-compatibility contract (FR-011)
+
+- A project with no `preserve.yml` MUST observe byte-identical init/upgrade behaviour and output to
+  today. The existing init/upgrade test suites pass unchanged.
+- The `installed.lock` format is unchanged (preserve intent lives in its own file).
+
+## 7. Interaction contract — parent-managed & plugin (D8)
+
+- A declared agentic path in a parent-managed sub-repo is a no-op: agentic paths are filtered from
+  the bundle before the preserve check, so the predicate is never consulted for them.
+- A declared path that the plugin would otherwise own is preserved, not migrated (declared check
+  precedes the plugin-migration branch).
+
+## C-id ⇄ test ⇄ acceptance map
+
+| C  | Contract                                                                                           | Test(s)                                                                        | Satisfies                                              |
+| -- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| C1 | Manifest parse/serialize, normalise, degrade-to-empty                                              | `tests/domain/preserve_config_test.ts`                                         | FR-001, FR-007                                         |
+| C2 | `FsPreserveStore` read/write/absent round-trip                                                     | `tests/infrastructure/fs_preserve_store_test.ts`                               | FR-001, FR-009                                         |
+| C3 | upgrade emits `preserve/"declared"` even when SHA matches; ordering before plugin-migration        | `tests/domain/upgrade_plan_test.ts`                                            | FR-003, FR-007, C7                                     |
+| C4 | init filters preserved paths from the write set; reports them; empty set ⇒ unchanged               | `tests/application/init_project_test.ts`                                       | FR-002, FR-010, FR-011                                 |
+| C5 | `DiffProjectUseCase` read-only; differs/matches/missing                                            | `tests/application/diff_project_test.ts`                                       | FR-006, FR-009                                         |
+| C6 | end-to-end: `init --force` keeps declared file; `--reset-preserved` overwrites it; notices emitted | `tests/integration/init_preserve_test.ts`                                      | FR-002, FR-004, FR-005, SC-001, SC-002, SC-005, SC-006 |
+| C7 | declared path absent from bundle ⇒ warn no-op; declared agentic path in parent-managed ⇒ no-op     | `tests/application/init_project_test.ts` + `tests/domain/upgrade_plan_test.ts` | FR-008, D8                                             |
+
+## SC coverage
+
+- **SC-001** (force keeps preserved, byte-identical) → C6
+- **SC-002** (N skips → N notices) → C6, C3 (notice path)
+- **SC-003** (read-only divergence view) → C5
+- **SC-004** (no-preserve project unchanged) → C4, C6 (control case)
+- **SC-005** (reset only when invoked) → C6
+- **SC-006** (2026-06-08 `product-owner.md` regression closed) → C6 (the fixture file)

--- a/.specflow/specs/011-preserve-customisations/data-model.md
+++ b/.specflow/specs/011-preserve-customisations/data-model.md
@@ -1,0 +1,131 @@
+# Data Model — Preserve per-project customisations
+
+Phase 1 structures for issue #367. All types are TypeScript on Deno; domain types are pure (no I/O,
+no Deno globals). Paths are project-relative, forward-slash, matching the bundle's destination-path
+form.
+
+## PreserveConfig (domain — `src/domain/preserve_config.ts`, pure)
+
+```ts
+export type PreserveConfig = {
+  /** Project-relative destination paths the maintainer has declared preserved. */
+  readonly preserved: ReadonlyArray<string>;
+};
+
+export const EMPTY_PRESERVE_CONFIG: PreserveConfig = { preserved: [] };
+
+/** Parse `.specflow/preserve.yml`. Unparseable / empty ⇒ EMPTY_PRESERVE_CONFIG (never throws). */
+export function parsePreserveConfig(yaml: string): PreserveConfig;
+
+/** Serialize to canonical YAML (stable key order, trailing newline). */
+export function serializePreserveConfig(cfg: PreserveConfig): string;
+```
+
+**Normalisation rule**: `parsePreserveConfig` trims each entry, drops blanks and duplicates, and
+normalises a leading `./` away and backslashes to forward slashes, so membership tests against the
+bundle's destination paths are exact. A non-list / malformed document degrades to
+`EMPTY_PRESERVE_CONFIG` (the handler emits a warn) — it never aborts a refresh.
+
+## PreserveStore (port — `src/application/ports.ts`)
+
+```ts
+export interface PreserveStore {
+  /** Reads `.specflow/preserve.yml`; absent file ⇒ EMPTY_PRESERVE_CONFIG. */
+  read(projectDir: string): Promise<PreserveConfig>;
+  write(projectDir: string, cfg: PreserveConfig): Promise<void>;
+}
+```
+
+Adapter `FsPreserveStore` (`src/infrastructure/fs_preserve_store.ts`) mirrors `FsLockStore`:
+try/catch `Deno.errors.NotFound` → `EMPTY_PRESERVE_CONFIG`. Tests use an in-memory fake.
+
+## UpgradeAction.preserve — extended (domain — `src/domain/upgrade_plan.ts`)
+
+```ts
+| {
+    kind: "preserve";
+    dest: string;
+    reason: "customized" | "declared";   // ← "declared" is new
+    pluginAvailable: boolean;
+  }
+```
+
+```ts
+export type UpgradePlanOptions = {
+  // ...existing fields (pluginInstalled, isPluginCovered, ...)
+  /** True when the maintainer declared `dest` preserved in .specflow/preserve.yml. */
+  readonly isDeclaredPreserved?: (dest: string) => boolean;
+};
+```
+
+**Branch ordering in `computeUpgradePlan`** (declared check first):
+
+1. `isDeclaredPreserved(dest)` → `preserve / reason:"declared"` (wins over unchanged, auto-update,
+   and plugin-migration).
+2. existing plugin-migration branch (`covered && vanilla → migrate-to-plugin`).
+3. existing customised branch (`diskSha !== lockSha → preserve / reason:"customized"`).
+4. existing `auto-update` / `unchanged` / `add-new` / `remove` branches.
+
+## InitProjectInput / InitResult — extended (application — `src/application/init_project.ts`)
+
+```ts
+export type InitProjectInput = {
+  // ...existing fields
+  /** Destination paths to leave untouched on a forced refresh. Absent ⇒ today's behaviour. */
+  readonly preservedPaths?: ReadonlySet<string>;
+};
+
+export type InitResult = {
+  // ...existing fields
+  /** Paths skipped because they were declared preserved (for the handler's per-file notice). */
+  readonly preserved: ReadonlyArray<string>;
+};
+```
+
+`InitProjectUseCase.execute` builds `bundleToWrite` = `bundle` minus `preservedPaths`, calls
+`writer.writeBundle(bundleToWrite, …)`, and reports the removed set as `preserved`.
+
+## DivergenceResult / DiffProjectResult (application — `src/application/diff_project.ts`)
+
+```ts
+export type DivergenceResult =
+  | { kind: "differs"; dest: string; diskContent: string; bundledContent: string }
+  | { kind: "matches"; dest: string }
+  | { kind: "missing"; dest: string }; // declared/lock-tracked on disk but absent from new bundle
+
+export type DiffProjectInput = {
+  readonly projectDir: string;
+  /** When true, restrict to paths whose on-disk SHA differs from the lock SHA. */
+  readonly onlyCustomised: boolean;
+};
+
+export type DiffProjectResult = {
+  readonly results: ReadonlyArray<DivergenceResult>;
+  readonly fromVersion: string; // installed templates version the bundle was mapped for
+};
+```
+
+`DiffProjectUseCase` depends on `FsReader` + `LockStore` + `findHarness` only — **no `FsWriter`**
+(read-only invariant). Rendering of `differs` results uses the existing `renderUnifiedDiff`
+(`src/domain/diff.ts`) in `diff_handler.ts`.
+
+## RefreshMode (value object — conceptual)
+
+```ts
+type RefreshMode = "normal" | "force" | "force-reset-preserved";
+```
+
+Modelled for clarity; in code the intent is threaded as a predicate/empty-set from the handler (D6),
+so the domain never branches on the mode. Only `force-reset-preserved` may overwrite a preserved
+file.
+
+## Entity / state summary
+
+- **Project installation** [aggregate root] — identified by `installed.lock`; owns the managed-file
+  set and (now) the `preserve.yml` declarations. Enforces: a declared file is never silently
+  overwritten.
+- **Managed file** — identified by destination path. Two orthogonal axes:
+  - content: `vanilla` (disk SHA = bundle SHA) | `customised` (disk SHA ≠ lock SHA)
+  - declaration: `declared-preserved` | `not-declared`
+- A refresh's treatment of a file is a pure function of (content axis, declaration axis, refresh
+  mode, plugin coverage), resolved by the branch ordering above.

--- a/.specflow/specs/011-preserve-customisations/plan.md
+++ b/.specflow/specs/011-preserve-customisations/plan.md
@@ -1,0 +1,182 @@
+# Implementation Plan: Preserve per-project customisations across template refreshes
+
+**Branch**: `011-preserve-customisations` | **Date**: 2026-06-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `.specflow/specs/011-preserve-customisations/spec.md` (issue
+mkrlabs/specflow#367)
+
+## Summary
+
+`specflow upgrade` already auto-preserves a customised managed file (on-disk SHA ≠ lock SHA →
+`UpgradeAction kind:"preserve"; reason:"customized"`). But `specflow init --force` **bypasses
+`computeUpgradePlan` entirely** — it calls `writer.writeBundle(bundle, targetDir, {overwrite:true})`
+with no per-file discrimination, so a forced refresh overwrites every managed file unconditionally.
+That is how a customised `.claude/agents/product-owner.md` was silently reverted to the bundled
+generic on 2026-06-08.
+
+The fix adds an **explicit, force-surviving preserve declaration** plus a **read-only divergence
+view** and an explicit **reset opt-out**:
+
+1. A project-level `.specflow/preserve.yml` manifest (a flat list of project-relative paths)
+   declares which managed files are the maintainer's. A new pure domain type (`preserve_config.ts`),
+   a `PreserveStore` port, and an `FsPreserveStore` adapter (mirroring `FsLockStore`) read it.
+2. `init --force` filters preserved paths out of the write set in `InitProjectUseCase`; `upgrade`
+   honours the same declaration by promoting declared paths to `preserve` (new `reason:"declared"`)
+   in `computeUpgradePlan`, even when the file is not hash-diverged. Both paths emit a per-file
+   notice (FR-004) — no silent skip.
+3. A net-new top-level `specflow diff` command shows, read-only, how each managed file diverges from
+   its bundled original, reusing the existing `renderUnifiedDiff` and `CORE_BUNDLE`.
+4. A `--reset-preserved` flag on `init`/`upgrade` flips the preserve predicate off for one run,
+   restoring the bundled versions; never the default, and it reports each override.
+
+Together: US1 restores control over a forced refresh, US2 makes long-term preservation safe via
+visible divergence, US3 provides the deliberate escape hatch.
+
+## Technical Context
+
+**Language/Version**: TypeScript on Deno v2.x **Primary Dependencies**: Deno std (`@std/yaml` for
+the manifest, `@std/assert` for tests); existing in-repo `renderUnifiedDiff` (`src/domain/diff.ts`),
+`CORE_BUNDLE` (`src/.../templates_bundle.ts`), hexagonal ports in `src/application/ports.ts`
+**Storage**: a new `.specflow/preserve.yml` (flat YAML list); state of record stays in the existing
+`.specflow/installed.lock` **Testing**: `deno task test` (Deno.test); hermetic fakes for every port
+(`FsReader`, `FsWriter`, `LockStore`, new `PreserveStore`) — no network, no real binary **Target
+Platform**: GitHub-hosted runners + local engineer machine; the CLI binary itself **Project Type**:
+Single-project CLI repo, hexagonal (domain / application / infrastructure / cli) **Performance
+Goals**: N/A — one-shot init/upgrade/diff invocations over ≤ low-hundreds of managed files
+**Constraints**: `diff` MUST mutate nothing; the feature MUST be inert when no `preserve.yml` exists
+(FR-011 — no default-path behaviour change); preserve must be honoured identically by `init --force`
+and `upgrade` (FR-002/FR-003) **Scale/Scope**: a managed bundle of ~90 files; preserve lists of a
+handful of paths in practice
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+The CLI half ships a bundled placeholder constitution; the active governance is `AGENTS.md` + the
+monorepo `CLAUDE.md` + constitution § (OSS/private boundary). Relevant gates:
+
+- **OSS/private boundary (§I)** — PASS. Public CLI half only; no private-half code, names, or
+  secrets. The manifest holds project-relative template paths, nothing cross-boundary.
+- **Hexagonal layering** — PASS. New pure domain (`preserve_config.ts`), a new port in `ports.ts`, a
+  new infra adapter (`fs_preserve_store.ts`), handler-side wiring — no layer inversion. The
+  declared-preserve predicate is injected into the domain (`UpgradePlanOptions`), not imported by
+  it, exactly like `isPluginCoveredPath`.
+- **No silent failure / no silent caps** — PASS, and central to the fix: the silent `--force`
+  overwrite is replaced by an explicit, surfaced preserve; every skip and every reset-override is
+  logged per file (FR-004/FR-005).
+- **TDD / test-first** — PASS. Every change lands behind a hermetic Deno.test using injected fakes;
+  the new `diff` use-case and the preserve predicate are unit-testable without a real binary.
+- **Conventional commits + branch-and-PR for non-trivial CLI changes** — PASS. Work is on branch
+  `011-preserve-customisations`, merged via PR on `mkrlabs/specflow`.
+- **Backward compatibility** — PASS. Absent `preserve.yml` ⇒ `EMPTY_PRESERVE_CONFIG` ⇒ today's
+  behaviour byte-for-byte (FR-011). The lock format is unchanged (preserve intent lives in its own
+  file, not the lock).
+
+No violations → Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specflow/specs/011-preserve-customisations/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions D1..D8
+├── data-model.md        # Phase 1 — PreserveConfig, PreserveStore, DivergenceResult, RefreshMode
+├── quickstart.md        # Phase 1 — manual repro + automated coverage map
+├── contracts/
+│   └── preserve-and-diff.md   # Phase 1 — manifest contract, preserve-plan contract, diff command
+│                              #           contract, reset contract, C1..C7 ⇄ tests ⇄ SC/FR map
+└── tasks.md             # Phase 2 — /specflow tasks output (NOT created here)
+```
+
+### Source Code (repository root = `apps/specflow/`)
+
+```text
+src/domain/
+├── preserve_config.ts        # NEW — PreserveConfig type, parse/serialize, EMPTY_PRESERVE_CONFIG (pure)
+└── upgrade_plan.ts           # EDIT — preserve.reason += "declared"; UpgradePlanOptions.isDeclaredPreserved;
+                              #        declared check ordered BEFORE the plugin-migration branch
+
+src/application/
+├── ports.ts                  # EDIT — add PreserveStore port
+├── init_project.ts           # EDIT — InitProjectInput.preservedPaths; filter the write set; report preserved
+└── diff_project.ts           # NEW — DiffProjectUseCase (read-only): lock → bundle → disk → DivergenceResult[]
+
+src/infrastructure/
+└── fs_preserve_store.ts      # NEW — reads/writes .specflow/preserve.yml; mirrors FsLockStore (absent ⇒ EMPTY)
+
+src/cli/
+├── parser.ts                 # EDIT — `diff` intent; --reset-preserved on init & upgrade
+├── handlers/init_handler.ts  # EDIT — load PreserveStore, pass preservedPaths (or empty on --reset-preserved),
+                              #        warn unknown paths, log each preserved/overridden file
+├── handlers/upgrade_handler.ts # EDIT — same wiring via isDeclaredPreserved predicate
+├── handlers/diff_handler.ts  # NEW — runDiff: wire reader+lock+harness, render via renderUnifiedDiff
+├── main.ts                   # EDIT — dispatch `case "diff"`
+└── help.ts                   # EDIT — one usage line for `specflow diff`
+
+tests/
+├── domain/preserve_config_test.ts        # NEW
+├── domain/upgrade_plan_test.ts           # EDIT — declared-preserve cases
+├── application/init_project_test.ts      # EDIT — preservedPaths filters write set
+├── application/diff_project_test.ts      # NEW
+├── infrastructure/fs_preserve_store_test.ts  # NEW
+└── integration/init_preserve_test.ts     # NEW — init --force keeps it; --reset-preserved overwrites
+```
+
+**Structure Decision**: Single-project hexagonal CLI repo; all changes live in the existing
+`src/{domain,application,infrastructure,cli}` + `tests/` directories. Two net-new domain/application
+files (`preserve_config.ts`, `diff_project.ts`), one net-new port + adapter (`PreserveStore` /
+`fs_preserve_store.ts`), one net-new handler (`diff_handler.ts`). The declared-preserve predicate is
+a function-parameter seam injected into `computeUpgradePlan` (no new coupling), exactly mirroring
+the existing `isPluginCoveredPath` predicate.
+
+## Phase 0: Outline & Research
+
+See [research.md](./research.md). All unknowns resolved (architect design pass, agent
+`a337df927febff143`); no NEEDS CLARIFICATION remains. Key decisions:
+
+- **D1** Declaration mechanism = a single `.specflow/preserve.yml` manifest (flat path list).
+  Rejected per-file frontmatter (unworkable for non-markdown bundle files) and `.specflow-override`
+  sidecars (file-count blow-up, invisible to review sweeps).
+- **D2** Preserve intent lives in its OWN file, not embedded in `installed.lock` — the lock is a
+  state record; the manifest is user intent. (`parentManaged` embeds a derived _fact_; preserve is
+  deliberate _intent_.)
+- **D3** `init --force` does NOT use `computeUpgradePlan`; the preserve filter is injected at the
+  `writer.writeBundle` call site in `InitProjectUseCase` (filter preserved paths out of the write
+  set). `upgrade` honours the manifest via a new `isDeclaredPreserved` predicate in
+  `UpgradePlanOptions`.
+- **D4** `UpgradeAction.preserve.reason` gains a `"declared"` variant alongside `"customized"`; the
+  declared check is ordered BEFORE both the `unchanged` and the plugin-migration branches, so a
+  declared file is never auto-updated nor migrated away.
+- **D5** `specflow diff` is a net-new top-level read-only command (not a subcommand of `upgrade`),
+  reusing `renderUnifiedDiff` (`src/domain/diff.ts`) and `CORE_BUNDLE`; `DiffProjectUseCase` has no
+  `FsWriter` dependency.
+- **D6** `--reset-preserved` is parsed in `parser.ts` and threaded through both handlers; the
+  use-cases never see the flag — they only see the resulting predicate / empty set.
+- **D7** Unknown-path validation (FR-008) happens in the handlers against `Object.keys(bundle)` at
+  run time; the domain parser stays pure and bundle-agnostic.
+- **D8** Parent-managed (009): agentic paths are filtered out of the bundle BEFORE the preserve
+  check, so a declared agentic path in a parent-managed sub-repo is a clean no-op (no special case).
+
+## Phase 1: Design & Contracts
+
+- [data-model.md](./data-model.md) — `PreserveConfig`, `PreserveStore`, `DivergenceResult`,
+  `RefreshMode`, the `preserve.reason` union extension, and the empty/absent normalisation rule.
+- [contracts/preserve-and-diff.md](./contracts/preserve-and-diff.md) — the manifest contract, the
+  preserve-plan contract (init filter + upgrade predicate), the `diff` command contract, the reset
+  contract, and the C1–C7 ⇄ test ⇄ SC/FR acceptance mapping.
+- [quickstart.md](./quickstart.md) — manual repro (customise → `init --force` clobbers → declare →
+  `init --force` preserves), the diff view, the reset path, and the automated-coverage table.
+
+**Agent context update**: point the plan reference in the agent context file at this plan (handled
+by the plan script step; no-op if the marker is absent).
+
+### Post-design Constitution re-check
+
+Still PASS. The design adds two pure/application files, one port + adapter, one read-only handler,
+and a flag — it strictly removes a silent-overwrite path and adds no default-path behaviour.
+Hexagonal layering intact; OSS/private boundary untouched.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/.specflow/specs/011-preserve-customisations/quickstart.md
+++ b/.specflow/specs/011-preserve-customisations/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart — Preserve per-project customisations
+
+Manual reproduction of the bug and the fix, plus the automated-coverage map. Issue #367.
+
+## Manual repro — the regression (before the fix)
+
+```bash
+# In a Specflow-initialised project:
+$ printf '\n# my project-specific PO config\n' >> .claude/agents/product-owner.md   # customise
+$ specflow init --here --force                                                       # forced refresh
+# ⇒ .claude/agents/product-owner.md silently reverted to the generic bundled version.
+```
+
+## Manual repro — the fix (after this feature)
+
+```bash
+# 1. Declare the file preserved:
+$ cat .specflow/preserve.yml
+preserved:
+  - .claude/agents/product-owner.md
+
+# 2. A forced refresh now keeps it, and says so:
+$ specflow init --here --force
+…
+preserved .claude/agents/product-owner.md — declared in .specflow/preserve.yml
+…
+# ⇒ the customised file is byte-identical to before the refresh.
+
+# 3. upgrade honours the same declaration:
+$ specflow upgrade
+…
+preserved .claude/agents/product-owner.md — declared in .specflow/preserve.yml
+
+# 4. See how the preserved file has drifted from the evolving bundle (read-only):
+$ specflow diff
+--- bundled .claude/agents/product-owner.md
++++ on-disk .claude/agents/product-owner.md
+@@ …
++# my project-specific PO config
+# ⇒ mutates nothing; exit 0.
+
+# 5. Deliberately discard the customisation for a clean bundle (explicit opt-out):
+$ specflow init --here --force --reset-preserved
+…
+override .claude/agents/product-owner.md — --reset-preserved overrode the declaration
+# ⇒ file restored to the bundled version. Never happens without the flag.
+```
+
+## Edge-case probes
+
+```bash
+# Declared path that isn't a managed file ⇒ ineffective, warned, not fatal:
+$ printf 'preserved:\n  - not/a/bundled/file.md\n' > .specflow/preserve.yml
+$ specflow init --here --force
+warn: not/a/bundled/file.md — declared preserved but not a managed file (ignored)
+
+# Declared path dropped upstream ⇒ kept on disk, surfaced:
+$ specflow diff
+missing  .claude/agents/old-agent.md — on disk, no longer in the bundle (kept)
+
+# No preserve.yml ⇒ today's behaviour, byte-for-byte (FR-011).
+```
+
+## Automated coverage map
+
+| Spec item                                         | Test                                             | Kind           |
+| ------------------------------------------------- | ------------------------------------------------ | -------------- |
+| Manifest parse/serialize/normalise/degrade        | `tests/domain/preserve_config_test.ts`           | unit (pure)    |
+| Store read/write/absent                           | `tests/infrastructure/fs_preserve_store_test.ts` | unit (fake fs) |
+| upgrade emits `preserve/"declared"`, ordering     | `tests/domain/upgrade_plan_test.ts`              | unit (pure)    |
+| init filters write set; no-preserve unchanged     | `tests/application/init_project_test.ts`         | unit (fakes)   |
+| diff read-only: differs/matches/missing           | `tests/application/diff_project_test.ts`         | unit (fakes)   |
+| end-to-end force-keep + reset-overwrite + notices | `tests/integration/init_preserve_test.ts`        | integration    |
+
+All tests are hermetic — injected `FsReader` / `FsWriter` / `LockStore` / `PreserveStore` fakes, the
+in-repo `CORE_BUNDLE`, and a temp project dir for the integration test. No network, no real binary,
+no live `gh`.
+
+## Done when
+
+- `specflow init --force` leaves a declared file byte-identical (SC-001) with a per-file notice
+  (SC-002).
+- `specflow diff` shows divergence read-only (SC-003).
+- A no-preserve project is unchanged (SC-004); `--reset-preserved` overwrites only when passed
+  (SC-005); the `product-owner.md` regression is closed (SC-006).
+- `deno task test` green; `deno fmt --check` + `deno lint` clean.

--- a/.specflow/specs/011-preserve-customisations/research.md
+++ b/.specflow/specs/011-preserve-customisations/research.md
@@ -1,0 +1,144 @@
+# Research — Preserve per-project customisations across template refreshes
+
+Phase 0 decisions for issue #367. Grounded in the architect design pass (agent `a337df927febff143`)
+against the real code: `src/domain/upgrade_plan.ts`,
+`src/application/{init_project,upgrade_project}.ts`,
+`src/cli/handlers/{init_handler,upgrade_handler}.ts`,
+`src/domain/{installed_lock,merge_block,diff}.ts`, `src/infrastructure/fs_lock_store.ts`.
+
+## D1 — Declaration mechanism: a single `.specflow/preserve.yml` manifest
+
+**Decision**: A flat YAML list of project-relative paths at `.specflow/preserve.yml`:
+
+```yaml
+preserved:
+  - .claude/agents/product-owner.md
+  - .claude/agents/developer.md
+```
+
+**Rationale**: One file to commit, `cat`, and parse; version-controlled next to `installed.lock`;
+invisible to harnesses. It is pure intent — no SHA, no timestamp (those live in the lock).
+
+**Alternatives considered**: (a) per-file frontmatter (`specflow_preserve: true`) — rejected: the
+managed bundle contains non-markdown files (`.gitignore`, shell scripts, JSON stubs) that have no
+frontmatter, forcing a special-case scheme; (b) per-file `.specflow-override` sidecars — rejected:
+doubles the file count and the declaration is invisible to a reviewer scanning the file it protects.
+
+## D2 — Preserve intent lives in its own file, not in `installed.lock`
+
+**Decision**: Keep declarations in `.specflow/preserve.yml`; do NOT embed them in `InstalledLock`.
+
+**Rationale**: The lock is a **state record** (SHAs, installed-at, templates version); the manifest
+is a **user-intent record**. A maintainer editing preserves must not have to understand or hand-edit
+the lock format. The `parentManaged` precedent embeds a _derived fact_ in the lock; preserve
+declarations are _deliberate intent_ — a different concern that deserves its own file. Keeping the
+lock format unchanged also preserves backward compatibility for free.
+
+**Alternatives considered**: a `preserved: string[]` key on the lock — rejected: couples intent to
+state and complicates hand-editing.
+
+## D3 — Injection point: init filters the write set; upgrade gains a predicate
+
+**Decision**: `init --force` does **not** route through `computeUpgradePlan` — it calls
+`writer.writeBundle(bundle, targetDir, {overwrite:true, backupExisting:true})` directly. So the
+preserve filter is applied in `InitProjectUseCase.execute`: build `bundleToWrite` by removing the
+declared-preserved paths from `bundle` before the `writeBundle` call, and return the skipped set in
+`InitResult.preserved`. `upgrade` already respects `computeUpgradePlan`'s `preserve` action, so it
+only needs the plan to _emit_ `preserve` for declared paths — via a new
+`UpgradePlanOptions.isDeclaredPreserved?: (dest) => boolean` predicate.
+
+**Rationale**: Injecting at each path's actual decision site is the smallest correct change and
+keeps both paths honouring the same `PreserveStore`. The predicate mirrors the existing
+`isPluginCoveredPath` seam (a pure predicate imported by the use case, not by the domain).
+
+**Alternatives considered**: routing `init --force` through `computeUpgradePlan` — rejected: a much
+larger refactor of the init path for no behavioural gain; the two commands have legitimately
+different write strategies.
+
+## D4 — `preserve.reason` gains a `"declared"` variant; ordering matters
+
+**Decision**: Extend the union to `preserve; reason: "customized" | "declared"; pluginAvailable`. In
+`computeUpgradePlan`, check `isDeclaredPreserved(dest)` **before** the
+`diskSha === newSha → unchanged` branch AND **before** the plugin-migration branch, emitting
+`preserve / reason:"declared"` when true.
+
+**Rationale**: A declared file must be preserved even when it currently matches the bundle (FR-007)
+and must not be migrated away to the plugin (spec edge case: "preservation takes precedence over
+migration"). Ordering the declared check first is what guarantees both. Customised+covered files
+keep their existing `reason:"customized"; pluginAvailable:true` handling.
+
+**Alternatives considered**: a separate `declared-preserve` action kind — rejected: the handler
+already renders `preserve`; a new `reason` value reuses that rendering and the existing skip-notice
+path with a one-word change.
+
+## D5 — `specflow diff` is a net-new top-level read-only command
+
+**Decision**: A new top-level `specflow diff` command. New `DiffProjectUseCase` (`diff_project.ts`)
+depends on `FsReader` + `LockStore` + `findHarness` — **no `FsWriter`**. It maps `CORE_BUNDLE` for
+the installed templates version (the same call `upgrade_handler.ts` already makes), reads each
+lock-tracked file from disk, and returns `DivergenceResult[]` (`differs` | `matches` | `missing`).
+The new `diff_handler.ts` renders each `differs` via the existing `renderUnifiedDiff`
+(`src/domain/diff.ts`), prints "no divergence" + exit 0 when empty, and never returns non-zero
+except on error.
+
+**Rationale**: Divergence auditing is conceptually independent of upgrading (a maintainer runs it
+any time), so a top-level verb is more discoverable than an `upgrade` sub-flag. `upgrade --dry-run`
+already shows the _plan_, not file-level diffs — `diff` fills a distinct need. Reusing
+`renderUnifiedDiff` + `CORE_BUNDLE` means no new rendering or bundle-read port.
+
+**Alternatives considered**: `specflow upgrade --diff` — rejected: conflates auditing with the
+upgrade flow and is less discoverable; a post-publish or networked diff — rejected: the embedded
+bundle is already local and authoritative.
+
+## D6 — `--reset-preserved` threads through handlers only
+
+**Decision**: Parse `--reset-preserved` in `parser.ts` (boolean) for both `init` and `upgrade`. In
+the handlers: when set, `init_handler` passes an empty `preservedPaths` set; `upgrade_handler`
+passes `isDeclaredPreserved: () => false`. Each handler logs a per-path warning for every preserve
+it overrode (FR-005). The use-cases never read the flag — they see only the resulting
+predicate/empty set.
+
+**Rationale**: Keeps the domain/use-case ignorant of CLI intent; the flag is purely a wiring
+concern. Symmetry with FR-004's preserve notice: overrides are surfaced per file, never silent.
+
+**Alternatives considered**: a `RefreshMode` enum passed into the domain — modelled as a value
+object in data-model.md for clarity, but the predicate form is what the code threads (no need for
+the domain to branch on mode).
+
+## D7 — Unknown-path validation at run time, in the handlers
+
+**Decision**: `preserve_config.ts` parses the YAML without judging path validity. The handlers,
+after loading the store, compare declared paths against `Object.keys(bundle)` and emit a yellow
+`warn:` line per unknown path (FR-008), filtering them out before the use case runs.
+
+**Rationale**: Keeps the domain parser pure and bundle-agnostic; surfaces the warning at the same
+moment the user sees refresh output. A typo'd path is ineffective-but-not-fatal, exactly as the spec
+requires.
+
+**Alternatives considered**: validating in the parser — rejected: would force the bundle into the
+pure domain layer.
+
+## D8 — Parent-managed and plugin-coverage interactions
+
+**Decision**: No special case needed for parent-managed (009). Agentic paths are filtered out of the
+bundle by `isAgenticPath` BEFORE the preserve check, so a declared agentic path in a parent-managed
+sub-repo is simply never in `bundleToWrite` — the preserve predicate is never consulted for it. For
+plugin-coverage, ordering the declared-preserve check first (D4) ensures a declared file is never
+migrated to the plugin.
+
+**Rationale**: Both interactions resolve by ordering alone; introducing flags or special cases would
+add surface for no behavioural gain.
+
+## Open risks
+
+- **`--reset-preserved` flag scoping** — `stdParseArgs` boolean registration is global; registering
+  `--reset-preserved` once covers both `init` and `upgrade`. Confirm the flag is only _acted on_ in
+  the two relevant handlers (a stray `--reset-preserved` on an unrelated command is inert).
+- **Manifest path normalisation** — declared paths must match the bundle's destination-path form
+  exactly (project-relative, forward-slash). The handler comparison and any preserve-set membership
+  test must normalise consistently; cover with a unit test (leading `./`, backslashes on Windows).
+- **`diff` over a removed-upstream path** — a declared path no longer in the new bundle yields a
+  `missing` divergence result (FR-009); ensure the handler renders it as "kept on disk, dropped from
+  bundle" rather than crashing on an absent bundle entry.
+- **Empty/garbage `preserve.yml`** — must degrade to `EMPTY_PRESERVE_CONFIG` (treat unparseable as
+  empty + a warn), never abort init/upgrade.

--- a/.specflow/specs/011-preserve-customisations/spec.md
+++ b/.specflow/specs/011-preserve-customisations/spec.md
@@ -1,0 +1,266 @@
+# Feature Specification: Preserve per-project customisations across template refreshes
+
+**Feature Branch**: `011-preserve-customisations`\
+**Created**: 2026-06-09\
+**Status**: Draft\
+**Input**: GitHub issue mkrlabs/specflow#367 — "feat(init): preserve per-project agent
+customisations across template upgrades (--force)"
+
+## User Scenarios & Testing _(mandatory)_
+
+The "user" here is a **project maintainer** who has tailored one or more bundled Specflow files to
+their project — most often `.claude/agents/product-owner.md` (its GitHub Project handle and label
+conventions) or `.claude/agents/developer.md` (its test/build commands), but also phase docs and
+skill bodies they have locally tweaked. Those customisations live **inline in the file**, not in a
+sidecar, so the template lifecycle cannot see them as anything but "a managed file with a different
+hash."
+
+Today the contract is asymmetric: `specflow upgrade` already auto-detects a changed hash and quietly
+**preserves** the customised file, but `specflow init --force` overwrites **every** managed file
+unconditionally — on 2026-06-08 a single `--force` refresh replaced 88 of 91 bundled files, silently
+reverting a customised `product-owner.md` to the generic bundled version. The maintainer has no way
+to say "this file is mine, keep it even on a forced refresh," and no way to see how their copy
+diverges from the evolving bundle so they can fold in upstream improvements on purpose.
+
+### User Story 1 - Declare a file as mine so a forced refresh never clobbers it (Priority: P1)
+
+A maintainer who has customised a bundled file declares it **preserved**. From then on, neither
+`specflow upgrade` nor `specflow init --force` overwrites it — the on-disk content is left exactly
+as the maintainer left it, and each skipped file is reported with a clear, per-file line so the
+outcome is never silent.
+
+**Why this priority**: This is the headline regression the issue exists to close. Without it, the
+one operation a maintainer reaches for to refresh templates (`init --force`) is the one that
+destroys their inline configuration with no warning. Restoring control over a forced refresh is the
+whole point; it is independently shippable and demonstrable on its own.
+
+**Independent Test**: In a fixture project with a customised managed file declared preserved, run
+`specflow init --force` and assert the file is byte-identical to its pre-refresh content, that a
+notice naming the path was emitted, and that non-preserved managed files were still refreshed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a customised managed file that the maintainer has declared preserved, **When**
+   `specflow init --force` runs, **Then** the file's on-disk content is unchanged and a notice names
+   it as preserved.
+2. **Given** the same preserved file, **When** `specflow upgrade` runs and the bundle ships a new
+   version of that file, **Then** the on-disk content is still unchanged and the file is reported as
+   preserved (consistent with the `--force` behaviour).
+3. **Given** a managed file that is **not** declared preserved, **When** `specflow init --force`
+   runs, **Then** it is refreshed to the bundled version exactly as today (no behaviour change for
+   undeclared files).
+4. **Given** several preserved files skipped in one refresh, **When** the run completes, **Then**
+   one clear line per skipped file is emitted, each naming the path and that it was preserved by the
+   maintainer's declaration.
+
+---
+
+### User Story 2 - See how my customised files diverge from the bundle (Priority: P2)
+
+A maintainer wants to decide, deliberately, whether to adopt upstream improvements to a file they
+have customised. They ask Specflow to show how each customised (or preserved) file diverges from the
+bundled original for the installed templates version, without changing any file, so they can fold in
+the parts they want by hand.
+
+**Why this priority**: Preserving a file freezes it; over several template releases the maintainer's
+copy silently falls behind upstream fixes. A divergence view turns "preserved" from a dead end into
+an informed choice — it is what makes long-term preservation safe. It is independently testable
+against a project with at least one customised file and delivers value the moment it can render a
+diff, independently of the reset flow in US3.
+
+**Independent Test**: In a fixture with one customised managed file, run the divergence view and
+assert it reports that file's difference against the bundled original, touches zero files, and exits
+without error when nothing diverges.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with one or more customised managed files, **When** the maintainer runs the
+   divergence view, **Then** it shows, per file, how the on-disk content differs from the bundled
+   original — and modifies nothing on disk.
+2. **Given** a project whose managed files all match the bundle, **When** the divergence view runs,
+   **Then** it reports "no divergence" and exits successfully.
+3. **Given** a preserved file that has fallen behind several bundle releases, **When** the
+   divergence view runs, **Then** the maintainer can see exactly which lines upstream changed.
+
+---
+
+### User Story 3 - Deliberately discard my customisations for a clean refresh (Priority: P3)
+
+A maintainer who has decided to abandon their customisations and return to the generic bundled
+versions can explicitly opt out of preservation for a single refresh, so a forced refresh overwrites
+even preserved files. This never happens by default — it requires an explicit, intentional opt-out.
+
+**Why this priority**: The escape hatch matters but is the rarest path; US1 and US2 already deliver
+the protective behaviour and the visibility. The reset is the deliberate "I really do want the clean
+bundle back" lever, valuable but not on the critical path, and only acceptable if it is impossible
+to trigger by accident.
+
+**Independent Test**: In a fixture with a preserved customised file, run a forced refresh with the
+explicit reset opt-out and assert the file is overwritten with the bundled version; run the same
+forced refresh **without** the opt-out and assert the file is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a preserved customised file, **When** a forced refresh runs with the explicit reset
+   opt-out, **Then** the file is overwritten with the bundled version and the override is reported.
+2. **Given** the same preserved file, **When** a forced refresh runs without the opt-out, **Then**
+   the file is preserved (the opt-out is never the default).
+
+### Edge Cases
+
+- **Preserve declared for a vanilla file** — the maintainer marks a file preserved but has not
+  actually changed it (it matches the bundle). The declaration is honored (the file is left alone)
+  and surfaced informatively; it is not an error.
+- **Preserve declared for an unknown path** — a path that is not part of the managed bundle (a typo,
+  or a file Specflow does not own). This is reported as an ineffective declaration (warn, no-op),
+  not a fatal error and not a silent success.
+- **Upstream removed the file** — a preserved path no longer exists in the new bundle. The
+  maintainer's on-disk file is kept (preservation wins over removal) and the situation is surfaced
+  so they know the bundle no longer ships it.
+- **New bundled file added upstream** — a brand-new managed file the project does not yet have must
+  still be added by a refresh; a preserve list governs existing files and must never block
+  legitimate additions.
+- **Parent-managed sub-repo** — in a workspace sub-repo where agentic files are intentionally not
+  provisioned (009-parent-managed-init), a preserve declaration for an agent path is moot; the
+  feature must not resurrect suppressed files.
+- **Plugin-owned file** — a preserved path that the plugin now owns (the `migrate-to-plugin` path):
+  preservation of the on-disk customised copy takes precedence over migration, consistent with the
+  existing "customized → preserve" rule.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: A maintainer MUST be able to declare one or more managed files as **preserved**, in a
+  project-level, version-controllable declaration that survives across runs.
+- **FR-002**: A forced refresh (`specflow init --force`) MUST NOT overwrite a file declared
+  preserved; the on-disk content MUST be left intact.
+- **FR-003**: `specflow upgrade` MUST honor the same explicit preserve declaration, so the
+  protection is identical whichever refresh path the maintainer uses.
+- **FR-004**: Every file skipped because it is preserved MUST be reported with a clear, per-file
+  line that names the path and identifies preservation (declared by the maintainer) as the reason —
+  no silent skips.
+- **FR-005**: The system MUST provide an explicit opt-out that, only when intentionally invoked,
+  overrides preserve declarations for a single forced refresh and restores the bundled versions; the
+  opt-out MUST NOT be the default and MUST report which preserved files it overrode.
+- **FR-006**: A maintainer MUST be able to view how each customised (or preserved) managed file
+  diverges from its bundled original for the installed templates version, in a read-only operation
+  that modifies no files.
+- **FR-007**: A preserve declaration for a file that currently matches the bundle MUST be honored
+  and surfaced informatively (no divergence yet), not treated as an error.
+- **FR-008**: A preserve declaration for a path outside the managed bundle MUST be reported as
+  ineffective (warning) rather than silently honored or treated as fatal.
+- **FR-009**: A preserved file that no longer exists in the new bundle MUST be kept on disk, and the
+  situation surfaced so the maintainer knows the bundle dropped it.
+- **FR-010**: A refresh MUST still add managed files that are new in the bundle; the preserve
+  declaration governs existing files only and MUST NOT suppress legitimate additions.
+- **FR-011**: For a project that declares no preserves, init and upgrade behaviour MUST be unchanged
+  from today (the feature is inert by default).
+- **FR-012**: Preserved files MUST remain tracked against the bundle so the divergence view and
+  future refreshes can compare them as the bundle evolves.
+
+### Key Entities _(see Domain Model section below for full structure)_
+
+- **Project installation** — a Specflow-initialised project, identified by its installed lock; owns
+  the set of managed files and the preserve declarations.
+- **Managed file** — a bundled file Specflow installs and tracks by destination path; may be
+  vanilla, customised, or preserved.
+- **Preserve declaration** — the maintainer's stated intent that a specific managed file is theirs
+  and must survive a forced refresh.
+
+## Domain Model _(mandatory)_
+
+**Bounded context:** Project template lifecycle (init / upgrade / preserve).
+
+**Vocabulary (Ubiquitous language):**
+
+- **Bundle** — the set of template files embedded in the Specflow binary for a given templates
+  version.
+- **Managed file** — a file Specflow installs from the bundle and tracks (by destination path) in
+  the installed lock.
+- **Customisation** — a managed file whose on-disk content differs from the version recorded in the
+  lock (the maintainer edited it).
+- **Preserve declaration** — an explicit, project-level statement that a managed file must be kept
+  on disk and never overwritten by a refresh, even a forced one.
+- **Forced refresh** — `specflow init --force`: a refresh that, today, overwrites every managed file
+  unconditionally.
+- **Divergence** — the difference between a managed file's on-disk content and its bundled original
+  for the installed templates version.
+- **Reset (opt-out)** — an explicit, non-default request to override preserve declarations for one
+  forced refresh and restore the bundled versions.
+
+**Entities (have identity):**
+
+- **Project installation** [aggregate root] — identified by its installed lock; owns the
+  managed-file set and the preserve declarations, and enforces the "preserved is never silently
+  overwritten" invariant across init and upgrade.
+- **Managed file** — identified by its destination path; its state is one of {vanilla, customised}
+  and, orthogonally, {declared-preserved, not-declared}.
+
+**Value objects (no identity, immutable):**
+
+- **PreserveDeclaration(path)** — a maintainer's intent to protect one managed path; honored whether
+  or not the file currently diverges.
+- **Divergence(path, bundledContent, diskContent)** — a read-only comparison result; exists iff the
+  on-disk content differs from the bundled original.
+- **RefreshMode(normal | force | force-reset-preserved)** — the intent of a refresh run; only
+  `force-reset-preserved` may overwrite a preserved file.
+
+**Invariants (rules the domain must never break):**
+
+- A file declared preserved MUST NOT be overwritten by any refresh unless the maintainer explicitly
+  requests the reset opt-out for that run.
+- A refresh that skips a file because it is preserved MUST surface that fact — preservation is never
+  silent, symmetric to the silent overwrite this feature removes.
+- A project with no preserve declarations MUST observe exactly today's init/upgrade behaviour — the
+  feature adds no default-path behaviour change.
+- The divergence view MUST be read-only — observing divergence MUST NOT mutate any file.
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- **Merging upstream changes into a preserved file** — folding new bundle content into a customised
+  file is a manual decision the maintainer makes, aided by the divergence view; this feature does
+  not auto-merge.
+- **Parent-managed provisioning (009-parent-managed-init)** — whether agentic files are provisioned
+  at all in a workspace sub-repo is owned there; this feature only governs files that are present.
+- **Plugin coverage / migration (`migrate-to-plugin`)** — which files the plugin owns is owned by
+  the plugin-coverage map; this feature defers to the existing "customized → preserve" precedence.
+- **Recovering already-lost customisations** — content clobbered before this feature shipped is
+  recoverable from git, per the issue; this feature prevents future loss, it does not restore past
+  loss.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: After a managed file is declared preserved, `specflow init --force` leaves it
+  byte-identical to its pre-refresh content — zero preserved files are overwritten.
+- **SC-002**: For N preserved files skipped in a refresh, exactly N clear notices are emitted, each
+  naming the path; zero preserved files are skipped silently.
+- **SC-003**: A maintainer can view the divergence of every customised managed file from its bundled
+  original in a single read-only command that mutates zero files.
+- **SC-004**: For a project with no preserve declarations, init and upgrade produce output identical
+  to current behaviour — the existing init/upgrade test suite passes unchanged.
+- **SC-005**: The reset opt-out restores the bundled version for preserved files only when
+  explicitly invoked, and never on a default forced refresh.
+- **SC-006**: The 2026-06-08 failure mode — a customised `product-owner.md` reverted to the generic
+  bundle by `init --force` — does not recur once that file is declared preserved.
+
+## Assumptions
+
+- The **declaration mechanism** (a project-level manifest such as `.specflow/preserve.yml`, a
+  per-file frontmatter flag, or a per-file sidecar) is a design decision for the plan phase; the
+  spec stays mechanism-agnostic and only requires that the declaration be project-level and
+  version-controllable. The issue lists all three as candidates.
+- The existing SHA-based auto-preserve in `specflow upgrade`
+  (`UpgradeAction kind: "preserve"; reason:
+  "customized"`) remains; this feature adds an
+  **explicit, force-surviving** preserve layer on top of that implicit behaviour and unifies how
+  both refresh paths treat declared files.
+- The divergence view compares on-disk content against the binary's embedded bundle for the
+  currently-installed templates version (the same source `upgrade` already reads), so no network or
+  external fetch is required.
+- Preserve declarations are committed to the project's version control alongside `.specflow/`, so
+  they travel with the repo and are reviewable.
+- The feature targets the public CLI half (`apps/specflow/`) only; no private-half code, names, or
+  secrets are involved.

--- a/.specflow/specs/011-preserve-customisations/tasks.md
+++ b/.specflow/specs/011-preserve-customisations/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Preserve per-project customisations across template refreshes
+
+**Feature**: `011-preserve-customisations` | **Branch**: `011-preserve-customisations` | **Issue**:
+mkrlabs/specflow#367 **Inputs**: [plan.md](./plan.md) · [spec.md](./spec.md) ·
+[data-model.md](./data-model.md) ·
+[contracts/preserve-and-diff.md](./contracts/preserve-and-diff.md) · [research.md](./research.md)
+
+TDD throughout: each behavioural task pairs a failing Deno.test with the implementation that makes
+it pass. All tests hermetic — injected `FsReader`/`FsWriter`/`LockStore`/`PreserveStore` fakes,
+in-repo `CORE_BUNDLE`, temp dirs. No network, no real binary, no live `gh`.
+
+---
+
+## Phase 1: Setup
+
+- [x] T001 Confirm `@std/yaml` is already imported in `deno.json`/import map (used by
+      `installed_lock.ts`); no new dependency needed. Record the exact specifier to reuse in
+      `preserve_config.ts`. — `@std/yaml` (`jsr:@std/yaml@^1.0.0`), `parse`/`stringify` named
+      exports.
+
+## Phase 2: Foundational (blocking prerequisites for all user stories)
+
+- [x] T002 [P] Write failing unit tests for the preserve manifest in
+      `tests/domain/preserve_config_test.ts`: round-trip parse↔serialize; `EMPTY_PRESERVE_CONFIG`
+      for absent/empty/malformed input; normalisation (trim, de-dupe, strip leading `./`,
+      backslash→slash). (C1)
+- [x] T003 Implement the pure domain type in `src/domain/preserve_config.ts` — `PreserveConfig`,
+      `parsePreserveConfig` (never throws), `serializePreserveConfig`, `EMPTY_PRESERVE_CONFIG` —
+      making T002 pass. No I/O, no Deno globals.
+- [x] T004 [P] Write failing unit tests for the store in
+      `tests/infrastructure/fs_preserve_store_test.ts`: read absent file ⇒ `EMPTY_PRESERVE_CONFIG`;
+      write then read round-trips; malformed file degrades to empty. (C2)
+- [x] T005 Add the `PreserveStore` port to `src/application/ports.ts` and implement
+      `src/infrastructure/fs_preserve_store.ts` (reads/writes `.specflow/preserve.yml`, mirrors
+      `FsLockStore`'s `Deno.errors.NotFound` handling), making T004 pass.
+
+## Phase 3: User Story 1 — declare a file so a forced refresh never clobbers it (P1) 🎯 MVP
+
+**Goal**: `init --force` and `upgrade` both preserve a declared file, with a per-file notice.
+**Independent test**: fixture with a customised declared file → `init --force` leaves it
+byte-identical and emits a notice; a non-declared file is still refreshed.
+
+- [x] T006 [P] [US1] Extend `tests/domain/upgrade_plan_test.ts`: a declared path yields
+      `preserve / reason:"declared"` even when disk SHA == bundle SHA; the declared check precedes
+      the plugin-migration and unchanged/auto-update branches; a non-declared path is unaffected.
+      (C3)
+- [x] T007 [US1] Edit `src/domain/upgrade_plan.ts`: add `"declared"` to `preserve.reason`; add
+      `isDeclaredPreserved?: (dest) => boolean` to `UpgradePlanOptions`; insert the declared check
+      as the FIRST branch in `computeUpgradePlan`. Make T006 pass.
+- [x] T008 [P] [US1] Extend `tests/application/init_project_test.ts`: with `preservedPaths` set,
+      those dests are absent from the writer's written set and present in `InitResult.preserved`;
+      with the set absent/empty, the written set and result equal today's behaviour. (C4)
+- [x] T009 [US1] Edit `src/application/init_project.ts`: add `InitProjectInput.preservedPaths` and
+      `InitResult.preserved`; build `bundleToWrite` = `bundle` minus `preservedPaths` before
+      `writer.writeBundle`; report the removed set. Make T008 pass.
+- [x] T010 [US1] Wire both handlers: in `src/cli/handlers/init_handler.ts` and
+      `src/cli/handlers/upgrade_handler.ts`, load the `PreserveStore`, build the preserved set /
+      `isDeclaredPreserved` predicate, and pass it into the use case / `UpgradePlanOptions`. Emit
+      one notice line per preserved file (contract §3). (Init uses `FsPreserveStore`; upgrade passes
+      the predicate.)
+- [x] T011 [US1] Add the end-to-end integration test `tests/integration/init_preserve_test.ts`
+      (declare path → `init --force` keeps it byte-identical + notice emitted; non-declared file
+      refreshed). Uses the `product-owner.md` fixture to close the 2026-06-08 regression. (C6
+      partial — SC-001, SC-002, SC-006)
+
+**Checkpoint**: US1 is independently shippable — preserve works on both refresh paths with notices.
+
+## Phase 4: User Story 2 — see how customised files diverge from the bundle (P2)
+
+**Goal**: `specflow diff` shows per-file divergence, read-only. **Independent test**: fixture with
+one customised file → `specflow diff` shows its diff, touches zero files, prints "no divergence" +
+exit 0 when nothing differs.
+
+- [x] T012 [P] [US2] Write failing unit tests in `tests/application/diff_project_test.ts`: `differs`
+      (with both contents), `matches`, `missing` (tracked on disk, absent from bundle); empty
+      project ⇒ empty results; assert no `FsWriter` is touched. (C5)
+- [x] T013 [US2] Implement `src/application/diff_project.ts` — `DiffProjectUseCase` depending on
+      `FsReader` + `LockStore` + `findHarness` only (NO `FsWriter`); maps `CORE_BUNDLE` for the
+      installed templates version, reads each tracked file, returns `DivergenceResult[]` +
+      `fromVersion`. Make T012 pass.
+- [x] T014 [US2] Add the `diff` intent to `src/cli/parser.ts` (`{ kind: "diff"; onlyCustomised }`,
+      parse `--only-customised`), implement `src/cli/handlers/diff_handler.ts` (`runDiff`: wire
+      `DenoFsReader` + `FsLockStore` + `findHarness`, render each `differs` via the existing
+      `renderUnifiedDiff` from `src/domain/diff.ts`, print "no divergence" + exit 0 when empty,
+      non-zero only on error), add `case "diff"` to `src/cli/main.ts` dispatch, and one usage line
+      to `src/cli/help.ts`. (C4-diff, SC-003)
+
+**Checkpoint**: US2 is independently shippable — read-only divergence auditing works.
+
+## Phase 5: User Story 3 — deliberately discard customisations for a clean refresh (P3)
+
+**Goal**: `--reset-preserved` overrides declarations for one run; never default. **Independent
+test**: preserved file + `init --force --reset-preserved` ⇒ overwritten; same without the flag ⇒
+preserved.
+
+- [x] T015 [US3] Add `--reset-preserved` (boolean) to `src/cli/parser.ts` for both `init` and
+      `upgrade` intents.
+- [x] T016 [US3] In both handlers: when `--reset-preserved` is set, `init_handler` passes an empty
+      preserved set and `upgrade_handler` passes `isDeclaredPreserved: () => false`; emit a per-file
+      override warning (contract §3, FR-005). Extend `tests/integration/init_preserve_test.ts` with
+      the reset-overwrites and no-flag-preserves cases. (C6 — SC-005)
+
+**Checkpoint**: US3 shippable — the deliberate escape hatch works and is never the default.
+
+## Phase 6: Polish & cross-cutting concerns
+
+- [x] T017 [P] Edge case FR-008: declared path not in the bundle ⇒ handler emits one `warn:` line
+      and filters it out (no fatal, no silent honour). Cover in
+      `tests/application/init_project_test.ts` (or a handler-level test). (C7)
+- [x] T018 [P] Edge case FR-009: a declared/tracked path absent from the new bundle ⇒ kept on disk;
+      `diff` renders it as `missing`. Cover in `tests/application/diff_project_test.ts`.
+- [x] T019 [P] Edge case D8: a declared agentic path in a parent-managed sub-repo is a no-op
+      (agentic paths filtered before the preserve check). Add an assertion in the upgrade-plan or
+      init test. (C7)
+- [x] T020 Run `deno task test` (full suite green, incl. unchanged init/upgrade suites — SC-004),
+      `deno fmt --check`, `deno lint`, and a typecheck. Fix any fallout.
+- [x] T021 Update `CHANGELOG.md` (Unreleased) with the preserve manifest, `specflow diff`, and
+      `--reset-preserved`; add a short `docs/` note on `.specflow/preserve.yml` if a managed-files
+      doc exists.
+
+---
+
+## Dependencies & order
+
+- **Setup (T001)** → **Foundational (T002–T005)** block everything.
+- **US1 (T006–T011)** depends on Foundational; it is the MVP.
+- **US2 (T012–T014)** depends only on Foundational (the lock + bundle read) — independent of US1.
+- **US3 (T015–T016)** depends on US1's handler wiring (the predicate/set seam).
+- **Polish (T017–T021)** last; T020 gates the merge.
+
+## Parallel opportunities
+
+- T002 ‖ T004 (different test files, pure).
+- Within US1: T006 ‖ T008 (different test files). T007 must precede the upgrade-handler half of
+  T010; T009 must precede the init-handler half of T010.
+- US2 (T012–T014) can proceed in parallel with US1 once Foundational lands (separate files:
+  `diff_project.ts`, `diff_handler.ts`).
+- Polish T017 ‖ T018 ‖ T019 (different edge cases / files).
+
+## MVP scope
+
+**User Story 1 alone** (T001–T011) is a shippable MVP: it closes the headline regression — a
+declared file survives `init --force` with a visible notice. US2 (divergence view) and US3 (reset)
+are independent increments layered on the same foundation.

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -169,6 +169,24 @@ Specflow merges its `.gitignore` block into your existing file (non-destructivel
 `# --- Specflow: gitignore ---` markers). Other specflow-managed files use upgrade-aware semantics:
 if you customize a generated file, `specflow upgrade` will preserve it unless you pass `--force`.
 
+**Declaring a file preserved across a forced refresh.** `specflow upgrade` auto-preserves a file
+whose hash diverged, but `specflow init --force` would otherwise overwrite every managed file. To
+keep a customized file (e.g. a tailored `.claude/agents/product-owner.md`) even through a forced
+refresh, list it in a version-controllable `.specflow/preserve.yml` manifest:
+
+```yaml
+preserved:
+  - .claude/agents/product-owner.md
+```
+
+Both `init --force` and `upgrade` then leave that file untouched and print one notice per preserved
+path — never a silent skip. The file stays lock-tracked, so `specflow diff` keeps showing how it has
+drifted from the evolving bundle. A project with no `preserve.yml` behaves exactly as before. To
+deliberately discard a customization and restore the bundled version for one run, add
+`--reset-preserved` (it overrides every declaration for that run and reports each override; it is
+never the default). A declared path that is not a managed bundle file is reported as an ineffective
+declaration (a warning) rather than silently honored.
+
 Pass `--dry-run` to preview the plan without touching disk — combined with `--force` it shows which
 files would be overwritten and which would be merged, but writes nothing. `--dry-run` is the trump
 card: it wins over `--force`.
@@ -316,6 +334,10 @@ specflow upgrade                  # update templates to the binary's version
                                   #    vanilla agent/command files are auto-migrated to the plugin)
 specflow upgrade --dry-run        # preview the upgrade plan
 specflow upgrade --force          # apply destructive changes (backs up customizations)
+specflow upgrade --reset-preserved  # ignore .specflow/preserve.yml for this run (reports each override)
+specflow diff                     # show how managed files diverge from the bundle (read-only)
+specflow diff --only-customised   # restrict the diff to files you actually changed
+specflow init --here --force --reset-preserved  # forced refresh that overrides preserve declarations
 specflow reconcile --status       # list files pending post-upgrade reconciliation (JSON)
 specflow reconcile <path> --accept-upstream  # take new template version (backs up local)
 specflow reconcile <path> --accept-current   # keep local version (re-stamps lock SHA)

--- a/src/application/diff_project.ts
+++ b/src/application/diff_project.ts
@@ -1,0 +1,114 @@
+import type { FsReader, Harness, LockStore } from "./ports.ts";
+import type { CoreBundle } from "../domain/core_bundle.ts";
+import { sha256Hex } from "../domain/sha256.ts";
+
+/**
+ * Per-file outcome of comparing a managed file's on-disk content against the
+ * bundled original for the installed templates version (spec 011 / issue #367,
+ * US2).
+ *
+ *  - `differs`  — on disk AND in the bundle, but the contents diverge. Carries
+ *    both blobs so the handler can render a unified diff.
+ *  - `matches`  — on disk and byte-identical to the bundled original.
+ *  - `missing`  — lock-tracked (and present on disk) but absent from the new
+ *    bundle: upstream dropped the file, the maintainer kept it (FR-009).
+ */
+export type DivergenceResult =
+  | { kind: "differs"; dest: string; diskContent: string; bundledContent: string }
+  | { kind: "matches"; dest: string }
+  | { kind: "missing"; dest: string };
+
+export type DiffProjectInput = {
+  readonly projectDir: string;
+  /**
+   * When true, restrict the result set to paths whose on-disk SHA differs from
+   * the lock SHA — i.e. files the maintainer actually customised. Default
+   * (false) reports every lock-tracked managed path.
+   */
+  readonly onlyCustomised: boolean;
+};
+
+export type DiffProjectResult = {
+  readonly results: ReadonlyArray<DivergenceResult>;
+  /** Installed templates version the bundle was mapped for (lock version). */
+  readonly fromVersion: string;
+};
+
+/**
+ * Read-only dependencies for the divergence view. Deliberately carries **no
+ * `FsWriter`**: observing divergence must mutate nothing (contract §4 / the
+ * read-only invariant). The only ports are a reader, the lock store, the
+ * embedded `CORE_BUNDLE`, and the harness resolver — exactly the inputs needed
+ * to reconstruct the bundled original `upgrade` would compare against.
+ */
+export type DiffProjectDeps = {
+  reader: FsReader;
+  lockStore: LockStore;
+  core: CoreBundle;
+  findHarness: (key: string) => Harness | null;
+};
+
+/**
+ * Computes, read-only, how each lock-tracked managed file diverges from its
+ * bundled original for the installed templates version (US2 / FR-006).
+ *
+ * The bundle is mapped through the lock's harness/backend/scheme exactly the
+ * way `upgrade` maps it, so the comparison is against the same bytes a refresh
+ * would write. A path tracked in the lock but absent from the freshly-mapped
+ * bundle is surfaced as `missing` rather than silently dropped (FR-009).
+ */
+export class DiffProjectUseCase {
+  constructor(private readonly deps: DiffProjectDeps) {}
+
+  async execute(input: DiffProjectInput): Promise<DiffProjectResult> {
+    const { reader, lockStore, core, findHarness } = this.deps;
+
+    const lock = await lockStore.read(input.projectDir);
+    // No lock ⇒ nothing is tracked, so there is nothing to compare. Surface an
+    // empty result with an empty version rather than throwing — `diff` is a
+    // read-only audit, not a precondition-gated mutation.
+    if (lock === null) return { results: [], fromVersion: "" };
+
+    const harness = findHarness(lock.harness);
+    if (!harness) {
+      throw new Error(`unknown harness in lock: ${lock.harness}`);
+    }
+
+    const bundle = harness.mapBundle(core, {
+      backlogBackend: lock.backlogBackend,
+      versionScheme: lock.versionScheme,
+    });
+
+    const results: DivergenceResult[] = [];
+    for (const [dest, entry] of lock.entries) {
+      const diskContent = await reader.readText(input.projectDir, dest);
+      // A lock entry whose file is gone from disk is outside this view's remit
+      // (the divergence is between disk and bundle); skip it rather than invent
+      // a result.
+      if (diskContent === null) continue;
+
+      const diskSha = await sha256Hex(diskContent);
+      const isCustomised = diskSha !== entry.sha256;
+      if (input.onlyCustomised && !isCustomised) continue;
+
+      const bundled = bundle[dest];
+      if (bundled === undefined) {
+        // Tracked on disk but dropped from the new bundle (FR-009).
+        results.push({ kind: "missing", dest });
+        continue;
+      }
+      if (bundled.content === diskContent) {
+        results.push({ kind: "matches", dest });
+      } else {
+        results.push({
+          kind: "differs",
+          dest,
+          diskContent,
+          bundledContent: bundled.content,
+        });
+      }
+    }
+
+    return { results, fromVersion: lock.templatesVersion };
+  }
+}

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -23,6 +23,13 @@ export type InitResult =
     warnings: string[];
     backups: string[];
     lockWritten: boolean;
+    /**
+     * Destination paths skipped from the WRITE set because they were declared
+     * preserved (`.specflow/preserve.yml`, spec 011 / issue #367). Reported so
+     * the handler can emit one per-file notice (FR-004). These paths remain
+     * lock-tracked (FR-012) — only the write was skipped.
+     */
+    preserved: ReadonlyArray<string>;
   }
   | {
     status: "conflicts";
@@ -67,6 +74,16 @@ export type InitProjectInput = {
    * Absent ⇒ treated as `false` (standalone, full provisioning).
    */
   parentManaged?: boolean;
+  /**
+   * Destination paths to leave untouched on a forced refresh — the
+   * maintainer's preserve declarations (`.specflow/preserve.yml`, spec 011 /
+   * issue #367). These are removed from the WRITE set only; they STAY
+   * lock-tracked (FR-012) so `specflow diff` and future upgrades still
+   * compare them. Absent/empty ⇒ today's behaviour (FR-011). The handler
+   * resolves the set (and validates membership / `--reset-preserved`); the
+   * use case never reads the manifest or any CLI flag.
+   */
+  preservedPaths?: ReadonlySet<string>;
 };
 
 export class InitProjectUseCase {
@@ -115,13 +132,32 @@ export class InitProjectUseCase {
       }
     }
 
+    // Preserve filter (spec 011 / issue #367): declared paths are removed from
+    // the WRITE set so a forced refresh never clobbers them, but they stay in
+    // `bundle` for lock-entry construction below — preserved files MUST remain
+    // lock-tracked (FR-012). Only dests that are actually in the bundle count
+    // as preserved (a declared path outside the bundle is a handler-side warn).
+    // Computed before the dry-run short-circuit so the previewed
+    // "would write N files" count excludes preserved paths too.
+    const preservedSet = input.preservedPaths ?? new Set<string>();
+    const preserved: string[] = [];
+    const bundleToWrite: Bundle = {};
+    for (const [dest, file] of Object.entries(bundle)) {
+      if (preservedSet.has(dest)) {
+        preserved.push(dest);
+        continue;
+      }
+      bundleToWrite[dest] = file;
+    }
+
     // Dry-run short-circuit: no writes, no lock, no git init. Synthesize
-    // an InitResult from the bundle so the caller can print the same
-    // "would write N files" summary as a real run.
+    // an InitResult from `bundleToWrite` (the post-preserve-filter set) so the
+    // caller prints the same "would write N files" summary as a real run —
+    // excluding the preserved paths it would skip.
     if (input.dryRun) {
       const mergedPaths: string[] = [];
       let writtenCount = 0;
-      for (const [dest, file] of Object.entries(bundle)) {
+      for (const [dest, file] of Object.entries(bundleToWrite)) {
         if (file.mergeBlock !== undefined || file.mergeJson !== undefined) {
           mergedPaths.push(dest);
         } else {
@@ -135,10 +171,11 @@ export class InitProjectUseCase {
         warnings,
         backups: [],
         lockWritten: false,
+        preserved,
       };
     }
 
-    const report = await writer.writeBundle(bundle, input.targetDir, {
+    const report = await writer.writeBundle(bundleToWrite, input.targetDir, {
       overwrite: input.force,
       backupExisting: input.force,
     });
@@ -199,9 +236,12 @@ export class InitProjectUseCase {
       }
     }
 
+    // Count from `bundleToWrite` (the post-preserve-filter set), NOT the full
+    // `bundle`: preserved paths were skipped on disk, so "wrote N files" must
+    // not count files this run never touched (spec 011 / issue #367).
     const mergedPaths: string[] = [];
     let writtenCount = 0;
-    for (const [dest, file] of Object.entries(bundle)) {
+    for (const [dest, file] of Object.entries(bundleToWrite)) {
       if (file.mergeBlock !== undefined || file.mergeJson !== undefined) {
         mergedPaths.push(dest);
       } else {
@@ -216,6 +256,7 @@ export class InitProjectUseCase {
       warnings,
       backups: report.backups.map((b) => b.dest),
       lockWritten: true,
+      preserved,
     };
   }
 }

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -2,6 +2,7 @@ import type { Bundle } from "../domain/template.ts";
 import type { Release } from "../domain/release.ts";
 import type { CheckOutcome } from "../domain/check_result.ts";
 import type { InstalledLock } from "../domain/installed_lock.ts";
+import type { PreserveConfig } from "../domain/preserve_config.ts";
 
 export interface FsWriter {
   detectConflicts(bundle: Bundle, targetDir: string): Promise<string[]>;
@@ -85,6 +86,20 @@ export interface LockStore {
 
 export interface FsReader {
   readText(projectDir: string, rel: string): Promise<string | null>;
+}
+
+/**
+ * Filesystem-backed store for `.specflow/preserve.yml` — the maintainer's
+ * preserve declarations (spec 011 / issue #367).
+ *
+ * Mirrors {@link LockStore}: an absent manifest reads as
+ * `EMPTY_PRESERVE_CONFIG` (the feature is inert when no file exists, FR-011),
+ * and a malformed manifest degrades to empty rather than aborting a refresh —
+ * the handler surfaces the warning.
+ */
+export interface PreserveStore {
+  read(projectDir: string): Promise<PreserveConfig>;
+  write(projectDir: string, cfg: PreserveConfig): Promise<void>;
 }
 
 /**

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -3,7 +3,11 @@ import type { Bundle, TemplateFile } from "../domain/template.ts";
 import { sha256Hex } from "../domain/sha256.ts";
 import type { InstalledLock, LockEntry } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
-import { computeUpgradePlan, type UpgradePlan } from "../domain/upgrade_plan.ts";
+import {
+  computeUpgradePlan,
+  type UpgradeAction,
+  type UpgradePlan,
+} from "../domain/upgrade_plan.ts";
 import { canonicalBlockBody, extractBlock } from "../domain/merge_block.ts";
 import { isPluginCoveredPath } from "../domain/plugin_coverage.ts";
 import { isAgenticPath } from "../domain/parent_managed.ts";
@@ -33,6 +37,16 @@ export type UpgradeProjectInput = {
    * `false`.
    */
   parentManagedOverride?: boolean;
+  /**
+   * Declared-preserve predicate (spec 011 / issue #367). Returns true for any
+   * dest the maintainer listed in `.specflow/preserve.yml`. Threaded straight
+   * into `computeUpgradePlan` so declared files become `preserve/"declared"`
+   * (winning over auto-update, plugin-migration, and removal). Built by the
+   * handler from the manifest (and flipped off when `--reset-preserved` is
+   * passed); the use case never reads the manifest or any CLI flag. Absent ⇒
+   * no declared preserves (today's behaviour).
+   */
+  isDeclaredPreserved?: (dest: string) => boolean;
 };
 
 export type UpgradeProjectResult =
@@ -155,15 +169,23 @@ export class UpgradeProjectUseCase {
         isPluginCovered: (dest) => isPluginCoveredPath(lock.harness, dest),
         isSkipIfExists: (dest) => bundle[dest]?.skipIfExists === true,
         resetBaseline: input.resetBaseline ?? false,
+        isDeclaredPreserved: input.isDeclaredPreserved ?? (() => false),
       },
     );
+
+    // A declared-preserve (spec 011 / issue #367) is immune to `--force`: the
+    // maintainer overrides it only via `--reset-preserved` (which flips the
+    // predicate off, so the file never reaches here as reason:"declared").
+    // Only a `customized` preserve is overwritten by `--force`.
+    const isForceWritablePreserve = (a: UpgradeAction): boolean =>
+      a.kind === "preserve" && a.reason === "customized" && input.force;
 
     const hasActualWork = plan.some((a) =>
       a.kind === "auto-update" ||
       a.kind === "add-new" ||
       a.kind === "migrate-to-plugin" ||
       a.kind === "defer-to-plugin" ||
-      (a.kind === "preserve" && input.force) ||
+      isForceWritablePreserve(a) ||
       (a.kind === "remove" && (!a.wasCustomized || input.force))
     );
     if (!hasActualWork && plan.every((a) => a.kind === "unchanged")) {
@@ -195,7 +217,9 @@ export class UpgradeProjectUseCase {
     // so the agent can preview the reconciliation plan.
     const stagingWrites: Bundle = {};
     for (const action of plan) {
-      if (action.kind !== "preserve") continue;
+      // Stage only `customized` preserves for reconcile; a declared-preserve is
+      // a deliberate freeze, not a pending reconciliation.
+      if (action.kind !== "preserve" || action.reason !== "customized") continue;
       const file = bundle[action.dest];
       if (!file) continue;
       stagingWrites[`.specflow/upgrade-staging/${action.dest}`] = file;
@@ -221,7 +245,7 @@ export class UpgradeProjectUseCase {
       if (
         action.kind === "auto-update" ||
         action.kind === "add-new" ||
-        (action.kind === "preserve" && input.force)
+        isForceWritablePreserve(action)
       ) {
         const file = bundle[action.dest];
         if (file) toWrite[action.dest] = file;

--- a/src/cli/handlers/diff_handler.ts
+++ b/src/cli/handlers/diff_handler.ts
@@ -1,0 +1,79 @@
+import { resolve } from "@std/path";
+import { bold, cyan, dim, green, red, yellow } from "@std/fmt/colors";
+import { DiffProjectUseCase, type DivergenceResult } from "../../application/diff_project.ts";
+import { DenoFsReader } from "../../infrastructure/fs_reader.ts";
+import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
+import { findHarness } from "../harnesses.ts";
+import { CORE_BUNDLE } from "../../templates_bundle.ts";
+import { renderUnifiedDiff } from "../../domain/diff.ts";
+
+export type DiffIntent = {
+  kind: "diff";
+  /** `--only-customised`: restrict to paths whose disk SHA ≠ lock SHA. */
+  onlyCustomised: boolean;
+};
+
+/**
+ * `specflow diff` (spec 011 / issue #367, US2) — render, read-only, how each
+ * managed file on disk diverges from the bundled original for the installed
+ * templates version (FR-006).
+ *
+ * Wires only read-capable adapters (reader + lock store + the embedded bundle):
+ * the use case has no writer, so the command mutates nothing (contract §4). A
+ * present diff is success — the exit code is non-zero only on a genuine error
+ * (e.g. an unknown harness in the lock).
+ */
+export async function runDiff(intent: DiffIntent): Promise<number> {
+  const projectDir = resolve(Deno.cwd());
+
+  const useCase = new DiffProjectUseCase({
+    reader: new DenoFsReader(),
+    lockStore: new FsLockStore(),
+    core: CORE_BUNDLE,
+    findHarness,
+  });
+
+  let result;
+  try {
+    result = await useCase.execute({ projectDir, onlyCustomised: intent.onlyCustomised });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(red(`error: ${msg}`));
+    return 2;
+  }
+
+  const differs = result.results.filter(
+    (r): r is Extract<DivergenceResult, { kind: "differs" }> => r.kind === "differs",
+  );
+  const missing = result.results.filter((r) => r.kind === "missing");
+
+  if (differs.length === 0 && missing.length === 0) {
+    console.log(green("✓ no divergence — every managed file matches the bundle"));
+    return 0;
+  }
+
+  for (const r of differs) {
+    console.log(bold(`\n---- diff: ${r.dest} ----`));
+    console.log(renderUnifiedDiff(
+      r.bundledContent,
+      r.diskContent,
+      `bundled ${r.dest}`,
+      `on-disk ${r.dest}`,
+    ));
+  }
+
+  for (const r of missing) {
+    console.log(
+      yellow(`missing  ${r.dest} — on disk, no longer in the bundle (kept)`),
+    );
+  }
+
+  console.log();
+  console.log(
+    dim(
+      `  ${differs.length} diverged, ${missing.length} dropped-upstream ` +
+        `(templates ${result.fromVersion}) ${cyan("· read-only, nothing written")}`,
+    ),
+  );
+  return 0;
+}

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -26,7 +26,9 @@ import { DenoFsWriter } from "../../infrastructure/deno_fs_writer.ts";
 import { DenoGit } from "../../infrastructure/deno_git.ts";
 import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
 import { FsParentWorkspaceReader } from "../../infrastructure/fs_parent_workspace_reader.ts";
-import { isParentManaged } from "../../domain/parent_managed.ts";
+import { FsPreserveStore } from "../../infrastructure/fs_preserve_store.ts";
+import { isAgenticPath, isParentManaged } from "../../domain/parent_managed.ts";
+import { resolvePreserveDeclarations } from "./preserve_resolution.ts";
 import { CORE_BUNDLE } from "../../templates_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 
@@ -49,6 +51,13 @@ export type InitIntent = {
    * on disk — trumps `--force` (no overwrites, no backups, no lock).
    */
   dryRun: boolean;
+  /**
+   * `--reset-preserved`. Explicit, non-default opt-out (spec 011 / issue
+   * #367): override every preserve declaration for THIS run, restoring the
+   * bundled versions. The handler passes an empty preserved set and emits a
+   * per-file override warning (FR-005). Never the default.
+   */
+  resetPreserved: boolean;
 };
 
 async function resolveHarnessKey(
@@ -422,6 +431,31 @@ export async function runInit(intent: InitIntent): Promise<number> {
     );
   }
 
+  // Preserve declarations (spec 011 / issue #367). Resolve the manifest
+  // against the actual bundle dests for this run so we can (a) warn on
+  // ineffective declarations (FR-008), (b) drop preserved paths from the
+  // write set, and (c) emit one notice per preserved/overridden file
+  // (FR-004/FR-005). The bundle is mapped exactly as the use case maps it,
+  // including the parent-managed agentic filter so a declared agentic path in
+  // a parent-managed sub-repo is a clean no-op (D8 — it is simply not a dest).
+  const mappedForPreserve = harness.mapBundle(CORE_BUNDLE, { backlogBackend, versionScheme });
+  const bundleDests = parentManaged
+    ? Object.keys(mappedForPreserve).filter((d) => !isAgenticPath(d))
+    : Object.keys(mappedForPreserve);
+  const preserveCfg = await new FsPreserveStore().read(targetDir);
+  const { known: declaredKnown, unknown: declaredUnknown } = resolvePreserveDeclarations(
+    preserveCfg,
+    bundleDests,
+  );
+  for (const path of declaredUnknown) {
+    console.error(
+      yellow(`warn: ${path} — declared preserved but not a managed file (ignored)`),
+    );
+  }
+  // `--reset-preserved` overrides the declarations for this run: pass an empty
+  // set and surface each override (FR-005). Otherwise honour the declarations.
+  const preservedPaths = intent.resetPreserved ? new Set<string>() : new Set(declaredKnown);
+
   const useCase = new InitProjectUseCase({
     writer: new DenoFsWriter(),
     git: new DenoGit(),
@@ -441,6 +475,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
       force: intent.force,
       dryRun: intent.dryRun,
       parentManaged,
+      preservedPaths,
     });
   } catch (err) {
     // Surface the actionable first-line message for known structured
@@ -471,6 +506,20 @@ export async function runInit(intent: InitIntent): Promise<number> {
   }
 
   for (const w of result.warnings) console.error(yellow(`warn: ${w}`));
+  // Preserve notices (FR-004) / reset overrides (FR-005) — never silent.
+  if (intent.resetPreserved) {
+    for (const path of declaredKnown) {
+      console.log(
+        yellow(`override ${path} — --reset-preserved overrode the declaration`),
+      );
+    }
+  } else {
+    for (const path of result.preserved) {
+      console.log(
+        cyan(`preserved ${path} — declared in .specflow/preserve.yml`),
+      );
+    }
+  }
   for (const b of result.backups) console.log(dim(`↳ backed up ${b} → ${b}.specflow.bak`));
   const mergedSuffix = result.filesMerged.length > 0
     ? ` (+ merged: ${result.filesMerged.join(", ")})`

--- a/src/cli/handlers/preserve_resolution.ts
+++ b/src/cli/handlers/preserve_resolution.ts
@@ -1,0 +1,42 @@
+import { type PreserveConfig } from "../../domain/preserve_config.ts";
+
+/**
+ * Result of reconciling a parsed preserve manifest against the actual bundle
+ * destinations for a refresh run (spec 011 / issue #367).
+ *
+ * Splitting "known" from "unknown" is the FR-008 seam: a declared path that
+ * is not a managed bundle file is ineffective — it must surface exactly one
+ * `warn:` line and be filtered out, never silently honoured nor treated as
+ * fatal.
+ */
+export type PreserveResolution = {
+  /** Declared paths that are real bundle dests — these are actually preserved. */
+  readonly known: ReadonlyArray<string>;
+  /** Declared paths absent from the bundle — ineffective, warned, filtered out. */
+  readonly unknown: ReadonlyArray<string>;
+};
+
+/**
+ * Reconcile preserve declarations against the bundle's destination paths.
+ *
+ * `bundleDests` is `Object.keys(bundle)` for the run. Membership is exact
+ * (the manifest is already normalised to the bundle's project-relative,
+ * forward-slash form by `parsePreserveConfig`). Declaration order is
+ * preserved in both partitions so notices/warnings render deterministically.
+ *
+ * Pure — no I/O, no CLI flag awareness; the `--reset-preserved` opt-out is a
+ * handler concern applied to the resulting set, not here.
+ */
+export function resolvePreserveDeclarations(
+  cfg: PreserveConfig,
+  bundleDests: Iterable<string>,
+): PreserveResolution {
+  const dests = new Set(bundleDests);
+  const known: string[] = [];
+  const unknown: string[] = [];
+  for (const path of cfg.preserved) {
+    if (dests.has(path)) known.push(path);
+    else unknown.push(path);
+  }
+  return { known, unknown };
+}

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -9,6 +9,8 @@ import { DenoFsWriter } from "../../infrastructure/deno_fs_writer.ts";
 import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
 import { FsPluginDetector } from "../../infrastructure/fs_plugin_detector.ts";
 import { FsParentWorkspaceReader } from "../../infrastructure/fs_parent_workspace_reader.ts";
+import { FsPreserveStore } from "../../infrastructure/fs_preserve_store.ts";
+import { resolvePreserveDeclarations } from "./preserve_resolution.ts";
 import { isAgenticPath, isParentManaged } from "../../domain/parent_managed.ts";
 import { CORE_BUNDLE, TEMPLATES_VERSION } from "../../templates_bundle.ts";
 import { renderUnifiedDiff } from "../../domain/diff.ts";
@@ -22,6 +24,12 @@ export type UpgradeIntent = {
   force: boolean;
   backlog: BacklogBackend | null;
   resetBaseline: boolean;
+  /**
+   * `--reset-preserved` (spec 011 / issue #367): ignore preserve declarations
+   * for this upgrade so declared files follow normal upgrade rules. Never the
+   * default; reported per overridden file.
+   */
+  resetPreserved: boolean;
 };
 
 /**
@@ -252,6 +260,37 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     parentManagedOverride = isParentManaged(providingAncestor, standaloneOverride);
   }
 
+  // Preserve declarations (spec 011 / issue #367). Resolve the manifest against
+  // the bundle dests for the lock's harness/backend so we can warn ineffective
+  // declarations (FR-008) and build the predicate the use case threads into the
+  // plan. The parent-managed agentic filter is applied first so a declared
+  // agentic path in a parent-managed sub-repo is a clean no-op (D8). When
+  // `--reset-preserved` is passed, the predicate is forced off (FR-005).
+  let declaredKnown: ReadonlyArray<string> = [];
+  if (lockForDetection !== null) {
+    const harnessForPreserve = findHarness(lockForDetection.harness);
+    if (harnessForPreserve) {
+      const mapped = harnessForPreserve.mapBundle(CORE_BUNDLE, {
+        backlogBackend: lockForDetection.backlogBackend,
+        versionScheme: lockForDetection.versionScheme,
+      });
+      const parentManaged = (parentManagedOverride ?? lockForDetection.parentManaged) ?? false;
+      const bundleDests = parentManaged
+        ? Object.keys(mapped).filter((d) => !isAgenticPath(d))
+        : Object.keys(mapped);
+      const cfg = await new FsPreserveStore().read(projectDir);
+      const { known, unknown } = resolvePreserveDeclarations(cfg, bundleDests);
+      declaredKnown = known;
+      for (const path of unknown) {
+        console.error(
+          yellow(`warn: ${path} — declared preserved but not a managed file (ignored)`),
+        );
+      }
+    }
+  }
+  const declaredSet = intent.resetPreserved ? new Set<string>() : new Set(declaredKnown);
+  const isDeclaredPreserved = (dest: string): boolean => declaredSet.has(dest);
+
   const useCase = new UpgradeProjectUseCase({
     reader: new DenoFsReader(),
     writer: new DenoFsWriter(),
@@ -269,6 +308,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
       dryRun: intent.dryRun,
       force: intent.force,
       resetBaseline: intent.resetBaseline,
+      isDeclaredPreserved,
       ...(parentManagedOverride !== undefined ? { parentManagedOverride } : {}),
     });
   } catch (err) {
@@ -283,6 +323,20 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
   }
 
   renderSummary(result.plan, result.fromVersion, result.toVersion);
+
+  // Declared-preserve notices (FR-004) — one line per declared file kept.
+  const declaredPreserves = result.plan.filter(
+    (a) => a.kind === "preserve" && a.reason === "declared",
+  );
+  for (const a of declaredPreserves) {
+    console.log(cyan(`preserved ${a.dest} — declared in .specflow/preserve.yml`));
+  }
+  // `--reset-preserved` overrides (FR-005) — one line per declaration ignored.
+  if (intent.resetPreserved) {
+    for (const path of declaredKnown) {
+      console.log(yellow(`override ${path} — --reset-preserved overrode the declaration`));
+    }
+  }
 
   const preserves = result.plan.filter((a) => a.kind === "preserve");
   if (preserves.length > 0 && !intent.force) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -11,6 +11,7 @@ ${bold("Usage:")}
   specflow check [--project]          Diagnose the environment (and optionally the project)
   specflow upgrade [--dry-run] [--force] [--backlog <name>] [--reset-baseline]
                                       Update project templates to the binary's version
+  specflow diff [--only-customised]   Show how managed files diverge from the bundled originals (read-only)
   specflow reconcile --status         List files pending post-upgrade reconciliation
   specflow reconcile <path> --accept-upstream | --accept-current
                                       Resolve a preserved file after upgrade
@@ -36,6 +37,8 @@ ${bold("Flags (for init):")}
                       (v1.2.3), or a CHANGELOG.md with Keep-a-Changelog headers. Falls back to
                       "date" when no signal is found.
   --force             Overwrite locally-customized files (existing content backed up to *.specflow.bak)
+  --reset-preserved   Ignore .specflow/preserve.yml for this run so declared files are refreshed too
+                      (never the default; reported per overridden file)
   --dry-run           Show the plan without writing — trumps --force
 
 ${bold("Flags (for upgrade):")}
@@ -46,6 +49,12 @@ ${bold("Flags (for upgrade):")}
   --reset-baseline    Trust the on-disk content as the new SHA baseline. Use when files are flagged
                       "customized locally" but you never edited them (heals stale lock SHAs). Combine
                       with --dry-run to preview what would change.
+  --reset-preserved   Ignore .specflow/preserve.yml for this run so declared files follow normal
+                      upgrade rules (never the default; reported per overridden file).
+
+${bold("Flags (for diff):")}
+  --only-customised   Restrict the output to files whose on-disk content diverges from the recorded
+                      lock baseline — i.e. files you actually customized (skips unchanged managed files).
 
 ${bold("Docs:")}    ${cyan("https://specflow.makerlabs.dev")}
 ${bold("Cloud:")}   ${cyan("https://specflow.makerlabs.app")} ${

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -84,6 +84,12 @@ export type Intent =
      * set, no writes happen. See issue #366.
      */
     dryRun: boolean;
+    /**
+     * `--reset-preserved`. Explicit opt-out (spec 011 / issue #367): override
+     * preserve declarations for this forced refresh, restoring the bundled
+     * versions. Never the default; reported per overridden file.
+     */
+    resetPreserved: boolean;
   }
   | { kind: "self-update"; checkOnly: boolean }
   | { kind: "check"; projectMode: boolean }
@@ -102,6 +108,22 @@ export type Intent =
      * content as the new baseline. See `UpgradeProjectInput.resetBaseline`.
      */
     resetBaseline: boolean;
+    /**
+     * `--reset-preserved`. Explicit opt-out (spec 011 / issue #367): ignore
+     * preserve declarations for this upgrade so declared files are overwritten
+     * with the bundle. Never the default; reported per overridden file.
+     */
+    resetPreserved: boolean;
+  }
+  | {
+    /**
+     * `specflow diff` (spec 011 / issue #367, US2) — read-only divergence view:
+     * show how each managed file on disk differs from the bundled original for
+     * the installed templates version. Mutates nothing.
+     */
+    kind: "diff";
+    /** `--only-customised`: restrict to paths whose disk SHA ≠ lock SHA. */
+    onlyCustomised: boolean;
   }
   | { kind: "unknown"; received: string }
   | { kind: "reconcile-status" }
@@ -145,6 +167,8 @@ export function parseArgs(argv: string[]): Intent {
       "dry-run",
       "project",
       "reset-baseline",
+      "reset-preserved",
+      "only-customised",
       "status",
       "accept-upstream",
       "accept-current",
@@ -213,6 +237,7 @@ export function parseArgs(argv: string[]): Intent {
       scheme: schemeResult.value,
       force: Boolean(parsed.force),
       dryRun: Boolean(parsed["dry-run"]),
+      resetPreserved: Boolean(parsed["reset-preserved"]),
     };
   }
 
@@ -237,7 +262,12 @@ export function parseArgs(argv: string[]): Intent {
       force: Boolean(parsed.force),
       backlog: backlogResult.value,
       resetBaseline: Boolean(parsed["reset-baseline"]),
+      resetPreserved: Boolean(parsed["reset-preserved"]),
     };
+  }
+
+  if (command === "diff") {
+    return { kind: "diff", onlyCustomised: Boolean(parsed["only-customised"]) };
   }
 
   if (command === "reconcile") {

--- a/src/domain/preserve_config.ts
+++ b/src/domain/preserve_config.ts
@@ -1,0 +1,97 @@
+import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
+
+/**
+ * The maintainer's project-level preserve declarations, parsed from
+ * `.specflow/preserve.yml`.
+ *
+ * A **preserve declaration** is deliberate intent — "this managed file is
+ * mine, keep it even on a forced refresh" — and lives in its own manifest
+ * (not the lock, which is a state record). See spec 011 / issue #367.
+ */
+export type PreserveConfig = {
+  /** Project-relative, forward-slash destination paths declared preserved. */
+  readonly preserved: ReadonlyArray<string>;
+};
+
+/**
+ * Canonical "no declarations" value. An absent or unparseable manifest
+ * degrades to this so init/upgrade stay byte-identical to today (FR-011).
+ */
+export const EMPTY_PRESERVE_CONFIG: PreserveConfig = { preserved: [] };
+
+/**
+ * Normalise one declared path so membership tests against the bundle's
+ * destination-path form (project-relative, forward-slash) are exact:
+ * trim surrounding whitespace, fold backslashes to forward slashes, and
+ * strip ALL leading `./` segments (`././x` → `x`).
+ */
+function normalisePath(raw: string): string {
+  let p = raw.trim().replaceAll("\\", "/");
+  while (p.startsWith("./")) p = p.slice(2);
+  return p;
+}
+
+/**
+ * True when a normalised path contains a `..` segment.
+ *
+ * Such entries are dropped at parse time (treated as ineffective, like any
+ * unknown path). Containment rationale: declared paths are only ever tested
+ * for membership against bundle-derived destination keys — which are
+ * project-relative and never contain `..` — and are NEVER used for I/O. A
+ * `..`-bearing entry could therefore never match a managed file and is
+ * harmless today, but dropping it during parse makes the project-relative
+ * containment invariant explicit rather than incidental.
+ */
+function hasParentTraversal(p: string): boolean {
+  return p === ".." || p.split("/").includes("..");
+}
+
+/**
+ * Parse `.specflow/preserve.yml` into a {@link PreserveConfig}.
+ *
+ * Pure and total: it NEVER throws and NEVER judges bundle membership
+ * (unknown-path validation is a run-time handler concern, D7). Any
+ * unparseable, empty, or structurally-wrong document degrades to
+ * {@link EMPTY_PRESERVE_CONFIG} — a malformed manifest must surface a
+ * warning at the handler, never abort a refresh.
+ *
+ * Entries are normalised (trim, strip leading `./`, backslash→slash),
+ * with blanks dropped and duplicates removed while preserving first-seen
+ * order. Non-string list entries are ignored. Entries containing a `..`
+ * path segment are dropped (containment — see {@link hasParentTraversal}).
+ */
+export function parsePreserveConfig(yaml: string): PreserveConfig {
+  let root: unknown;
+  try {
+    root = parseYaml(yaml);
+  } catch {
+    // Unparseable YAML is treated as "no declarations" — the handler warns.
+    return EMPTY_PRESERVE_CONFIG;
+  }
+  if (root === null || typeof root !== "object" || Array.isArray(root)) {
+    return EMPTY_PRESERVE_CONFIG;
+  }
+  const rawPreserved = (root as Record<string, unknown>).preserved;
+  if (!Array.isArray(rawPreserved)) return EMPTY_PRESERVE_CONFIG;
+
+  const seen = new Set<string>();
+  const preserved: string[] = [];
+  for (const entry of rawPreserved) {
+    if (typeof entry !== "string") continue;
+    const p = normalisePath(entry);
+    if (p.length === 0 || hasParentTraversal(p) || seen.has(p)) continue;
+    seen.add(p);
+    preserved.push(p);
+  }
+  if (preserved.length === 0) return EMPTY_PRESERVE_CONFIG;
+  return { preserved };
+}
+
+/**
+ * Serialize a {@link PreserveConfig} to canonical YAML (single `preserved:`
+ * key, trailing newline). Round-trips with {@link parsePreserveConfig} on
+ * canonical input.
+ */
+export function serializePreserveConfig(cfg: PreserveConfig): string {
+  return stringifyYaml({ preserved: [...cfg.preserved] });
+}

--- a/src/domain/upgrade_plan.ts
+++ b/src/domain/upgrade_plan.ts
@@ -5,7 +5,16 @@ export type UpgradeAction =
   | {
     kind: "preserve";
     dest: string;
-    reason: "customized";
+    /**
+     * Why the file is preserved:
+     *   - `"customized"`: the on-disk SHA diverges from the lock (the
+     *     maintainer edited it) — the existing implicit auto-preserve.
+     *   - `"declared"`: the maintainer listed the path in
+     *     `.specflow/preserve.yml` (spec 011 / issue #367). A declared
+     *     file is preserved regardless of its SHA and wins over
+     *     auto-update, plugin-migration, and removal.
+     */
+    reason: "customized" | "declared";
     /**
      * True when the `specflow-plugin` plugin owns this path AND the
      * plugin is installed on the host. The handler surfaces an extra
@@ -94,6 +103,15 @@ export type UpgradePlanOptions = {
    * customised a file loses their edit signal. Document accordingly.
    */
   resetBaseline?: boolean;
+  /**
+   * True when the maintainer declared `dest` preserved in
+   * `.specflow/preserve.yml` (spec 011 / issue #367). A declared path is
+   * promoted to `preserve / reason:"declared"` as the FIRST branch of the
+   * plan — it wins over unchanged, auto-update, plugin-migration, AND
+   * removal (a declared path dropped upstream is kept on disk, FR-009).
+   * Injected by the upgrade handler; the domain never reads the manifest.
+   */
+  isDeclaredPreserved?: (dest: string) => boolean;
 };
 
 export function computeUpgradePlan(
@@ -112,6 +130,7 @@ export function computeUpgradePlan(
   const isPluginCoveredFn = opts.isPluginCovered ?? (() => false);
   const isSkipIfExists = opts.isSkipIfExists ?? (() => false);
   const resetBaseline = opts.resetBaseline ?? false;
+  const isDeclaredPreserved = opts.isDeclaredPreserved ?? (() => false);
   const actions: UpgradeAction[] = [];
   const sortedDests = [...newShas.keys()].sort();
 
@@ -119,6 +138,21 @@ export function computeUpgradePlan(
     const newSha = newShas.get(dest)!;
     const diskSha = diskShas.get(dest);
     let lockSha = lock.entries.get(dest)?.sha256;
+
+    // Declared-preserve wins over everything (spec 011 / issue #367): a path
+    // the maintainer listed in .specflow/preserve.yml is kept regardless of
+    // its SHA — before the unchanged, auto-update, and plugin-migration
+    // branches. The file is only present here (in newShas) so `pluginAvailable`
+    // is reported from coverage for the handler's reconcile hint.
+    if (isDeclaredPreserved(dest)) {
+      actions.push({
+        kind: "preserve",
+        dest,
+        reason: "declared",
+        pluginAvailable: pluginInstalled && isPluginCoveredFn(dest),
+      });
+      continue;
+    }
 
     // Reset-baseline: if the on-disk content disagrees with the lock SHA,
     // trust the disk. This heals stale locks left by pre-v1.0 binaries
@@ -190,6 +224,17 @@ export function computeUpgradePlan(
   for (const dest of orphanDests) {
     const diskSha = diskShas.get(dest);
     if (diskSha === undefined) continue;
+    // FR-009: a declared path the bundle dropped is kept on disk
+    // (preservation wins over removal), surfaced as preserve/declared.
+    if (isDeclaredPreserved(dest)) {
+      actions.push({
+        kind: "preserve",
+        dest,
+        reason: "declared",
+        pluginAvailable: pluginInstalled && isPluginCoveredFn(dest),
+      });
+      continue;
+    }
     const lockSha = lock.entries.get(dest)!.sha256;
     actions.push({
       kind: "remove",

--- a/src/infrastructure/fs_preserve_store.ts
+++ b/src/infrastructure/fs_preserve_store.ts
@@ -1,0 +1,38 @@
+import { dirname, join } from "@std/path";
+import {
+  EMPTY_PRESERVE_CONFIG,
+  parsePreserveConfig,
+  type PreserveConfig,
+  serializePreserveConfig,
+} from "../domain/preserve_config.ts";
+import type { PreserveStore } from "../application/ports.ts";
+
+/**
+ * Reads / writes the project-level preserve manifest at
+ * `.specflow/preserve.yml`. Mirrors `FsLockStore`: an absent file reads as
+ * `EMPTY_PRESERVE_CONFIG`, and a malformed file degrades to empty via the
+ * pure `parsePreserveConfig` (which never throws) — a broken manifest must
+ * surface a warning at the handler, never abort init/upgrade.
+ */
+export class FsPreserveStore implements PreserveStore {
+  preservePath(projectDir: string): string {
+    return join(projectDir, ".specflow/preserve.yml");
+  }
+
+  async read(projectDir: string): Promise<PreserveConfig> {
+    const path = this.preservePath(projectDir);
+    try {
+      const raw = await Deno.readTextFile(path);
+      return parsePreserveConfig(raw);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) return EMPTY_PRESERVE_CONFIG;
+      throw err;
+    }
+  }
+
+  async write(projectDir: string, cfg: PreserveConfig): Promise<void> {
+    const path = this.preservePath(projectDir);
+    await Deno.mkdir(dirname(path), { recursive: true });
+    await Deno.writeTextFile(path, serializePreserveConfig(cfg));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,10 @@ export async function run(argv: string[]): Promise<number> {
       const { runUpgrade } = await import("./cli/handlers/upgrade_handler.ts");
       return await runUpgrade(intent);
     }
+    case "diff": {
+      const { runDiff } = await import("./cli/handlers/diff_handler.ts");
+      return await runDiff(intent);
+    }
     case "reconcile-status":
     case "reconcile-path": {
       const { runReconcile } = await import("./cli/handlers/reconcile_handler.ts");

--- a/tests/application/diff_project_test.ts
+++ b/tests/application/diff_project_test.ts
@@ -1,0 +1,211 @@
+import { assert, assertEquals } from "@std/assert";
+import { DiffProjectUseCase } from "../../src/application/diff_project.ts";
+import type { FsReader, Harness, LockStore } from "../../src/application/ports.ts";
+import type { InstalledLock, LockEntry } from "../../src/domain/installed_lock.ts";
+import type { CoreBundle } from "../../src/domain/core_bundle.ts";
+import { sha256Hex } from "../../src/domain/sha256.ts";
+
+/**
+ * Fake harness mirroring the init/upgrade test fakes: project-root suffix → flat
+ * dest. Lets the diff use case map a synthetic CORE_BUNDLE without the real
+ * harness machinery.
+ */
+function fakeClaudeHarness(): Harness {
+  return {
+    key: "claude",
+    displayName: "Claude Code (fake)",
+    mapBundle: (core) => {
+      const out: Record<string, { content: string; executable: boolean }> = {};
+      for (const e of core) {
+        if (e.category === "project-root" && e.suffix) {
+          out[e.suffix] = { content: e.content, executable: e.executable };
+        }
+      }
+      return out;
+    },
+  };
+}
+
+function bundleEntry(dest: string, content: string): CoreBundle[number] {
+  return {
+    category: "project-root" as const,
+    name: "root",
+    suffix: dest,
+    content,
+    executable: false,
+  };
+}
+
+function fakeLockStore(lock: InstalledLock | null): LockStore {
+  return {
+    read: () => Promise.resolve(lock),
+    write: () => Promise.resolve(),
+    lockPath: (d) => `${d}/.specflow/installed.lock`,
+  };
+}
+
+/** In-memory reader over a dest→content map; `null` for absent paths. */
+function fakeReader(disk: Record<string, string>): FsReader {
+  return {
+    readText: (_dir, rel) => Promise.resolve(rel in disk ? disk[rel] : null),
+  };
+}
+
+async function lockWith(
+  entries: Record<string, string>,
+): Promise<InstalledLock> {
+  const map = new Map<string, LockEntry>();
+  for (const [dest, content] of Object.entries(entries)) {
+    map.set(dest, {
+      sha256: await sha256Hex(content),
+      installedAt: "2026-06-09T00:00:00.000Z",
+      templatesVersion: "1.2.3",
+    });
+  }
+  return {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    templatesVersion: "1.2.3",
+    entries: map,
+  };
+}
+
+const findHarness = (key: string): Harness | null => key === "claude" ? fakeClaudeHarness() : null;
+
+function makeUseCase(opts: {
+  lock: InstalledLock | null;
+  disk: Record<string, string>;
+  core: CoreBundle;
+}): DiffProjectUseCase {
+  return new DiffProjectUseCase({
+    reader: fakeReader(opts.disk),
+    lockStore: fakeLockStore(opts.lock),
+    core: opts.core,
+    findHarness,
+  });
+}
+
+Deno.test("DiffProjectUseCase: a customised file is reported as 'differs' with both contents", async () => {
+  const dest = ".claude/agents/product-owner.md";
+  const bundled = "# bundled\n";
+  const onDisk = "# bundled\n# my customisation\n";
+  const lock = await lockWith({ [dest]: bundled });
+  const uc = makeUseCase({
+    lock,
+    disk: { [dest]: onDisk },
+    core: [bundleEntry(dest, bundled)],
+  });
+  const { results, fromVersion } = await uc.execute({
+    projectDir: "/tmp/p",
+    onlyCustomised: false,
+  });
+  assertEquals(fromVersion, "1.2.3");
+  assertEquals(results.length, 1);
+  const r = results[0];
+  assertEquals(r.kind, "differs");
+  if (r.kind === "differs") {
+    assertEquals(r.dest, dest);
+    assertEquals(r.diskContent, onDisk);
+    assertEquals(r.bundledContent, bundled);
+  }
+});
+
+Deno.test("DiffProjectUseCase: a vanilla file is reported as 'matches'", async () => {
+  const dest = "AGENTS.md";
+  const content = "# agents\n";
+  const lock = await lockWith({ [dest]: content });
+  const uc = makeUseCase({
+    lock,
+    disk: { [dest]: content },
+    core: [bundleEntry(dest, content)],
+  });
+  const { results } = await uc.execute({ projectDir: "/tmp/p", onlyCustomised: false });
+  assertEquals(results.length, 1);
+  assertEquals(results[0].kind, "matches");
+  assertEquals(results[0].dest, dest);
+});
+
+Deno.test("DiffProjectUseCase: a lock-tracked path absent from the new bundle is 'missing' (FR-009)", async () => {
+  const dropped = ".claude/agents/old-agent.md";
+  const kept = "AGENTS.md";
+  const content = "# agents\n";
+  const lock = await lockWith({ [dropped]: "# old\n", [kept]: content });
+  // The new bundle no longer ships `dropped` — only `kept`.
+  const uc = makeUseCase({
+    lock,
+    disk: { [dropped]: "# old (edited)\n", [kept]: content },
+    core: [bundleEntry(kept, content)],
+  });
+  const { results } = await uc.execute({ projectDir: "/tmp/p", onlyCustomised: false });
+  const missing = results.find((r) => r.dest === dropped);
+  assert(missing !== undefined, "dropped path should appear in results");
+  assertEquals(missing!.kind, "missing");
+});
+
+Deno.test("DiffProjectUseCase: empty project yields empty results", async () => {
+  const lock = await lockWith({});
+  const uc = makeUseCase({ lock, disk: {}, core: [] });
+  const { results } = await uc.execute({ projectDir: "/tmp/p", onlyCustomised: false });
+  assertEquals(results.length, 0);
+});
+
+Deno.test("DiffProjectUseCase: no lock yields empty results (nothing tracked)", async () => {
+  const uc = makeUseCase({ lock: null, disk: {}, core: [] });
+  const { results, fromVersion } = await uc.execute({
+    projectDir: "/tmp/p",
+    onlyCustomised: false,
+  });
+  assertEquals(results.length, 0);
+  assertEquals(fromVersion, "");
+});
+
+Deno.test("DiffProjectUseCase: onlyCustomised restricts to paths whose disk SHA differs from lock SHA", async () => {
+  const customised = ".claude/agents/product-owner.md";
+  const vanilla = "AGENTS.md";
+  const bundledPo = "# po\n";
+  const vanillaContent = "# agents\n";
+  const lock = await lockWith({ [customised]: bundledPo, [vanilla]: vanillaContent });
+  const uc = makeUseCase({
+    lock,
+    disk: {
+      [customised]: "# po\n# edited\n", // disk SHA ≠ lock SHA
+      [vanilla]: vanillaContent, // disk SHA == lock SHA
+    },
+    core: [bundleEntry(customised, bundledPo), bundleEntry(vanilla, vanillaContent)],
+  });
+  const { results } = await uc.execute({ projectDir: "/tmp/p", onlyCustomised: true });
+  assertEquals(results.length, 1);
+  assertEquals(results[0].dest, customised);
+});
+
+// Read-only invariant (contract §4): the use case MUST NOT construct or touch an
+// FsWriter. We enforce this structurally — DiffProjectDeps has no writer slot —
+// and behaviourally by asserting the deps object the use case accepts has no
+// writer-shaped member.
+Deno.test("DiffProjectUseCase: deps carry no FsWriter (read-only invariant)", async () => {
+  const dest = "AGENTS.md";
+  const content = "# agents\n";
+  const lock = await lockWith({ [dest]: content });
+  const deps = {
+    reader: fakeReader({ [dest]: content }),
+    lockStore: fakeLockStore(lock),
+    core: [bundleEntry(dest, content)] as CoreBundle,
+    findHarness,
+  };
+  // Structural assertion: no writer / write-capable port handed to the use case.
+  assertEquals("writer" in deps, false);
+  for (const v of Object.values(deps)) {
+    if (v && typeof v === "object") {
+      assertEquals(
+        "writeBundle" in v || "deletePaths" in v,
+        false,
+        "no write-capable adapter may be injected into the diff use case",
+      );
+    }
+  }
+  const uc = new DiffProjectUseCase(deps);
+  const { results } = await uc.execute({ projectDir: "/tmp/p", onlyCustomised: false });
+  assertEquals(results[0].kind, "matches");
+});

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -459,3 +459,223 @@ Deno.test("InitProjectUseCase uses harness.mapBundle output as the file tree", a
   // The fake harness maps project-root suffix → flat dest.
   assert(writer.written.includes("/tmp/demo:CLAUDE.md"));
 });
+
+// ---------------------------------------------------------------------------
+// 011-preserve-customisations: preservedPaths filter (issue #367)
+// ---------------------------------------------------------------------------
+
+const PRESERVE_CORE: CoreBundle = [
+  ".claude/agents/product-owner.md",
+  ".claude/agents/developer.md",
+  "AGENTS.md",
+].map((dest) => ({
+  category: "project-root" as const,
+  name: "root",
+  suffix: dest,
+  content: `# ${dest}\n`,
+  executable: false,
+})) as CoreBundle;
+
+Deno.test("InitProjectUseCase: preservedPaths are absent from the write set and reported", async () => {
+  const writer = fakeFsWriter();
+  const uc = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore: fakeLockStore(),
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: PRESERVE_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  const result = await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: false,
+    preservedPaths: new Set([".claude/agents/product-owner.md"]),
+  });
+  // The preserved path is NOT written.
+  assertEquals(writer.written.includes("/tmp/demo:.claude/agents/product-owner.md"), false);
+  // Other managed files ARE written.
+  assert(writer.written.includes("/tmp/demo:.claude/agents/developer.md"));
+  assert(writer.written.includes("/tmp/demo:AGENTS.md"));
+  // The result reports the preserved path.
+  assertEquals(result.status, "initialized");
+  if (result.status === "initialized") {
+    assertEquals(result.preserved, [".claude/agents/product-owner.md"]);
+  }
+});
+
+// MED-1: filesWritten must reflect the post-preserve-filter write set, NOT
+// the full bundle — otherwise a refresh reports writing files it skipped.
+Deno.test("InitProjectUseCase: filesWritten excludes preserved paths", async () => {
+  const uc = new InitProjectUseCase({
+    writer: fakeFsWriter(),
+    git: fakeGit(),
+    lockStore: fakeLockStore(),
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: PRESERVE_CORE, // 3 non-mergeable files
+    ensureDir: () => Promise.resolve(),
+  });
+  const result = await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: false,
+    preservedPaths: new Set([".claude/agents/product-owner.md"]),
+  });
+  assertEquals(result.status, "initialized");
+  if (result.status === "initialized") {
+    // 3 files in the bundle, 1 preserved ⇒ exactly 2 actually written.
+    assertEquals(result.filesWritten, 2);
+    assertEquals(result.preserved, [".claude/agents/product-owner.md"]);
+  }
+});
+
+// MED-1 (dry-run): the previewed "would write N" count must also exclude
+// preserved paths, and the dry-run result must report them as preserved.
+Deno.test("InitProjectUseCase: dry-run filesWritten excludes preserved paths", async () => {
+  const uc = new InitProjectUseCase({
+    writer: fakeFsWriter(),
+    git: fakeGit(),
+    lockStore: fakeLockStore(),
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: PRESERVE_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  const result = await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: true,
+    preservedPaths: new Set([".claude/agents/product-owner.md"]),
+  });
+  assertEquals(result.status, "initialized");
+  if (result.status === "initialized") {
+    assertEquals(result.filesWritten, 2);
+    assertEquals(result.preserved, [".claude/agents/product-owner.md"]);
+  }
+});
+
+// F1 (HARD): a preserved file must stay lock-tracked (FR-012) so diff and
+// future upgrades still see it — skipping the WRITE must NOT drop the lock entry.
+Deno.test("InitProjectUseCase: preserved file remains in the installed.lock (FR-012)", async () => {
+  const lockStore = fakeLockStore();
+  const uc = new InitProjectUseCase({
+    writer: fakeFsWriter(),
+    git: fakeGit(),
+    lockStore,
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: PRESERVE_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: false,
+    preservedPaths: new Set([".claude/agents/product-owner.md"]),
+  });
+  const lock = lockStore.lastWritten!;
+  assert(lock.entries.has(".claude/agents/product-owner.md"));
+  assert(lock.entries.has(".claude/agents/developer.md"));
+});
+
+// F2: a brand-new bundle path is still written even when preserves are set —
+// the preserve list governs existing files only (FR-010).
+Deno.test("InitProjectUseCase: new bundle path still written when preserves are set (FR-010)", async () => {
+  const writer = fakeFsWriter();
+  const uc = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore: fakeLockStore(),
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: PRESERVE_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: false,
+    // a path NOT in the bundle is inert; the real bundle path is written.
+    preservedPaths: new Set([".claude/agents/product-owner.md"]),
+  });
+  assert(writer.written.includes("/tmp/demo:AGENTS.md"));
+  assert(writer.written.includes("/tmp/demo:.claude/agents/developer.md"));
+});
+
+// T019 / D8 (C7): a declared agentic path in a parent-managed sub-repo is a
+// clean no-op. Agentic dests are filtered out of the bundle BEFORE the preserve
+// filter runs, so the predicate is never consulted for them — the path is
+// neither written nor reported as preserved (it was never a bundle dest here).
+Deno.test("InitProjectUseCase: declared agentic path in a parent-managed sub-repo is a no-op (D8)", async () => {
+  const writer = fakeFsWriter();
+  const lockStore = fakeLockStore();
+  const uc = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore,
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: MIXED_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  const agenticDest = ".claude/agents/developer.md";
+  const result = await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: false,
+    parentManaged: true,
+    // Declare an agentic path preserved — in a parent-managed run it is already
+    // filtered from the bundle, so this declaration is inert.
+    preservedPaths: new Set([agenticDest]),
+  });
+  const writtenDests = writer.written.map((w) => w.replace("/tmp/demo:", ""));
+  // The agentic path is absent from writes (suppressed by parent-managed).
+  assertEquals(writtenDests.includes(agenticDest), false);
+  // It is NOT reported as preserved — it was never a bundle dest for this run.
+  assertEquals(result.status, "initialized");
+  if (result.status === "initialized") {
+    assertEquals(result.preserved.includes(agenticDest), false);
+  }
+  // Non-agentic dests are still provisioned (the run is otherwise normal).
+  assert(writtenDests.includes("AGENTS.md"));
+});
+
+// Absent / empty preservedPaths ⇒ today's behaviour: full bundle written,
+// empty preserved report.
+Deno.test("InitProjectUseCase: absent preservedPaths writes the full bundle (FR-011)", async () => {
+  const writer = fakeFsWriter();
+  const uc = new InitProjectUseCase({
+    writer,
+    git: fakeGit(),
+    lockStore: fakeLockStore(),
+    harness: fakeClaudeHarness(),
+    backlogBackend: "local",
+    versionScheme: "semver",
+    core: PRESERVE_CORE,
+    ensureDir: () => Promise.resolve(),
+  });
+  const result = await uc.execute({
+    targetDir: "/tmp/demo",
+    initGit: false,
+    force: true,
+    dryRun: false,
+  });
+  assert(writer.written.includes("/tmp/demo:.claude/agents/product-owner.md"));
+  if (result.status === "initialized") {
+    assertEquals(result.preserved, []);
+  }
+});

--- a/tests/cli/handlers/preserve_resolution_test.ts
+++ b/tests/cli/handlers/preserve_resolution_test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import { resolvePreserveDeclarations } from "../../../src/cli/handlers/preserve_resolution.ts";
+import { EMPTY_PRESERVE_CONFIG } from "../../../src/domain/preserve_config.ts";
+
+// T017 / FR-008 (C7): a declared path that is NOT a managed bundle dest is
+// ineffective — it lands in `unknown` (exactly one warn at the handler), never
+// in `known`, and never aborts. Real bundle dests partition into `known`.
+Deno.test("resolvePreserveDeclarations: splits known bundle dests from unknown declarations", () => {
+  const cfg = {
+    preserved: [".claude/agents/product-owner.md", "not/a/bundled/file.md"],
+  };
+  const bundleDests = [".claude/agents/product-owner.md", "AGENTS.md"];
+  const { known, unknown } = resolvePreserveDeclarations(cfg, bundleDests);
+  assertEquals(known, [".claude/agents/product-owner.md"]);
+  // Exactly one ineffective declaration is surfaced for a single warn line.
+  assertEquals(unknown, ["not/a/bundled/file.md"]);
+});
+
+Deno.test("resolvePreserveDeclarations: a declaration absent from the bundle is unknown, not honoured (FR-008)", () => {
+  const cfg = { preserved: ["typo/path.md"] };
+  const { known, unknown } = resolvePreserveDeclarations(cfg, [".claude/agents/product-owner.md"]);
+  assertEquals(known, []);
+  assertEquals(unknown, ["typo/path.md"]);
+});
+
+Deno.test("resolvePreserveDeclarations: empty config yields empty partitions", () => {
+  const { known, unknown } = resolvePreserveDeclarations(EMPTY_PRESERVE_CONFIG, ["AGENTS.md"]);
+  assertEquals(known, []);
+  assertEquals(unknown, []);
+});
+
+// Declaration order is preserved across both partitions for deterministic
+// notice/warning rendering.
+Deno.test("resolvePreserveDeclarations: preserves declaration order in both partitions", () => {
+  const cfg = { preserved: ["z.md", "a.md", "missing.md", "m.md"] };
+  const { known, unknown } = resolvePreserveDeclarations(cfg, ["a.md", "m.md", "z.md"]);
+  assertEquals(known, ["z.md", "a.md", "m.md"]);
+  assertEquals(unknown, ["missing.md"]);
+});

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -25,6 +25,7 @@ Deno.test("parseArgs returns init intent with a project name", () => {
     scheme: null,
     force: false,
     dryRun: false,
+    resetPreserved: false,
   });
 });
 
@@ -41,6 +42,7 @@ Deno.test("parseArgs returns init intent with --here", () => {
     scheme: null,
     force: false,
     dryRun: false,
+    resetPreserved: false,
   });
 });
 
@@ -57,6 +59,7 @@ Deno.test("parseArgs returns init intent with --no-git", () => {
     scheme: null,
     force: false,
     dryRun: false,
+    resetPreserved: false,
   });
 });
 
@@ -99,6 +102,7 @@ Deno.test("parseArgs init with --force", () => {
     scheme: null,
     force: true,
     dryRun: false,
+    resetPreserved: false,
   });
 });
 
@@ -115,6 +119,7 @@ Deno.test("parseArgs init with --dry-run", () => {
     scheme: null,
     force: false,
     dryRun: true,
+    resetPreserved: false,
   });
 });
 
@@ -138,6 +143,7 @@ Deno.test("parseArgs returns upgrade intent", () => {
     force: false,
     backlog: null,
     resetBaseline: false,
+    resetPreserved: false,
   });
 });
 
@@ -148,6 +154,7 @@ Deno.test("parseArgs returns upgrade intent with --dry-run --force", () => {
     force: true,
     backlog: null,
     resetBaseline: false,
+    resetPreserved: false,
   });
 });
 
@@ -158,6 +165,18 @@ Deno.test("parseArgs returns upgrade intent with --reset-baseline", () => {
     force: false,
     backlog: null,
     resetBaseline: true,
+    resetPreserved: false,
+  });
+});
+
+Deno.test("parseArgs returns diff intent (default onlyCustomised false)", () => {
+  assertEquals(parseArgs(["diff"]), { kind: "diff", onlyCustomised: false });
+});
+
+Deno.test("parseArgs returns diff intent with --only-customised", () => {
+  assertEquals(parseArgs(["diff", "--only-customised"]), {
+    kind: "diff",
+    onlyCustomised: true,
   });
 });
 

--- a/tests/domain/preserve_config_test.ts
+++ b/tests/domain/preserve_config_test.ts
@@ -1,0 +1,102 @@
+import { assertEquals } from "@std/assert";
+import {
+  EMPTY_PRESERVE_CONFIG,
+  parsePreserveConfig,
+  serializePreserveConfig,
+} from "../../src/domain/preserve_config.ts";
+
+Deno.test("parsePreserveConfig reads a flat preserved list", () => {
+  const cfg = parsePreserveConfig(
+    "preserved:\n  - .claude/agents/product-owner.md\n  - .claude/agents/developer.md\n",
+  );
+  assertEquals(cfg.preserved, [
+    ".claude/agents/product-owner.md",
+    ".claude/agents/developer.md",
+  ]);
+});
+
+Deno.test("parsePreserveConfig returns EMPTY_PRESERVE_CONFIG for empty input", () => {
+  assertEquals(parsePreserveConfig(""), EMPTY_PRESERVE_CONFIG);
+  assertEquals(parsePreserveConfig("   \n  \n"), EMPTY_PRESERVE_CONFIG);
+});
+
+Deno.test("parsePreserveConfig degrades to empty on malformed / non-list input", () => {
+  // A bare scalar, a list at the root, and a non-list `preserved` all degrade.
+  assertEquals(parsePreserveConfig("just a string"), EMPTY_PRESERVE_CONFIG);
+  assertEquals(parsePreserveConfig("- a\n- b\n"), EMPTY_PRESERVE_CONFIG);
+  assertEquals(parsePreserveConfig("preserved: not-a-list\n"), EMPTY_PRESERVE_CONFIG);
+  assertEquals(parsePreserveConfig("preserved: {a: 1}\n"), EMPTY_PRESERVE_CONFIG);
+  // Genuinely unparseable YAML must not throw.
+  assertEquals(parsePreserveConfig("preserved:\n  - [unterminated\n"), EMPTY_PRESERVE_CONFIG);
+});
+
+Deno.test("parsePreserveConfig normalises entries (trim, strip ./, backslash→slash)", () => {
+  const cfg = parsePreserveConfig(
+    "preserved:\n" +
+      "  - '  .claude/agents/po.md  '\n" +
+      "  - ./AGENTS.md\n" +
+      "  - .claude\\agents\\dev.md\n",
+  );
+  assertEquals(cfg.preserved, [
+    ".claude/agents/po.md",
+    "AGENTS.md",
+    ".claude/agents/dev.md",
+  ]);
+});
+
+Deno.test("parsePreserveConfig strips ALL leading ./ segments", () => {
+  const cfg = parsePreserveConfig(
+    "preserved:\n  - ././x\n  - ./././y.md\n",
+  );
+  assertEquals(cfg.preserved, ["x", "y.md"]);
+});
+
+Deno.test("parsePreserveConfig treats YAML null (~) as no declarations", () => {
+  // `preserved: ~` parses to a null value, not a list — must degrade to empty.
+  assertEquals(parsePreserveConfig("preserved: ~\n"), EMPTY_PRESERVE_CONFIG);
+  assertEquals(parsePreserveConfig("preserved: null\n"), EMPTY_PRESERVE_CONFIG);
+});
+
+Deno.test("parsePreserveConfig drops entries with a .. path segment (containment)", () => {
+  const cfg = parsePreserveConfig(
+    "preserved:\n" +
+      "  - ../../etc/passwd\n" +
+      "  - a/../b.md\n" +
+      "  - ..\n" +
+      "  - kept.md\n",
+  );
+  // Every `..`-bearing entry is dropped; only the clean path survives.
+  assertEquals(cfg.preserved, ["kept.md"]);
+});
+
+Deno.test("parsePreserveConfig drops blanks and de-dupes preserving first order", () => {
+  const cfg = parsePreserveConfig(
+    "preserved:\n" +
+      "  - a.md\n" +
+      "  - ''\n" +
+      "  - '  '\n" +
+      "  - a.md\n" +
+      "  - ./a.md\n" +
+      "  - b.md\n",
+  );
+  assertEquals(cfg.preserved, ["a.md", "b.md"]);
+});
+
+Deno.test("parsePreserveConfig ignores non-string list entries", () => {
+  const cfg = parsePreserveConfig("preserved:\n  - a.md\n  - 42\n  - true\n  - b.md\n");
+  assertEquals(cfg.preserved, ["a.md", "b.md"]);
+});
+
+Deno.test("serializePreserveConfig round-trips through parse (idempotent on canonical input)", () => {
+  const cfg = { preserved: ["a.md", "b.md"] };
+  const yaml = serializePreserveConfig(cfg);
+  assertEquals(parsePreserveConfig(yaml).preserved, ["a.md", "b.md"]);
+  // serialize is stable / idempotent.
+  assertEquals(serializePreserveConfig(parsePreserveConfig(yaml)), yaml);
+  assertEquals(yaml.endsWith("\n"), true);
+});
+
+Deno.test("serializePreserveConfig of EMPTY_PRESERVE_CONFIG parses back to empty", () => {
+  const yaml = serializePreserveConfig(EMPTY_PRESERVE_CONFIG);
+  assertEquals(parsePreserveConfig(yaml), EMPTY_PRESERVE_CONFIG);
+});

--- a/tests/domain/upgrade_plan_test.ts
+++ b/tests/domain/upgrade_plan_test.ts
@@ -347,3 +347,101 @@ Deno.test("computeUpgradePlan: stale lock without resetBaseline → preserve cus
   assertEquals(plan.length, 1);
   assertEquals(plan[0].kind, "preserve");
 });
+
+// ---------------------------------------------------------------------------
+// 011-preserve-customisations: declared-preserve (issue #367)
+// ---------------------------------------------------------------------------
+
+// A declared path is preserved even when its on-disk SHA matches the bundle
+// (FR-007: a declaration for a vanilla file is honoured, not an error).
+Deno.test("computeUpgradePlan: declared path is preserve/declared even when SHA matches bundle", () => {
+  const path = ".claude/agents/product-owner.md";
+  const plan = computeUpgradePlan(
+    new Map([[path, "same-sha"]]),
+    lockWith(path, "same-sha"),
+    new Map([[path, "same-sha"]]),
+    { isDeclaredPreserved: (d) => d === path },
+  );
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].kind, "preserve");
+  if (plan[0].kind === "preserve") {
+    assertEquals(plan[0].reason, "declared");
+  }
+});
+
+// The declared check precedes the plugin-migration branch: a declared,
+// plugin-covered, vanilla file is preserved (declared), NOT migrated.
+Deno.test("computeUpgradePlan: declared check wins over plugin migration", () => {
+  const path = ".claude/agents/developer.md";
+  const plan = computeUpgradePlan(
+    new Map([[path, "vanilla-sha"]]),
+    lockWith(path, "vanilla-sha"),
+    new Map([[path, "new-sha"]]),
+    {
+      pluginInstalled: true,
+      isPluginCovered: () => true,
+      isDeclaredPreserved: (d) => d === path,
+    },
+  );
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].kind, "preserve");
+  if (plan[0].kind === "preserve") assertEquals(plan[0].reason, "declared");
+});
+
+// The declared check wins over auto-update (disk==lock, differs from bundle).
+Deno.test("computeUpgradePlan: declared check wins over auto-update", () => {
+  const path = ".claude/agents/po.md";
+  const plan = computeUpgradePlan(
+    new Map([[path, "old-sha"]]),
+    lockWith(path, "old-sha"),
+    new Map([[path, "new-sha"]]),
+    { isDeclaredPreserved: (d) => d === path },
+  );
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].kind, "preserve");
+  if (plan[0].kind === "preserve") assertEquals(plan[0].reason, "declared");
+});
+
+// F3: a declared path that is absent from the NEW bundle but tracked in the
+// lock and present on disk yields preserve/declared, NOT remove (FR-009 —
+// preservation wins over removal).
+Deno.test("computeUpgradePlan: declared path absent from newShas → preserve/declared not remove", () => {
+  const path = ".claude/agents/old-agent.md";
+  const plan = computeUpgradePlan(
+    new Map([[path, "disk-sha"]]),
+    lockWith(path, "disk-sha"),
+    new Map(), // dropped upstream
+    { isDeclaredPreserved: (d) => d === path },
+  );
+  assertEquals(plan.length, 1);
+  assertEquals(plan[0].kind, "preserve");
+  if (plan[0].kind === "preserve") assertEquals(plan[0].reason, "declared");
+});
+
+// A non-declared path is unaffected by the predicate (control case).
+Deno.test("computeUpgradePlan: non-declared path unaffected by isDeclaredPreserved", () => {
+  const path = "CLAUDE.md";
+  const plan = computeUpgradePlan(
+    new Map([[path, "old-sha"]]),
+    lockWith(path, "old-sha"),
+    new Map([[path, "new-sha"]]),
+    { isDeclaredPreserved: (d) => d === ".claude/agents/po.md" },
+  );
+  assertEquals(plan[0].kind, "auto-update");
+});
+
+// D8: a declared agentic path that is absent from the bundle AND not on disk
+// (e.g. suppressed in a parent-managed sub-repo) produces no spurious action —
+// the predicate only fires for dests present in newShas or tracked+on-disk.
+Deno.test("computeUpgradePlan: declared path neither in bundle nor on disk → no action", () => {
+  const path = ".claude/agents/inherited.md";
+  const plan = computeUpgradePlan(
+    new Map(), // not on disk
+    lockWith("CLAUDE.md", "x"), // unrelated lock entry
+    new Map([["CLAUDE.md", "x"]]),
+    { isDeclaredPreserved: (d) => d === path },
+  );
+  // Only the unrelated CLAUDE.md is considered; the declared inherited path
+  // is never resurrected.
+  assertEquals(plan.some((a) => a.dest === path), false);
+});

--- a/tests/infrastructure/fs_preserve_store_test.ts
+++ b/tests/infrastructure/fs_preserve_store_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "@std/assert";
+import { FsPreserveStore } from "../../src/infrastructure/fs_preserve_store.ts";
+import { EMPTY_PRESERVE_CONFIG } from "../../src/domain/preserve_config.ts";
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-preserve-store-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("FsPreserveStore.read returns EMPTY_PRESERVE_CONFIG when the manifest is absent", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FsPreserveStore();
+    assertEquals(await store.read(dir), EMPTY_PRESERVE_CONFIG);
+  });
+});
+
+Deno.test("FsPreserveStore write-then-read round-trips", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FsPreserveStore();
+    await store.write(dir, {
+      preserved: [".claude/agents/product-owner.md", ".claude/agents/developer.md"],
+    });
+    const cfg = await store.read(dir);
+    assertEquals(cfg.preserved, [
+      ".claude/agents/product-owner.md",
+      ".claude/agents/developer.md",
+    ]);
+  });
+});
+
+Deno.test("FsPreserveStore.read degrades a malformed manifest to empty (no throw)", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.mkdir(`${dir}/.specflow`, { recursive: true });
+    await Deno.writeTextFile(`${dir}/.specflow/preserve.yml`, "preserved:\n  - [unterminated\n");
+    const store = new FsPreserveStore();
+    assertEquals(await store.read(dir), EMPTY_PRESERVE_CONFIG);
+  });
+});
+
+Deno.test("FsPreserveStore.write creates the .specflow directory if missing", async () => {
+  await withTempDir(async (dir) => {
+    const store = new FsPreserveStore();
+    await store.write(dir, { preserved: ["a.md"] });
+    const raw = await Deno.readTextFile(`${dir}/.specflow/preserve.yml`);
+    assertEquals(raw.includes("a.md"), true);
+  });
+});

--- a/tests/integration/init_preserve_test.ts
+++ b/tests/integration/init_preserve_test.ts
@@ -1,0 +1,164 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd: string },
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-preserve-integ-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+const PRESERVED = ".claude/agents/product-owner.md";
+// A managed file NOT declared preserved — must still be refreshed by --force.
+const REFRESHED = ".claude/agents/code-reviewer.md";
+const CUSTOM_MARK = "\n# my project-specific PO config — DO NOT CLOBBER\n";
+
+/**
+ * Init a project, customise the product-owner agent, and declare it preserved.
+ * Returns the project dir and the byte-exact customised content so callers can
+ * assert byte-identity after a forced refresh.
+ */
+async function initWithDeclaredCustomisation(
+  parent: string,
+): Promise<{ projectDir: string; customised: string }> {
+  const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+  assertEquals(init.code, 0, `init precondition failed: ${init.stderr}`);
+  const projectDir = join(parent, "demo");
+
+  const poPath = join(projectDir, PRESERVED);
+  const original = await Deno.readTextFile(poPath);
+  const customised = original + CUSTOM_MARK;
+  await Deno.writeTextFile(poPath, customised);
+
+  await Deno.writeTextFile(
+    join(projectDir, ".specflow/preserve.yml"),
+    `preserved:\n  - ${PRESERVED}\n`,
+  );
+  return { projectDir, customised };
+}
+
+// T011 / C6 — SC-001, SC-002, SC-006: a declared file survives `init --force`
+// byte-identical and emits a per-file notice; a non-declared managed file is
+// still refreshed. Closes the 2026-06-08 product-owner.md regression.
+Deno.test("init --force preserves a declared file byte-identical and emits a notice", async () => {
+  await withTempDir(async (parent) => {
+    const { projectDir, customised } = await initWithDeclaredCustomisation(parent);
+
+    // Mutate a NON-declared managed file so we can prove --force still refreshes it.
+    const refreshedPath = join(projectDir, REFRESHED);
+    await Deno.writeTextFile(refreshedPath, "# clobbered locally\n");
+
+    const refresh = await runSpecflow(["init", "--here", "--force", "--no-git"], {
+      cwd: projectDir,
+    });
+    assertEquals(refresh.code, 0, refresh.stderr);
+
+    // SC-001 / SC-006: the declared file is byte-identical to its pre-refresh content.
+    const afterPo = await Deno.readTextFile(join(projectDir, PRESERVED));
+    assertEquals(afterPo, customised, "declared file must survive --force byte-identical");
+
+    // SC-002: a per-file preserve notice names the path.
+    assertStringIncludes(refresh.stdout, `preserved ${PRESERVED}`);
+
+    // The non-declared managed file IS refreshed (our local edit is gone).
+    const afterRefreshed = await Deno.readTextFile(refreshedPath);
+    assertEquals(
+      afterRefreshed.includes("# clobbered locally"),
+      false,
+      "a non-declared managed file must be refreshed by --force",
+    );
+  });
+});
+
+// T016 / C6 — SC-005: `init --force --reset-preserved` overwrites the declared
+// file AND emits a per-file override warning; the same run WITHOUT the flag
+// preserves it (the opt-out is never the default).
+Deno.test("init --force --reset-preserved overwrites the declared file and warns; no flag preserves", async () => {
+  await withTempDir(async (parent) => {
+    const { projectDir, customised } = await initWithDeclaredCustomisation(parent);
+
+    // Control: without --reset-preserved the customisation survives.
+    const keep = await runSpecflow(["init", "--here", "--force", "--no-git"], {
+      cwd: projectDir,
+    });
+    assertEquals(keep.code, 0, keep.stderr);
+    assertEquals(
+      await Deno.readTextFile(join(projectDir, PRESERVED)),
+      customised,
+      "without --reset-preserved the declaration must be honoured",
+    );
+
+    // With --reset-preserved the bundled version is restored and the override warned.
+    const reset = await runSpecflow(
+      ["init", "--here", "--force", "--reset-preserved", "--no-git"],
+      { cwd: projectDir },
+    );
+    assertEquals(reset.code, 0, reset.stderr);
+
+    const afterReset = await Deno.readTextFile(join(projectDir, PRESERVED));
+    assert(
+      !afterReset.includes("DO NOT CLOBBER"),
+      "with --reset-preserved the customisation must be overwritten by the bundle",
+    );
+    assertStringIncludes(reset.stdout, `override ${PRESERVED}`);
+  });
+});
+
+// T011 control — FR-011: a project with no preserve.yml observes today's
+// behaviour: the customised file is clobbered by --force (no preserve notice).
+Deno.test("init --force without a preserve.yml clobbers a customised file (FR-011 control)", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0, init.stderr);
+    const projectDir = join(parent, "demo");
+
+    const poPath = join(projectDir, PRESERVED);
+    await Deno.writeTextFile(poPath, (await Deno.readTextFile(poPath)) + CUSTOM_MARK);
+
+    const refresh = await runSpecflow(["init", "--here", "--force", "--no-git"], {
+      cwd: projectDir,
+    });
+    assertEquals(refresh.code, 0, refresh.stderr);
+    const after = await Deno.readTextFile(poPath);
+    assertEquals(
+      after.includes("DO NOT CLOBBER"),
+      false,
+      "with no preserve.yml the customisation is clobbered (today's behaviour)",
+    );
+    assertEquals(
+      refresh.stdout.includes("preserved "),
+      false,
+      "no preserve notice when nothing is declared",
+    );
+  });
+});

--- a/tests/integration/upgrade_preserve_test.ts
+++ b/tests/integration/upgrade_preserve_test.ts
@@ -1,0 +1,182 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+async function runSpecflow(
+  args: string[],
+  opts: { cwd: string },
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const p = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      MAIN,
+      ...args,
+    ],
+    cwd: opts.cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await p.output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "specflow-upgrade-preserve-integ-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** SHA-256 hex of a UTF-8 string — matches the lock's `sha256` format. */
+async function sha256Hex(text: string): Promise<string> {
+  const buf = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Re-stamp the lock SHA for a single managed dest to match arbitrary content.
+ *
+ * After init, every managed file's on-disk SHA equals its lock SHA equals the
+ * bundle SHA. To simulate "the bundle ships a NEWER version of this file" WITHOUT
+ * mutating the embedded bundle, we instead rewrite the file on disk to known
+ * content and re-stamp its lock SHA to that content. The file is then "vanilla"
+ * (disk == lock) yet diverges from the real bundle — exactly the state the
+ * upgrade planner reads as an available auto-update for that dest.
+ */
+async function restampLockSha(
+  projectDir: string,
+  dest: string,
+  newSha: string,
+): Promise<void> {
+  const lockPath = join(projectDir, ".specflow/installed.lock");
+  const yaml = await Deno.readTextFile(lockPath);
+  // Match the entry block for `dest` (YAML key) and replace its sha256 line.
+  const escaped = dest.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`(^  ${escaped}:\\n    sha256: )[0-9a-f]+`, "m");
+  const next = yaml.replace(re, `$1${newSha}`);
+  if (next === yaml) {
+    throw new Error(`failed to re-stamp lock SHA for ${dest} (entry not found)`);
+  }
+  await Deno.writeTextFile(lockPath, next);
+}
+
+const DECLARED = ".claude/agents/product-owner.md";
+const UNDECLARED = ".claude/agents/code-reviewer.md";
+const CUSTOM_MARK = "\n# my project-specific config — DO NOT CLOBBER\n";
+
+/**
+ * HIGH-2 — end-to-end coverage for `upgrade` honouring a declared preserve.
+ *
+ * Distinct seam from init: init loads preserves as a `preservedPaths` Set,
+ * whereas upgrade threads an `isDeclaredPreserved` predicate through
+ * computeUpgradePlan. This test drives the real binary (handler →
+ * UpgradeProjectUseCase → computeUpgradePlan) against a real fs + real
+ * FsPreserveStore so a wiring regression in upgrade_handler.ts would be
+ * caught (it would not be by the init integration test).
+ *
+ * Fixture: an installed project where a customised+declared file looks vanilla
+ * vs its lock but diverges from the bundle (the bundle effectively ships a
+ * newer version). Expectation: `specflow upgrade` leaves the declared file
+ * byte-identical AND prints the "preserved … declared in .specflow/preserve.yml"
+ * notice, while a non-declared customised file follows normal upgrade rules.
+ */
+Deno.test("upgrade honours a declared preserve end-to-end: declared file untouched, notice emitted", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0, `init precondition failed: ${init.stderr}`);
+    const projectDir = join(parent, "demo");
+
+    // Customise the declared file and re-stamp its lock SHA so it reads as
+    // vanilla-but-diverged-from-bundle (an available auto-update the bundle ships).
+    const declaredPath = join(projectDir, DECLARED);
+    const declaredContent = (await Deno.readTextFile(declaredPath)) + CUSTOM_MARK;
+    await Deno.writeTextFile(declaredPath, declaredContent);
+    await restampLockSha(projectDir, DECLARED, await sha256Hex(declaredContent));
+
+    // Same treatment for a NON-declared file — it must still be refreshed.
+    const undeclaredPath = join(projectDir, UNDECLARED);
+    const undeclaredContent = (await Deno.readTextFile(undeclaredPath)) + CUSTOM_MARK;
+    await Deno.writeTextFile(undeclaredPath, undeclaredContent);
+    await restampLockSha(projectDir, UNDECLARED, await sha256Hex(undeclaredContent));
+
+    // Declare ONLY the first file preserved.
+    await Deno.writeTextFile(
+      join(projectDir, ".specflow/preserve.yml"),
+      `preserved:\n  - ${DECLARED}\n`,
+    );
+
+    const upgrade = await runSpecflow(["upgrade"], { cwd: projectDir });
+    assertEquals(upgrade.code, 0, upgrade.stderr);
+
+    // The declared file is left byte-identical to its customised content.
+    assertEquals(
+      await Deno.readTextFile(declaredPath),
+      declaredContent,
+      "declared file must survive upgrade byte-identical",
+    );
+    // The declared-preserve notice names the path and the manifest.
+    assertStringIncludes(
+      upgrade.stdout,
+      `preserved ${DECLARED} — declared in .specflow/preserve.yml`,
+    );
+
+    // The non-declared file follows normal upgrade behaviour: vanilla vs lock
+    // but diverged from the bundle ⇒ auto-updated, so the local mark is gone.
+    const afterUndeclared = await Deno.readTextFile(undeclaredPath);
+    assert(
+      !afterUndeclared.includes("DO NOT CLOBBER"),
+      "a non-declared file must follow normal upgrade rules (refreshed from the bundle)",
+    );
+  });
+});
+
+/**
+ * `--reset-preserved` opt-out on the upgrade path: the declared file is no
+ * longer preserved and follows normal upgrade rules, with a per-file override
+ * line. Proves the predicate is forced off when the flag is present.
+ */
+Deno.test("upgrade --reset-preserved overrides a declaration and refreshes the file", async () => {
+  await withTempDir(async (parent) => {
+    const init = await runSpecflow(["init", "demo", "--no-git"], { cwd: parent });
+    assertEquals(init.code, 0, `init precondition failed: ${init.stderr}`);
+    const projectDir = join(parent, "demo");
+
+    const declaredPath = join(projectDir, DECLARED);
+    const declaredContent = (await Deno.readTextFile(declaredPath)) + CUSTOM_MARK;
+    await Deno.writeTextFile(declaredPath, declaredContent);
+    await restampLockSha(projectDir, DECLARED, await sha256Hex(declaredContent));
+
+    await Deno.writeTextFile(
+      join(projectDir, ".specflow/preserve.yml"),
+      `preserved:\n  - ${DECLARED}\n`,
+    );
+
+    const upgrade = await runSpecflow(["upgrade", "--reset-preserved"], {
+      cwd: projectDir,
+    });
+    assertEquals(upgrade.code, 0, upgrade.stderr);
+
+    // With --reset-preserved the declaration is ignored: the file is refreshed
+    // and a per-file override line is printed.
+    const after = await Deno.readTextFile(declaredPath);
+    assert(
+      !after.includes("DO NOT CLOBBER"),
+      "with --reset-preserved the declared file follows normal upgrade rules",
+    );
+    assertStringIncludes(upgrade.stdout, `override ${DECLARED}`);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #367. `specflow upgrade` already auto-preserves a customised managed file, but `specflow init --force` bypassed `computeUpgradePlan` and rewrote the whole bundle unconditionally — which silently reverted a customised `.claude/agents/product-owner.md` to the generic bundled version on a forced refresh.

This adds an **explicit, force-surviving preserve declaration**, a **read-only divergence view**, and an explicit **reset opt-out**:

- **`.specflow/preserve.yml`** manifest — a flat list of project-relative paths the maintainer declares as theirs. New pure domain `preserve_config.ts` + `PreserveStore` port + `FsPreserveStore` adapter (mirrors `FsLockStore`).
- **`init --force` honours it** — `InitProjectUseCase` filters declared paths out of the write set while **keeping their `installed.lock` entries** (so they stay tracked for `diff` and future upgrades).
- **`upgrade` honours the same declaration** — new `preserve.reason: "declared"` in `computeUpgradePlan`, ordered **first** so a declared file is never auto-updated, migrated to the plugin, or removed.
- **`specflow diff`** — new top-level **read-only** command showing how each managed file diverges from the bundled original (reuses `renderUnifiedDiff`; no `FsWriter` dependency).
- **`--reset-preserved`** — explicit, never-default opt-out that overrides preserves for one run, reported per file.
- Every preserve skip / override / unknown-path declaration emits a **per-file notice** — no silent behaviour. Absent `preserve.yml` ⇒ byte-identical to today (`installed.lock` format unchanged).

## Spec

Full spec-driven artifacts under `.specflow/specs/011-preserve-customisations/` (spec, plan, research, data-model, contracts, quickstart, tasks).

## Testing

- ~20 new tests (pure domain, store, upgrade-plan, init filter, diff use-case, two integration suites for `init --force` and `upgrade` end-to-end).
- Full suite **867 passed / 0 failed**; `deno fmt`/`lint`/`check` clean.

## Notes

- The already-published behaviour for projects without a `preserve.yml` is unchanged (FR-011).
- No `CHANGELOG.md` in this repo (release flow uses inline SemVer tags + `gh release` notes); documented in `docs/llms.md` instead.

## Agent adoption

`specflow init --force` and `specflow upgrade` now respect a `.specflow/preserve.yml` manifest: any managed file listed there is kept on a forced refresh instead of being overwritten by the bundled version. If your project has customised any bundled file — most commonly `.claude/agents/product-owner.md` (its GitHub Project handle + label conventions) or `.claude/agents/developer.md` (its build/test commands) — declare those paths so a future `--force` refresh can't silently revert them. Use the new read-only `specflow diff` to see how your copies have drifted from the bundle, and `--reset-preserved` to deliberately discard a customisation.

```prompt
Find which bundled Specflow files I have customised, then protect them from forced template refreshes:

1. Run `specflow diff` and note every file reported as diverged from the bundle.
2. Create or update `.specflow/preserve.yml` with a top-level `preserved:` list
   containing each diverged project-relative path, e.g.:

   preserved:
     - .claude/agents/product-owner.md
     - .claude/agents/developer.md

3. Commit `.specflow/preserve.yml`.

From now on `specflow init --force` and `specflow upgrade` will keep those files
and print a per-file "preserved …" notice. To intentionally take the bundled
version back, run the refresh with `--reset-preserved`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)