### PR TITLE
feat(agents): machine-readable agent output contracts (#378)

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specflow/specs/011-preserve-customisations",
-  "linked_issue": 367,
+  "feature_directory": ".specflow/specs/012-agent-output-contracts",
+  "linked_issue": 378,
   "workflow_shape": "full"
 }

--- a/.specflow/specs/012-agent-output-contracts/checklists/requirements.md
+++ b/.specflow/specs/012-agent-output-contracts/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: Machine-readable agent output contracts
+
+**Purpose**: Validate specification completeness before planning
+**Created**: 2026-06-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable and technology-agnostic
+- [x] All acceptance scenarios defined; edge cases identified
+- [x] Scope clearly bounded; dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] No implementation details in specification
+
+## Notes
+
+Domain Model populated inline (domain is well-bounded by the source contract
+system); no [NEEDS CLARIFICATION] markers needed. The one genuinely deferred
+decision — the exact frontmatter field name used to express "preload" — is
+recorded as an Assumption (implementation detail for the plan), not a spec
+ambiguity. Spec is ready for `/specflow clarify` (optional, no open markers) or
+`/specflow plan`.

--- a/.specflow/specs/012-agent-output-contracts/contracts/handoff.md
+++ b/.specflow/specs/012-agent-output-contracts/contracts/handoff.md
@@ -1,0 +1,22 @@
+# Contract: HANDOFF block
+
+Defined by skill `handoff-protocol`. Preloaded by: developer, review-coordinator. Emitted immediately
+after the WORKFLOW STATUS block, **only when** `HANDOFF_TARGET ≠ none`.
+
+## Format
+
+```text
+HANDOFF
+TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user
+REASON: <one sentence>
+REQUESTED_ACTION: <one imperative sentence — executable without reinterpretation>
+PAYLOAD: <concrete filenames, ids, findings, spec ids the next actor needs>
+OPEN_RISKS: <comma list | none>
+```
+
+## Rules
+
+- Block exists **iff** `HANDOFF_TARGET ≠ none`; if there is no real handoff, omit it entirely.
+- `TARGET` must equal the WORKFLOW STATUS `HANDOFF_TARGET`.
+- `REQUESTED_ACTION` is precise enough to execute without re-deriving intent.
+- `PAYLOAD` names concrete artifacts, never vague references.

--- a/.specflow/specs/012-agent-output-contracts/contracts/qa-summary.md
+++ b/.specflow/specs/012-agent-output-contracts/contracts/qa-summary.md
@@ -1,0 +1,27 @@
+# Contract: QA SUMMARY block
+
+Defined by skill `qa-report-contract`. Preloaded by: qa-tester. Emitted once, after the prose (and
+before the WORKFLOW STATUS block, since qa-tester also carries workflow-contract).
+
+## Format
+
+```text
+QA SUMMARY
+QA_SCOPE: <one sentence>
+QA_VERDICT: pass | fail | blocked
+NEW_UNIT_TESTS: <integer>
+NEW_FUNCTIONAL_TESTS: <integer>
+NEW_BROWSER_TESTS: <integer>
+TOTAL_PASS_COUNT: <integer>
+TOTAL_FAIL_COUNT: <integer>
+BUGS_FOUND: <integer>
+QA_RECOMMENDATION: <one sentence>
+```
+
+## Rules
+
+- `QA_VERDICT: pass` only when the requested QA scope is complete **and** `TOTAL_FAIL_COUNT == 0`.
+- `QA_VERDICT: fail` when tests exposed real product bugs or failing automation.
+- `QA_VERDICT: blocked` when QA could not run (missing environment/prereqs) — distinct from `fail`.
+- Every numeric field is an explicit integer, including `0`.
+- `BUGS_FOUND` counts product issues / failing flows, not stylistic concerns.

--- a/.specflow/specs/012-agent-output-contracts/contracts/review-summary.md
+++ b/.specflow/specs/012-agent-output-contracts/contracts/review-summary.md
@@ -1,0 +1,27 @@
+# Contract: REVIEW SUMMARY block
+
+Defined by skill `review-findings-contract`. Preloaded by: architecture-auditor, performance-auditor,
+security-auditor, a11y-auditor, dependency-auditor, code-reviewer, test-reviewer. Emitted once, after
+the prose (and before the WORKFLOW STATUS block when the agent also carries workflow-contract).
+
+## Format
+
+```text
+REVIEW SUMMARY
+REVIEW_SCOPE: <reviewer name or gate scope>
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+## Rules
+
+- `REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` **and** `HIGH_COUNT == 0`.
+- `REVIEW_VERDICT: fail` when `CRITICAL_COUNT > 0` **or** `HIGH_COUNT > 0`.
+- `REVIEW_VERDICT: needs_followup` when only Medium/Low findings remain.
+- Every count is an explicit integer, including `0`.
+- Verdict and counts must never contradict.

--- a/.specflow/specs/012-agent-output-contracts/contracts/workflow-status.md
+++ b/.specflow/specs/012-agent-output-contracts/contracts/workflow-status.md
@@ -1,0 +1,28 @@
+# Contract: WORKFLOW STATUS block
+
+Defined by skill `workflow-contract`. Preloaded by: developer, review-coordinator, qa-tester, and all
+auditors/reviewers (via workflow-contract). Emitted once, at end of turn, after the agent's prose.
+
+## Format
+
+```text
+WORKFLOW STATUS
+STATE: in_progress | blocked | awaiting_review | awaiting_qa | awaiting_user | done | failed
+DONE_CRITERIA_MET: yes | no
+SUMMARY: <one sentence — outcome, not effort>
+ARTIFACTS: <comma list | none>
+FILES_CHANGED: <comma list | none>
+VALIDATION: <comma list of "command (result)" | none>
+BLOCKERS: <one sentence | none>
+NEXT_ACTION: <one sentence>
+HANDOFF_TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user | none
+```
+
+## Rules
+
+- Exactly one block per turn; never replaces prose (additive).
+- `STATE: done` only when assigned exit criteria are met; otherwise use `awaiting_review` /
+  `awaiting_qa` / `blocked`. Never `done` with `DONE_CRITERIA_MET: no`.
+- `FILES_CHANGED: none` for read-only agents (auditors/reviewers).
+- `VALIDATION` is explicit, e.g. `deno task test (pass)`.
+- `HANDOFF_TARGET: none` when work terminates here.

--- a/.specflow/specs/012-agent-output-contracts/data-model.md
+++ b/.specflow/specs/012-agent-output-contracts/data-model.md
@@ -1,0 +1,92 @@
+# Data Model — Machine-readable agent output contracts
+
+There is no runtime data store. The "model" here is the schema of the four output blocks and the
+wiring relation between agents and contracts. These are documentation entities, asserted by tests.
+
+## Entity: Contract
+
+A bundled `user-invocable: false` skill defining one output block's schema.
+
+| Field | Value |
+|---|---|
+| name | `workflow-contract` \| `handoff-protocol` \| `review-findings-contract` \| `qa-report-contract` |
+| user-invocable | always `false` |
+| defines block | `WORKFLOW STATUS` \| `HANDOFF` \| `REVIEW SUMMARY` \| `QA SUMMARY` |
+| location | `templates/core/skills/<name>/SKILL.md` |
+
+Identity = `name`. Immutable schema once shipped (changing a block's fields is a new contract version,
+out of scope here).
+
+## Entity: Wired agent
+
+An existing bundled agent that preloads ≥1 contract.
+
+| Field | Value |
+|---|---|
+| name | agent file stem under `templates/core/agents/` |
+| skills | YAML array of contract names in frontmatter |
+| obligation | emit each preloaded contract's block at end of turn |
+
+## Value object: WORKFLOW STATUS block
+
+Emitted by `workflow-contract` preloaders. Fields (all present each emission):
+
+- `STATE` ∈ {`in_progress`, `blocked`, `awaiting_review`, `awaiting_qa`, `awaiting_user`, `done`, `failed`}
+- `DONE_CRITERIA_MET` ∈ {`yes`, `no`}
+- `SUMMARY` — one sentence (outcome, not effort)
+- `ARTIFACTS` — comma list or `none`
+- `FILES_CHANGED` — comma list or `none` (`none` for read-only agents)
+- `VALIDATION` — comma list of command(results) or `none`
+- `BLOCKERS` — one sentence or `none`
+- `NEXT_ACTION` — one sentence
+- `HANDOFF_TARGET` ∈ {`developer`, `review-coordinator`, `qa-tester`, `product-owner`, `workflow-manager`, `user`, `none`}
+
+Invariant: `STATE: done` ⇒ `DONE_CRITERIA_MET: yes`.
+
+## Value object: HANDOFF block
+
+Emitted by `handoff-protocol` preloaders **iff** `HANDOFF_TARGET ≠ none`.
+
+- `TARGET` — must equal the workflow block's `HANDOFF_TARGET`
+- `REASON` — one sentence
+- `REQUESTED_ACTION` — one imperative sentence, executable without reinterpretation
+- `PAYLOAD` — concrete filenames / ids / findings the next actor needs
+- `OPEN_RISKS` — comma list or `none`
+
+Invariant: block exists ⟺ `HANDOFF_TARGET ≠ none`; `TARGET == HANDOFF_TARGET`.
+
+## Value object: REVIEW SUMMARY block
+
+Emitted by `review-findings-contract` preloaders.
+
+- `REVIEW_SCOPE` — reviewer name / gate scope
+- `REVIEW_VERDICT` ∈ {`pass`, `fail`, `needs_followup`}
+- `CRITICAL_COUNT`, `HIGH_COUNT`, `MEDIUM_COUNT`, `LOW_COUNT` — explicit integers ≥ 0
+- `TOP_ISSUES` — ≤5 lines or `none`
+- `RECOMMENDATION` — one sentence
+
+Invariants: `pass` ⟺ `CRITICAL_COUNT == 0 ∧ HIGH_COUNT == 0` and nothing else outstanding; `fail` ⟺
+`CRITICAL_COUNT > 0 ∨ HIGH_COUNT > 0`; `needs_followup` ⟺ only Medium/Low remain. Every count is an
+explicit integer including 0.
+
+## Value object: QA SUMMARY block
+
+Emitted by `qa-report-contract` preloaders.
+
+- `QA_SCOPE` — one sentence
+- `QA_VERDICT` ∈ {`pass`, `fail`, `blocked`}
+- `NEW_UNIT_TESTS`, `NEW_FUNCTIONAL_TESTS`, `NEW_BROWSER_TESTS`, `TOTAL_PASS_COUNT`, `TOTAL_FAIL_COUNT`, `BUGS_FOUND` — explicit integers ≥ 0
+- `QA_RECOMMENDATION` — one sentence
+
+Invariants: `pass` ⟺ scope complete ∧ `TOTAL_FAIL_COUNT == 0`; `blocked` = could not run
+(environment/prereq), distinct from `fail`.
+
+## Relation
+
+`Wired agent —preloads→ Contract` (many-to-many). The wiring table in research.md is the authoritative
+mapping; tests assert it holds in the bundled output. The wired set is: the five auditors
+(architecture, performance, security, a11y, dependency) and two reviewers (code, test) →
+`review-findings-contract` + `workflow-contract`; `review-coordinator` →
+`workflow-contract` + `handoff-protocol` + `review-findings-contract` (its aggregated REVIEW SUMMARY
+conforms to the same schema); `developer` and `workflow-manager` → `workflow-contract` +
+`handoff-protocol`; `qa-tester` → `qa-report-contract` + `workflow-contract`.

--- a/.specflow/specs/012-agent-output-contracts/plan.md
+++ b/.specflow/specs/012-agent-output-contracts/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Machine-readable agent output contracts
+
+**Branch**: `012-agent-output-contracts` | **Date**: 2026-06-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `.specflow/specs/012-agent-output-contracts/spec.md` (issue mkrlabs/specflow#378, epic mkrlabs/specflow-monorepo#12)
+
+## Summary
+
+Add four `user-invocable: false` **contract skills** to the bundled template set and wire the
+relevant bundled agents to preload them, so agent output carries normalized, fenced, machine-readable
+blocks (`WORKFLOW STATUS`, `HANDOFF`, `REVIEW SUMMARY`, `QA SUMMARY`) appended after the existing
+prose. This is pure additive content shipped through the existing `init`/`upgrade` bundle — no
+runtime/domain code changes. It is the foundation that the multi-seat audit synthesis (#379) and the
+status ledger / `/status-audit` parser (#381) consume.
+
+The work has two surfaces:
+
+1. **Content** — author 4 new `templates/core/skills/<name>/SKILL.md` files; add a `skills:`
+   frontmatter array to the relevant `templates/core/agents/*.md` files.
+2. **Distribution** — regenerate the embedded bundle (`deno task bundle` → `src/templates_bundle.ts`)
+   so `specflow init`/`upgrade` ship the new files; add tests asserting the bundle carries the four
+   contracts and the agents carry the preload frontmatter.
+
+## Technical Context
+
+**Language/Version**: TypeScript on Deno v2.x
+**Primary Dependencies**: none new — uses the existing template-bundle pipeline (`scripts/bundle-templates.ts`, `src/templates_bundle.ts`, `src/domain/core_bundle.ts`) and `@std/assert` for tests
+**Storage**: bundled template files under `templates/core/{skills,agents}/`; embedded into `src/templates_bundle.ts` at build time
+**Testing**: `deno task test` (which runs `deno task bundle` first); hermetic — no network
+**Target Platform**: the Specflow CLI binary; the artifacts land in any project's `.claude/` via `init`/`upgrade`
+**Project Type**: cli (single project, hexagonal)
+**Performance Goals**: N/A — static content; the only runtime cost is bundle size (4 small markdown files + a frontmatter line per agent)
+**Constraints**: additive only; no existing agent prose behaviour regresses; upgrade must respect the spec-011 customisation-preservation path
+**Scale/Scope**: 4 new skill files, ~6–8 agent frontmatter edits, 1 bundle regen, 1–2 test files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The bundled `constitution.md` is the placeholder default (no project-specific principles defined), so
+no explicit constitutional gate applies. The de-facto invariants observed in this codebase still hold
+and are honoured by this plan:
+
+- **Hexagonal discipline** — N/A: this feature adds no domain/application/infrastructure code; it is
+  template content + the existing bundle generator. No new ports/adapters, no layer crossings.
+- **Additive, non-breaking** — contracts append output; no agent's existing behaviour is replaced (FR-009).
+- **Test the contract** — bundle-inclusion and frontmatter-wiring are asserted by tests (Phase 1 contracts).
+- **Ship through the one bundle path** — no bespoke install logic; reuses `init`/`upgrade` (FR-011).
+
+Result: **PASS** (no violations; Complexity Tracking not required).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specflow/specs/012-agent-output-contracts/
+├── plan.md              # This file
+├── research.md          # Phase 0 — the two resolved decisions
+├── data-model.md        # Phase 1 — contracts as domain entities
+├── quickstart.md        # Phase 1 — how to verify the feature end-to-end
+├── contracts/           # Phase 1 — the 4 block schemas (the feature's actual contracts)
+│   ├── workflow-status.md
+│   ├── handoff.md
+│   ├── review-summary.md
+│   └── qa-summary.md
+└── tasks.md             # Phase 2 (/specflow tasks)
+```
+
+### Source Code (repository root)
+
+```text
+templates/core/
+├── skills/
+│   ├── workflow-contract/SKILL.md         # NEW (user-invocable: false)
+│   ├── handoff-protocol/SKILL.md          # NEW
+│   ├── review-findings-contract/SKILL.md  # NEW
+│   └── qa-report-contract/SKILL.md        # NEW
+└── agents/
+    ├── architecture-auditor.md   # EDIT: + skills: [review-findings-contract, workflow-contract]
+    ├── performance-auditor.md    # EDIT: + skills: [review-findings-contract, workflow-contract]
+    ├── security-auditor.md       # EDIT: + skills: [review-findings-contract, workflow-contract]
+    ├── code-reviewer.md          # EDIT: + skills: [review-findings-contract, workflow-contract]
+    ├── test-reviewer.md          # EDIT: + skills: [review-findings-contract, workflow-contract]
+    ├── review-coordinator.md     # EDIT: + skills: [workflow-contract, handoff-protocol]
+    ├── qa-tester.md              # EDIT: + skills: [qa-report-contract, workflow-contract]
+    └── developer.md              # EDIT: + skills: [workflow-contract, handoff-protocol]
+
+src/templates_bundle.ts           # REGENERATED by `deno task bundle`
+tests/                            # NEW/UPDATED: bundle-inclusion + frontmatter-wiring assertions
+```
+
+**Structure Decision**: No new source directories. The feature is template content under the existing
+`templates/core/` tree plus the build-time-regenerated `src/templates_bundle.ts`. Tests live beside
+the existing template/bundle tests under `tests/`. The exact bundled-auditor set is whatever is
+present in `templates/core/agents/` at implementation time (Phase 0 confirms `architecture-auditor`,
+`performance-auditor`, `security-auditor`, `code-reviewer`, `test-reviewer`, `review-coordinator`,
+`qa-tester`, `developer` are bundled; `a11y-auditor` / `dependency-auditor` are wired only if also
+present in the bundle).
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/.specflow/specs/012-agent-output-contracts/quickstart.md
+++ b/.specflow/specs/012-agent-output-contracts/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart — verifying the agent output contracts
+
+## What this feature delivers
+
+Four `user-invocable: false` contract skills in the bundle, and `skills:` frontmatter wiring on the
+auditor / reviewer / qa / developer agents so their output ends with a normalized, fenced block.
+
+## Build & test
+
+```bash
+cd apps/specflow-cli
+deno task bundle      # regenerate src/templates_bundle.ts with the 4 new contracts
+deno task test        # runs bundle + the new inclusion/wiring assertions
+```
+
+## Manual verification (content present)
+
+```bash
+# the four contracts exist and are non-user-invocable
+for c in workflow-contract handoff-protocol review-findings-contract qa-report-contract; do
+  grep -q "user-invocable: false" templates/core/skills/$c/SKILL.md && echo "ok $c"
+done
+
+# the bundle carries them
+grep -c "review-findings-contract" src/templates_bundle.ts   # > 0
+
+# a wired agent preloads the right contracts
+grep -A0 "skills:" templates/core/agents/security-auditor.md   # review-findings-contract, workflow-contract
+grep -A0 "skills:" templates/core/agents/qa-tester.md          # qa-report-contract, workflow-contract
+```
+
+## End-to-end (behavioural)
+
+In a project scaffolded from this bundle, dispatch a wired agent (e.g. the security-auditor over a
+small diff). Confirm its output ends with a `REVIEW SUMMARY` block whose verdict and four counts are
+explicit integers, and that the human-readable prose above it is unchanged in character. Dispatch the
+developer on a trivial change and confirm a `WORKFLOW STATUS` block (and a `HANDOFF` block iff
+`HANDOFF_TARGET ≠ none`).
+
+## Success signals
+
+- `deno task test` green, including the new contract-inclusion + agent-wiring assertions.
+- All four contracts present and `user-invocable: false`.
+- Every wired agent carries its `skills:` entries; no agent's prose output regressed.
+- `specflow init` / `specflow upgrade` in a fresh/existing project deliver the contracts (upgrade
+  preserving any team-customised files per spec 011).

--- a/.specflow/specs/012-agent-output-contracts/research.md
+++ b/.specflow/specs/012-agent-output-contracts/research.md
@@ -1,0 +1,72 @@
+# Research — Machine-readable agent output contracts
+
+Two decisions the spec deferred as implementation detail. Both resolved; no open NEEDS CLARIFICATION.
+
+## Decision 1 — How an agent "preloads" a contract
+
+**Decision**: Add a `skills:` array field to the agent's YAML frontmatter listing the contract skill
+names (e.g. `skills: [review-findings-contract, workflow-contract]`). The contract skills are
+ordinary bundled skills marked `user-invocable: false`, so they never appear as user commands but are
+loaded into the agent's context when it runs.
+
+**Rationale**: This is exactly the mechanism proven in the source `miximodel` system
+(`skills: workflow-contract, handoff-protocol, review-findings-contract` in agent frontmatter). The
+contract lives in exactly one place (the SKILL.md) and every preloading agent references it by name —
+zero duplication, single source of schema truth. `user-invocable: false` keeps the four contracts out
+of the user-facing skill list while still loadable by agents and discoverable by the future
+`/status-audit` parser.
+
+**Alternatives considered**:
+- *Inline the contract text into each agent body* — rejected: 8 copies of each block schema drift
+  apart the first time one is edited; defeats the "single schema both sides agree on" goal (FR-002).
+- *A new bespoke frontmatter field (e.g. `contracts:`)* — rejected: `skills:` is the established
+  Claude Code preload field and what miximodel uses; inventing a parallel field adds surface for no gain.
+
+## Decision 2 — Bundle inclusion and test strategy
+
+**Decision**: Author the four contracts as standard `templates/core/skills/<name>/SKILL.md` files and
+regenerate the embedded bundle with `deno task bundle`. Add assertions (under `tests/`) that (a)
+`CORE_BUNDLE` contains the four contract paths and (b) each wired agent's bundled content carries the
+expected `skills:` entries.
+
+**T001 verification result (2026-06-12)**: the generator is **NOT glob-driven**. `scripts/
+bundle-templates.ts` reads `templates/manifest.json` and only bundles the entries listed there
+(`for (const e of m.core) …`). A throwaway `templates/core/skills/_probe/SKILL.md` was added, `deno
+task bundle` run, and `grep -c _probe src/templates_bundle.ts` returned `0` — the probe was not picked
+up. The four new skill dirs therefore MUST be registered in `templates/manifest.json` as
+`{ "category": "skill", "name": "<name>", "source": "core/skills/<name>/SKILL.md" }` entries (done in
+T002–T005 / T016). The `user-invocable: false` frontmatter is preserved through bundling because
+`ensureSkillFrontmatter` only injects missing `name:`/`description:` and never strips other fields.
+
+**Rationale**: The bundle pipeline is already directory-driven (`deno task test` runs `deno task
+bundle` first, so a stale bundle can't pass CI). Asserting both the presence of the contracts and the
+agent wiring locks the two halves of the feature together — an agent can't lose its preload line, and
+a contract can't drop out of the bundle, without a red test. This directly backs SC-001 and SC-004.
+
+**Alternatives considered**:
+- *Manual bundle registration* — rejected unless Phase-0 verification shows the generator is not
+  glob-based (it is; confirmed by the existing skills all living under `templates/core/skills/`).
+- *Snapshot-test the whole bundle* — rejected: brittle; a targeted presence+wiring assertion is
+  more legible and survives unrelated bundle changes.
+
+**Verification step (implementation)**: after authoring, run `deno task bundle` and grep
+`src/templates_bundle.ts` for the four contract paths before writing the assertion, to confirm the
+generator is in fact glob-based for this tree.
+
+## Wired-agent set (confirmed present in `templates/core/agents/`)
+
+| Agent | Contracts to preload |
+|---|---|
+| architecture-auditor, performance-auditor, security-auditor, a11y-auditor, dependency-auditor | `review-findings-contract`, `workflow-contract` |
+| code-reviewer, test-reviewer | `review-findings-contract`, `workflow-contract` |
+| review-coordinator | `workflow-contract`, `handoff-protocol`, `review-findings-contract` |
+| qa-tester | `qa-report-contract`, `workflow-contract` |
+| developer | `workflow-contract`, `handoff-protocol` |
+| workflow-manager | `workflow-contract`, `handoff-protocol` |
+
+All five auditors and both reviewers are review-shaped → review-findings + workflow. The
+review-coordinator is review-shaped AND an orchestrator → it also carries `review-findings-contract`
+so its AGGREGATED `REVIEW SUMMARY` block conforms to the same schema as its seats. The developer and
+workflow-manager are work/orchestration-shaped → workflow + handoff (workflow-manager is the primary
+HANDOFF consumer/orchestrator). QA is its own shape → qa-report + workflow. No FinOps seat
+(Cloud-specific, out of scope).

--- a/.specflow/specs/012-agent-output-contracts/spec.md
+++ b/.specflow/specs/012-agent-output-contracts/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Machine-readable agent output contracts
+
+**Feature Branch**: `012-agent-output-contracts`
+**Created**: 2026-06-12
+**Status**: Draft
+**Input**: User description: "Machine-readable agent output contracts for the Specflow CLI bundled fleet (mechanism A from the miximodel audit-team port, epic mkrlabs/specflow-monorepo#12). Add four user-invocable:false contract skills to the bundled template set and wire the existing auditor/review/qa/developer agents to preload them, so their output carries normalized fenced blocks parsable by downstream tooling."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A reviewer agent emits a parsable verdict (Priority: P1)
+
+When any review or audit agent finishes its work, its final output carries a single, fixed-format `REVIEW SUMMARY` block — an explicit verdict plus severity counts — appended after its human-readable prose. A person skims the prose; a downstream skill, script, or supervisor reads the block without interpreting natural language.
+
+**Why this priority**: This is the foundational capability the whole epic stands on. Without a normalized verdict block, mechanism B (multi-seat audit synthesis) cannot merge findings across seats and mechanism C (status supervision) cannot detect a failing gate. Every other story depends on this one.
+
+**Independent Test**: Dispatch any `*-auditor` agent over a small scope; confirm its output ends with a `REVIEW SUMMARY` block whose verdict and four severity counts are explicit integers, and that the prose above it is unchanged in character from today's output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a security-auditor reviewing code with two high-severity findings, **When** it completes, **Then** its output ends with a `REVIEW SUMMARY` block carrying `REVIEW_VERDICT: fail`, `HIGH` count `2`, and the other counts as explicit integers including zero.
+2. **Given** an architecture-auditor that finds only one low-severity nit, **When** it completes, **Then** the block carries `REVIEW_VERDICT: needs_followup` (critical and high both zero, but not entirely clean).
+3. **Given** any auditor that finds nothing, **When** it completes, **Then** the block carries `REVIEW_VERDICT: pass` with all four counts `0`.
+
+---
+
+### User Story 2 - A working agent reports structured state and a precise handoff (Priority: P1)
+
+When a workflow agent (developer, review-coordinator) finishes a segment of work, it appends a `WORKFLOW STATUS` block stating where it is (in progress, blocked, awaiting review/qa, done, failed), whether its exit criteria were actually met, what changed, and who should act next. When that next actor is another agent, it also appends a `HANDOFF` block naming the target, the exact requested action, and the payload the next actor needs.
+
+**Why this priority**: Structured state is what lets an orchestrator or supervisor route work without re-reading the whole transcript, and it is the second half of the parsable-output foundation. Equal priority to Story 1 — both are prerequisites for mechanisms B and C.
+
+**Independent Test**: Dispatch the developer agent on a trivial change; confirm the output ends with a `WORKFLOW STATUS` block whose `STATE` and `HANDOFF_TARGET` are drawn from the fixed allowed values, followed by a `HANDOFF` block iff `HANDOFF_TARGET` is not `none`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the developer finishes implementing but review has not happened, **When** it reports, **Then** `STATE: awaiting_review` (never `done`) and a `HANDOFF` block targets the review-coordinator with a concrete `REQUESTED_ACTION` and the changed-file list as `PAYLOAD`.
+2. **Given** an agent cannot proceed because a prerequisite is missing, **When** it reports, **Then** `STATE: blocked`, `DONE_CRITERIA_MET: no`, the obstacle is named in `BLOCKERS`, and no `done` is emitted.
+3. **Given** an agent's assigned scope is genuinely complete with nothing downstream, **When** it reports, **Then** `STATE: done` with `HANDOFF_TARGET: none` and no `HANDOFF` block.
+
+---
+
+### User Story 3 - A QA run reports countable results (Priority: P2)
+
+When the qa-tester agent finishes a validation run, it appends a `QA SUMMARY` block with an explicit verdict (pass / fail / blocked), test counts, and a bug count, so a supervisor can tell a clean run from a real-bug run from an environment-blocked run without reading the narrative.
+
+**Why this priority**: QA is one consumer of the contract system rather than a prerequisite for the others, so it trails the two P1 foundations — but it completes the set of agent roles the downstream ledger expects.
+
+**Independent Test**: Dispatch the qa-tester on a project with a passing suite; confirm the output ends with a `QA SUMMARY` block whose verdict and numeric fields are explicit integers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a QA run where every requested check passes, **When** it reports, **Then** `QA_VERDICT: pass` with a zero bug count.
+2. **Given** a QA run that cannot execute because the environment is missing, **When** it reports, **Then** `QA_VERDICT: blocked` (distinct from `fail`).
+
+---
+
+### User Story 4 - A project that adopts a new Specflow version inherits the contracts (Priority: P2)
+
+A team running `specflow init` or `specflow upgrade` receives the four contract skills and the contract-aware agent frontmatter as part of the standard bundled fleet, with no extra opt-in step. Their agents start emitting the normalized blocks immediately.
+
+**Why this priority**: The contracts are a product capability, not a Specflow-internal convenience — their value is realized only when shipped to user projects. P2 because the format must be settled (Stories 1–3) before it is distributed.
+
+**Independent Test**: Scaffold a fresh project with the new bundle; confirm the four contract skills are present and the bundled agents carry the contract preload references.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh `specflow init`, **When** the bundle is installed, **Then** the four contract skills exist and the auditor/review/qa/developer agents reference the relevant contracts.
+2. **Given** an existing project on an older bundle, **When** it upgrades, **Then** the contract skills are added without overwriting the team's own customised files.
+
+---
+
+### Edge Cases
+
+- **A non-preloaded agent** (one not in the wired set) produces no contract block — the contracts are scoped to the named roles, not forced on every agent.
+- **An agent with nothing to hand off** omits the `HANDOFF` block entirely rather than emitting it with `TARGET: none`.
+- **A clean review** still emits a full `REVIEW SUMMARY` with explicit `0` counts — absence of findings is never expressed by an absent block.
+- **An agent claims `done` while exit criteria are unmet** — this is a contradiction the format makes detectable (`STATE: done` with `DONE_CRITERIA_MET: no`); the contract forbids it, and a downstream audit can flag any leak.
+- **A team has hand-customised one of the bundled agents** — an upgrade must not silently clobber their version while still making the contract available.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The bundle MUST provide four contract artifacts — a workflow-status contract, a handoff contract, a review-findings contract, and a QA-report contract — each marked non-user-invocable (they are agent instructions, never invoked directly by a person).
+- **FR-002**: Each contract artifact MUST document its block's exact shape: the field names, the allowed values for any enumerated field, the integer requirement for count fields, and the omit-when-empty rules — precisely enough that an author and a parser independently agree on the schema.
+- **FR-003**: The workflow-status contract MUST define a `WORKFLOW STATUS` block with fields `STATE`, `DONE_CRITERIA_MET`, `SUMMARY`, `ARTIFACTS`, `FILES_CHANGED`, `VALIDATION`, `BLOCKERS`, `NEXT_ACTION`, `HANDOFF_TARGET`, and constrain `STATE` to a fixed set (in progress, blocked, awaiting review, awaiting qa, awaiting user, done, failed).
+- **FR-004**: The handoff contract MUST define a `HANDOFF` block with fields `TARGET`, `REASON`, `REQUESTED_ACTION`, `PAYLOAD`, `OPEN_RISKS`, emitted only when the workflow-status `HANDOFF_TARGET` is not `none`, and require `TARGET` to match that `HANDOFF_TARGET`.
+- **FR-005**: The review-findings contract MUST define a `REVIEW SUMMARY` block with a `REVIEW_VERDICT` constrained to {pass, fail, needs_followup}, explicit integer counts for Critical / High / Medium / Low, a top-issues summary, and a recommendation; and MUST define the verdict rule: `pass` only when Critical and High are both zero, `fail` when either is non-zero, `needs_followup` when only Medium/Low remain.
+- **FR-006**: The QA-report contract MUST define a `QA SUMMARY` block with a `QA_VERDICT` constrained to {pass, fail, blocked}, explicit integer test counts and bug count, and a recommendation.
+- **FR-007**: Every count / numeric field across all contracts MUST be an explicit integer including zero — never blank, never "none" for a number.
+- **FR-008**: The bundled agents MUST be wired to preload the relevant contracts so the blocks are produced automatically: every `*-auditor` agent carries the review-findings and workflow-status contracts; the review-coordinator carries the workflow-status and handoff contracts; the qa-tester carries the QA-report and workflow-status contracts; the developer carries the workflow-status and handoff contracts.
+- **FR-009**: Contract output MUST be additive — appended after the agent's existing human-readable prose at end of turn — and MUST NOT replace or suppress that prose. No wired agent's existing behaviour regresses.
+- **FR-010**: A contract block MUST appear at most once per agent turn, in a fixed position (after the prose; handoff after workflow-status when both apply).
+- **FR-011**: The contracts and the contract-aware agents MUST ship through the standard distribution path so a project gains them via `specflow init` (fresh) and `specflow upgrade` (existing), the latter without clobbering files the team has marked as their own.
+
+### Key Entities *(see Domain Model section below for full structure)*
+
+- **Contract**: a named, non-user-invocable instruction set that defines one normalized output block's schema and the rules for filling it.
+- **Status block**: the fenced, fixed-format text an agent appends — an instance of a contract's schema (`WORKFLOW STATUS`, `HANDOFF`, `REVIEW SUMMARY`, `QA SUMMARY`).
+- **Wired agent**: an existing bundled agent declared to preload one or more contracts, thereby obligated to emit their blocks.
+
+## Domain Model *(mandatory)*
+
+**Bounded context:** Agent Output Contracts — the schema layer that makes Specflow agent output machine-readable, sitting between the agents that produce work and the skills/scripts that supervise it.
+
+**Vocabulary (Ubiquitous language):**
+
+- **Contract** — a non-user-invocable skill whose sole job is to instruct a preloading agent to emit one normalized block. It is documentation-of-schema, not executable logic.
+- **Block** — the fenced, fixed-shape text an agent appends at end of turn (`WORKFLOW STATUS`, `HANDOFF`, `REVIEW SUMMARY`, `QA SUMMARY`).
+- **Preload** — the declarative link by which an agent commits to a contract, so the contract's instructions are in force every time that agent runs.
+- **Wired agent** — a bundled agent that preloads at least one contract.
+- **Verdict** — the single enumerated field (`REVIEW_VERDICT`, `QA_VERDICT`) that summarizes a gate's outcome.
+- **Handoff target** — the next actor named by an agent; `none` when work terminates with that agent.
+
+**Entities (have identity):**
+
+- **Contract** [aggregate root] — identified by its name (`workflow-contract`, `handoff-protocol`, `review-findings-contract`, `qa-report-contract`). Owns its block's schema and fill rules. Source of truth for both producers (agents) and future consumers (parsers).
+- **Wired agent** — identified by its agent name; holds the set of contracts it preloads. Existing entity; this feature adds the preload links and the obligation, not the agent.
+
+**Value objects (no identity, immutable):**
+
+- **Block(fields…)** — one emitted instance of a contract; meaningful only by its content, interchangeable if identical.
+- **Verdict(value)** — constrained to its contract's allowed set; enforces the verdict-derivation rule (e.g. review `pass` ⇒ Critical = High = 0).
+- **SeverityCounts(critical, high, medium, low)** — four non-negative integers; the review verdict is a function of them.
+
+**Invariants (rules the domain must never break):**
+
+- A `REVIEW_VERDICT: pass` requires Critical and High counts both zero — verdict and counts can never contradict.
+- An agent must not emit `STATE: done` while `DONE_CRITERIA_MET: no`.
+- A `HANDOFF` block exists iff `HANDOFF_TARGET` ≠ `none`, and its `TARGET` equals that `HANDOFF_TARGET`.
+- Every numeric field is an explicit integer (including 0); never blank.
+- A block is additive: it never removes or replaces the agent's prose, and appears at most once per turn.
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- **Status supervision (mechanism C, epic issue #381)** — parses and consumes these blocks (status ledger + `/status-audit`). This feature only guarantees the blocks are produced to a fixed schema; it reads nothing.
+- **Multi-seat audit synthesis (mechanism B, epic issue #379)** — aggregates `REVIEW SUMMARY` blocks across parallel seats; depends on this schema but is built separately.
+- **Cloud / Mobile agent fleets** — only the CLI bundled fleet is wired here.
+- **FinOps cost-projection seat** — Cloud-specific; not part of this port.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of the wired agents (every `*-auditor`, review-coordinator, qa-tester, developer) emit their declared contract block(s) on a representative dispatch — zero wired agents produce prose-only output.
+- **SC-002**: A reader given only a contract's documentation and an emitted block can confirm the block is well-formed (every required field present, every enumerated value in range, every count an integer) with no judgement calls — the schema is unambiguous.
+- **SC-003**: Across a sample of dispatches, zero blocks violate an invariant (no `pass`-with-findings, no `done`-with-unmet-criteria, no handoff/target mismatch).
+- **SC-004**: A freshly scaffolded project and an upgraded existing project both contain the four contracts and contract-aware agents, and the upgrade preserves any team-customised files.
+- **SC-005**: The wired agents' existing human-readable output is unchanged in substance — the contracts add a trailing block and nothing else (no regression in the prose review/QA/work summaries teams rely on).
+
+## Assumptions
+
+- The contract format is ported faithfully from the proven `miximodel` system; field names and allowed values follow that source unless a Specflow-specific role name differs (e.g. handoff targets are Specflow's agent names).
+- Contracts are scoped to the named agent roles, not applied globally — agents outside the wired set intentionally produce no blocks.
+- "Preload" is expressed through the existing bundled-agent definition mechanism (a frontmatter declaration on the agent), consistent with how miximodel wires it; the exact field is an implementation detail for the plan.
+- Distribution reuses Specflow's existing `init` / `upgrade` bundling and the established customisation-preservation behaviour (spec 011); this feature adds files to the bundle and does not change the upgrade machinery.
+- Downstream consumers (mechanisms B and C) are built later against this schema; this feature is complete when the blocks are produced correctly, independent of any consumer existing yet.

--- a/.specflow/specs/012-agent-output-contracts/tasks.md
+++ b/.specflow/specs/012-agent-output-contracts/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Machine-readable agent output contracts
+
+**Feature**: `012-agent-output-contracts` | **Branch**: `012-agent-output-contracts` | **Issue**: mkrlabs/specflow#378 (epic mkrlabs/specflow-monorepo#12)
+**Inputs**: [plan.md](./plan.md) · [spec.md](./spec.md) · [data-model.md](./data-model.md) · [research.md](./research.md) · contracts/{workflow-status,handoff,review-summary,qa-summary}.md
+
+Content-first feature: the four `contracts/*.md` files in this spec dir are the canonical block
+schemas — each SKILL.md embeds its block format verbatim from there. Distribution is asserted by
+tests run under `deno task test` (which runs `deno task bundle` first, so a stale bundle fails CI).
+All assertions hermetic — read the in-repo `templates/core/` tree and `CORE_BUNDLE`; no network.
+
+---
+
+## Phase 1: Setup / verify the bundle is glob-driven
+
+- [ ] T001 Confirm the bundle generator picks up net-new skill dirs automatically: add a throwaway
+      `templates/core/skills/_probe/SKILL.md`, run `deno task bundle`, grep `src/templates_bundle.ts`
+      for `_probe`, then delete the probe + re-bundle. Record the result in research.md Decision 2. If
+      NOT glob-driven, note the manual-registration point in `scripts/bundle-templates.ts` for T010.
+
+## Phase 2: Foundational — author the four contracts (blocking; everything else preloads these)
+
+- [ ] T002 [P] Create `templates/core/skills/workflow-contract/SKILL.md` — frontmatter
+      `name: workflow-contract`, `description:` (one line), `user-invocable: false`; body embeds the
+      `WORKFLOW STATUS` format + rules from `contracts/workflow-status.md` (FR-003, FR-007, FR-010).
+- [ ] T003 [P] Create `templates/core/skills/handoff-protocol/SKILL.md` — `user-invocable: false`;
+      body embeds the `HANDOFF` format + rules from `contracts/handoff.md` (FR-004).
+- [ ] T004 [P] Create `templates/core/skills/review-findings-contract/SKILL.md` —
+      `user-invocable: false`; body embeds the `REVIEW SUMMARY` format + verdict rules from
+      `contracts/review-summary.md` (FR-005, FR-007).
+- [ ] T005 [P] Create `templates/core/skills/qa-report-contract/SKILL.md` — `user-invocable: false`;
+      body embeds the `QA SUMMARY` format + rules from `contracts/qa-summary.md` (FR-006, FR-007).
+
+## Phase 3: US1 + US2 + US3 — wire the agents (preload contracts via `skills:` frontmatter)
+
+Each task adds a `skills:` array to the agent's existing YAML frontmatter; no other frontmatter or
+body change. Additive only (FR-008, FR-009). All `[P]` — distinct files.
+
+- [ ] T006 [P] [US1] `templates/core/agents/architecture-auditor.md` → `skills: [review-findings-contract, workflow-contract]`
+- [ ] T007 [P] [US1] `templates/core/agents/performance-auditor.md` → same pair
+- [ ] T008 [P] [US1] `templates/core/agents/security-auditor.md` → same pair
+- [ ] T009 [P] [US1] `templates/core/agents/a11y-auditor.md` → same pair
+- [ ] T010 [P] [US1] `templates/core/agents/dependency-auditor.md` → same pair
+- [ ] T011 [P] [US1] `templates/core/agents/code-reviewer.md` → same pair
+- [ ] T012 [P] [US1] `templates/core/agents/test-reviewer.md` → same pair
+- [ ] T013 [P] [US2] `templates/core/agents/review-coordinator.md` → `skills: [workflow-contract, handoff-protocol]`
+- [ ] T014 [P] [US2] `templates/core/agents/developer.md` → `skills: [workflow-contract, handoff-protocol]`
+- [ ] T015 [P] [US3] `templates/core/agents/qa-tester.md` → `skills: [qa-report-contract, workflow-contract]`
+
+## Phase 4: Distribution — regenerate the bundle
+
+- [ ] T016 Run `deno task bundle`; confirm `src/templates_bundle.ts` now contains the four contract
+      paths and the updated agent contents. (If T001 found the generator is not glob-driven, register
+      the four skill dirs first.)
+
+## Phase 5: Tests — lock the two halves together (US1–US4)
+
+- [ ] T017 [P] Add `tests/templates/agent_output_contracts_test.ts`:
+      (a) the four contracts are in `CORE_BUNDLE` and each carries `user-invocable: false`;
+      (b) each wired agent's bundled content carries the expected `skills:` entries (table from
+      research.md). Backs SC-001, SC-004.
+- [ ] T018 [P] Add a schema-self-consistency assertion: each contract SKILL.md body contains its
+      fenced block header (`WORKFLOW STATUS` / `HANDOFF` / `REVIEW SUMMARY` / `QA SUMMARY`) and the
+      verdict-rule lines, so the schema text can't silently drift from the spec contracts (FR-002).
+- [ ] T019 Run the full `deno task test` suite; confirm green with zero regressions to existing
+      template/bundle tests (FR-009, SC-005).
+
+## Phase 6: Polish
+
+- [ ] T020 Update the bundled `using-specflow` skill registry (and any agent-fleet doc) to mention
+      the four contracts as `user-invocable: false` preloaded skills, so the fleet listing stays
+      accurate. No behavioural change.
+- [ ] T021 Sanity-check `specflow upgrade` path mentally against spec 011: the four new skills are
+      net-new files (added, not overwriting), and no wired agent that a team may have customised is
+      clobbered (added `skills:` line only lands on the bundled version; customised copies are
+      preserved). Document the conclusion in quickstart.md if any caveat surfaces.
+
+---
+
+## Dependencies / parallelism
+
+- T002–T005 (contracts) block T006–T015 (wiring references them) and T016 (bundle).
+- T006–T015 are mutually parallel (distinct agent files).
+- T016 (bundle) blocks T017–T019 (tests read the bundle).
+- T020–T021 are polish, after green tests.
+
+## MVP / increment boundary
+
+US1 (REVIEW SUMMARY on auditors/reviewers) alone is a shippable increment: T002+T004, T006–T012, T016,
+T017, T019. US2/US3 layer on the workflow/handoff/QA shapes. US4 (distribution) is satisfied by the
+bundle regen + tests covering init/upgrade inclusion.

--- a/plugin/agents/a11y-auditor.md
+++ b/plugin/agents/a11y-auditor.md
@@ -3,6 +3,7 @@ name: a11y-auditor
 description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: cyan
 disable-model-invocation: true
@@ -40,8 +41,9 @@ CLI-only project is a no-op by design.
 
 Spawned by the `review-coordinator` during `/specflow review`. Review
 ONLY the files provided in the prompt (and only if they include FE
-source — otherwise skip per the gate above). Output the
-`FINDING` / `VERDICT` structure used by code-reviewer.
+source — otherwise skip per the gate above). Output the `FINDING`
+structure used by code-reviewer, followed by the canonical
+`REVIEW SUMMARY` block (see "Output format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -178,4 +180,9 @@ backlog material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: a11y-auditor`,
+`REVIEW_VERDICT: pass | fail | needs_followup`, the four severity counts,
+`TOP_ISSUES`, `RECOMMENDATION`), then the `WORKFLOW STATUS` block per
+`workflow-contract`. Audit-mode (Mode 2) emits neither block.

--- a/plugin/agents/architecture-auditor.md
+++ b/plugin/agents/architecture-auditor.md
@@ -3,6 +3,7 @@ name: architecture-auditor
 description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: blue
 disable-model-invocation: true
@@ -14,8 +15,9 @@ depending on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
-the files provided in the prompt. Output the `FINDING` / `VERDICT` structure
-used by code-reviewer.
+the files provided in the prompt. Output the `FINDING` structure used by
+code-reviewer, followed by the canonical `REVIEW SUMMARY` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -157,17 +159,31 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
-finding as:
+Same `FINDING` structure as code-reviewer. Format each finding as:
 
 ```
 FINDING <severity>: <one-line summary>
   Path: <file:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
-
-VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
 ```
 
-Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
-omits VERDICT — backlog material is not pass/fail.
+After the findings, emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`:
+
+```
+REVIEW SUMMARY
+REVIEW_SCOPE: architecture-auditor
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` and `HIGH_COUNT == 0`;
+`fail` when either is > 0; `needs_followup` when only Medium/Low remain. Then
+emit the `WORKFLOW STATUS` block per `workflow-contract`. Audit-mode (Mode 2)
+emits neither block — backlog material is not pass/fail.

--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -3,6 +3,7 @@ name: code-reviewer
 description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 ---
@@ -38,10 +39,21 @@ FINDING
   suggestion: <one sentence, actionable>
 ```
 
-End with a single-line verdict:
+After the findings, emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`:
 
 ```
-VERDICT: PASS | FAIL (<N> CRITICAL, <M> HIGH)
+REVIEW SUMMARY
+REVIEW_SCOPE: code-reviewer
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
 ```
 
-PASS if zero CRITICAL and zero HIGH findings. Otherwise FAIL.
+`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` and `HIGH_COUNT == 0`;
+`fail` when either is > 0; `needs_followup` when only Medium/Low remain. Then
+emit the `WORKFLOW STATUS` block per `workflow-contract`.

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -3,6 +3,7 @@ name: dependency-auditor
 description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: magenta
 disable-model-invocation: true
@@ -15,8 +16,9 @@ depending on the dispatch shape.
 
 Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
 the files provided in the prompt (typically dependency manifests +
-lockfiles touched by the diff). Output the `FINDING` / `VERDICT` structure
-used by code-reviewer.
+lockfiles touched by the diff). Output the `FINDING` structure used by
+code-reviewer, followed by the canonical `REVIEW SUMMARY` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -209,17 +211,31 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
-finding as:
+Same `FINDING` structure as code-reviewer. Format each finding as:
 
 ```
 FINDING <severity>: <one-line summary>
   Path: <manifest:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
-
-VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
 ```
 
-Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
-omits VERDICT — backlog material is not pass/fail.
+After the findings, emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`:
+
+```
+REVIEW SUMMARY
+REVIEW_SCOPE: dependency-auditor
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` and `HIGH_COUNT == 0`;
+`fail` when either is > 0; `needs_followup` when only Medium/Low remain. Then
+emit the `WORKFLOW STATUS` block per `workflow-contract`. Audit-mode (Mode 2)
+emits neither block — backlog material is not pass/fail.

--- a/plugin/agents/developer.md
+++ b/plugin/agents/developer.md
@@ -3,6 +3,7 @@ name: developer
 description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: workflow-contract, handoff-protocol
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
@@ -95,20 +96,17 @@ For each task assigned:
 
 ## Completion report format
 
+End your turn with a human-facing summary, then the machine-readable status
+block. The human-facing summary captures the reasoning the status block does
+not:
+
 ```
 TASK <id or name>
-Status: DONE | BLOCKED
-
-Files changed
-  - <path>:<lines or new>
 
 Decisions
   - <why X over Y>
   - (if applicable) Bootstrapped <test runner> because the project had
     no test infra
-
-Validation run
-  - <command>: <result>
 
 Tech debt surfaced (Boy Scout — too big to fix in scope)
   - <one-liner> @ <path>:<line> — reason it's too big
@@ -116,10 +114,15 @@ Tech debt surfaced (Boy Scout — too big to fix in scope)
 
 Risks / follow-ups
   - <…>
-
-Next owner
-  - <reviewer | qa | user | product-owner (if tech-debt items present)>
 ```
 
-Never report done if a validation failed. If blocked, say what you tried, what
-failed, and what decision the next owner needs to make.
+Do NOT define a separate status block here. The authoritative machine-readable
+status is the `WORKFLOW STATUS` block from the preloaded `workflow-contract`
+(it carries `STATE`, `DONE_CRITERIA_MET`, `FILES_CHANGED`, `VALIDATION`,
+`BLOCKERS`, `NEXT_ACTION`, `HANDOFF_TARGET`) — emit exactly one such block
+after the summary above, and a `HANDOFF` block per `handoff-protocol` whenever
+`HANDOFF_TARGET ≠ none`.
+
+Never report `STATE: done` if a validation failed (use `blocked` / `failed`).
+If blocked, say what you tried, what failed, and what decision the next owner
+needs to make in the prose and the `BLOCKERS` field.

--- a/plugin/agents/performance-auditor.md
+++ b/plugin/agents/performance-auditor.md
@@ -3,6 +3,7 @@ name: performance-auditor
 description: Reviews code for performance issues — N+1 queries, blocking I/O on hot paths, missing indexes, cache misuse, hot-path allocation, sync-in-async, large bundles, render-thrash. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit performance).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 disable-model-invocation: true
@@ -14,8 +15,9 @@ on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
-the files provided in the prompt. Output the `FINDING` / `VERDICT` structure
-used by code-reviewer.
+the files provided in the prompt. Output the `FINDING` structure used by
+code-reviewer, followed by the canonical `REVIEW SUMMARY` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -141,4 +143,9 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: performance-auditor`,
+`REVIEW_VERDICT: pass | fail | needs_followup`, the four severity counts,
+`TOP_ISSUES`, `RECOMMENDATION`), then the `WORKFLOW STATUS` block per
+`workflow-contract`. Audit-mode (Mode 2) emits neither block.

--- a/plugin/agents/qa-tester.md
+++ b/plugin/agents/qa-tester.md
@@ -3,6 +3,7 @@ name: qa-tester
 description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: qa-report-contract, workflow-contract
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
@@ -33,19 +34,9 @@ P2. Unit tests for services, domain logic, and validators.
 
 ## Required report
 
-```
-QA SUMMARY
-  Tests added: <count>
-  Tests modified: <count>
-
-  Coverage deltas
-    - <area>: <before → after>
-
-  Suite result
-    passed: <N>
-    failed: <M>
-    skipped: <K>
-
-  Bugs found (route to developer)
-    - <…>
-```
+After your prose, emit exactly one `QA SUMMARY` block as defined by the
+preloaded `qa-report-contract` skill (it is the single authoritative schema:
+`QA_SCOPE`, `QA_VERDICT: pass | fail | blocked`, the test counts, `BUGS_FOUND`,
+`QA_RECOMMENDATION`). Then emit the `WORKFLOW STATUS` block per
+`workflow-contract`. Route any bug found to the developer via the
+`HANDOFF_TARGET`/`NEXT_ACTION` fields of the workflow block.

--- a/plugin/agents/review-coordinator.md
+++ b/plugin/agents/review-coordinator.md
@@ -3,6 +3,7 @@ name: review-coordinator
 description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
+skills: workflow-contract, handoff-protocol, review-findings-contract
 maxTurns: 30
 color: purple
 ---
@@ -24,11 +25,15 @@ in parallel and aggregate results.
 3. Wait for all three (or two) to complete.
 4. Aggregate findings by severity. Collapse duplicates (same file:line from two
    agents = one finding with both attributions).
-5. Produce the report using this exact block:
+5. Produce the report in two parts: a human-facing per-seat roll-up, then the
+   single canonical `REVIEW SUMMARY` block carrying the AGGREGATED counts across
+   all seats.
+
+### Per-seat roll-up (human-facing)
 
 ```
-REVIEW SUMMARY
-  code-reviewer      : <PASS | N CRIT, M HIGH, K MED, L LOW>
+PER-SEAT ROLL-UP
+  code-reviewer      : <pass | N CRIT, M HIGH, K MED, L LOW>
   security-auditor   : <…>
   test-reviewer      : <… | SKIPPED>
 
@@ -42,7 +47,32 @@ HIGH findings:
 MEDIUM / LOW findings: <N>, list suppressed — see per-agent reports for details.
 ```
 
+### Aggregated REVIEW SUMMARY block (canonical)
+
+Emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`. Its counts are the SUM of every seat's findings
+(after de-duplication); its verdict is derived from those aggregated counts:
+
+```
+REVIEW SUMMARY
+REVIEW_SCOPE: review gate (aggregated across code-reviewer, security-auditor, test-reviewer)
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer — summed across seats>
+HIGH_COUNT: <integer — summed across seats>
+MEDIUM_COUNT: <integer — summed across seats>
+LOW_COUNT: <integer — summed across seats>
+TOP_ISSUES: <up to 5 lines — the highest-severity findings | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+`REVIEW_VERDICT: pass` only when aggregated `CRITICAL_COUNT == 0` and
+`HIGH_COUNT == 0`; `fail` when either is > 0; `needs_followup` when only
+Medium/Low remain. Then emit the `WORKFLOW STATUS` block per `workflow-contract`
+and, when handing the gate result back, the `HANDOFF` block per
+`handoff-protocol`.
+
 ## Rules
 
-- Never emit freeform prose outside the structured block.
+- The roll-up and the `REVIEW SUMMARY` block are the only structured output;
+  keep any prose minimal.
 - Never edit files yourself — you coordinate, you do not fix.

--- a/plugin/agents/security-auditor.md
+++ b/plugin/agents/security-auditor.md
@@ -3,6 +3,7 @@ name: security-auditor
 description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: red
 ---
@@ -13,8 +14,9 @@ on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specflow review`. Review
-ONLY the files provided in the prompt. Output the `FINDING` / `VERDICT`
-structure used by code-reviewer.
+ONLY the files provided in the prompt. Output the `FINDING` structure
+used by code-reviewer, followed by the canonical `REVIEW SUMMARY` block
+(see "Output format (Mode 1)" below).
 
 ### Always-check rules
 
@@ -118,4 +120,11 @@ End with a `VERDICT` line: `clean` (all alerts dismissed or ticketed),
 
 ## Output format (Mode 1)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: security-auditor`,
+`REVIEW_VERDICT: pass | fail | needs_followup`, the four severity counts,
+`TOP_ISSUES`, `RECOMMENDATION`), then the `WORKFLOW STATUS` block per
+`workflow-contract`. (Mode 2 alert triage keeps its own
+`VERDICT: clean | escalation_needed | error` line — it is not a PR review
+and is out of scope for the review-findings-contract.)

--- a/plugin/agents/test-reviewer.md
+++ b/plugin/agents/test-reviewer.md
@@ -3,6 +3,7 @@ name: test-reviewer
 description: Reviews test coverage and quality for changed code. Spawned by the review-coordinator when the diff contains test files.
 model: sonnet
 tools: Read, Grep, Glob
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 ---
@@ -27,4 +28,8 @@ referenced against the implementation files they cover.
 
 ## Output format
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: test-reviewer`, `REVIEW_VERDICT: pass | fail | needs_followup`,
+the four severity counts, `TOP_ISSUES`, `RECOMMENDATION`), then the
+`WORKFLOW STATUS` block per `workflow-contract`.

--- a/plugin/agents/workflow-manager.md
+++ b/plugin/agents/workflow-manager.md
@@ -3,6 +3,7 @@ name: workflow-manager
 description: Orchestrates multi-phase feature delivery across specialist agents. Use as the lead session agent for long-running implementations.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
+skills: workflow-contract, handoff-protocol
 maxTurns: 60
 color: purple
 ---
@@ -52,3 +53,13 @@ Every delegated phase must end with a structured report. If an agent claims
 
 Blocked? Report owner, blocker, impact, and the exact decision needed. If
 review or QA fails twice on the same issue family, stop and escalate.
+
+## Output format
+
+You are the primary HANDOFF orchestrator. When you delegate a phase or
+escalate, end your turn with exactly one `WORKFLOW STATUS` block per the
+preloaded `workflow-contract` (set `HANDOFF_TARGET` to the specialist you are
+delegating to, or `user` when escalating), followed by a `HANDOFF` block per
+`handoff-protocol` whenever `HANDOFF_TARGET ≠ none`. Read the structured
+blocks delegated agents return and reconcile them against the phase gate
+before advancing.

--- a/plugin/skills/handoff-protocol/SKILL.md
+++ b/plugin/skills/handoff-protocol/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: handoff-protocol
+description: Defines the machine-readable HANDOFF block emitted right after WORKFLOW STATUS whenever an agent hands work to another actor. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# handoff-protocol
+
+This skill defines the **HANDOFF** block. Agents that preload it (`developer`,
+`review-coordinator`, `workflow-manager`) emit it **immediately after the
+WORKFLOW STATUS block, and only when** that block's `HANDOFF_TARGET` is not
+`none`. It gives the next actor a precise, executable instruction plus the
+concrete payload they need, so the handoff requires no re-derivation of intent.
+The block is additive — it appends to the prose, never replaces it.
+
+Agents that hand off but do NOT preload this contract (e.g. `qa-tester`, which
+routes bugs to the developer) signal the target through the WORKFLOW STATUS
+`HANDOFF_TARGET` field rather than emitting a full HANDOFF block — they carry
+`workflow-contract` but not `handoff-protocol` by design.
+
+## Format
+
+```text
+HANDOFF
+TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user
+REASON: <one sentence>
+REQUESTED_ACTION: <one imperative sentence — executable without reinterpretation>
+PAYLOAD: <concrete filenames, ids, findings, spec ids the next actor needs>
+OPEN_RISKS: <comma list | none>
+```
+
+## Rules
+
+- Block exists **iff** `HANDOFF_TARGET ≠ none`; if there is no real handoff, omit it entirely.
+- `TARGET` must equal the WORKFLOW STATUS `HANDOFF_TARGET`.
+- `REQUESTED_ACTION` is precise enough to execute without re-deriving intent.
+- `PAYLOAD` names concrete artifacts, never vague references.

--- a/plugin/skills/qa-report-contract/SKILL.md
+++ b/plugin/skills/qa-report-contract/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: qa-report-contract
+description: Defines the machine-readable QA SUMMARY block the qa-tester emits once after its prose, with test counts and a verdict. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# qa-report-contract
+
+This skill defines the **QA SUMMARY** block. The agent that preloads it
+(`qa-tester`) emits exactly one such block **after its prose** (and before the
+WORKFLOW STATUS block, since `qa-tester` also carries `workflow-contract`). It
+normalizes the QA pass's test counts, bug count, and verdict so downstream
+tooling can gate on QA results without parsing the prose. The block is additive
+— it appends to the prose, never replaces it.
+
+## Format
+
+```text
+QA SUMMARY
+QA_SCOPE: <one sentence>
+QA_VERDICT: pass | fail | blocked
+NEW_UNIT_TESTS: <integer>
+NEW_FUNCTIONAL_TESTS: <integer>
+NEW_BROWSER_TESTS: <integer>
+TOTAL_PASS_COUNT: <integer>
+TOTAL_FAIL_COUNT: <integer>
+BUGS_FOUND: <integer>
+QA_RECOMMENDATION: <one sentence>
+```
+
+## Rules
+
+- `QA_VERDICT: pass` only when the requested QA scope is complete **and** `TOTAL_FAIL_COUNT == 0`.
+- `QA_VERDICT: fail` when tests exposed real product bugs or failing automation.
+- `QA_VERDICT: blocked` when QA could not run (missing environment/prereqs) — distinct from `fail`.
+- Every numeric field is an explicit integer, including `0`.
+- `BUGS_FOUND` counts product issues / failing flows, not stylistic concerns.

--- a/plugin/skills/review-findings-contract/SKILL.md
+++ b/plugin/skills/review-findings-contract/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: review-findings-contract
+description: Defines the machine-readable REVIEW SUMMARY block every auditor/reviewer emits once after its prose, with severity counts and a verdict. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# review-findings-contract
+
+This skill defines the **REVIEW SUMMARY** block. Agents that preload it
+(`architecture-auditor`, `performance-auditor`, `security-auditor`,
+`a11y-auditor`, `dependency-auditor`, `code-reviewer`, `test-reviewer`, and the
+`review-coordinator`) emit exactly one such block **after their prose** (and
+before the WORKFLOW STATUS block when the agent also carries `workflow-contract`).
+It normalizes the review's severity counts and verdict so a coordinator can
+synthesize multiple seats' findings without re-reading each prose report. The
+`review-coordinator` emits the same block with the **aggregated** counts summed
+across every seat. The block is additive — it appends to the prose, never
+replaces it.
+
+## Format
+
+```text
+REVIEW SUMMARY
+REVIEW_SCOPE: <reviewer name or gate scope>
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+## Rules
+
+- `REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` **and** `HIGH_COUNT == 0`.
+- `REVIEW_VERDICT: fail` when `CRITICAL_COUNT > 0` **or** `HIGH_COUNT > 0`.
+- `REVIEW_VERDICT: needs_followup` when only Medium/Low findings remain.
+- Every count is an explicit integer, including `0`.
+- Verdict and counts must never contradict.

--- a/plugin/skills/using-specflow/SKILL.md
+++ b/plugin/skills/using-specflow/SKILL.md
@@ -47,6 +47,13 @@ not re-read the file with `Read`.
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |
 
+**Preloaded output-contract skills** (`user-invocable: false` — never invoke
+directly): `workflow-contract`, `handoff-protocol`, `review-findings-contract`,
+`qa-report-contract`. These define the machine-readable `WORKFLOW STATUS` /
+`HANDOFF` / `REVIEW SUMMARY` / `QA SUMMARY` blocks. They are loaded into an
+agent's context via the agent's `skills:` frontmatter (see the agent registry
+below) and never appear as user commands.
+
 ## Specflow agent registry
 
 Dispatch these via `Task({ subagent_type: "<name>", ... })` (or your

--- a/plugin/skills/workflow-contract/SKILL.md
+++ b/plugin/skills/workflow-contract/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: workflow-contract
+description: Defines the machine-readable WORKFLOW STATUS block every workflow-shaped agent emits once at end of turn. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# workflow-contract
+
+This skill defines the **WORKFLOW STATUS** block. Agents that preload it
+(`developer`, `review-coordinator`, `workflow-manager`, `qa-tester`, and all
+five auditors + both reviewers via this contract) emit exactly one such block at
+the **end of their turn, after the prose**. The block is additive — it never replaces the prose narrative; it
+appends a normalized, fenced, machine-readable summary that downstream tooling
+(audit synthesis, the status ledger, `/status-audit`) can parse without
+re-reading the prose.
+
+## Format
+
+```text
+WORKFLOW STATUS
+STATE: in_progress | blocked | awaiting_review | awaiting_qa | awaiting_user | done | failed
+DONE_CRITERIA_MET: yes | no
+SUMMARY: <one sentence — outcome, not effort>
+ARTIFACTS: <comma list | none>
+FILES_CHANGED: <comma list | none>
+VALIDATION: <comma list of "command (result)" | none>
+BLOCKERS: <one sentence | none>
+NEXT_ACTION: <one sentence>
+HANDOFF_TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user | none
+```
+
+## Rules
+
+- Exactly one block per turn; never replaces prose (additive).
+- `STATE: done` only when assigned exit criteria are met; otherwise use `awaiting_review` /
+  `awaiting_qa` / `blocked`. Never `done` with `DONE_CRITERIA_MET: no`.
+- `FILES_CHANGED: none` for read-only agents (auditors/reviewers).
+- `VALIDATION` is explicit, e.g. `deno task test (pass)`.
+- `HANDOFF_TARGET: none` when work terminates here.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5122,6 +5122,13 @@ not re-read the file with \`Read\`.
 | \`specflow-auto\` | Auto-chain orchestration (legacy entry point — most users invoke \`/specflow specify\` instead). |
 | \`specflow-review\` | Auto-invoke alias preserved for the \`/specflow review\` phase. |
 
+**Preloaded output-contract skills** (\`user-invocable: false\` — never invoke
+directly): \`workflow-contract\`, \`handoff-protocol\`, \`review-findings-contract\`,
+\`qa-report-contract\`. These define the machine-readable \`WORKFLOW STATUS\` /
+\`HANDOFF\` / \`REVIEW SUMMARY\` / \`QA SUMMARY\` blocks. They are loaded into an
+agent's context via the agent's \`skills:\` frontmatter (see the agent registry
+below) and never appear as user commands.
+
 ## Specflow agent registry
 
 Dispatch these via \`Task({ subagent_type: "<name>", ... })\` (or your
@@ -6211,6 +6218,195 @@ This skill does not:
     skipIfExists: false,
   },
   {
+    category: "skill",
+    name: "workflow-contract",
+    suffix: null,
+    content: `---
+name: workflow-contract
+description: Defines the machine-readable WORKFLOW STATUS block every workflow-shaped agent emits once at end of turn. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# workflow-contract
+
+This skill defines the **WORKFLOW STATUS** block. Agents that preload it
+(\`developer\`, \`review-coordinator\`, \`workflow-manager\`, \`qa-tester\`, and all
+five auditors + both reviewers via this contract) emit exactly one such block at
+the **end of their turn, after the prose**. The block is additive — it never replaces the prose narrative; it
+appends a normalized, fenced, machine-readable summary that downstream tooling
+(audit synthesis, the status ledger, \`/status-audit\`) can parse without
+re-reading the prose.
+
+## Format
+
+\`\`\`text
+WORKFLOW STATUS
+STATE: in_progress | blocked | awaiting_review | awaiting_qa | awaiting_user | done | failed
+DONE_CRITERIA_MET: yes | no
+SUMMARY: <one sentence — outcome, not effort>
+ARTIFACTS: <comma list | none>
+FILES_CHANGED: <comma list | none>
+VALIDATION: <comma list of "command (result)" | none>
+BLOCKERS: <one sentence | none>
+NEXT_ACTION: <one sentence>
+HANDOFF_TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user | none
+\`\`\`
+
+## Rules
+
+- Exactly one block per turn; never replaces prose (additive).
+- \`STATE: done\` only when assigned exit criteria are met; otherwise use \`awaiting_review\` /
+  \`awaiting_qa\` / \`blocked\`. Never \`done\` with \`DONE_CRITERIA_MET: no\`.
+- \`FILES_CHANGED: none\` for read-only agents (auditors/reviewers).
+- \`VALIDATION\` is explicit, e.g. \`deno task test (pass)\`.
+- \`HANDOFF_TARGET: none\` when work terminates here.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
+    name: "handoff-protocol",
+    suffix: null,
+    content: `---
+name: handoff-protocol
+description: Defines the machine-readable HANDOFF block emitted right after WORKFLOW STATUS whenever an agent hands work to another actor. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# handoff-protocol
+
+This skill defines the **HANDOFF** block. Agents that preload it (\`developer\`,
+\`review-coordinator\`, \`workflow-manager\`) emit it **immediately after the
+WORKFLOW STATUS block, and only when** that block's \`HANDOFF_TARGET\` is not
+\`none\`. It gives the next actor a precise, executable instruction plus the
+concrete payload they need, so the handoff requires no re-derivation of intent.
+The block is additive — it appends to the prose, never replaces it.
+
+Agents that hand off but do NOT preload this contract (e.g. \`qa-tester\`, which
+routes bugs to the developer) signal the target through the WORKFLOW STATUS
+\`HANDOFF_TARGET\` field rather than emitting a full HANDOFF block — they carry
+\`workflow-contract\` but not \`handoff-protocol\` by design.
+
+## Format
+
+\`\`\`text
+HANDOFF
+TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user
+REASON: <one sentence>
+REQUESTED_ACTION: <one imperative sentence — executable without reinterpretation>
+PAYLOAD: <concrete filenames, ids, findings, spec ids the next actor needs>
+OPEN_RISKS: <comma list | none>
+\`\`\`
+
+## Rules
+
+- Block exists **iff** \`HANDOFF_TARGET ≠ none\`; if there is no real handoff, omit it entirely.
+- \`TARGET\` must equal the WORKFLOW STATUS \`HANDOFF_TARGET\`.
+- \`REQUESTED_ACTION\` is precise enough to execute without re-deriving intent.
+- \`PAYLOAD\` names concrete artifacts, never vague references.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
+    name: "review-findings-contract",
+    suffix: null,
+    content: `---
+name: review-findings-contract
+description: Defines the machine-readable REVIEW SUMMARY block every auditor/reviewer emits once after its prose, with severity counts and a verdict. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# review-findings-contract
+
+This skill defines the **REVIEW SUMMARY** block. Agents that preload it
+(\`architecture-auditor\`, \`performance-auditor\`, \`security-auditor\`,
+\`a11y-auditor\`, \`dependency-auditor\`, \`code-reviewer\`, \`test-reviewer\`, and the
+\`review-coordinator\`) emit exactly one such block **after their prose** (and
+before the WORKFLOW STATUS block when the agent also carries \`workflow-contract\`).
+It normalizes the review's severity counts and verdict so a coordinator can
+synthesize multiple seats' findings without re-reading each prose report. The
+\`review-coordinator\` emits the same block with the **aggregated** counts summed
+across every seat. The block is additive — it appends to the prose, never
+replaces it.
+
+## Format
+
+\`\`\`text
+REVIEW SUMMARY
+REVIEW_SCOPE: <reviewer name or gate scope>
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+\`\`\`
+
+## Rules
+
+- \`REVIEW_VERDICT: pass\` only when \`CRITICAL_COUNT == 0\` **and** \`HIGH_COUNT == 0\`.
+- \`REVIEW_VERDICT: fail\` when \`CRITICAL_COUNT > 0\` **or** \`HIGH_COUNT > 0\`.
+- \`REVIEW_VERDICT: needs_followup\` when only Medium/Low findings remain.
+- Every count is an explicit integer, including \`0\`.
+- Verdict and counts must never contradict.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
+    name: "qa-report-contract",
+    suffix: null,
+    content: `---
+name: qa-report-contract
+description: Defines the machine-readable QA SUMMARY block the qa-tester emits once after its prose, with test counts and a verdict. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# qa-report-contract
+
+This skill defines the **QA SUMMARY** block. The agent that preloads it
+(\`qa-tester\`) emits exactly one such block **after its prose** (and before the
+WORKFLOW STATUS block, since \`qa-tester\` also carries \`workflow-contract\`). It
+normalizes the QA pass's test counts, bug count, and verdict so downstream
+tooling can gate on QA results without parsing the prose. The block is additive
+— it appends to the prose, never replaces it.
+
+## Format
+
+\`\`\`text
+QA SUMMARY
+QA_SCOPE: <one sentence>
+QA_VERDICT: pass | fail | blocked
+NEW_UNIT_TESTS: <integer>
+NEW_FUNCTIONAL_TESTS: <integer>
+NEW_BROWSER_TESTS: <integer>
+TOTAL_PASS_COUNT: <integer>
+TOTAL_FAIL_COUNT: <integer>
+BUGS_FOUND: <integer>
+QA_RECOMMENDATION: <one sentence>
+\`\`\`
+
+## Rules
+
+- \`QA_VERDICT: pass\` only when the requested QA scope is complete **and** \`TOTAL_FAIL_COUNT == 0\`.
+- \`QA_VERDICT: fail\` when tests exposed real product bugs or failing automation.
+- \`QA_VERDICT: blocked\` when QA could not run (missing environment/prereqs) — distinct from \`fail\`.
+- Every numeric field is an explicit integer, including \`0\`.
+- \`BUGS_FOUND\` counts product issues / failing flows, not stylistic concerns.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
     category: "backlog-cmd",
     name: "backlog",
     suffix: null,
@@ -6576,6 +6772,7 @@ name: developer
 description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: workflow-contract, handoff-protocol
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
@@ -6668,20 +6865,17 @@ For each task assigned:
 
 ## Completion report format
 
+End your turn with a human-facing summary, then the machine-readable status
+block. The human-facing summary captures the reasoning the status block does
+not:
+
 \`\`\`
 TASK <id or name>
-Status: DONE | BLOCKED
-
-Files changed
-  - <path>:<lines or new>
 
 Decisions
   - <why X over Y>
   - (if applicable) Bootstrapped <test runner> because the project had
     no test infra
-
-Validation run
-  - <command>: <result>
 
 Tech debt surfaced (Boy Scout — too big to fix in scope)
   - <one-liner> @ <path>:<line> — reason it's too big
@@ -6689,13 +6883,18 @@ Tech debt surfaced (Boy Scout — too big to fix in scope)
 
 Risks / follow-ups
   - <…>
-
-Next owner
-  - <reviewer | qa | user | product-owner (if tech-debt items present)>
 \`\`\`
 
-Never report done if a validation failed. If blocked, say what you tried, what
-failed, and what decision the next owner needs to make.
+Do NOT define a separate status block here. The authoritative machine-readable
+status is the \`WORKFLOW STATUS\` block from the preloaded \`workflow-contract\`
+(it carries \`STATE\`, \`DONE_CRITERIA_MET\`, \`FILES_CHANGED\`, \`VALIDATION\`,
+\`BLOCKERS\`, \`NEXT_ACTION\`, \`HANDOFF_TARGET\`) — emit exactly one such block
+after the summary above, and a \`HANDOFF\` block per \`handoff-protocol\` whenever
+\`HANDOFF_TARGET ≠ none\`.
+
+Never report \`STATE: done\` if a validation failed (use \`blocked\` / \`failed\`).
+If blocked, say what you tried, what failed, and what decision the next owner
+needs to make in the prose and the \`BLOCKERS\` field.
 `,
     executable: false,
     backend: null,
@@ -6710,6 +6909,7 @@ name: review-coordinator
 description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
+skills: workflow-contract, handoff-protocol, review-findings-contract
 maxTurns: 30
 color: purple
 ---
@@ -6731,11 +6931,15 @@ in parallel and aggregate results.
 3. Wait for all three (or two) to complete.
 4. Aggregate findings by severity. Collapse duplicates (same file:line from two
    agents = one finding with both attributions).
-5. Produce the report using this exact block:
+5. Produce the report in two parts: a human-facing per-seat roll-up, then the
+   single canonical \`REVIEW SUMMARY\` block carrying the AGGREGATED counts across
+   all seats.
+
+### Per-seat roll-up (human-facing)
 
 \`\`\`
-REVIEW SUMMARY
-  code-reviewer      : <PASS | N CRIT, M HIGH, K MED, L LOW>
+PER-SEAT ROLL-UP
+  code-reviewer      : <pass | N CRIT, M HIGH, K MED, L LOW>
   security-auditor   : <…>
   test-reviewer      : <… | SKIPPED>
 
@@ -6749,9 +6953,34 @@ HIGH findings:
 MEDIUM / LOW findings: <N>, list suppressed — see per-agent reports for details.
 \`\`\`
 
+### Aggregated REVIEW SUMMARY block (canonical)
+
+Emit exactly one \`REVIEW SUMMARY\` block per the preloaded
+\`review-findings-contract\`. Its counts are the SUM of every seat's findings
+(after de-duplication); its verdict is derived from those aggregated counts:
+
+\`\`\`
+REVIEW SUMMARY
+REVIEW_SCOPE: review gate (aggregated across code-reviewer, security-auditor, test-reviewer)
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer — summed across seats>
+HIGH_COUNT: <integer — summed across seats>
+MEDIUM_COUNT: <integer — summed across seats>
+LOW_COUNT: <integer — summed across seats>
+TOP_ISSUES: <up to 5 lines — the highest-severity findings | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+\`\`\`
+
+\`REVIEW_VERDICT: pass\` only when aggregated \`CRITICAL_COUNT == 0\` and
+\`HIGH_COUNT == 0\`; \`fail\` when either is > 0; \`needs_followup\` when only
+Medium/Low remain. Then emit the \`WORKFLOW STATUS\` block per \`workflow-contract\`
+and, when handing the gate result back, the \`HANDOFF\` block per
+\`handoff-protocol\`.
+
 ## Rules
 
-- Never emit freeform prose outside the structured block.
+- The roll-up and the \`REVIEW SUMMARY\` block are the only structured output;
+  keep any prose minimal.
 - Never edit files yourself — you coordinate, you do not fix.
 `,
     executable: false,
@@ -6767,6 +6996,7 @@ name: code-reviewer
 description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 ---
@@ -6802,13 +7032,24 @@ FINDING
   suggestion: <one sentence, actionable>
 \`\`\`
 
-End with a single-line verdict:
+After the findings, emit exactly one \`REVIEW SUMMARY\` block per the preloaded
+\`review-findings-contract\`:
 
 \`\`\`
-VERDICT: PASS | FAIL (<N> CRITICAL, <M> HIGH)
+REVIEW SUMMARY
+REVIEW_SCOPE: code-reviewer
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
 \`\`\`
 
-PASS if zero CRITICAL and zero HIGH findings. Otherwise FAIL.
+\`REVIEW_VERDICT: pass\` only when \`CRITICAL_COUNT == 0\` and \`HIGH_COUNT == 0\`;
+\`fail\` when either is > 0; \`needs_followup\` when only Medium/Low remain. Then
+emit the \`WORKFLOW STATUS\` block per \`workflow-contract\`.
 `,
     executable: false,
     backend: null,
@@ -6823,6 +7064,7 @@ name: security-auditor
 description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: red
 ---
@@ -6833,8 +7075,9 @@ on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the \`review-coordinator\` during \`/specflow review\`. Review
-ONLY the files provided in the prompt. Output the \`FINDING\` / \`VERDICT\`
-structure used by code-reviewer.
+ONLY the files provided in the prompt. Output the \`FINDING\` structure
+used by code-reviewer, followed by the canonical \`REVIEW SUMMARY\` block
+(see "Output format (Mode 1)" below).
 
 ### Always-check rules
 
@@ -6938,7 +7181,14 @@ End with a \`VERDICT\` line: \`clean\` (all alerts dismissed or ticketed),
 
 ## Output format (Mode 1)
 
-Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
+Same \`FINDING\` structure as code-reviewer, followed by exactly one
+\`REVIEW SUMMARY\` block per the preloaded \`review-findings-contract\`
+(\`REVIEW_SCOPE: security-auditor\`,
+\`REVIEW_VERDICT: pass | fail | needs_followup\`, the four severity counts,
+\`TOP_ISSUES\`, \`RECOMMENDATION\`), then the \`WORKFLOW STATUS\` block per
+\`workflow-contract\`. (Mode 2 alert triage keeps its own
+\`VERDICT: clean | escalation_needed | error\` line — it is not a PR review
+and is out of scope for the review-findings-contract.)
 `,
     executable: false,
     backend: null,
@@ -6953,6 +7203,7 @@ name: test-reviewer
 description: Reviews test coverage and quality for changed code. Spawned by the review-coordinator when the diff contains test files.
 model: sonnet
 tools: Read, Grep, Glob
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 ---
@@ -6977,7 +7228,11 @@ referenced against the implementation files they cover.
 
 ## Output format
 
-Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
+Same \`FINDING\` structure as code-reviewer, followed by exactly one
+\`REVIEW SUMMARY\` block per the preloaded \`review-findings-contract\`
+(\`REVIEW_SCOPE: test-reviewer\`, \`REVIEW_VERDICT: pass | fail | needs_followup\`,
+the four severity counts, \`TOP_ISSUES\`, \`RECOMMENDATION\`), then the
+\`WORKFLOW STATUS\` block per \`workflow-contract\`.
 `,
     executable: false,
     backend: null,
@@ -6992,6 +7247,7 @@ name: qa-tester
 description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: qa-report-contract, workflow-contract
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
@@ -7022,22 +7278,12 @@ P2. Unit tests for services, domain logic, and validators.
 
 ## Required report
 
-\`\`\`
-QA SUMMARY
-  Tests added: <count>
-  Tests modified: <count>
-
-  Coverage deltas
-    - <area>: <before → after>
-
-  Suite result
-    passed: <N>
-    failed: <M>
-    skipped: <K>
-
-  Bugs found (route to developer)
-    - <…>
-\`\`\`
+After your prose, emit exactly one \`QA SUMMARY\` block as defined by the
+preloaded \`qa-report-contract\` skill (it is the single authoritative schema:
+\`QA_SCOPE\`, \`QA_VERDICT: pass | fail | blocked\`, the test counts, \`BUGS_FOUND\`,
+\`QA_RECOMMENDATION\`). Then emit the \`WORKFLOW STATUS\` block per
+\`workflow-contract\`. Route any bug found to the developer via the
+\`HANDOFF_TARGET\`/\`NEXT_ACTION\` fields of the workflow block.
 `,
     executable: false,
     backend: null,
@@ -7052,6 +7298,7 @@ name: workflow-manager
 description: Orchestrates multi-phase feature delivery across specialist agents. Use as the lead session agent for long-running implementations.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
+skills: workflow-contract, handoff-protocol
 maxTurns: 60
 color: purple
 ---
@@ -7101,6 +7348,16 @@ Every delegated phase must end with a structured report. If an agent claims
 
 Blocked? Report owner, blocker, impact, and the exact decision needed. If
 review or QA fails twice on the same issue family, stop and escalate.
+
+## Output format
+
+You are the primary HANDOFF orchestrator. When you delegate a phase or
+escalate, end your turn with exactly one \`WORKFLOW STATUS\` block per the
+preloaded \`workflow-contract\` (set \`HANDOFF_TARGET\` to the specialist you are
+delegating to, or \`user\` when escalating), followed by a \`HANDOFF\` block per
+\`handoff-protocol\` whenever \`HANDOFF_TARGET ≠ none\`. Read the structured
+blocks delegated agents return and reconcile them against the phase gate
+before advancing.
 `,
     executable: false,
     backend: null,
@@ -7680,6 +7937,7 @@ name: performance-auditor
 description: Reviews code for performance issues — N+1 queries, blocking I/O on hot paths, missing indexes, cache misuse, hot-path allocation, sync-in-async, large bundles, render-thrash. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit performance).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 disable-model-invocation: true
@@ -7691,8 +7949,9 @@ on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the \`review-coordinator\` during \`/specflow review\`. Review ONLY
-the files provided in the prompt. Output the \`FINDING\` / \`VERDICT\` structure
-used by code-reviewer.
+the files provided in the prompt. Output the \`FINDING\` structure used by
+code-reviewer, followed by the canonical \`REVIEW SUMMARY\` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -7818,7 +8077,12 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
+Same \`FINDING\` structure as code-reviewer, followed by exactly one
+\`REVIEW SUMMARY\` block per the preloaded \`review-findings-contract\`
+(\`REVIEW_SCOPE: performance-auditor\`,
+\`REVIEW_VERDICT: pass | fail | needs_followup\`, the four severity counts,
+\`TOP_ISSUES\`, \`RECOMMENDATION\`), then the \`WORKFLOW STATUS\` block per
+\`workflow-contract\`. Audit-mode (Mode 2) emits neither block.
 `,
     executable: false,
     backend: null,
@@ -7833,6 +8097,7 @@ name: a11y-auditor
 description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: cyan
 disable-model-invocation: true
@@ -7870,8 +8135,9 @@ CLI-only project is a no-op by design.
 
 Spawned by the \`review-coordinator\` during \`/specflow review\`. Review
 ONLY the files provided in the prompt (and only if they include FE
-source — otherwise skip per the gate above). Output the
-\`FINDING\` / \`VERDICT\` structure used by code-reviewer.
+source — otherwise skip per the gate above). Output the \`FINDING\`
+structure used by code-reviewer, followed by the canonical
+\`REVIEW SUMMARY\` block (see "Output format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -8008,7 +8274,12 @@ backlog material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same \`FINDING\` / \`VERDICT\` structure as code-reviewer.
+Same \`FINDING\` structure as code-reviewer, followed by exactly one
+\`REVIEW SUMMARY\` block per the preloaded \`review-findings-contract\`
+(\`REVIEW_SCOPE: a11y-auditor\`,
+\`REVIEW_VERDICT: pass | fail | needs_followup\`, the four severity counts,
+\`TOP_ISSUES\`, \`RECOMMENDATION\`), then the \`WORKFLOW STATUS\` block per
+\`workflow-contract\`. Audit-mode (Mode 2) emits neither block.
 `,
     executable: false,
     backend: null,
@@ -8023,6 +8294,7 @@ name: architecture-auditor
 description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: blue
 disable-model-invocation: true
@@ -8034,8 +8306,9 @@ depending on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the \`review-coordinator\` during \`/specflow review\`. Review ONLY
-the files provided in the prompt. Output the \`FINDING\` / \`VERDICT\` structure
-used by code-reviewer.
+the files provided in the prompt. Output the \`FINDING\` structure used by
+code-reviewer, followed by the canonical \`REVIEW SUMMARY\` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -8177,20 +8450,34 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same \`FINDING\` / \`VERDICT\` structure as code-reviewer. Format each
-finding as:
+Same \`FINDING\` structure as code-reviewer. Format each finding as:
 
 \`\`\`
 FINDING <severity>: <one-line summary>
   Path: <file:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
-
-VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
 \`\`\`
 
-Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
-omits VERDICT — backlog material is not pass/fail.
+After the findings, emit exactly one \`REVIEW SUMMARY\` block per the preloaded
+\`review-findings-contract\`:
+
+\`\`\`
+REVIEW SUMMARY
+REVIEW_SCOPE: architecture-auditor
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+\`\`\`
+
+\`REVIEW_VERDICT: pass\` only when \`CRITICAL_COUNT == 0\` and \`HIGH_COUNT == 0\`;
+\`fail\` when either is > 0; \`needs_followup\` when only Medium/Low remain. Then
+emit the \`WORKFLOW STATUS\` block per \`workflow-contract\`. Audit-mode (Mode 2)
+emits neither block — backlog material is not pass/fail.
 `,
     executable: false,
     backend: null,
@@ -8205,6 +8492,7 @@ name: dependency-auditor
 description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: magenta
 disable-model-invocation: true
@@ -8217,8 +8505,9 @@ depending on the dispatch shape.
 
 Spawned by the \`review-coordinator\` during \`/specflow review\`. Review ONLY
 the files provided in the prompt (typically dependency manifests +
-lockfiles touched by the diff). Output the \`FINDING\` / \`VERDICT\` structure
-used by code-reviewer.
+lockfiles touched by the diff). Output the \`FINDING\` structure used by
+code-reviewer, followed by the canonical \`REVIEW SUMMARY\` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -8411,20 +8700,34 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same \`FINDING\` / \`VERDICT\` structure as code-reviewer. Format each
-finding as:
+Same \`FINDING\` structure as code-reviewer. Format each finding as:
 
 \`\`\`
 FINDING <severity>: <one-line summary>
   Path: <manifest:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
-
-VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
 \`\`\`
 
-Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
-omits VERDICT — backlog material is not pass/fail.
+After the findings, emit exactly one \`REVIEW SUMMARY\` block per the preloaded
+\`review-findings-contract\`:
+
+\`\`\`
+REVIEW SUMMARY
+REVIEW_SCOPE: dependency-auditor
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+\`\`\`
+
+\`REVIEW_VERDICT: pass\` only when \`CRITICAL_COUNT == 0\` and \`HIGH_COUNT == 0\`;
+\`fail\` when either is > 0; \`needs_followup\` when only Medium/Low remain. Then
+emit the \`WORKFLOW STATUS\` block per \`workflow-contract\`. Audit-mode (Mode 2)
+emits neither block — backlog material is not pass/fail.
 `,
     executable: false,
     backend: null,

--- a/templates/core/agents/a11y-auditor.md
+++ b/templates/core/agents/a11y-auditor.md
@@ -3,6 +3,7 @@ name: a11y-auditor
 description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: cyan
 disable-model-invocation: true
@@ -40,8 +41,9 @@ CLI-only project is a no-op by design.
 
 Spawned by the `review-coordinator` during `/specflow review`. Review
 ONLY the files provided in the prompt (and only if they include FE
-source — otherwise skip per the gate above). Output the
-`FINDING` / `VERDICT` structure used by code-reviewer.
+source — otherwise skip per the gate above). Output the `FINDING`
+structure used by code-reviewer, followed by the canonical
+`REVIEW SUMMARY` block (see "Output format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -178,4 +180,9 @@ backlog material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: a11y-auditor`,
+`REVIEW_VERDICT: pass | fail | needs_followup`, the four severity counts,
+`TOP_ISSUES`, `RECOMMENDATION`), then the `WORKFLOW STATUS` block per
+`workflow-contract`. Audit-mode (Mode 2) emits neither block.

--- a/templates/core/agents/architecture-auditor.md
+++ b/templates/core/agents/architecture-auditor.md
@@ -3,6 +3,7 @@ name: architecture-auditor
 description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: blue
 disable-model-invocation: true
@@ -14,8 +15,9 @@ depending on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
-the files provided in the prompt. Output the `FINDING` / `VERDICT` structure
-used by code-reviewer.
+the files provided in the prompt. Output the `FINDING` structure used by
+code-reviewer, followed by the canonical `REVIEW SUMMARY` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -157,17 +159,31 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
-finding as:
+Same `FINDING` structure as code-reviewer. Format each finding as:
 
 ```
 FINDING <severity>: <one-line summary>
   Path: <file:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
-
-VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
 ```
 
-Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
-omits VERDICT — backlog material is not pass/fail.
+After the findings, emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`:
+
+```
+REVIEW SUMMARY
+REVIEW_SCOPE: architecture-auditor
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` and `HIGH_COUNT == 0`;
+`fail` when either is > 0; `needs_followup` when only Medium/Low remain. Then
+emit the `WORKFLOW STATUS` block per `workflow-contract`. Audit-mode (Mode 2)
+emits neither block — backlog material is not pass/fail.

--- a/templates/core/agents/code-reviewer.md
+++ b/templates/core/agents/code-reviewer.md
@@ -3,6 +3,7 @@ name: code-reviewer
 description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
 tools: Read, Grep, Glob
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 ---
@@ -38,10 +39,21 @@ FINDING
   suggestion: <one sentence, actionable>
 ```
 
-End with a single-line verdict:
+After the findings, emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`:
 
 ```
-VERDICT: PASS | FAIL (<N> CRITICAL, <M> HIGH)
+REVIEW SUMMARY
+REVIEW_SCOPE: code-reviewer
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
 ```
 
-PASS if zero CRITICAL and zero HIGH findings. Otherwise FAIL.
+`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` and `HIGH_COUNT == 0`;
+`fail` when either is > 0; `needs_followup` when only Medium/Low remain. Then
+emit the `WORKFLOW STATUS` block per `workflow-contract`.

--- a/templates/core/agents/dependency-auditor.md
+++ b/templates/core/agents/dependency-auditor.md
@@ -3,6 +3,7 @@ name: dependency-auditor
 description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: magenta
 disable-model-invocation: true
@@ -15,8 +16,9 @@ depending on the dispatch shape.
 
 Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
 the files provided in the prompt (typically dependency manifests +
-lockfiles touched by the diff). Output the `FINDING` / `VERDICT` structure
-used by code-reviewer.
+lockfiles touched by the diff). Output the `FINDING` structure used by
+code-reviewer, followed by the canonical `REVIEW SUMMARY` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -209,17 +211,31 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer. Format each
-finding as:
+Same `FINDING` structure as code-reviewer. Format each finding as:
 
 ```
 FINDING <severity>: <one-line summary>
   Path: <manifest:line>
   Rationale: <2-3 sentences>
   Suggested fix: <code sketch or pointer>
-
-VERDICT: <APPROVE | REQUEST_CHANGES | NEEDS_DISCUSSION>
 ```
 
-Always emit exactly one VERDICT line at the end. Audit-mode (Mode 2)
-omits VERDICT — backlog material is not pass/fail.
+After the findings, emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`:
+
+```
+REVIEW SUMMARY
+REVIEW_SCOPE: dependency-auditor
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` and `HIGH_COUNT == 0`;
+`fail` when either is > 0; `needs_followup` when only Medium/Low remain. Then
+emit the `WORKFLOW STATUS` block per `workflow-contract`. Audit-mode (Mode 2)
+emits neither block — backlog material is not pass/fail.

--- a/templates/core/agents/developer.md
+++ b/templates/core/agents/developer.md
@@ -3,6 +3,7 @@ name: developer
 description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: workflow-contract, handoff-protocol
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
@@ -95,20 +96,17 @@ For each task assigned:
 
 ## Completion report format
 
+End your turn with a human-facing summary, then the machine-readable status
+block. The human-facing summary captures the reasoning the status block does
+not:
+
 ```
 TASK <id or name>
-Status: DONE | BLOCKED
-
-Files changed
-  - <path>:<lines or new>
 
 Decisions
   - <why X over Y>
   - (if applicable) Bootstrapped <test runner> because the project had
     no test infra
-
-Validation run
-  - <command>: <result>
 
 Tech debt surfaced (Boy Scout — too big to fix in scope)
   - <one-liner> @ <path>:<line> — reason it's too big
@@ -116,10 +114,15 @@ Tech debt surfaced (Boy Scout — too big to fix in scope)
 
 Risks / follow-ups
   - <…>
-
-Next owner
-  - <reviewer | qa | user | product-owner (if tech-debt items present)>
 ```
 
-Never report done if a validation failed. If blocked, say what you tried, what
-failed, and what decision the next owner needs to make.
+Do NOT define a separate status block here. The authoritative machine-readable
+status is the `WORKFLOW STATUS` block from the preloaded `workflow-contract`
+(it carries `STATE`, `DONE_CRITERIA_MET`, `FILES_CHANGED`, `VALIDATION`,
+`BLOCKERS`, `NEXT_ACTION`, `HANDOFF_TARGET`) — emit exactly one such block
+after the summary above, and a `HANDOFF` block per `handoff-protocol` whenever
+`HANDOFF_TARGET ≠ none`.
+
+Never report `STATE: done` if a validation failed (use `blocked` / `failed`).
+If blocked, say what you tried, what failed, and what decision the next owner
+needs to make in the prose and the `BLOCKERS` field.

--- a/templates/core/agents/performance-auditor.md
+++ b/templates/core/agents/performance-auditor.md
@@ -3,6 +3,7 @@ name: performance-auditor
 description: Reviews code for performance issues — N+1 queries, blocking I/O on hot paths, missing indexes, cache misuse, hot-path allocation, sync-in-async, large bundles, render-thrash. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit performance).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 disable-model-invocation: true
@@ -14,8 +15,9 @@ on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specflow review`. Review ONLY
-the files provided in the prompt. Output the `FINDING` / `VERDICT` structure
-used by code-reviewer.
+the files provided in the prompt. Output the `FINDING` structure used by
+code-reviewer, followed by the canonical `REVIEW SUMMARY` block (see "Output
+format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
@@ -141,4 +143,9 @@ material for the PO to triage.
 
 ## Output format (Mode 1 — PR review)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: performance-auditor`,
+`REVIEW_VERDICT: pass | fail | needs_followup`, the four severity counts,
+`TOP_ISSUES`, `RECOMMENDATION`), then the `WORKFLOW STATUS` block per
+`workflow-contract`. Audit-mode (Mode 2) emits neither block.

--- a/templates/core/agents/qa-tester.md
+++ b/templates/core/agents/qa-tester.md
@@ -3,6 +3,7 @@ name: qa-tester
 description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: qa-report-contract, workflow-contract
 permissionMode: acceptEdits
 maxTurns: 40
 disable-model-invocation: true
@@ -33,19 +34,9 @@ P2. Unit tests for services, domain logic, and validators.
 
 ## Required report
 
-```
-QA SUMMARY
-  Tests added: <count>
-  Tests modified: <count>
-
-  Coverage deltas
-    - <area>: <before → after>
-
-  Suite result
-    passed: <N>
-    failed: <M>
-    skipped: <K>
-
-  Bugs found (route to developer)
-    - <…>
-```
+After your prose, emit exactly one `QA SUMMARY` block as defined by the
+preloaded `qa-report-contract` skill (it is the single authoritative schema:
+`QA_SCOPE`, `QA_VERDICT: pass | fail | blocked`, the test counts, `BUGS_FOUND`,
+`QA_RECOMMENDATION`). Then emit the `WORKFLOW STATUS` block per
+`workflow-contract`. Route any bug found to the developer via the
+`HANDOFF_TARGET`/`NEXT_ACTION` fields of the workflow block.

--- a/templates/core/agents/review-coordinator.md
+++ b/templates/core/agents/review-coordinator.md
@@ -3,6 +3,7 @@ name: review-coordinator
 description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
+skills: workflow-contract, handoff-protocol, review-findings-contract
 maxTurns: 30
 color: purple
 ---
@@ -24,11 +25,15 @@ in parallel and aggregate results.
 3. Wait for all three (or two) to complete.
 4. Aggregate findings by severity. Collapse duplicates (same file:line from two
    agents = one finding with both attributions).
-5. Produce the report using this exact block:
+5. Produce the report in two parts: a human-facing per-seat roll-up, then the
+   single canonical `REVIEW SUMMARY` block carrying the AGGREGATED counts across
+   all seats.
+
+### Per-seat roll-up (human-facing)
 
 ```
-REVIEW SUMMARY
-  code-reviewer      : <PASS | N CRIT, M HIGH, K MED, L LOW>
+PER-SEAT ROLL-UP
+  code-reviewer      : <pass | N CRIT, M HIGH, K MED, L LOW>
   security-auditor   : <…>
   test-reviewer      : <… | SKIPPED>
 
@@ -42,7 +47,32 @@ HIGH findings:
 MEDIUM / LOW findings: <N>, list suppressed — see per-agent reports for details.
 ```
 
+### Aggregated REVIEW SUMMARY block (canonical)
+
+Emit exactly one `REVIEW SUMMARY` block per the preloaded
+`review-findings-contract`. Its counts are the SUM of every seat's findings
+(after de-duplication); its verdict is derived from those aggregated counts:
+
+```
+REVIEW SUMMARY
+REVIEW_SCOPE: review gate (aggregated across code-reviewer, security-auditor, test-reviewer)
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer — summed across seats>
+HIGH_COUNT: <integer — summed across seats>
+MEDIUM_COUNT: <integer — summed across seats>
+LOW_COUNT: <integer — summed across seats>
+TOP_ISSUES: <up to 5 lines — the highest-severity findings | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+`REVIEW_VERDICT: pass` only when aggregated `CRITICAL_COUNT == 0` and
+`HIGH_COUNT == 0`; `fail` when either is > 0; `needs_followup` when only
+Medium/Low remain. Then emit the `WORKFLOW STATUS` block per `workflow-contract`
+and, when handing the gate result back, the `HANDOFF` block per
+`handoff-protocol`.
+
 ## Rules
 
-- Never emit freeform prose outside the structured block.
+- The roll-up and the `REVIEW SUMMARY` block are the only structured output;
+  keep any prose minimal.
 - Never edit files yourself — you coordinate, you do not fix.

--- a/templates/core/agents/security-auditor.md
+++ b/templates/core/agents/security-auditor.md
@@ -3,6 +3,7 @@ name: security-auditor
 description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
 tools: Read, Grep, Glob, Bash
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: red
 ---
@@ -13,8 +14,9 @@ on the dispatch shape.
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specflow review`. Review
-ONLY the files provided in the prompt. Output the `FINDING` / `VERDICT`
-structure used by code-reviewer.
+ONLY the files provided in the prompt. Output the `FINDING` structure
+used by code-reviewer, followed by the canonical `REVIEW SUMMARY` block
+(see "Output format (Mode 1)" below).
 
 ### Always-check rules
 
@@ -118,4 +120,11 @@ End with a `VERDICT` line: `clean` (all alerts dismissed or ticketed),
 
 ## Output format (Mode 1)
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: security-auditor`,
+`REVIEW_VERDICT: pass | fail | needs_followup`, the four severity counts,
+`TOP_ISSUES`, `RECOMMENDATION`), then the `WORKFLOW STATUS` block per
+`workflow-contract`. (Mode 2 alert triage keeps its own
+`VERDICT: clean | escalation_needed | error` line — it is not a PR review
+and is out of scope for the review-findings-contract.)

--- a/templates/core/agents/test-reviewer.md
+++ b/templates/core/agents/test-reviewer.md
@@ -3,6 +3,7 @@ name: test-reviewer
 description: Reviews test coverage and quality for changed code. Spawned by the review-coordinator when the diff contains test files.
 model: sonnet
 tools: Read, Grep, Glob
+skills: review-findings-contract, workflow-contract
 maxTurns: 20
 color: yellow
 ---
@@ -27,4 +28,8 @@ referenced against the implementation files they cover.
 
 ## Output format
 
-Same `FINDING` / `VERDICT` structure as code-reviewer.
+Same `FINDING` structure as code-reviewer, followed by exactly one
+`REVIEW SUMMARY` block per the preloaded `review-findings-contract`
+(`REVIEW_SCOPE: test-reviewer`, `REVIEW_VERDICT: pass | fail | needs_followup`,
+the four severity counts, `TOP_ISSUES`, `RECOMMENDATION`), then the
+`WORKFLOW STATUS` block per `workflow-contract`.

--- a/templates/core/agents/workflow-manager.md
+++ b/templates/core/agents/workflow-manager.md
@@ -3,6 +3,7 @@ name: workflow-manager
 description: Orchestrates multi-phase feature delivery across specialist agents. Use as the lead session agent for long-running implementations.
 model: sonnet
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
+skills: workflow-contract, handoff-protocol
 maxTurns: 60
 color: purple
 ---
@@ -52,3 +53,13 @@ Every delegated phase must end with a structured report. If an agent claims
 
 Blocked? Report owner, blocker, impact, and the exact decision needed. If
 review or QA fails twice on the same issue family, stop and escalate.
+
+## Output format
+
+You are the primary HANDOFF orchestrator. When you delegate a phase or
+escalate, end your turn with exactly one `WORKFLOW STATUS` block per the
+preloaded `workflow-contract` (set `HANDOFF_TARGET` to the specialist you are
+delegating to, or `user` when escalating), followed by a `HANDOFF` block per
+`handoff-protocol` whenever `HANDOFF_TARGET ≠ none`. Read the structured
+blocks delegated agents return and reconcile them against the phase gate
+before advancing.

--- a/templates/core/skills/handoff-protocol/SKILL.md
+++ b/templates/core/skills/handoff-protocol/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: handoff-protocol
+description: Defines the machine-readable HANDOFF block emitted right after WORKFLOW STATUS whenever an agent hands work to another actor. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# handoff-protocol
+
+This skill defines the **HANDOFF** block. Agents that preload it (`developer`,
+`review-coordinator`, `workflow-manager`) emit it **immediately after the
+WORKFLOW STATUS block, and only when** that block's `HANDOFF_TARGET` is not
+`none`. It gives the next actor a precise, executable instruction plus the
+concrete payload they need, so the handoff requires no re-derivation of intent.
+The block is additive — it appends to the prose, never replaces it.
+
+Agents that hand off but do NOT preload this contract (e.g. `qa-tester`, which
+routes bugs to the developer) signal the target through the WORKFLOW STATUS
+`HANDOFF_TARGET` field rather than emitting a full HANDOFF block — they carry
+`workflow-contract` but not `handoff-protocol` by design.
+
+## Format
+
+```text
+HANDOFF
+TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user
+REASON: <one sentence>
+REQUESTED_ACTION: <one imperative sentence — executable without reinterpretation>
+PAYLOAD: <concrete filenames, ids, findings, spec ids the next actor needs>
+OPEN_RISKS: <comma list | none>
+```
+
+## Rules
+
+- Block exists **iff** `HANDOFF_TARGET ≠ none`; if there is no real handoff, omit it entirely.
+- `TARGET` must equal the WORKFLOW STATUS `HANDOFF_TARGET`.
+- `REQUESTED_ACTION` is precise enough to execute without re-deriving intent.
+- `PAYLOAD` names concrete artifacts, never vague references.

--- a/templates/core/skills/qa-report-contract/SKILL.md
+++ b/templates/core/skills/qa-report-contract/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: qa-report-contract
+description: Defines the machine-readable QA SUMMARY block the qa-tester emits once after its prose, with test counts and a verdict. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# qa-report-contract
+
+This skill defines the **QA SUMMARY** block. The agent that preloads it
+(`qa-tester`) emits exactly one such block **after its prose** (and before the
+WORKFLOW STATUS block, since `qa-tester` also carries `workflow-contract`). It
+normalizes the QA pass's test counts, bug count, and verdict so downstream
+tooling can gate on QA results without parsing the prose. The block is additive
+— it appends to the prose, never replaces it.
+
+## Format
+
+```text
+QA SUMMARY
+QA_SCOPE: <one sentence>
+QA_VERDICT: pass | fail | blocked
+NEW_UNIT_TESTS: <integer>
+NEW_FUNCTIONAL_TESTS: <integer>
+NEW_BROWSER_TESTS: <integer>
+TOTAL_PASS_COUNT: <integer>
+TOTAL_FAIL_COUNT: <integer>
+BUGS_FOUND: <integer>
+QA_RECOMMENDATION: <one sentence>
+```
+
+## Rules
+
+- `QA_VERDICT: pass` only when the requested QA scope is complete **and** `TOTAL_FAIL_COUNT == 0`.
+- `QA_VERDICT: fail` when tests exposed real product bugs or failing automation.
+- `QA_VERDICT: blocked` when QA could not run (missing environment/prereqs) — distinct from `fail`.
+- Every numeric field is an explicit integer, including `0`.
+- `BUGS_FOUND` counts product issues / failing flows, not stylistic concerns.

--- a/templates/core/skills/review-findings-contract/SKILL.md
+++ b/templates/core/skills/review-findings-contract/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: review-findings-contract
+description: Defines the machine-readable REVIEW SUMMARY block every auditor/reviewer emits once after its prose, with severity counts and a verdict. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# review-findings-contract
+
+This skill defines the **REVIEW SUMMARY** block. Agents that preload it
+(`architecture-auditor`, `performance-auditor`, `security-auditor`,
+`a11y-auditor`, `dependency-auditor`, `code-reviewer`, `test-reviewer`, and the
+`review-coordinator`) emit exactly one such block **after their prose** (and
+before the WORKFLOW STATUS block when the agent also carries `workflow-contract`).
+It normalizes the review's severity counts and verdict so a coordinator can
+synthesize multiple seats' findings without re-reading each prose report. The
+`review-coordinator` emits the same block with the **aggregated** counts summed
+across every seat. The block is additive — it appends to the prose, never
+replaces it.
+
+## Format
+
+```text
+REVIEW SUMMARY
+REVIEW_SCOPE: <reviewer name or gate scope>
+REVIEW_VERDICT: pass | fail | needs_followup
+CRITICAL_COUNT: <integer>
+HIGH_COUNT: <integer>
+MEDIUM_COUNT: <integer>
+LOW_COUNT: <integer>
+TOP_ISSUES: <one sentence, or up to 5 lines | none>
+RECOMMENDATION: <one sentence — what the next actor should do>
+```
+
+## Rules
+
+- `REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` **and** `HIGH_COUNT == 0`.
+- `REVIEW_VERDICT: fail` when `CRITICAL_COUNT > 0` **or** `HIGH_COUNT > 0`.
+- `REVIEW_VERDICT: needs_followup` when only Medium/Low findings remain.
+- Every count is an explicit integer, including `0`.
+- Verdict and counts must never contradict.

--- a/templates/core/skills/using-specflow/SKILL.md
+++ b/templates/core/skills/using-specflow/SKILL.md
@@ -47,6 +47,13 @@ not re-read the file with `Read`.
 | `specflow-auto` | Auto-chain orchestration (legacy entry point — most users invoke `/specflow specify` instead). |
 | `specflow-review` | Auto-invoke alias preserved for the `/specflow review` phase. |
 
+**Preloaded output-contract skills** (`user-invocable: false` — never invoke
+directly): `workflow-contract`, `handoff-protocol`, `review-findings-contract`,
+`qa-report-contract`. These define the machine-readable `WORKFLOW STATUS` /
+`HANDOFF` / `REVIEW SUMMARY` / `QA SUMMARY` blocks. They are loaded into an
+agent's context via the agent's `skills:` frontmatter (see the agent registry
+below) and never appear as user commands.
+
 ## Specflow agent registry
 
 Dispatch these via `Task({ subagent_type: "<name>", ... })` (or your

--- a/templates/core/skills/workflow-contract/SKILL.md
+++ b/templates/core/skills/workflow-contract/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: workflow-contract
+description: Defines the machine-readable WORKFLOW STATUS block every workflow-shaped agent emits once at end of turn. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# workflow-contract
+
+This skill defines the **WORKFLOW STATUS** block. Agents that preload it
+(`developer`, `review-coordinator`, `workflow-manager`, `qa-tester`, and all
+five auditors + both reviewers via this contract) emit exactly one such block at
+the **end of their turn, after the prose**. The block is additive — it never replaces the prose narrative; it
+appends a normalized, fenced, machine-readable summary that downstream tooling
+(audit synthesis, the status ledger, `/status-audit`) can parse without
+re-reading the prose.
+
+## Format
+
+```text
+WORKFLOW STATUS
+STATE: in_progress | blocked | awaiting_review | awaiting_qa | awaiting_user | done | failed
+DONE_CRITERIA_MET: yes | no
+SUMMARY: <one sentence — outcome, not effort>
+ARTIFACTS: <comma list | none>
+FILES_CHANGED: <comma list | none>
+VALIDATION: <comma list of "command (result)" | none>
+BLOCKERS: <one sentence | none>
+NEXT_ACTION: <one sentence>
+HANDOFF_TARGET: developer | review-coordinator | qa-tester | product-owner | workflow-manager | user | none
+```
+
+## Rules
+
+- Exactly one block per turn; never replaces prose (additive).
+- `STATE: done` only when assigned exit criteria are met; otherwise use `awaiting_review` /
+  `awaiting_qa` / `blocked`. Never `done` with `DONE_CRITERIA_MET: no`.
+- `FILES_CHANGED: none` for read-only agents (auditors/reviewers).
+- `VALIDATION` is explicit, e.g. `deno task test (pass)`.
+- `HANDOFF_TARGET: none` when work terminates here.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -37,6 +37,10 @@
     { "category": "skill", "name": "executing-plans", "source": "core/skills/executing-plans/SKILL.md" },
     { "category": "skill", "name": "verification-before-completion", "source": "core/skills/verification-before-completion/SKILL.md" },
     { "category": "skill", "name": "brainstorming", "source": "core/skills/brainstorming/SKILL.md" },
+    { "category": "skill", "name": "workflow-contract", "source": "core/skills/workflow-contract/SKILL.md" },
+    { "category": "skill", "name": "handoff-protocol", "source": "core/skills/handoff-protocol/SKILL.md" },
+    { "category": "skill", "name": "review-findings-contract", "source": "core/skills/review-findings-contract/SKILL.md" },
+    { "category": "skill", "name": "qa-report-contract", "source": "core/skills/qa-report-contract/SKILL.md" },
     { "category": "backlog-cmd", "name": "backlog", "source": "core/commands/backlog.md" },
 
     { "category": "agent", "name": "product-owner", "source": "core/agents/product-owner.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -94,12 +94,14 @@ Deno.test("specflow init --ai codex scaffolds a Codex layout", async () => {
     // writing-plans (A1) + requesting-code-review (A3) +
     // using-specflow bootstrap (B6) + subagent-driven-development (A2) +
     // executing-plans (A4) + verification-before-completion (A5) +
-    // brainstorming (A6) = 11. The audit-security phase (#303) lands
+    // brainstorming (A6) + 4 output-contract skills (#378:
+    // workflow-contract, handoff-protocol, review-findings-contract,
+    // qa-report-contract) = 15. The audit-security phase (#303) lands
     // under specflow/phases/, not as a top-level skill — no bump here.
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 11);
+    assertEquals(agentsSkillsCount, 15);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -90,13 +90,15 @@ Deno.test("specflow init --ai copilot scaffolds a Copilot layout", async () => {
     // requesting-code-review (#273) + using-specflow (#282) +
     // subagent-driven-development (#272) + executing-plans (#274) +
     // verification-before-completion (#275) + brainstorming (#276) +
+    // 4 output-contract skills (#378: workflow-contract, handoff-protocol,
+    // review-findings-contract, qa-report-contract) +
     // backlog + 15 agents (11 original + performance-auditor #304 +
     // a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
-    // #322) = 47.
+    // #322) = 51.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 47);
+    assertEquals(instructionsCount, 51);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -82,13 +82,15 @@ Deno.test("specflow init --ai windsurf scaffolds a Windsurf layout", async () =>
     // requesting-code-review (#273) + using-specflow (#282) +
     // subagent-driven-development (#272) + executing-plans (#274) +
     // verification-before-completion (#275) + brainstorming (#276) +
+    // 4 output-contract skills (#378: workflow-contract, handoff-protocol,
+    // review-findings-contract, qa-report-contract) +
     // backlog + 15 agent workflows (11 original + performance-auditor #304
     // + a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
-    // #322) = 47.
+    // #322) = 51.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 47);
+    assertEquals(workflowsCount, 51);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specflow/memory/constitution.md")), true);

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -114,6 +114,19 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: "plugin/skills/brainstorming/SKILL.md",
     source: "templates/core/skills/brainstorming/SKILL.md",
   },
+  // Four machine-readable output-contract skills (#378). `user-invocable:
+  // false` — never user-invoked; preloaded into agent context via the
+  // `skills:` frontmatter to normalize the WORKFLOW STATUS / HANDOFF /
+  // REVIEW SUMMARY / QA SUMMARY blocks agents emit after their prose.
+  ...[
+    "workflow-contract",
+    "handoff-protocol",
+    "review-findings-contract",
+    "qa-report-contract",
+  ].map((name) => ({
+    plugin: `plugin/skills/${name}/SKILL.md`,
+    source: `templates/core/skills/${name}/SKILL.md`,
+  })),
   ...[
     "claude",
     "codex",

--- a/tests/templates/agent_output_contracts_test.ts
+++ b/tests/templates/agent_output_contracts_test.ts
@@ -1,0 +1,103 @@
+import { assert, assertEquals } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import type { CoreEntry } from "../../src/domain/core_bundle.ts";
+
+/**
+ * Locks the two halves of feature 012 (machine-readable agent output contracts)
+ * together: the four contract skills must ship in the bundle as
+ * `user-invocable: false`, AND every wired agent's bundled content must carry
+ * the exact `skills:` preload entries from the research.md mapping table. If a
+ * contract drops out of the bundle, or an agent loses its preload line, one of
+ * these assertions goes red — the contract and its consumers can't drift apart
+ * silently (FR-002, SC-001, SC-004).
+ */
+
+/** The four contract skills, by bundled `name`. Identity = name (data-model.md). */
+const CONTRACT_SKILLS = [
+  "workflow-contract",
+  "handoff-protocol",
+  "review-findings-contract",
+  "qa-report-contract",
+] as const;
+
+/** Authoritative wired-agent → contracts mapping (research.md). */
+const AGENT_WIRING: Record<string, readonly string[]> = {
+  "architecture-auditor": ["review-findings-contract", "workflow-contract"],
+  "performance-auditor": ["review-findings-contract", "workflow-contract"],
+  "security-auditor": ["review-findings-contract", "workflow-contract"],
+  "a11y-auditor": ["review-findings-contract", "workflow-contract"],
+  "dependency-auditor": ["review-findings-contract", "workflow-contract"],
+  "code-reviewer": ["review-findings-contract", "workflow-contract"],
+  "test-reviewer": ["review-findings-contract", "workflow-contract"],
+  "review-coordinator": ["workflow-contract", "handoff-protocol", "review-findings-contract"],
+  "developer": ["workflow-contract", "handoff-protocol"],
+  "workflow-manager": ["workflow-contract", "handoff-protocol"],
+  "qa-tester": ["qa-report-contract", "workflow-contract"],
+};
+
+function skillEntry(name: string): CoreEntry | undefined {
+  return CORE_BUNDLE.find((e) => e.category === "skill" && e.name === name);
+}
+
+function agentEntry(name: string): CoreEntry | undefined {
+  return CORE_BUNDLE.find((e) => e.category === "agent" && e.name === name);
+}
+
+/** Extracts the YAML frontmatter block from a bundled markdown file's content. */
+function frontmatter(content: string): string {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  assert(m, "expected a leading YAML frontmatter block");
+  return m[1];
+}
+
+/** Reads the inline comma-list `skills:` frontmatter field, if present. */
+function skillsField(frontmatterBody: string): string[] {
+  const line = frontmatterBody
+    .split("\n")
+    .find((l) => /^skills:\s/.test(l));
+  assert(line, "expected a `skills:` frontmatter line");
+  return line
+    .replace(/^skills:\s*/, "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// (a) The four contracts are in CORE_BUNDLE and each is user-invocable: false.
+for (const name of CONTRACT_SKILLS) {
+  Deno.test(`contract skill "${name}" is bundled as a skill`, () => {
+    const entry = skillEntry(name);
+    assert(entry, `contract skill "${name}" missing from CORE_BUNDLE`);
+  });
+
+  Deno.test(`contract skill "${name}" is user-invocable: false`, () => {
+    const entry = skillEntry(name)!;
+    const fm = frontmatter(entry.content);
+    assert(
+      /^user-invocable:\s*false\s*$/m.test(fm),
+      `contract "${name}" must declare \`user-invocable: false\` in its frontmatter`,
+    );
+  });
+
+  Deno.test(`contract skill "${name}" carries name + description`, () => {
+    const fm = frontmatter(skillEntry(name)!.content);
+    assert(new RegExp(`^name:\\s*${name}\\s*$`, "m").test(fm), "name mismatch");
+    assert(/^description:\s+\S/m.test(fm), "expected a one-line description");
+  });
+}
+
+// (b) Each wired agent's bundled content carries the expected skills: entries.
+for (const [agent, expected] of Object.entries(AGENT_WIRING)) {
+  Deno.test(`agent "${agent}" preloads ${expected.join(" + ")}`, () => {
+    const entry = agentEntry(agent);
+    assert(entry, `wired agent "${agent}" missing from CORE_BUNDLE`);
+    const got = skillsField(frontmatter(entry.content));
+    // Order-insensitive: load order of `skills:` is not a semantic contract,
+    // so compare as sets — only the membership matters.
+    assertEquals(
+      new Set(got),
+      new Set(expected),
+      `agent "${agent}" skills: frontmatter does not match the research.md mapping`,
+    );
+  });
+}

--- a/tests/templates/contract_schema_consistency_test.ts
+++ b/tests/templates/contract_schema_consistency_test.ts
@@ -1,0 +1,65 @@
+import { assert } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import type { CoreEntry } from "../../src/domain/core_bundle.ts";
+
+/**
+ * Schema-self-consistency guard (FR-002): each contract SKILL.md body must
+ * contain its fenced block header AND the verdict/state rule lines that define
+ * the block's invariants. This keeps the bundled schema text from silently
+ * drifting away from the canonical contracts in
+ * `.specflow/specs/012-agent-output-contracts/contracts/*.md` — if a header or
+ * a load-bearing rule line is dropped from a SKILL.md, the matching assertion
+ * goes red.
+ */
+
+function skillContent(name: string): string {
+  const entry: CoreEntry | undefined = CORE_BUNDLE.find(
+    (e) => e.category === "skill" && e.name === name,
+  );
+  assert(entry, `contract skill "${name}" missing from CORE_BUNDLE`);
+  return entry.content;
+}
+
+/**
+ * For each contract: the fenced block header that downstream parsers key on,
+ * plus a sample of the verdict/state rule lines that encode the block's
+ * invariants. Substrings are matched verbatim against the canonical contract.
+ */
+const SCHEMA_MARKERS: Record<string, string[]> = {
+  "workflow-contract": [
+    "WORKFLOW STATUS",
+    "STATE: in_progress | blocked | awaiting_review | awaiting_qa | awaiting_user | done | failed",
+    "Never `done` with `DONE_CRITERIA_MET: no`.",
+    "`HANDOFF_TARGET: none` when work terminates here.",
+  ],
+  "handoff-protocol": [
+    "HANDOFF",
+    "Block exists **iff** `HANDOFF_TARGET ≠ none`",
+    "`TARGET` must equal the WORKFLOW STATUS `HANDOFF_TARGET`.",
+  ],
+  "review-findings-contract": [
+    "REVIEW SUMMARY",
+    "REVIEW_VERDICT: pass | fail | needs_followup",
+    "`REVIEW_VERDICT: pass` only when `CRITICAL_COUNT == 0` **and** `HIGH_COUNT == 0`.",
+    "`REVIEW_VERDICT: fail` when `CRITICAL_COUNT > 0` **or** `HIGH_COUNT > 0`.",
+    "Verdict and counts must never contradict.",
+  ],
+  "qa-report-contract": [
+    "QA SUMMARY",
+    "QA_VERDICT: pass | fail | blocked",
+    "`QA_VERDICT: pass` only when the requested QA scope is complete **and** `TOTAL_FAIL_COUNT == 0`.",
+    "`QA_VERDICT: blocked` when QA could not run (missing environment/prereqs) — distinct from `fail`.",
+  ],
+};
+
+for (const [name, markers] of Object.entries(SCHEMA_MARKERS)) {
+  Deno.test(`contract "${name}" body carries its block header + rule lines`, () => {
+    const body = skillContent(name);
+    for (const marker of markers) {
+      assert(
+        body.includes(marker),
+        `contract "${name}" is missing required schema text: ${JSON.stringify(marker)}`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
Closes #378 · epic mkrlabs/specflow-monorepo#12 (miximodel audit-team port, mechanism A).

## What
Four `user-invocable: false` contract skills — `workflow-contract`, `handoff-protocol`, `review-findings-contract`, `qa-report-contract` — added to the bundled fleet and preloaded (via `skills:` frontmatter) by the auditor / reviewer / qa / orchestration agents. Agent output now ends with normalized, parsable fenced blocks (`WORKFLOW STATUS` / `HANDOFF` / `REVIEW SUMMARY` / `QA SUMMARY`).

## Scope note
Beyond the issue's literal "additive frontmatter", the review gate surfaced that several agents' existing bodies defined output formats *contradicting* the contracts they now preload (auditors emitting `APPROVE/REQUEST_CHANGES`, coordinator's bespoke block). Wiring an agent to a contract it doesn't honour is a defect, so all 11 wired agents' bodies were reconciled to emit the canonical block (`REVIEW_VERDICT: pass|fail|needs_followup`). `workflow-manager` was added to the wiring (it was a genuine gap — the primary handoff orchestrator).

## How it ships
- Registered in `templates/manifest.json` (the bundler is manifest-driven, not glob-driven), bundle regenerated, `plugin/` mirror synced.
- Tests: `tests/templates/agent_output_contracts_test.ts` (bundle inclusion + `user-invocable:false` + order-insensitive wiring map), `tests/templates/contract_schema_consistency_test.ts` (each contract body carries its block header + rules), plugin-sync + init-count assertions updated.

## Validation
`deno task test` → **887 passed / 0 failed**; `deno lint` + `deno fmt` clean. Review gate: PASS (after one fix cycle that cleared 3 HIGH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)