### PR TITLE
feat(agents): per-agent effort tuning rubric (#382)

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specflow/specs/015-status-ledger",
-  "linked_issue": 381,
+  "feature_directory": ".specflow/specs/016-agent-effort-rubric",
+  "linked_issue": 382,
   "workflow_shape": "full"
 }

--- a/.specflow/specs/016-agent-effort-rubric/checklists/requirements.md
+++ b/.specflow/specs/016-agent-effort-rubric/checklists/requirements.md
@@ -1,0 +1,17 @@
+# Specification Quality Checklist: Per-agent `effort` tuning rubric
+
+**Created**: 2026-06-13 · **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details · [x] User value focused · [x] Mandatory sections complete
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers · [x] Testable, unambiguous · [x] Measurable SCs
+- [x] Acceptance scenarios + edge cases · [x] Scope bounded; assumptions identified
+
+## Feature Readiness
+- [x] FRs have acceptance criteria · [x] Scenarios cover flows · [x] No impl details
+
+## Notes
+Mechanical frontmatter feature (Size S). Model pins verified: xhigh set (developer/qa-tester/devops-sre)
+is Opus-pinned → valid. architect/product-manager not in CLI bundle. No open markers.

--- a/.specflow/specs/016-agent-effort-rubric/contracts/effort-map.md
+++ b/.specflow/specs/016-agent-effort-rubric/contracts/effort-map.md
@@ -1,0 +1,28 @@
+# Contract: agent → effort assignment (authoritative)
+
+Every bundled agent under `templates/core/agents/` gets exactly this `effort:`. `xhigh` only on Opus.
+
+| Agent | model (current) | effort | Role class |
+|---|---|---|---|
+| review-coordinator | sonnet | **low** | pure orchestrator (dispatch only) |
+| workflow-manager | sonnet | **low** | pure orchestrator |
+| a11y-auditor | sonnet | **medium** | read-only auditor (structured findings) |
+| architecture-auditor | sonnet | **medium** | read-only auditor |
+| dependency-auditor | sonnet | **medium** | read-only auditor |
+| performance-auditor | sonnet | **medium** | read-only auditor |
+| security-auditor | sonnet | **medium** | read-only auditor |
+| code-reviewer | sonnet | **medium** | structured reviewer |
+| test-reviewer | sonnet | **medium** | structured reviewer |
+| specflow-expert | sonnet | **medium** | Q&A / explainer |
+| product-owner | opus | **medium** | backlog management |
+| ui-ux-designer | sonnet | **high** | design / higher-order reasoning |
+| developer | opus | **xhigh** | coding / agentic |
+| qa-tester | opus | **xhigh** | runs suites / agentic |
+| devops-sre | opus | **xhigh** | operates infra / agentic |
+
+Tally: 2 low · 9 medium · 1 high · 3 xhigh = 15.
+
+## Rules
+- Insert `effort:` into existing frontmatter (adjacent to `model:`); change nothing else.
+- The three `xhigh` agents are all `model: opus` — valid. No sonnet-pinned agent gets `xhigh`.
+- The README's tier member lists must match this table exactly.

--- a/.specflow/specs/016-agent-effort-rubric/data-model.md
+++ b/.specflow/specs/016-agent-effort-rubric/data-model.md
@@ -1,0 +1,21 @@
+# Data Model — per-agent effort rubric
+
+No runtime store. The model is the agent→tier assignment + the model-compat invariant. Asserted by a test.
+
+## Entity: Agent
+Identity = file stem. Gains one `effort:` frontmatter field. Carries an existing `model:`.
+
+## Value object: EffortTier(value, roleDefinition)
+`value` ∈ {low, medium, high, xhigh}. Role definitions per contracts/effort-map.md.
+
+## Relation: assignment (authoritative — see contracts/effort-map.md)
+- low: review-coordinator, workflow-manager
+- medium: a11y-auditor, architecture-auditor, dependency-auditor, performance-auditor, security-auditor, code-reviewer, test-reviewer, specflow-expert, product-owner
+- high: ui-ux-designer
+- xhigh: developer, qa-tester, devops-sre  (all model: opus)
+
+## Invariants
+- Every bundled agent has exactly one `effort:` ∈ {low, medium, high, xhigh}.
+- `effort: xhigh` ⇒ `model:` is opus.
+- Additive frontmatter only (no body/description/tools change).
+- README member lists == actual assignments (no drift).

--- a/.specflow/specs/016-agent-effort-rubric/plan.md
+++ b/.specflow/specs/016-agent-effort-rubric/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Per-agent `effort` tuning rubric
+
+**Branch**: `016-agent-effort-rubric` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)
+**Input**: issue mkrlabs/specflow#382, epic mkrlabs/specflow-monorepo#12
+
+## Summary
+
+Add one `effort:` frontmatter field (low|medium|high|xhigh) to each of the 15 bundled agents under
+`templates/core/agents/` per the documented rubric, and ship a `templates/core/agents/README.md`
+(→ `.claude/agents/README.md`) explaining the rubric + rationale + the `xhigh`-is-Opus-only caveat.
+Additive frontmatter only. Regenerate the bundle, mirror to plugin, add a test asserting every agent
+has a valid `effort:` and no Sonnet-pinned agent carries `xhigh`.
+
+## Technical Context
+
+**Language/Version**: markdown (agents + README); Deno/TS for the test + bundle
+**Primary Dependencies**: none new — existing bundle pipeline
+**Storage**: bundled agent files + a new README
+**Testing**: `deno task test`; a test loops `templates/core/agents/*.md`, asserts one `effort:` ∈ the set, and cross-checks `model:` vs `effort:` (no sonnet+xhigh)
+**Project Type**: cli (no src/ code)
+**Constraints**: additive frontmatter only; xhigh ⇒ Opus model
+**Scale/Scope**: 15 frontmatter edits + 1 README + manifest/bundle/plugin/test
+
+## Constitution Check
+Placeholder constitution — no gate. Additive config + docs; ship through the bundle. **PASS.**
+
+## Project Structure
+```text
+templates/core/agents/*.md            # EDIT ×15 — add effort: per the contract map
+templates/core/agents/README.md       # NEW — rubric + rationale + Opus-only caveat
+templates/manifest.json               # EDIT — register the README
+src/templates_bundle.ts               # REGENERATED
+plugin/agents/*.md + plugin/agents/README.md   # mirror
+tests/templates/agent_effort_test.ts  # NEW — every agent has valid effort; no sonnet+xhigh
+```
+
+**Structure Decision**: Effort map is authoritative in `contracts/effort-map.md` (and mirrored into the
+README). The 15 agents already declare `model:`; insert `effort:` adjacent. Register the new README in
+the manifest like other bundled agent files; mirror to `plugin/`.
+
+## Complexity Tracking
+> No violations — empty.

--- a/.specflow/specs/016-agent-effort-rubric/quickstart.md
+++ b/.specflow/specs/016-agent-effort-rubric/quickstart.md
@@ -1,0 +1,26 @@
+# Quickstart — per-agent effort rubric
+
+## Build & test
+```bash
+cd apps/specflow-cli
+deno task bundle
+deno task test     # bundle + agent_effort_test (every agent has valid effort; no sonnet+xhigh)
+```
+
+## Manual verification
+```bash
+# every agent declares effort
+for f in templates/core/agents/*.md; do grep -q "^effort:" "$f" || echo "MISSING: $f"; done
+# no sonnet agent carries xhigh
+for f in templates/core/agents/*.md; do
+  m=$(awk -F': ' '/^model:/{print $2}' "$f"); e=$(awk -F': ' '/^effort:/{print $2}' "$f")
+  [ "$m" = sonnet ] && [ "$e" = xhigh ] && echo "BAD: $f sonnet+xhigh"
+done
+test -f templates/core/agents/README.md   # rubric doc present
+```
+
+## Success signals
+- `deno task test` green incl. `agent_effort_test`.
+- All 15 agents carry a valid `effort:`; xhigh only on the three opus agents.
+- README documents the four tiers, members, rationale, and the Opus-only caveat.
+- `specflow init`/`upgrade` deliver the tuned agents + README.

--- a/.specflow/specs/016-agent-effort-rubric/research.md
+++ b/.specflow/specs/016-agent-effort-rubric/research.md
@@ -1,0 +1,36 @@
+# Research — per-agent effort rubric
+
+## Decision 1 — Tier assignment for the 15 bundled agents
+
+**Decision**: Map each bundled agent to one tier by role class (authoritative table in
+contracts/effort-map.md):
+- **low** (pure orchestrators — route + dispatch, no generation): review-coordinator, workflow-manager.
+- **medium** (read-only structured-findings producers + Q&A + backlog): a11y-auditor,
+  architecture-auditor, dependency-auditor, performance-auditor, security-auditor, code-reviewer,
+  test-reviewer, specflow-expert, product-owner.
+- **high** (design / higher-order reasoning): ui-ux-designer.
+- **xhigh** (coding / agentic / operates infra): developer, qa-tester, devops-sre.
+
+**Rationale**: Mirrors miximodel's rubric. Orchestrators are fire-and-forget → cheapest; auditors/
+reviewers produce bounded structured findings → medium; design needs more reasoning → high; agents
+that write code across many files / run suites / operate infra → xhigh. The rubric's `architect` and
+`product-manager` entries don't apply — those are monorepo-root agents, not in the CLI bundle.
+
+**Alternatives considered**: low for the per-axis-scoped auditors — but a bundled auditor agent is a
+single entity serving both the report flow and scoped dispatch; medium is the right single value for
+the agent. code-reviewer/test-reviewer as low — they generate review findings, so medium fits.
+
+## Decision 2 — Model compatibility (xhigh is Opus-only)
+
+**Decision**: Verified current pins — developer=opus, devops-sre=opus, qa-tester=opus,
+product-owner=opus; all others=sonnet. The `xhigh` set (developer, qa-tester, devops-sre) is therefore
+Opus-pinned and valid. All other tiers (low/medium/high) are model-agnostic. The README documents the
+caveat; a test asserts no sonnet-pinned agent carries xhigh.
+
+**Rationale**: `xhigh` on Sonnet 400s. Locking this with a test prevents a future regression when an
+agent's model is changed without revisiting its effort.
+
+## Decision 3 — README + distribution
+
+**Decision**: Ship `templates/core/agents/README.md` (→ `.claude/agents/README.md`) with the tier table,
+rationale, and caveat; register it in the manifest; mirror agents + README to `plugin/`.

--- a/.specflow/specs/016-agent-effort-rubric/spec.md
+++ b/.specflow/specs/016-agent-effort-rubric/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Per-agent `effort` tuning rubric
+
+**Feature Branch**: `016-agent-effort-rubric`
+**Created**: 2026-06-13
+**Status**: Draft
+**Input**: User description: "Mechanism D of the miximodel audit-team port (epic mkrlabs/specflow-monorepo#12). Give every bundled agent an explicit `effort:` frontmatter field (low|medium|high|xhigh) per a documented rubric — low for pure orchestrators, medium for report-generating auditors/reviewers + product-owner, high for design/architecture, xhigh for coding/agentic agents — and add an agents README explaining the compound cost/quality rationale. No agent left without `effort:`."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Predictable token spend across the agent fleet (Priority: P1)
+
+A maintainer dispatches many agents (a `/code-audit` with several seats, a `review-coordinator` run). Today the effort level is the opaque default, over-provisioning fire-and-forget orchestrators and risking under-provisioning coding agents. With every agent carrying an explicit `effort:`, spend is intentional and legible: orchestrators run cheap, coding agents run deep.
+
+**Why this priority**: The entire value of mechanism D — explicit, rubric-driven effort so parallel dispatch is cost-predictable.
+
+**Independent Test**: Inspect each bundled agent's frontmatter; confirm every one has an `effort:` field whose value matches the rubric for its role.
+
+**Acceptance Scenarios**:
+
+1. **Given** any bundled agent, **When** its frontmatter is read, **Then** it has exactly one `effort:` field with a value in {low, medium, high, xhigh}.
+2. **Given** a pure orchestrator (review-coordinator, workflow-manager), **When** read, **Then** `effort: low`.
+3. **Given** a coding/agentic agent (developer, qa-tester, devops-sre), **When** read, **Then** `effort: xhigh`.
+
+---
+
+### User Story 2 - Understand why each agent is tuned as it is (Priority: P2)
+
+A maintainer (or a future agent author) reads an agents README that states the rubric and its rationale — the compound cost/quality tradeoff that makes `low` right for dispatchers and `xhigh` right for code-writers — so new agents follow the same logic.
+
+**Why this priority**: Durability — without the documented rationale, future agents are tuned ad hoc. Trails the assignment itself.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agents README, **When** read, **Then** it lists each effort tier, which agents are in it, and the rationale.
+2. **Given** the README, **When** read, **Then** it notes the model-compatibility caveat (`xhigh` is Opus-only) so an author doesn't set `xhigh` on a Sonnet-pinned agent.
+
+---
+
+### Edge Cases
+
+- **`xhigh` on a Sonnet-pinned agent** → invalid (would 400). The rubric assigns `xhigh` only to Opus-pinned agents; the README documents the caveat.
+- **An agent not explicitly named in the rubric** (e.g. specflow-expert, code-reviewer, test-reviewer) → assigned by its role class (read-only structured-findings/Q&A → medium), and the README records the mapping so none is left unclassified.
+- **A future agent added without `effort:`** → the README's rule (every agent declares effort) plus a test that asserts presence catches the omission.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every bundled agent under `templates/core/agents/` MUST carry exactly one `effort:` frontmatter field with a value in {`low`, `medium`, `high`, `xhigh`}.
+- **FR-002**: Assignments MUST follow the rubric: pure orchestrators (route+dispatch only) → `low`; report-generating auditors, structured reviewers, the Q&A explainer, and product-owner → `medium`; design/UX (and architecture-level reasoning) → `high`; coding/agentic agents (write code / run suites / operate infra) → `xhigh`.
+- **FR-003**: `effort: xhigh` MUST only be assigned to agents pinned to an Opus `model:` (xhigh is Opus-only); no Sonnet-pinned agent may carry `xhigh`.
+- **FR-004**: An agents README (`templates/core/agents/README.md`, delivered to `.claude/agents/README.md`) MUST document the rubric: each tier, its member agents, the compound cost/quality rationale, and the `xhigh`-is-Opus-only caveat.
+- **FR-005**: The change MUST be additive frontmatter only — no agent's description, body, tools, or other frontmatter is altered.
+- **FR-006**: The README and the updated agents MUST ship through the bundle (`init`/`upgrade`); the README registered in the manifest, the agents re-bundled. Plugin mirror updated (agents + README are markdown).
+
+### Key Entities *(see Domain Model section below for full structure)*
+
+- **Effort tier**: one of low/medium/high/xhigh, with a role definition and a member set.
+- **Agent effort assignment**: the binding of one agent to one tier.
+
+## Domain Model *(mandatory)*
+
+**Bounded context:** Agent Effort Tuning — a frontmatter-level cost/quality policy over the bundled agent fleet. Pure configuration + documentation; no runtime behaviour change (effort is a dispatch hint).
+
+**Vocabulary (Ubiquitous language):**
+
+- **Effort tier** — `low` | `medium` | `high` | `xhigh`; the reasoning budget hint.
+- **Role class** — orchestrator / auditor-reviewer / designer / coder; maps to a tier.
+- **Model-compatibility** — `xhigh` is Opus-only; other tiers are universal.
+
+**Entities (have identity):**
+
+- **Agent** — identified by file stem; gains one `effort:` field. Existing entity; this adds the field.
+
+**Value objects (no identity, immutable):**
+
+- **EffortTier(value, roleDefinition, rationale)** — documented in the README.
+
+**Invariants (rules the domain must never break):**
+
+- Every bundled agent has exactly one `effort:` ∈ {low, medium, high, xhigh}.
+- `xhigh` ⇒ the agent's `model:` is an Opus model.
+- The change is additive frontmatter only (no body/description/tools edits).
+- The README's member lists match the actual agent assignments (no drift).
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- Tuning agent prompts for quality (separate from effort).
+- The dispatch mechanism (effort is a hint, not a runtime switch).
+- Cloud/Mobile agent tuning; `architect`/`product-manager` (monorepo-root agents, not in the CLI bundle).
+- FinOps cost-projection seat (Cloud-specific).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of bundled agents carry an `effort:` field with a valid value — verifiable by a test that loops the agents.
+- **SC-002**: 0 Sonnet-pinned agents carry `xhigh` (model-compat invariant) — verifiable by a test cross-checking `model:` vs `effort:`.
+- **SC-003**: The README documents all four tiers, their members, the rationale, and the Opus-only caveat; its member lists match the actual assignments.
+- **SC-004**: No agent's description/body/tools changed (additive frontmatter only) — verifiable from the diff.
+- **SC-005**: A fresh `specflow init` / `upgrade` delivers the effort-tuned agents and the README.
+
+## Assumptions
+
+- The bundled fleet is the 15 agents under `templates/core/agents/`; `architect`/`product-manager` are monorepo-root agents and out of scope here.
+- Current model pins: developer/devops-sre/qa-tester/product-owner = opus; the rest = sonnet. So the rubric's `xhigh` set (developer, qa-tester, devops-sre) is Opus-pinned and valid; all other tiers are model-agnostic.
+- `effort` is consumed by the harness as a frontmatter hint (no Specflow runtime code reads it); shipping it is additive and safe for agents on any model (except the Opus-only `xhigh` constraint).
+- Distribution reuses the bundle/manifest path; agents + the new README are markdown → mirrored to `plugin/`.

--- a/.specflow/specs/016-agent-effort-rubric/tasks.md
+++ b/.specflow/specs/016-agent-effort-rubric/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Per-agent `effort` tuning rubric
+
+**Feature**: `016-agent-effort-rubric` | **Branch**: `016-agent-effort-rubric` | **Issue**: mkrlabs/specflow#382 (epic mkrlabs/specflow-monorepo#12)
+**Inputs**: [plan.md](./plan.md) · [spec.md](./spec.md) · contracts/effort-map.md (authoritative) · [research.md](./research.md) · [data-model.md](./data-model.md)
+
+Mechanical: add one `effort:` line per agent + a README. Asserted under `deno task test`.
+
+## Phase 1: Frontmatter
+- [ ] T001 Add `effort:` to each of the 15 `templates/core/agents/*.md` EXACTLY per contracts/effort-map.md
+      (low: review-coordinator, workflow-manager; medium: a11y/architecture/dependency/performance/
+      security-auditor, code-reviewer, test-reviewer, specflow-expert, product-owner; high: ui-ux-designer;
+      xhigh: developer, qa-tester, devops-sre). Insert adjacent to `model:`; change nothing else (FR-005).
+
+## Phase 2: README
+- [ ] T002 Author `templates/core/agents/README.md` (→ `.claude/agents/README.md`): the four-tier table
+      with member lists (matching effort-map.md), the compound cost/quality rationale, and the
+      `xhigh`-is-Opus-only caveat. (FR-004)
+
+## Phase 3: Distribution
+- [ ] T003 Register the README in `templates/manifest.json` (agent-file shape); `deno task bundle`;
+      confirm the 15 effort fields + the README are in `src/templates_bundle.ts`.
+- [ ] T004 Mirror the 15 agents + README to `plugin/agents/` byte-identical; extend
+      `tests/plugin/plugin_sync_test.ts`. Bump init `*_test.ts` counts ONLY if a new file lands in a
+      counted dir (the README under `.claude/agents/` — verify whether codex/copilot/windsurf count it;
+      adjust if so).
+
+## Phase 4: Tests
+- [ ] T005 `tests/templates/agent_effort_test.ts`: loop `templates/core/agents/*.md` — assert each has
+      exactly one `effort:` ∈ {low,medium,high,xhigh} (SC-001); assert no agent with `model: sonnet`
+      has `effort: xhigh` (SC-002); assert the per-agent value matches effort-map.md.
+- [ ] T006 Run `deno task test` GREEN; `deno fmt` + `deno lint` on touched TS.
+
+## Phase 5: Polish
+- [ ] T007 Sanity-check `upgrade` (spec 011): the 15 agents are CHANGED managed files (delivered unless
+      a user customised one → preserved); the README is net-new (added cleanly).
+
+## Dependencies
+- T001 → T003/T005. T002 → T003. T003 → T004. All quick.

--- a/plugin/agents/README.md
+++ b/plugin/agents/README.md
@@ -1,0 +1,58 @@
+# Agent effort rubric
+
+Every bundled agent declares an `effort:` field in its frontmatter. `effort`
+is a reasoning-budget hint the harness reads when it dispatches the agent: it
+trades **token spend** against **reasoning depth**. A higher tier thinks
+harder (and costs more); a lower tier returns faster and cheaper.
+
+Effort is assigned by **role class**, not by how important an agent feels. The
+goal is *legible, intentional spend*: when a coordinator fans out several
+agents in parallel, fire-and-forget dispatchers must not burn a coding-agent's
+budget, and a code-writer must not be starved of the depth it needs.
+
+## The four tiers
+
+| Tier     | Role class                                                     | Agents |
+| -------- | -------------------------------------------------------------- | ------ |
+| `low`    | Pure orchestrators — route and dispatch only, no deep reasoning | `review-coordinator`, `workflow-manager` |
+| `medium` | Read-only auditors, structured reviewers, the Q&A explainer, and the backlog owner | `a11y-auditor`, `architecture-auditor`, `dependency-auditor`, `performance-auditor`, `security-auditor`, `code-reviewer`, `test-reviewer`, `specflow-expert`, `product-owner` |
+| `high`   | Design / higher-order reasoning                                | `ui-ux-designer` |
+| `xhigh`  | Coding / agentic work — writes multi-file changes, runs suites, operates infra | `developer`, `qa-tester`, `devops-sre` |
+
+Tally: 2 `low` · 9 `medium` · 1 `high` · 3 `xhigh` = 15 agents.
+
+## Rationale — the compound cost/quality tradeoff
+
+Effort compounds. A coordinator that itself spawns N sub-agents pays its own
+reasoning budget *plus* every child's. So the budget belongs where the
+thinking actually happens:
+
+- **`low` for pure orchestrators.** `review-coordinator` and
+  `workflow-manager` don't reason about the work — they decide *who* runs and
+  aggregate what comes back. Spending deep-reasoning tokens on a dispatcher is
+  pure waste, multiplied across every fan-out.
+- **`medium` for auditors, reviewers, the explainer, and the PO.** These read
+  code (or backlog) and emit structured findings. They need genuine analysis
+  but not the open-ended exploration of writing a feature. `medium` buys
+  enough depth to spot real issues without over-provisioning a read-only pass.
+- **`high` for design.** `ui-ux-designer` does higher-order, open-ended
+  reasoning (synthesising a coherent design system from a brief), which
+  rewards more budget than a structured audit — but it isn't writing and
+  running multi-file code.
+- **`xhigh` for coding/agentic agents.** `developer`, `qa-tester`, and
+  `devops-sre` write multi-file changes, run suites, and operate
+  infrastructure. Under-provisioning them is the expensive failure mode: a
+  shallow coding pass ships bugs that cost far more than the saved tokens.
+  This is the one tier where spending *more* is the economical choice.
+
+## Caveat — `xhigh` is Opus-only
+
+`xhigh` is only valid on an agent pinned to an Opus `model:`. A Sonnet-pinned
+agent that declares `effort: xhigh` is rejected by the harness (it would 400
+on dispatch). The three `xhigh` agents above (`developer`, `qa-tester`,
+`devops-sre`) are all `model: opus`, which is why the tier is valid for them.
+
+When adding a new agent: pick its tier by role class from the table above, and
+**never** set `xhigh` unless the agent is also `model: opus`. Every bundled
+agent must carry exactly one `effort:` value from {`low`, `medium`, `high`,
+`xhigh`}.

--- a/plugin/agents/a11y-auditor.md
+++ b/plugin/agents/a11y-auditor.md
@@ -2,6 +2,7 @@
 name: a11y-auditor
 description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/architecture-auditor.md
+++ b/plugin/agents/architecture-auditor.md
@@ -2,6 +2,7 @@
 name: architecture-auditor
 description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/code-reviewer.md
+++ b/plugin/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/dependency-auditor.md
+++ b/plugin/agents/dependency-auditor.md
@@ -2,6 +2,7 @@
 name: dependency-auditor
 description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/developer.md
+++ b/plugin/agents/developer.md
@@ -2,6 +2,7 @@
 name: developer
 description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 skills: workflow-contract, handoff-protocol
 permissionMode: acceptEdits

--- a/plugin/agents/devops-sre.md
+++ b/plugin/agents/devops-sre.md
@@ -2,6 +2,7 @@
 name: devops-sre
 description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Manual-only — invoke explicitly when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40

--- a/plugin/agents/performance-auditor.md
+++ b/plugin/agents/performance-auditor.md
@@ -2,6 +2,7 @@
 name: performance-auditor
 description: Reviews code for performance issues — N+1 queries, blocking I/O on hot paths, missing indexes, cache misuse, hot-path allocation, sync-in-async, large bundles, render-thrash. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit performance).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -2,6 +2,7 @@
 name: product-owner
 description: Product Owner and business guardian. Owns the product backlog, all mutation semantics, epic / sub-task relationships, and recommends workflow (Specflow spec vs direct implementation). Use when the user asks about backlog, priorities, "what next", or wants to break work into an epic.
 model: opus
+effort: medium
 tools: Read, Write, Edit, Grep, Glob, Bash
 maxTurns: 30
 color: cyan

--- a/plugin/agents/qa-tester.md
+++ b/plugin/agents/qa-tester.md
@@ -2,6 +2,7 @@
 name: qa-tester
 description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 skills: qa-report-contract, workflow-contract
 permissionMode: acceptEdits

--- a/plugin/agents/review-coordinator.md
+++ b/plugin/agents/review-coordinator.md
@@ -2,6 +2,7 @@
 name: review-coordinator
 description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
+effort: low
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 skills: workflow-contract, handoff-protocol, review-findings-contract
 maxTurns: 30

--- a/plugin/agents/security-auditor.md
+++ b/plugin/agents/security-auditor.md
@@ -2,6 +2,7 @@
 name: security-auditor
 description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/specflow-expert.md
+++ b/plugin/agents/specflow-expert.md
@@ -9,6 +9,7 @@ description: >
   invocations (`specflow init`, `specflow upgrade`, `/specflow specify`,
   `/backlog ...`) — those are command runs, not questions.
 model: sonnet
+effort: medium
 tools: Read, WebFetch, Grep, Glob, Bash, Agent
 permissionMode: default
 maxTurns: 10

--- a/plugin/agents/test-reviewer.md
+++ b/plugin/agents/test-reviewer.md
@@ -2,6 +2,7 @@
 name: test-reviewer
 description: Reviews test coverage and quality for changed code. Spawned by the review-coordinator when the diff contains test files.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/plugin/agents/ui-ux-designer.md
+++ b/plugin/agents/ui-ux-designer.md
@@ -2,6 +2,7 @@
 name: ui-ux-designer
 description: Owns the project's `DESIGN.md` design system. Three modes auto-selected from DESIGN.md state — discovery interview when absent (creates a fresh, opinionated design system from the user's brief), edit mode when present (refactors typography / palette / spacing / components on demand), audit mode on explicit dispatch (scans existing UI source for drift against DESIGN.md). Stack-agnostic — produces a Markdown spec the user's developer agent translates into code. Never invokes itself.
 model: sonnet
+effort: high
 tools: Read, Edit, Write, Glob, Grep
 maxTurns: 30
 disable-model-invocation: true

--- a/plugin/agents/workflow-manager.md
+++ b/plugin/agents/workflow-manager.md
@@ -2,6 +2,7 @@
 name: workflow-manager
 description: Orchestrates multi-phase feature delivery across specialist agents. Use as the lead session agent for long-running implementations.
 model: sonnet
+effort: low
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
 skills: workflow-contract, handoff-protocol
 maxTurns: 60

--- a/src/domain/core_bundle.ts
+++ b/src/domain/core_bundle.ts
@@ -3,6 +3,7 @@ import type { BacklogBackend } from "./installed_lock.ts";
 export type CoreCategory =
   | "agent"
   | "agent-memory"
+  | "agent-doc"
   | "skill"
   | "phase"
   | "phase-script"

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -51,6 +51,8 @@ function destinationFor(entry: CoreEntry): string {
       return backlogScriptDestination(entry);
     case "agent-memory":
       throw new Error("agent-memory entries should be filtered before destinationFor");
+    case "agent-doc":
+      throw new Error("agent-doc entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -71,8 +73,9 @@ export class AntigravityHarness implements Harness {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
       const entry = applyScheme(backendApplied, opts);
-      // agent-memory is Claude-only (folder convention); other harnesses skip.
-      if (entry.category === "agent-memory") continue;
+      // agent-memory and the agent-fleet README are Claude-only conventions;
+      // other harnesses skip them.
+      if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;
       const dest = destinationFor(entry);
       let content: string;
       switch (entry.category) {

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -15,6 +15,13 @@ function destinationFor(entry: CoreEntry): string {
     case "agent-memory":
       if (!entry.suffix) throw new Error(`agent-memory needs suffix: ${entry.name}`);
       return `.claude/agents/${entry.name}/memory/${entry.suffix}`;
+    case "agent-doc":
+      // The agent-fleet README is a Claude-only convention; it sits beside the
+      // agent files at `.claude/agents/README.md`. Other harnesses skip it
+      // (the agents are transformed into harness-specific formats there, so a
+      // README describing the `.claude/agents/` layout has no destination).
+      if (!entry.suffix) throw new Error(`agent-doc needs suffix: ${entry.name}`);
+      return `.claude/agents/${entry.suffix}`;
     case "skill":
     case "backlog-skill":
       // Claude doesn't add a `specflow-` prefix — skill names are emitted

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -62,8 +62,9 @@ export class CodexHarness implements Harness {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
       const entry = applyScheme(backendApplied, opts);
-      // agent-memory is Claude-only (folder convention); other harnesses skip.
-      if (entry.category === "agent-memory") continue;
+      // agent-memory and the agent-fleet README are Claude-only conventions;
+      // other harnesses skip them.
+      if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;
       switch (entry.category) {
         case "agent":
           out[`.codex/agents/${entry.name}.toml`] = {

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -29,6 +29,8 @@ function destinationFor(entry: CoreEntry): string {
       return backlogScriptDestination(entry);
     case "agent-memory":
       throw new Error("agent-memory entries should be filtered before destinationFor");
+    case "agent-doc":
+      throw new Error("agent-doc entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -49,8 +51,9 @@ export class CopilotHarness implements Harness {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
       const entry = applyScheme(backendApplied, opts);
-      // agent-memory is Claude-only (folder convention); other harnesses skip.
-      if (entry.category === "agent-memory") continue;
+      // agent-memory and the agent-fleet README are Claude-only conventions;
+      // other harnesses skip them.
+      if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;
       const dest = destinationFor(entry);
       const isInstruction = entry.category === "backlog-cmd" ||
         entry.category === "agent" ||

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -22,6 +22,8 @@ function destinationFor(entry: CoreEntry): string {
       return backlogScriptDestination(entry);
     case "agent-memory":
       throw new Error("agent-memory entries should be filtered before destinationFor");
+    case "agent-doc":
+      throw new Error("agent-doc entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -42,8 +44,9 @@ export class CursorHarness implements Harness {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
       const entry = applyScheme(backendApplied, opts);
-      // agent-memory is Claude-only (folder convention); other harnesses skip.
-      if (entry.category === "agent-memory") continue;
+      // agent-memory and the agent-fleet README are Claude-only conventions;
+      // other harnesses skip them.
+      if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;
       const dest = destinationFor(entry);
       let content = entry.content;
       const isSkillFile = entry.category === "backlog-cmd" ||

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -114,6 +114,8 @@ function destinationFor(entry: CoreEntry): string {
       return backlogScriptDestination(entry);
     case "agent-memory":
       throw new Error("agent-memory entries should be filtered before destinationFor");
+    case "agent-doc":
+      throw new Error("agent-doc entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -134,8 +136,9 @@ export class OpenCodeHarness implements Harness {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
       const entry = applyScheme(backendApplied, opts);
-      // agent-memory is Claude-only (folder convention); other harnesses skip.
-      if (entry.category === "agent-memory") continue;
+      // agent-memory and the agent-fleet README are Claude-only conventions;
+      // other harnesses skip them.
+      if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;
       const dest = destinationFor(entry);
       let content: string;
       switch (entry.category) {

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -45,6 +45,8 @@ function destinationFor(entry: CoreEntry): string {
       return backlogScriptDestination(entry);
     case "agent-memory":
       throw new Error("agent-memory entries should be filtered before destinationFor");
+    case "agent-doc":
+      throw new Error("agent-doc entries should be filtered before destinationFor");
     case "spec-root":
       if (!entry.suffix) throw new Error(`spec-root needs suffix`);
       return `.specflow/${entry.suffix}`;
@@ -65,8 +67,9 @@ export class WindsurfHarness implements Harness {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
       const entry = applyScheme(backendApplied, opts);
-      // agent-memory is Claude-only (folder convention); other harnesses skip.
-      if (entry.category === "agent-memory") continue;
+      // agent-memory and the agent-fleet README are Claude-only conventions;
+      // other harnesses skip them.
+      if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;
       out[destinationFor(entry)] = {
         content: stripCascadeIgnoredFields(entry.content),
         executable: entry.executable,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -6493,6 +6493,7 @@ Do not duplicate it here — the dispatcher defers to the agent.
 name: product-owner
 description: Product Owner and business guardian. Owns the product backlog, all mutation semantics, epic / sub-task relationships, and recommends workflow (Specflow spec vs direct implementation). Use when the user asks about backlog, priorities, "what next", or wants to break work into an epic.
 model: opus
+effort: medium
 tools: Read, Write, Edit, Grep, Glob, Bash
 maxTurns: 30
 color: cyan
@@ -6774,6 +6775,7 @@ Line format: \`<one-liner> @ <path>:<line> — <reason out of scope>\`.
 name: developer
 description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 skills: workflow-contract, handoff-protocol
 permissionMode: acceptEdits
@@ -6911,6 +6913,7 @@ needs to make in the prose and the \`BLOCKERS\` field.
 name: review-coordinator
 description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
+effort: low
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 skills: workflow-contract, handoff-protocol, review-findings-contract
 maxTurns: 30
@@ -6998,6 +7001,7 @@ and, when handing the gate result back, the \`HANDOFF\` block per
 name: code-reviewer
 description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -7066,6 +7070,7 @@ emit the \`WORKFLOW STATUS\` block per \`workflow-contract\`.
 name: security-auditor
 description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -7205,6 +7210,7 @@ and is out of scope for the review-findings-contract.)
 name: test-reviewer
 description: Reviews test coverage and quality for changed code. Spawned by the review-coordinator when the diff contains test files.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -7249,6 +7255,7 @@ the four severity counts, \`TOP_ISSUES\`, \`RECOMMENDATION\`), then the
 name: qa-tester
 description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 skills: qa-report-contract, workflow-contract
 permissionMode: acceptEdits
@@ -7300,6 +7307,7 @@ preloaded \`qa-report-contract\` skill (it is the single authoritative schema:
 name: workflow-manager
 description: Orchestrates multi-phase feature delivery across specialist agents. Use as the lead session agent for long-running implementations.
 model: sonnet
+effort: low
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
 skills: workflow-contract, handoff-protocol
 maxTurns: 60
@@ -7374,6 +7382,7 @@ before advancing.
 name: devops-sre
 description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Manual-only — invoke explicitly when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40
@@ -7496,6 +7505,7 @@ description: >
   invocations (\`specflow init\`, \`specflow upgrade\`, \`/specflow specify\`,
   \`/backlog ...\`) — those are command runs, not questions.
 model: sonnet
+effort: medium
 tools: Read, WebFetch, Grep, Glob, Bash, Agent
 permissionMode: default
 maxTurns: 10
@@ -7719,6 +7729,7 @@ Agnostic of language / LLM / harness / backlog backend. Single binary via \`deno
 name: ui-ux-designer
 description: Owns the project's \`DESIGN.md\` design system. Three modes auto-selected from DESIGN.md state — discovery interview when absent (creates a fresh, opinionated design system from the user's brief), edit mode when present (refactors typography / palette / spacing / components on demand), audit mode on explicit dispatch (scans existing UI source for drift against DESIGN.md). Stack-agnostic — produces a Markdown spec the user's developer agent translates into code. Never invokes itself.
 model: sonnet
+effort: high
 tools: Read, Edit, Write, Glob, Grep
 maxTurns: 30
 disable-model-invocation: true
@@ -7939,6 +7950,7 @@ or other agents. Design decisions are not cheap and must be intentional
 name: performance-auditor
 description: Reviews code for performance issues — N+1 queries, blocking I/O on hot paths, missing indexes, cache misuse, hot-path allocation, sync-in-async, large bundles, render-thrash. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit performance).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -8099,6 +8111,7 @@ Same \`FINDING\` structure as code-reviewer, followed by exactly one
 name: a11y-auditor
 description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -8296,6 +8309,7 @@ Same \`FINDING\` structure as code-reviewer, followed by exactly one
 name: architecture-auditor
 description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -8494,6 +8508,7 @@ emits neither block — backlog material is not pass/fail.
 name: dependency-auditor
 description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20
@@ -8731,6 +8746,73 @@ RECOMMENDATION: <one sentence — what the next actor should do>
 \`fail\` when either is > 0; \`needs_followup\` when only Medium/Low remain. Then
 emit the \`WORKFLOW STATUS\` block per \`workflow-contract\`. Audit-mode (Mode 2)
 emits neither block — backlog material is not pass/fail.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "agent-doc",
+    name: "agents-readme",
+    suffix: "README.md",
+    content: `# Agent effort rubric
+
+Every bundled agent declares an \`effort:\` field in its frontmatter. \`effort\`
+is a reasoning-budget hint the harness reads when it dispatches the agent: it
+trades **token spend** against **reasoning depth**. A higher tier thinks
+harder (and costs more); a lower tier returns faster and cheaper.
+
+Effort is assigned by **role class**, not by how important an agent feels. The
+goal is *legible, intentional spend*: when a coordinator fans out several
+agents in parallel, fire-and-forget dispatchers must not burn a coding-agent's
+budget, and a code-writer must not be starved of the depth it needs.
+
+## The four tiers
+
+| Tier     | Role class                                                     | Agents |
+| -------- | -------------------------------------------------------------- | ------ |
+| \`low\`    | Pure orchestrators — route and dispatch only, no deep reasoning | \`review-coordinator\`, \`workflow-manager\` |
+| \`medium\` | Read-only auditors, structured reviewers, the Q&A explainer, and the backlog owner | \`a11y-auditor\`, \`architecture-auditor\`, \`dependency-auditor\`, \`performance-auditor\`, \`security-auditor\`, \`code-reviewer\`, \`test-reviewer\`, \`specflow-expert\`, \`product-owner\` |
+| \`high\`   | Design / higher-order reasoning                                | \`ui-ux-designer\` |
+| \`xhigh\`  | Coding / agentic work — writes multi-file changes, runs suites, operates infra | \`developer\`, \`qa-tester\`, \`devops-sre\` |
+
+Tally: 2 \`low\` · 9 \`medium\` · 1 \`high\` · 3 \`xhigh\` = 15 agents.
+
+## Rationale — the compound cost/quality tradeoff
+
+Effort compounds. A coordinator that itself spawns N sub-agents pays its own
+reasoning budget *plus* every child's. So the budget belongs where the
+thinking actually happens:
+
+- **\`low\` for pure orchestrators.** \`review-coordinator\` and
+  \`workflow-manager\` don't reason about the work — they decide *who* runs and
+  aggregate what comes back. Spending deep-reasoning tokens on a dispatcher is
+  pure waste, multiplied across every fan-out.
+- **\`medium\` for auditors, reviewers, the explainer, and the PO.** These read
+  code (or backlog) and emit structured findings. They need genuine analysis
+  but not the open-ended exploration of writing a feature. \`medium\` buys
+  enough depth to spot real issues without over-provisioning a read-only pass.
+- **\`high\` for design.** \`ui-ux-designer\` does higher-order, open-ended
+  reasoning (synthesising a coherent design system from a brief), which
+  rewards more budget than a structured audit — but it isn't writing and
+  running multi-file code.
+- **\`xhigh\` for coding/agentic agents.** \`developer\`, \`qa-tester\`, and
+  \`devops-sre\` write multi-file changes, run suites, and operate
+  infrastructure. Under-provisioning them is the expensive failure mode: a
+  shallow coding pass ships bugs that cost far more than the saved tokens.
+  This is the one tier where spending *more* is the economical choice.
+
+## Caveat — \`xhigh\` is Opus-only
+
+\`xhigh\` is only valid on an agent pinned to an Opus \`model:\`. A Sonnet-pinned
+agent that declares \`effort: xhigh\` is rejected by the harness (it would 400
+on dispatch). The three \`xhigh\` agents above (\`developer\`, \`qa-tester\`,
+\`devops-sre\`) are all \`model: opus\`, which is why the tier is valid for them.
+
+When adding a new agent: pick its tier by role class from the table above, and
+**never** set \`xhigh\` unless the agent is also \`model: opus\`. Every bundled
+agent must carry exactly one \`effort:\` value from {\`low\`, \`medium\`, \`high\`,
+\`xhigh\`}.
 `,
     executable: false,
     backend: null,

--- a/templates/core/agents/README.md
+++ b/templates/core/agents/README.md
@@ -1,0 +1,58 @@
+# Agent effort rubric
+
+Every bundled agent declares an `effort:` field in its frontmatter. `effort`
+is a reasoning-budget hint the harness reads when it dispatches the agent: it
+trades **token spend** against **reasoning depth**. A higher tier thinks
+harder (and costs more); a lower tier returns faster and cheaper.
+
+Effort is assigned by **role class**, not by how important an agent feels. The
+goal is *legible, intentional spend*: when a coordinator fans out several
+agents in parallel, fire-and-forget dispatchers must not burn a coding-agent's
+budget, and a code-writer must not be starved of the depth it needs.
+
+## The four tiers
+
+| Tier     | Role class                                                     | Agents |
+| -------- | -------------------------------------------------------------- | ------ |
+| `low`    | Pure orchestrators — route and dispatch only, no deep reasoning | `review-coordinator`, `workflow-manager` |
+| `medium` | Read-only auditors, structured reviewers, the Q&A explainer, and the backlog owner | `a11y-auditor`, `architecture-auditor`, `dependency-auditor`, `performance-auditor`, `security-auditor`, `code-reviewer`, `test-reviewer`, `specflow-expert`, `product-owner` |
+| `high`   | Design / higher-order reasoning                                | `ui-ux-designer` |
+| `xhigh`  | Coding / agentic work — writes multi-file changes, runs suites, operates infra | `developer`, `qa-tester`, `devops-sre` |
+
+Tally: 2 `low` · 9 `medium` · 1 `high` · 3 `xhigh` = 15 agents.
+
+## Rationale — the compound cost/quality tradeoff
+
+Effort compounds. A coordinator that itself spawns N sub-agents pays its own
+reasoning budget *plus* every child's. So the budget belongs where the
+thinking actually happens:
+
+- **`low` for pure orchestrators.** `review-coordinator` and
+  `workflow-manager` don't reason about the work — they decide *who* runs and
+  aggregate what comes back. Spending deep-reasoning tokens on a dispatcher is
+  pure waste, multiplied across every fan-out.
+- **`medium` for auditors, reviewers, the explainer, and the PO.** These read
+  code (or backlog) and emit structured findings. They need genuine analysis
+  but not the open-ended exploration of writing a feature. `medium` buys
+  enough depth to spot real issues without over-provisioning a read-only pass.
+- **`high` for design.** `ui-ux-designer` does higher-order, open-ended
+  reasoning (synthesising a coherent design system from a brief), which
+  rewards more budget than a structured audit — but it isn't writing and
+  running multi-file code.
+- **`xhigh` for coding/agentic agents.** `developer`, `qa-tester`, and
+  `devops-sre` write multi-file changes, run suites, and operate
+  infrastructure. Under-provisioning them is the expensive failure mode: a
+  shallow coding pass ships bugs that cost far more than the saved tokens.
+  This is the one tier where spending *more* is the economical choice.
+
+## Caveat — `xhigh` is Opus-only
+
+`xhigh` is only valid on an agent pinned to an Opus `model:`. A Sonnet-pinned
+agent that declares `effort: xhigh` is rejected by the harness (it would 400
+on dispatch). The three `xhigh` agents above (`developer`, `qa-tester`,
+`devops-sre`) are all `model: opus`, which is why the tier is valid for them.
+
+When adding a new agent: pick its tier by role class from the table above, and
+**never** set `xhigh` unless the agent is also `model: opus`. Every bundled
+agent must carry exactly one `effort:` value from {`low`, `medium`, `high`,
+`xhigh`}.

--- a/templates/core/agents/a11y-auditor.md
+++ b/templates/core/agents/a11y-auditor.md
@@ -2,6 +2,7 @@
 name: a11y-auditor
 description: Reviews front-end code for WCAG 2.1 AA accessibility issues — semantic HTML, heading hierarchy, alt text, form labels, keyboard nav, focus indicators, ARIA correctness, color contrast (where computable from source). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit accessibility).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/architecture-auditor.md
+++ b/templates/core/agents/architecture-auditor.md
@@ -2,6 +2,7 @@
 name: architecture-auditor
 description: Reviews code for architectural drift — hex-layer violations, circular deps, god files, bounded-context leaks, ports/adapters discipline, implicit globals, deep nesting, test-isolation bleed. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit architecture).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/code-reviewer.md
+++ b/templates/core/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Reviews code quality, architecture, DRY/YAGNI, readability, and conformance to the project constitution. Spawned by the review-coordinator during /specflow review.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/dependency-auditor.md
+++ b/templates/core/agents/dependency-auditor.md
@@ -2,6 +2,7 @@
 name: dependency-auditor
 description: Reviews dependency manifests for hygiene — outdated pins, unbounded ranges, unused declared deps, license violations, advisory-shape signals, peer-dep conflicts, typosquatting heuristics. Multi-manifest aware (npm / pyproject / Cargo / composer / Gemfile / go.mod / deno.json). Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit dependencies).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/developer.md
+++ b/templates/core/agents/developer.md
@@ -2,6 +2,7 @@
 name: developer
 description: Senior developer that implements tasks from tasks.md, fixes review feedback, and ships features. Manual-only — invoke explicitly when you have a tasks.md to execute or a review note to address.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 skills: workflow-contract, handoff-protocol
 permissionMode: acceptEdits

--- a/templates/core/agents/devops-sre.md
+++ b/templates/core/agents/devops-sre.md
@@ -2,6 +2,7 @@
 name: devops-sre
 description: Cloud infrastructure, CI/CD, containers, and observability across GCP / Azure / AWS. Manual-only — invoke explicitly when the task touches IaC (Terraform / Pulumi), pipelines, Docker / Kubernetes, monitoring / alerting, or production rollout.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 permissionMode: acceptEdits
 maxTurns: 40

--- a/templates/core/agents/performance-auditor.md
+++ b/templates/core/agents/performance-auditor.md
@@ -2,6 +2,7 @@
 name: performance-auditor
 description: Reviews code for performance issues — N+1 queries, blocking I/O on hot paths, missing indexes, cache misuse, hot-path allocation, sync-in-async, large bundles, render-thrash. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) full-codebase audit (spawned by /specflow audit performance).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -2,6 +2,7 @@
 name: product-owner
 description: Product Owner and business guardian. Owns the product backlog, all mutation semantics, epic / sub-task relationships, and recommends workflow (Specflow spec vs direct implementation). Use when the user asks about backlog, priorities, "what next", or wants to break work into an epic.
 model: opus
+effort: medium
 tools: Read, Write, Edit, Grep, Glob, Bash
 maxTurns: 30
 color: cyan

--- a/templates/core/agents/qa-tester.md
+++ b/templates/core/agents/qa-tester.md
@@ -2,6 +2,7 @@
 name: qa-tester
 description: Audits test coverage, writes missing tests, and runs the full suite. Manual-only — spawned by /specflow implement after the review gate passes; do not auto-invoke for casual "run tests" mentions.
 model: opus
+effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
 skills: qa-report-contract, workflow-contract
 permissionMode: acceptEdits

--- a/templates/core/agents/review-coordinator.md
+++ b/templates/core/agents/review-coordinator.md
@@ -2,6 +2,7 @@
 name: review-coordinator
 description: Coordinates parallel structural review agents (code, security, tests) and aggregates their findings. Use when /specflow review is running Phase 1.
 model: sonnet
+effort: low
 tools: Read, Grep, Glob, Bash, Agent(code-reviewer, security-auditor, test-reviewer)
 skills: workflow-contract, handoff-protocol, review-findings-contract
 maxTurns: 30

--- a/templates/core/agents/security-auditor.md
+++ b/templates/core/agents/security-auditor.md
@@ -2,6 +2,7 @@
 name: security-auditor
 description: Reviews code for security issues — input validation, authz, secrets, injection, SSRF, path traversal, silent error swallowing. Two dispatch shapes — (1) PR review (spawned by the review-coordinator during /specflow review), (2) alert triage (spawned by /release after the security-preflight workflow surfaces open GitHub security alerts).
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob, Bash
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/specflow-expert.md
+++ b/templates/core/agents/specflow-expert.md
@@ -9,6 +9,7 @@ description: >
   invocations (`specflow init`, `specflow upgrade`, `/specflow specify`,
   `/backlog ...`) — those are command runs, not questions.
 model: sonnet
+effort: medium
 tools: Read, WebFetch, Grep, Glob, Bash, Agent
 permissionMode: default
 maxTurns: 10

--- a/templates/core/agents/test-reviewer.md
+++ b/templates/core/agents/test-reviewer.md
@@ -2,6 +2,7 @@
 name: test-reviewer
 description: Reviews test coverage and quality for changed code. Spawned by the review-coordinator when the diff contains test files.
 model: sonnet
+effort: medium
 tools: Read, Grep, Glob
 skills: review-findings-contract, workflow-contract
 maxTurns: 20

--- a/templates/core/agents/ui-ux-designer.md
+++ b/templates/core/agents/ui-ux-designer.md
@@ -2,6 +2,7 @@
 name: ui-ux-designer
 description: Owns the project's `DESIGN.md` design system. Three modes auto-selected from DESIGN.md state — discovery interview when absent (creates a fresh, opinionated design system from the user's brief), edit mode when present (refactors typography / palette / spacing / components on demand), audit mode on explicit dispatch (scans existing UI source for drift against DESIGN.md). Stack-agnostic — produces a Markdown spec the user's developer agent translates into code. Never invokes itself.
 model: sonnet
+effort: high
 tools: Read, Edit, Write, Glob, Grep
 maxTurns: 30
 disable-model-invocation: true

--- a/templates/core/agents/workflow-manager.md
+++ b/templates/core/agents/workflow-manager.md
@@ -2,6 +2,7 @@
 name: workflow-manager
 description: Orchestrates multi-phase feature delivery across specialist agents. Use as the lead session agent for long-running implementations.
 model: sonnet
+effort: low
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
 skills: workflow-contract, handoff-protocol
 maxTurns: 60

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -59,6 +59,8 @@
     { "category": "agent", "name": "architecture-auditor", "source": "core/agents/architecture-auditor.md" },
     { "category": "agent", "name": "dependency-auditor", "source": "core/agents/dependency-auditor.md" },
 
+    { "category": "agent-doc", "name": "agents-readme", "suffix": "README.md", "source": "core/agents/README.md" },
+
     { "category": "agent-memory", "name": "product-owner", "suffix": "MEMORY.md", "source": "core/agents/product-owner/memory/MEMORY.md" },
     { "category": "agent-memory", "name": "developer", "suffix": "MEMORY.md", "source": "core/agents/developer/memory/MEMORY.md" },
     { "category": "agent-memory", "name": "qa-tester", "suffix": "MEMORY.md", "source": "core/agents/qa-tester/memory/MEMORY.md" },

--- a/tests/integration/init_test.ts
+++ b/tests/integration/init_test.ts
@@ -102,10 +102,20 @@ Deno.test("specflow init <name> writes a complete tree", async () => {
     const agentDirEntries = await Array.fromAsync(
       Deno.readDir(join(root, ".claude/agents")),
     );
-    const agentMdCount = agentDirEntries.filter((e) => e.isFile && e.name.endsWith(".md")).length;
+    // 15 agent definitions; the agent-fleet README (#382) is a sibling
+    // doc, not an agent, so it's excluded from this count and asserted
+    // separately below.
+    const agentMdCount = agentDirEntries.filter(
+      (e) => e.isFile && e.name.endsWith(".md") && e.name !== "README.md",
+    ).length;
     assertEquals(agentMdCount, 15);
     const memoryDirCount = agentDirEntries.filter((e) => e.isDirectory).length;
     assertEquals(memoryDirCount, 5);
+    // The effort-rubric README ships beside the agents (#382).
+    assertEquals(
+      await exists(join(root, ".claude/agents/README.md")),
+      true,
+    );
     // Spot-check one memory file
     assertEquals(
       await exists(join(root, ".claude/agents/product-owner/memory/MEMORY.md")),

--- a/tests/plugin/plugin_sync_test.ts
+++ b/tests/plugin/plugin_sync_test.ts
@@ -187,6 +187,13 @@ const SYNC_PAIRS: ReadonlyArray<{ plugin: string; source: string }> = [
     plugin: `plugin/agents/${name}.md`,
     source: `templates/core/agents/${name}.md`,
   })),
+  // Agent-fleet README documenting the per-agent `effort` rubric (#382).
+  // Ships beside the agent files at `.claude/agents/README.md`; mirrored
+  // into the plugin through the same byte-identical channel.
+  {
+    plugin: "plugin/agents/README.md",
+    source: "templates/core/agents/README.md",
+  },
 ];
 
 function abs(rel: string): string {

--- a/tests/templates/agent_effort_test.ts
+++ b/tests/templates/agent_effort_test.ts
@@ -1,0 +1,112 @@
+import { assert, assertEquals } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import type { CoreEntry } from "../../src/domain/core_bundle.ts";
+
+/**
+ * Locks the per-agent `effort` tuning rubric (feature 016, #382).
+ *
+ * Every bundled agent must carry exactly one `effort:` ∈ {low, medium, high,
+ * xhigh} (SC-001), no Sonnet-pinned agent may carry `xhigh` (SC-002, the
+ * model-compatibility invariant — `xhigh` is Opus-only), and each agent's
+ * value must match the authoritative assignment in
+ * `contracts/effort-map.md` (no drift between the contract and the shipped
+ * frontmatter).
+ */
+
+const VALID_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
+type Effort = (typeof VALID_EFFORTS)[number];
+
+/**
+ * Authoritative agent → effort assignment, mirroring
+ * `.specflow/specs/016-agent-effort-rubric/contracts/effort-map.md`.
+ * 2 low · 9 medium · 1 high · 3 xhigh = 15.
+ */
+const EFFORT_MAP: Record<string, Effort> = {
+  "review-coordinator": "low",
+  "workflow-manager": "low",
+  "a11y-auditor": "medium",
+  "architecture-auditor": "medium",
+  "dependency-auditor": "medium",
+  "performance-auditor": "medium",
+  "security-auditor": "medium",
+  "code-reviewer": "medium",
+  "test-reviewer": "medium",
+  "specflow-expert": "medium",
+  "product-owner": "medium",
+  "ui-ux-designer": "high",
+  "developer": "xhigh",
+  "qa-tester": "xhigh",
+  "devops-sre": "xhigh",
+};
+
+function agentEntries(): CoreEntry[] {
+  return CORE_BUNDLE.filter((e) => e.category === "agent");
+}
+
+/** Extracts the leading YAML frontmatter block from a bundled markdown file. */
+function frontmatter(content: string): string {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  assert(m, "expected a leading YAML frontmatter block");
+  return m[1];
+}
+
+/** Reads a single scalar frontmatter field (e.g. `effort:` / `model:`). */
+function scalarField(frontmatterBody: string, field: string): string | undefined {
+  const line = frontmatterBody
+    .split("\n")
+    .find((l) => new RegExp(`^${field}:\\s`).test(l));
+  return line?.replace(new RegExp(`^${field}:\\s*`), "").trim();
+}
+
+// SC-001: every bundled agent has exactly one valid `effort:`.
+for (const entry of agentEntries()) {
+  Deno.test(`agent "${entry.name}" declares exactly one valid effort`, () => {
+    const fm = frontmatter(entry.content);
+    const matches = fm.split("\n").filter((l) => /^effort:\s/.test(l));
+    assertEquals(
+      matches.length,
+      1,
+      `agent "${entry.name}" must declare exactly one \`effort:\` line`,
+    );
+    const value = scalarField(fm, "effort");
+    assert(
+      value !== undefined && (VALID_EFFORTS as readonly string[]).includes(value),
+      `agent "${entry.name}" effort "${value}" not in {${VALID_EFFORTS.join(", ")}}`,
+    );
+  });
+}
+
+// SC-002: no Sonnet-pinned agent carries `xhigh` (xhigh is Opus-only).
+for (const entry of agentEntries()) {
+  Deno.test(`agent "${entry.name}" respects xhigh⇒Opus`, () => {
+    const fm = frontmatter(entry.content);
+    const effort = scalarField(fm, "effort");
+    const model = scalarField(fm, "model");
+    if (effort === "xhigh") {
+      assertEquals(
+        model,
+        "opus",
+        `agent "${entry.name}" has effort: xhigh but model: ${model} — xhigh is Opus-only`,
+      );
+    }
+  });
+}
+
+// The bundled value matches the authoritative effort-map.md assignment.
+for (const [name, expected] of Object.entries(EFFORT_MAP)) {
+  Deno.test(`agent "${name}" effort matches effort-map.md (${expected})`, () => {
+    const entry = agentEntries().find((e) => e.name === name);
+    assert(entry, `agent "${name}" missing from CORE_BUNDLE`);
+    const value = scalarField(frontmatter(entry.content), "effort");
+    assertEquals(value, expected, `agent "${name}" effort drifted from the contract`);
+  });
+}
+
+// The contract covers exactly the bundled fleet — no agent unclassified,
+// no stale entry in the map (guards against a future agent added without an
+// effort assignment, per the spec's edge case).
+Deno.test("effort-map.md covers exactly the bundled agent fleet", () => {
+  const bundled = agentEntries().map((e) => e.name).sort();
+  const mapped = Object.keys(EFFORT_MAP).sort();
+  assertEquals(bundled, mapped);
+});


### PR DESCRIPTION
Closes #382 · epic mkrlabs/specflow-monorepo#12 (mechanism D — final CLI piece).

Adds an explicit `effort:` frontmatter (low|medium|high|xhigh) to all 15 bundled agents per a documented rubric, ships `.claude/agents/README.md` (new Claude-only `agent-doc` bundle category, symmetric with `agent-memory`), and a test enforcing valid effort + the `xhigh`⇒opus invariant. Additive frontmatter only.

`deno task test` → **1002 passed / 0 failed**; lint+fmt clean. Review gate PASS (0 findings; the `agent-doc` harness wiring verified exhaustive across all 8 harnesses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)