### PR TITLE
fix(hook): extract agent + contract fields from the real CC payload (#388)

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specflow/specs/016-agent-effort-rubric",
-  "linked_issue": 382,
+  "feature_directory": ".specflow/specs/017-hook-payload-fix",
+  "linked_issue": 388,
   "workflow_shape": "full"
 }

--- a/.specflow/specs/017-hook-payload-fix/checklists/requirements.md
+++ b/.specflow/specs/017-hook-payload-fix/checklists/requirements.md
@@ -1,0 +1,18 @@
+# Specification Quality Checklist: Fix log-subagent hook payload extraction
+
+**Created**: 2026-06-13 · **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details beyond the necessary payload-key facts · [x] User value focused · [x] Mandatory sections complete
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers · [x] Testable, unambiguous · [x] Measurable SCs
+- [x] Acceptance scenarios + edge cases · [x] Scope bounded; assumptions identified
+
+## Feature Readiness
+- [x] FRs have acceptance criteria · [x] Scenarios cover flows · [x] No speculative scope
+
+## Notes
+P1 bug. Real payload schema captured EMPIRICALLY (research.md) — not assumed. Three root causes
+confirmed: agent key (agent_type), output key (last_assistant_message), field-name case
+(UPPERCASE canonical). No open markers.

--- a/.specflow/specs/017-hook-payload-fix/contracts/ledger-entry-v2.md
+++ b/.specflow/specs/017-hook-payload-fix/contracts/ledger-entry-v2.md
@@ -1,0 +1,21 @@
+# Contract: corrected ledger entry
+
+## Base (always)
+```json
+{"ts":"…","event":"start|stop","session":"<id|unknown>","agent":"<agent_type|unknown>"}
+```
+
+## Enriched (stop, when last_assistant_message carries a contract block)
+```json
+{"ts":"…","event":"stop","session":"…","agent":"security-auditor",
+ "agent_id":"abf05f10d169e18fa","effort":"high",
+ "state":"awaiting_review","done_criteria_met":"yes","handoff_target":"review-coordinator",
+ "review_verdict":"fail"}
+```
+
+## Rules
+- `agent` from `agent_type` (fallbacks `agent_name`/`subagent_name`/`tool_name`/`unknown`).
+- Contract-block source: `last_assistant_message` (fallbacks `output`/`result`/`response`/`tool_response`/`message`/raw).
+- `agent_id`, `effort` optional (omit-if-absent).
+- Block fields matched against canonical UPPERCASE names case-insensitively; `review_verdict`/`qa_verdict` from their own block segments.
+- jq -n composition (JSON-safe); always exit 0; jq-absent → base line; start event → base line.

--- a/.specflow/specs/017-hook-payload-fix/data-model.md
+++ b/.specflow/specs/017-hook-payload-fix/data-model.md
@@ -1,0 +1,21 @@
+# Data Model — corrected ledger entry
+
+## Entity: Ledger entry (append-only)
+Base (unchanged): `ts`, `event`, `session`.
+Corrected: `agent` ← `agent_type` (was always `unknown`).
+New optional: `agent_id` (from `agent_id`), `effort` (from `effort.level`).
+Now-populated optional (from `last_assistant_message`, matched on UPPERCASE canonical names,
+case-insensitive, per block segment): `state`, `done_criteria_met`, `handoff_target`,
+`review_verdict`, `qa_verdict`.
+
+## Value object: PayloadKeys (the corrected extraction map)
+- agentName: `.agent_type // .agent_name // .subagent_name // .tool_name // "unknown"`
+- output:    `.last_assistant_message // .output // .result // .response // .tool_response // .message // (raw)`
+- agent_id:  `.agent_id`  (optional)
+- effort:    `.effort.level`  (optional)
+- block fields: case-insensitive grep of `STATE:` / `DONE_CRITERIA_MET:` / `HANDOFF_TARGET:` (WORKFLOW segment), `REVIEW_VERDICT:` (REVIEW segment), `QA_VERDICT:` (QA segment)
+
+## Invariants
+- `agent` == `agent_type` when present (never `unknown` for a real dispatch).
+- Optional keys omit-if-absent; base line always valid; exit 0 always; jq -n JSON-safe.
+- `REVIEW_VERDICT`/`QA_VERDICT` parsed from their own segments (distinct names + segmentation).

--- a/.specflow/specs/017-hook-payload-fix/plan.md
+++ b/.specflow/specs/017-hook-payload-fix/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Fix log-subagent hook payload extraction (#388)
+
+**Branch**: `017-hook-payload-fix` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)
+**Input**: issue mkrlabs/specflow#388 (follow-up from epic mkrlabs/specflow-monorepo#12 dogfood)
+
+## Summary
+
+Correct three payload-extraction bugs in `templates/harness-specific/claude/hooks/log-subagent.sh`,
+proven against the empirically-captured real Claude Code hook schema (research.md): (1) agent name ←
+`agent_type`; (2) contract-block source ← `last_assistant_message`; (3) field greps ← canonical
+UPPERCASE names (`STATE`/`DONE_CRITERIA_MET`/`HANDOFF_TARGET`/`REVIEW_VERDICT`/`QA_VERDICT`),
+case-insensitive. Add optional `agent_id` + `effort` fields. Re-anchor the enrichment test to the real
+payload shape (the original test agreed with the buggy hook, not reality). Update the ledger schema doc.
+
+## Technical Context
+
+**Language/Version**: bash + jq (hook); Deno/TS (test + bundle)
+**Primary Dependencies**: none new
+**Storage**: `.specflow/logs/agents.jsonl` (entry shape gains agent_id/effort + now-populated fields); `.specflow/logs/README.md` doc
+**Testing**: hermetic hook test fed a REAL-shaped SubagentStop payload (agent_type + last_assistant_message + UPPERCASE block) + legacy-key + lowercase-field + start/no-block/jq-absent cases
+**Project Type**: cli (no src/ code)
+**Constraints**: preserve all prior invariants (jq -n JSON-safety, per-block segmentation, omit-if-absent, exit 0, jq-absent fallback, backward-compatible base line)
+**Scale/Scope**: 1 hook edit + test fixture rewrite + schema-doc update + bundle regen
+
+## Constitution Check
+Placeholder constitution — no gate. Additive/corrective; ship through the bundle. **PASS.**
+
+## Project Structure
+```text
+templates/harness-specific/claude/hooks/log-subagent.sh   # EDIT — agent_type, last_assistant_message, UPPERCASE -i greps, agent_id/effort
+templates/core/specflow/logs/README.md                    # EDIT — document corrected key mapping + agent_id/effort
+src/templates_bundle.ts                                    # REGENERATED
+tests/templates/log_subagent_enrichment_test.ts           # EDIT — real-shape fixture + fallback/case cases
+```
+
+**Structure Decision**: Edit the hook in place (its manifest entry exists). The fix is localized to the
+extraction block (lines ~22-30 agent/session; ~43-85 output/segment/field greps) + the JQ_ARGS assembly
+to add agent_id/effort. No structural change to the segmentation or jq-composition design — those were
+correct; only the keys and field-name patterns were wrong.
+
+## Complexity Tracking
+> No violations — empty.

--- a/.specflow/specs/017-hook-payload-fix/quickstart.md
+++ b/.specflow/specs/017-hook-payload-fix/quickstart.md
@@ -1,0 +1,26 @@
+# Quickstart — hook payload fix (#388)
+
+## Build & test
+```bash
+cd apps/specflow-cli
+deno task bundle
+deno task test     # bundle + log_subagent_enrichment_test (real-shape fixture)
+```
+
+## Manual verification (real payload shape)
+```bash
+printf '{"session_id":"s1","agent_id":"a1","agent_type":"security-auditor","effort":{"level":"high"},"last_assistant_message":"...\nREVIEW SUMMARY\nREVIEW_VERDICT: fail\n"}' \
+  | bash templates/harness-specific/claude/hooks/log-subagent.sh stop
+tail -1 .specflow/logs/agents.jsonl
+#   → agent:"security-auditor", agent_id:"a1", effort:"high", review_verdict:"fail"
+
+# legacy/no-block still valid
+printf '{"session_id":"s1","agent_type":"developer"}' | bash …/log-subagent.sh stop
+tail -1 .specflow/logs/agents.jsonl   # → base + agent:"developer", valid JSON, exit 0
+```
+
+## Success signals
+- Real-shape fixture → `agent` populated from `agent_type` + `review_verdict` captured.
+- `agent_id`/`effort` present when in the payload; absent → omitted.
+- Legacy-key + lowercase-field fallbacks work; start/no-block/jq-absent → valid base line, exit 0.
+- `deno task test` green; schema doc updated.

--- a/.specflow/specs/017-hook-payload-fix/research.md
+++ b/.specflow/specs/017-hook-payload-fix/research.md
@@ -1,0 +1,47 @@
+# Research — real Claude Code hook payload (empirically captured)
+
+## The ground truth (captured 2026-06-13 by instrumenting the live hook + dispatching a subagent)
+
+**SubagentStart**:
+```json
+{"session_id":"…","transcript_path":"…/<session>.jsonl","cwd":"…","agent_id":"abf05f10d169e18fa","agent_type":"general-purpose","hook_event_name":"SubagentStart"}
+```
+
+**SubagentStop**:
+```json
+{"session_id":"…","transcript_path":"…/<session>.jsonl","cwd":"…","permission_mode":"bypassPermissions",
+ "agent_id":"abf05f10d169e18fa","agent_type":"general-purpose","effort":{"level":"high"},
+ "hook_event_name":"SubagentStop","stop_hook_active":false,
+ "agent_transcript_path":"…/subagents/agent-abf05f10d169e18fa.jsonl",
+ "last_assistant_message":"PONG","background_tasks":[],"session_crons":[]}
+```
+
+## Three confirmed root causes of the inert ledger
+
+| # | Symptom | Hook did | Real key | Fix |
+|---|---|---|---|---|
+| 1 | `agent: "unknown"` (219/219) | probed `.agent_name`/`.subagent_name`/`.tool_name` | **`agent_type`** | prefer `.agent_type`, keep old fallbacks |
+| 2 | zero contract fields | probed `.output`/`.result`/`.response`/`.tool_response`/`.message` | **`last_assistant_message`** | prefer `.last_assistant_message`, keep old fallbacks |
+| 3 | (latent) would miss fields even with 1+2 | grepped lowercase `state:`/`verdict:` | canonical **`STATE:`/`REVIEW_VERDICT:`/`QA_VERDICT:`** (uppercase, distinct) | grep canonical names case-insensitively |
+
+## Decisions
+
+1. **Output source = `last_assistant_message`** (the agent's final message, where end-of-turn blocks
+   live). No need to read `agent_transcript_path` — simpler and sufficient. Fallback chain kept for
+   version drift.
+2. **Agent name = `agent_type`** + fallbacks. Also capture **`agent_id`** (optional) — `/status-audit`
+   groups by agent, and two concurrent `security-auditor`s share `agent_type` but differ by `agent_id`.
+   Capture **`effort.level`** (optional, cheap context).
+3. **Field greps = canonical UPPERCASE names, case-insensitive** (`grep -iE 'STATE:…'`,
+   `'REVIEW_VERDICT:…'`, `'QA_VERDICT:…'`, `'DONE_CRITERIA_MET:…'`, `'HANDOFF_TARGET:…'`). `REVIEW_VERDICT`
+   and `QA_VERDICT` are already distinct names, so cross-contamination is fixed by the names alone;
+   per-block segmentation stays as defense-in-depth.
+4. **Test fixture = real shape.** The #381 test fed a synthetic `.output`-keyed payload with lowercase
+   fields, which is exactly why the bug shipped green. Replace/augment with a `SubagentStop`-shaped
+   fixture (`agent_type` + `last_assistant_message` + UPPERCASE block fields), plus a legacy-key case
+   and a lowercase-field case for the fallbacks.
+
+## Why the unit tests missed it
+The #381 hermetic test asserted enrichment against an ASSUMED payload shape (the keys the hook probed),
+so the test and the hook agreed with each other but neither matched reality. The fix's test must be
+anchored to the captured real shape (FR-007).

--- a/.specflow/specs/017-hook-payload-fix/spec.md
+++ b/.specflow/specs/017-hook-payload-fix/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Fix log-subagent hook to capture from the real Claude Code payload
+
+**Feature Branch**: `017-hook-payload-fix`
+**Created**: 2026-06-13
+**Status**: Draft
+**Input**: User description: "Bug #388 (P1). The log-subagent hook captures no agent name and no contract fields from the REAL Claude Code SubagentStop payload — a monorepo#12 dogfood showed 219/219 ledger entries came out agent:'unknown' with zero state/verdict fields despite agents emitting the blocks. The hook probes the wrong payload keys (and greps the wrong field-name case), so mechanism C (/status-audit) is inert in practice. Fix the extraction against the actual payload schema and add a test fixture using the REAL shape."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - The ledger actually records who ran and what they concluded (Priority: P1)
+
+When a subagent finishes, the `log-subagent` hook records its real agent identity and — when the agent emitted contract blocks — its state and verdict, into `.specflow/logs/agents.jsonl`. A `/status-audit` over that ledger then reports real agent names and verdicts instead of a wall of `unknown`.
+
+**Why this priority**: This is the bug. Until the hook reads the real payload keys, mechanism C (the entire status-supervision feature, #381) produces no usable signal — it parses the ledger fine but every entry is `unknown` with no verdict.
+
+**Independent Test**: Feed the hook a payload shaped exactly like the real Claude Code `SubagentStop` event (an `agent_type` + a `last_assistant_message` containing a `REVIEW SUMMARY` block); assert the appended JSONL line carries the real `agent` (from `agent_type`) and the parsed `review_verdict`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `SubagentStop` payload with `agent_type: "security-auditor"`, **When** the hook runs, **Then** the JSONL line has `agent: "security-auditor"` (not `unknown`).
+2. **Given** that payload's `last_assistant_message` contains a `REVIEW SUMMARY` block with `REVIEW_VERDICT: fail`, **When** the hook runs, **Then** the line carries `review_verdict: "fail"`.
+3. **Given** a payload with `agent_id`, **When** the hook runs, **Then** the line carries `agent_id` so two concurrent same-type agents are distinguishable in `/status-audit`.
+
+---
+
+### User Story 2 - Robust across payload-shape and field-case variation (Priority: P2)
+
+Extraction degrades gracefully: it prefers the real keys but keeps fallbacks for other Claude Code versions, matches the canonical UPPERCASE contract field names case-insensitively (agents' emitted casing varies), and still produces a valid backward-compatible line when a field or the whole block is absent.
+
+**Why this priority**: The original bug was brittleness against the real shape; the fix must not re-introduce brittleness against a slightly different shape or against case-varying LLM output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a payload using a legacy output key (`.output`) instead of `last_assistant_message`, **When** the hook runs, **Then** it still extracts the block (fallback chain).
+2. **Given** a block emitted with lowercase field names, **When** the hook parses, **Then** it still captures the values (case-insensitive match of the canonical names).
+3. **Given** a `start` event or a payload with no block, **When** the hook runs, **Then** it appends a valid base line (no empty contract keys) and exits 0.
+
+---
+
+### Edge Cases
+
+- **`last_assistant_message` absent** (older CC) → fall back to `.output`/`.result`/…/the agent transcript path is NOT required; if none yield text, emit the base line.
+- **`agent_type` absent** → fall back to `.agent_name`/`.subagent_name`/`.tool_name`/`unknown`.
+- **Field emitted as `REVIEW_VERDICT` vs `review_verdict` vs mixed case** → matched case-insensitively.
+- **jq absent** → base line only, exit 0 (unchanged).
+- **Hostile `agent_type`/`session_id`** (quotes/colons) → still JSON-safe (jq -n composition, unchanged).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The hook MUST derive the agent name from `agent_type` first, then fall back to `agent_name` / `subagent_name` / `tool_name` / `unknown`.
+- **FR-002**: The hook MUST derive the agent output for contract parsing from `last_assistant_message` first, then fall back to `output` / `result` / `response` / `tool_response` / `message`, then the raw payload.
+- **FR-003**: The hook MUST record an optional `agent_id` field (from the payload's `agent_id`) so concurrent same-type agents are distinguishable; omit-if-absent.
+- **FR-004**: The hook SHOULD record an optional `effort` field (from `effort.level`) when present; omit-if-absent. (Cheap, useful context; not required for the core fix.)
+- **FR-005**: Contract-field extraction MUST match the canonical UPPERCASE block field names — `STATE`, `DONE_CRITERIA_MET`, `HANDOFF_TARGET`, `REVIEW_VERDICT`, `QA_VERDICT` — case-insensitively (emitted casing varies). `REVIEW_VERDICT`/`QA_VERDICT` are distinct names, parsed from their own block segments.
+- **FR-006**: All prior invariants hold: JSON-safe `jq -n` composition; per-block segmentation; omit-if-absent optional keys; backward-compatible base line; `set -euo pipefail`; ALWAYS exit 0; jq-absent fallback emits the base line.
+- **FR-007**: The hook's enrichment test MUST use a fixture shaped like the REAL `SubagentStop` payload (`agent_type` + `last_assistant_message` with UPPERCASE block fields), plus a legacy-key fallback case and a case-insensitivity case.
+- **FR-008**: The ledger schema doc (`.specflow/logs/README.md`) MUST document the new `agent_id`/`effort` fields and that `agent` comes from `agent_type` and the block source is `last_assistant_message`.
+- **FR-009**: The change ships through the bundle (`init`/`upgrade`); the hook is the existing harness-specific claude entry (edit in place).
+
+### Key Entities *(see Domain Model below)*
+
+- **Hook payload**: the real Claude Code SubagentStart/Stop event object (keys documented in research.md).
+- **Ledger entry**: gains correct `agent` + optional `agent_id`/`effort` + the contract fields now actually captured.
+
+## Domain Model *(mandatory)*
+
+**Bounded context:** Status Supervision data-capture (the hook side of mechanism C). Owns the mapping from the real Claude Code hook payload → the JSONL ledger entry.
+
+**Vocabulary (Ubiquitous language):**
+
+- **Hook payload** — the JSON object Claude Code pipes to the hook on stdin per subagent event.
+- **`agent_type`** — the real payload key holding the dispatched agent's name.
+- **`last_assistant_message`** — the real `SubagentStop` key holding the agent's final message text (where contract blocks live).
+- **`agent_id`** — unique per dispatch; disambiguates concurrent same-type agents.
+
+**Entities (have identity):**
+
+- **Ledger entry** — identified by `(session, agent_id|agent, ts, event)`; append-only. This fixes which payload keys populate `agent` and adds `agent_id`.
+
+**Value objects (no identity, immutable):**
+
+- **PayloadKeys(agentName=agent_type→fallbacks, output=last_assistant_message→fallbacks, agent_id, effort.level)** — the corrected extraction map.
+
+**Invariants (rules the domain must never break):**
+
+- `agent` is `agent_type` when present (never `unknown` for a real dispatch carrying `agent_type`).
+- Contract fields are matched against the canonical UPPERCASE names, case-insensitively, each from its own block segment.
+- All prior hook invariants hold (JSON-safe, omit-if-absent, exit 0, backward-compatible, jq-absent fallback).
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- `/status-audit` reporting logic (#381) — unchanged; it benefits automatically from richer entries.
+- The contract block formats (#378) — unchanged; this matches them.
+- Reading the subagent transcript file (`agent_transcript_path`) — not needed; `last_assistant_message` carries the final block. (Possible future enhancement if a block ever lands in a non-final message.)
+- Cloud/Mobile.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A real-shaped `SubagentStop` fixture (`agent_type: "security-auditor"`, `last_assistant_message` with `REVIEW_VERDICT: fail`) yields a JSONL line with `agent: "security-auditor"` and `review_verdict: "fail"` — verified by the enrichment test.
+- **SC-002**: `agent_id` is captured when present; two concurrent same-type dispatches produce distinguishable entries.
+- **SC-003**: Legacy-key and case-insensitivity fallbacks both extract correctly (test-verified); start/no-block/jq-absent all emit a valid base line and exit 0.
+- **SC-004**: The schema doc documents the corrected key mapping + new fields.
+- **SC-005**: `deno task test` green; a fresh `init`/`upgrade` ships the fixed hook.
+
+## Assumptions
+
+- The real Claude Code hook payload schema is as captured empirically (research.md): SubagentStop carries `session_id`, `transcript_path`, `cwd`, `agent_id`, `agent_type`, `effort.level`, `hook_event_name`, `agent_transcript_path`, `last_assistant_message`. SubagentStart carries the same minus the stop-only fields. Fallback chains guard against version drift.
+- `last_assistant_message` contains the agent's final message, where end-of-turn contract blocks are emitted; sufficient without reading the transcript file.
+- The hook remains the bundled harness-specific claude entry; this is an edit-in-place + test + schema-doc update.

--- a/.specflow/specs/017-hook-payload-fix/tasks.md
+++ b/.specflow/specs/017-hook-payload-fix/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Fix log-subagent hook payload extraction (#388)
+
+**Feature**: `017-hook-payload-fix` | **Branch**: `017-hook-payload-fix` | **Issue**: mkrlabs/specflow#388
+**Inputs**: [spec.md](./spec.md) · [research.md](./research.md) (captured real payload) · [plan.md](./plan.md) · contracts/ledger-entry-v2.md
+
+TDD: re-anchor the test to the REAL payload first (it FAILS against the current hook — proving the bug),
+then fix the hook to green.
+
+## Phase 1: Test re-anchoring (RED)
+- [ ] T001 Rewrite/extend `tests/templates/log_subagent_enrichment_test.ts` so the primary enrichment
+      case feeds a REAL-shaped `SubagentStop` payload: `{session_id, agent_id, agent_type:"security-auditor",
+      effort:{level:"high"}, last_assistant_message:"…\nREVIEW SUMMARY\nREVIEW_VERDICT: fail\nWORKFLOW STATUS\nSTATE: awaiting_review\nHANDOFF_TARGET: review-coordinator\n"}` and assert `agent==="security-auditor"`,
+      `agent_id==="…"`, `effort==="high"`, `review_verdict==="fail"`, `state==="awaiting_review"`,
+      `handoff_target==="review-coordinator"`. Add: a legacy-`.output`-key case; a lowercase-field case
+      (`review_verdict: pass`) asserting it's still captured; the dual-block (REVIEW fail + QA pass) case
+      using UPPERCASE `REVIEW_VERDICT`/`QA_VERDICT`; keep the JSON-injection + start + no-block + jq cases.
+      Confirm the new real-shape assertions FAIL against the current hook.
+
+## Phase 2: Fix the hook (GREEN)
+- [ ] T002 Edit `templates/harness-specific/claude/hooks/log-subagent.sh`:
+      (a) AGENT ← `jq -r '.agent_type // .agent_name // .subagent_name // .tool_name // "unknown"'`.
+      (b) AGENT_ID ← `jq -r '.agent_id // ""'`; EFFORT ← `jq -r '.effort.level // ""'`.
+      (c) OUTPUT ← `jq -r '.last_assistant_message // .output // .result // .response // .tool_response // .message // ""'` (fallback to raw if empty).
+      (d) Field greps → canonical UPPERCASE names, case-insensitive: `grep -ioE 'STATE:[[:space:]]*[a-z_]+'`,
+          `'DONE_CRITERIA_MET:[[:space:]]*(yes|no)'`, `'HANDOFF_TARGET:[[:space:]]*[A-Za-z0-9_-]+'`,
+          `'REVIEW_VERDICT:[[:space:]]*(pass|fail|needs_followup)'` (REVIEW seg), `'QA_VERDICT:[[:space:]]*(pass|fail|blocked)'` (QA seg);
+          strip the field-name prefix case-insensitively. Update the segment() awk headers are already UPPERCASE (correct) — leave.
+      (e) Add `agent_id`/`effort` to the JQ_ARGS/JQ_FILTER assembly as omit-if-absent optional keys (same pattern as state/etc.).
+      Preserve: `set -euo pipefail`, jq -n composition, per-block segmentation, exit 0, jq-absent base-line fallback.
+- [ ] T003 `shellcheck` the hook clean; confirm T001 now GREEN.
+
+## Phase 3: Docs + distribution
+- [ ] T004 Update `templates/core/specflow/logs/README.md`: `agent` ← `agent_type`; block source ← `last_assistant_message`; new optional `agent_id`/`effort` fields; canonical UPPERCASE field names.
+- [ ] T005 `deno task bundle`; confirm the fixed hook is embedded in `src/templates_bundle.ts`. (Hook is harness-specific, not plugin-mirrored — no plugin change. No new skill folder — init counts unchanged.)
+
+## Phase 4: Validate
+- [ ] T006 `deno task test` GREEN; `deno fmt`+`deno lint` on the test; manual: pipe the real-shape + legacy + no-block payloads, confirm the JSONL lines per quickstart.md.
+
+## Dependencies
+- T001 (RED) → T002 (GREEN) → T003. T004 parallel. T005 after T002. T006 last.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -12489,24 +12489,39 @@ breaks a dispatch. A line is never rewritten; an agent's *current* state is its
 | --------- | ------------------- | --------------------------------------------- |
 | \`ts\`      | string (ISO-8601)   | UTC timestamp, e.g. \`2026-06-13T11:00:00Z\`.   |
 | \`event\`   | string              | \`start\` or \`stop\`.                            |
-| \`session\` | string              | Session id, or \`unknown\` if absent.           |
-| \`agent\`   | string              | Subagent name, or \`unknown\` if absent.        |
+| \`session\` | string              | \`session_id\`, or \`unknown\` if absent.         |
+| \`agent\`   | string              | Subagent name from \`agent_type\` (fallbacks \`agent_name\`/\`subagent_name\`/\`tool_name\`), or \`unknown\` if absent. |
+
+### Context fields (optional — omit-if-absent)
+
+Captured from the Claude Code event payload when present. \`agent_id\`
+disambiguates two concurrent agents of the same \`agent_type\` (e.g. two
+\`security-auditor\`s); \`effort\` records the agent's reasoning tier.
+
+| Field      | Type   | Source           | Notes                                            |
+| ---------- | ------ | ---------------- | ------------------------------------------------ |
+| \`agent_id\` | string | \`agent_id\`       | Per-dispatch agent id; omitted when absent.      |
+| \`effort\`   | string | \`effort.level\`   | \`low\` · \`medium\` · \`high\` · \`xhigh\`; omitted when absent. |
 
 ### Contract fields (optional — omit-if-absent)
 
-Parsed from the subagent's output text on **\`stop\`** events when it carries the
-machine-readable contract blocks (\`WORKFLOW STATUS\` / \`REVIEW SUMMARY\` /
-\`QA SUMMARY\`). Each key is present **only** when parsed — never emitted empty,
-never with a garbage value. An absent key means the field was not present in the
-output.
+Parsed from the subagent's final message (\`last_assistant_message\`, with
+fallbacks \`output\`/\`result\`/\`response\`/\`tool_response\`/\`message\`/raw payload) on
+**\`stop\`** events when it carries the machine-readable contract blocks
+(\`WORKFLOW STATUS\` / \`REVIEW SUMMARY\` / \`QA SUMMARY\`). The canonical field names
+inside those blocks are UPPERCASE (\`STATE:\`, \`DONE_CRITERIA_MET:\`,
+\`HANDOFF_TARGET:\`, \`REVIEW_VERDICT:\`, \`QA_VERDICT:\`) and are matched
+case-insensitively. Each key is present **only** when parsed — never emitted
+empty, never with a garbage value. An absent key means the field was not present
+in the output.
 
-| Field               | Type   | Source block      | Allowed values                                                                  |
-| ------------------- | ------ | ----------------- | ------------------------------------------------------------------------------- |
-| \`state\`             | string | \`WORKFLOW STATUS\` | \`in_progress\` · \`blocked\` · \`awaiting_review\` · \`awaiting_qa\` · \`awaiting_user\` · \`done\` · \`failed\` |
-| \`done_criteria_met\` | string | \`WORKFLOW STATUS\` | \`yes\` · \`no\`                                                                    |
-| \`handoff_target\`    | string | \`WORKFLOW STATUS\` | an agent name, or \`none\`                                                        |
-| \`review_verdict\`    | string | \`REVIEW SUMMARY\`  | \`pass\` · \`fail\` · \`needs_followup\`                                              |
-| \`qa_verdict\`        | string | \`QA SUMMARY\`      | \`pass\` · \`fail\` · \`blocked\`                                                     |
+| Field               | Type   | Source block / field             | Allowed values                                                                  |
+| ------------------- | ------ | -------------------------------- | ------------------------------------------------------------------------------- |
+| \`state\`             | string | \`WORKFLOW STATUS\` › \`STATE\`             | \`in_progress\` · \`blocked\` · \`awaiting_review\` · \`awaiting_qa\` · \`awaiting_user\` · \`done\` · \`failed\` |
+| \`done_criteria_met\` | string | \`WORKFLOW STATUS\` › \`DONE_CRITERIA_MET\` | \`yes\` · \`no\`                                                                    |
+| \`handoff_target\`    | string | \`WORKFLOW STATUS\` › \`HANDOFF_TARGET\`    | an agent name, or \`none\`                                                        |
+| \`review_verdict\`    | string | \`REVIEW SUMMARY\` › \`REVIEW_VERDICT\`     | \`pass\` · \`fail\` · \`needs_followup\`                                              |
+| \`qa_verdict\`        | string | \`QA SUMMARY\` › \`QA_VERDICT\`             | \`pass\` · \`fail\` · \`blocked\`                                                     |
 
 ## Examples
 
@@ -12519,7 +12534,7 @@ Base line (no contract block parsed, or a \`start\` event):
 Enriched \`stop\` line (contract block parsed from the output):
 
 \`\`\`json
-{"ts":"2026-06-13T11:42:00Z","event":"stop","session":"sess-123","agent":"security-auditor","state":"awaiting_review","done_criteria_met":"yes","handoff_target":"review-coordinator","review_verdict":"fail"}
+{"ts":"2026-06-13T11:42:00Z","event":"stop","session":"sess-123","agent":"security-auditor","agent_id":"abf05f10d169e18fa","effort":"high","state":"awaiting_review","done_criteria_met":"yes","handoff_target":"review-coordinator","review_verdict":"fail"}
 \`\`\`
 
 ## Invariants
@@ -16453,11 +16468,23 @@ TS=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Best-effort field extraction — the exact payload shape varies by
 # Claude Code version; defaults to "unknown" when fields are absent.
+#
+# The agent name lives under \`.agent_type\` in the real Claude Code
+# SubagentStart/Stop payload (empirically captured, #388); the earlier
+# \`.agent_name\`/\`.subagent_name\`/\`.tool_name\` probes matched nothing and the
+# ledger recorded \`agent:"unknown"\` for every event. We prefer \`.agent_type\`
+# and keep the historical keys as version-drift fallbacks.
 HAVE_JQ=0
+AGENT_ID=""
+EFFORT=""
 if command -v jq >/dev/null 2>&1 && [ -n "\$INPUT" ]; then
   HAVE_JQ=1
   SESSION=\$(printf '%s' "\$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")
-  AGENT=\$(printf '%s' "\$INPUT" | jq -r '.agent_name // .subagent_name // .tool_name // "unknown"' 2>/dev/null || echo "unknown")
+  AGENT=\$(printf '%s' "\$INPUT" | jq -r '.agent_type // .agent_name // .subagent_name // .tool_name // "unknown"' 2>/dev/null || echo "unknown")
+  # Optional context (omit-if-absent): \`agent_id\` disambiguates two concurrent
+  # agents of the same type in \`/status-audit\`; \`effort.level\` is cheap context.
+  AGENT_ID=\$(printf '%s' "\$INPUT" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+  EFFORT=\$(printf '%s' "\$INPUT" | jq -r '.effort.level // ""' 2>/dev/null || echo "")
 else
   SESSION="unknown"
   AGENT="unknown"
@@ -16475,11 +16502,14 @@ HANDOFF=""
 REVIEW=""
 QA=""
 if [ "\$HAVE_JQ" = "1" ] && [ "\$EVENT" = "stop" ]; then
-  # The key holding the agent's output text is Claude-Code-version-dependent;
-  # probe the likely candidates and fall back to the raw payload. The first
-  # candidate that yields a non-empty string wins.
+  # The agent's final message — where the end-of-turn contract blocks live — is
+  # carried under \`.last_assistant_message\` in the real SubagentStop payload
+  # (#388). The earlier \`.output\`/\`.result\`/… probes matched nothing, so the
+  # ledger captured zero contract fields. Prefer \`.last_assistant_message\`,
+  # keep the historical keys as version-drift fallbacks, then fall back to the
+  # raw payload. The first candidate that yields a non-empty string wins.
   OUTPUT=\$(printf '%s' "\$INPUT" | jq -r \\
-    '(.output // .result // .response // .tool_response // .message // "") | if type=="string" then . else tojson end' \\
+    '(.last_assistant_message // .output // .result // .response // .tool_response // .message // "") | if type=="string" then . else tojson end' \\
     2>/dev/null || echo "")
   if [ -z "\$OUTPUT" ]; then
     OUTPUT="\$INPUT"
@@ -16506,16 +16536,33 @@ if [ "\$HAVE_JQ" = "1" ] && [ "\$EVENT" = "stop" ]; then
   REVIEW_SEG=\$(segment "REVIEW SUMMARY")
   QA_SEG=\$(segment "QA SUMMARY")
 
-  # WORKFLOW STATUS fields — extracted only from the WORKFLOW STATUS segment.
-  STATE=\$(printf '%s' "\$WORKFLOW_SEG" | grep -oE 'state:[[:space:]]*[a-z_]+' | head -1 | sed -E 's/^state:[[:space:]]*//' || true)
-  DONE_MET=\$(printf '%s' "\$WORKFLOW_SEG" | grep -oE 'done_criteria_met:[[:space:]]*(yes|no)' | head -1 | sed -E 's/^done_criteria_met:[[:space:]]*//' || true)
-  HANDOFF=\$(printf '%s' "\$WORKFLOW_SEG" | grep -oE 'handoff_target:[[:space:]]*[A-Za-z0-9_-]+' | head -1 | sed -E 's/^handoff_target:[[:space:]]*//' || true)
+  # The #378 contract blocks use canonical UPPERCASE field names
+  # (\`STATE:\` / \`DONE_CRITERIA_MET:\` / \`HANDOFF_TARGET:\` / \`REVIEW_VERDICT:\` /
+  # \`QA_VERDICT:\`). The earlier lowercase \`state:\`/\`verdict:\` greps never
+  # matched a real contract block. We grep the canonical names
+  # CASE-INSENSITIVELY (\`-i\`) for robustness, then strip the \`FIELD:\` prefix.
+  # \`field_value\` lowercases the whole matched token before stripping the prefix
+  # so the case-insensitive sed needs no per-letter alternation; the values
+  # (state names, yes/no, verdicts, agent names) are themselves lowercase.
+  field_value() {
+    # \$1 = segment text; \$2 = canonical field name; \$3 = value charclass/alt.
+    printf '%s' "\$1" |
+      grep -ioE "\$2:[[:space:]]*\$3" |
+      head -1 |
+      tr '[:upper:]' '[:lower:]' |
+      sed -E "s/^[a-z_]+:[[:space:]]*//" || true
+  }
 
-  # \`verdict:\` appears under both REVIEW SUMMARY and QA SUMMARY; extracting it
-  # from each block's OWN segment is what keeps the two verdicts distinct even
-  # when both blocks (and overlapping value sets like pass/fail) are present.
-  REVIEW=\$(printf '%s' "\$REVIEW_SEG" | grep -oE 'verdict:[[:space:]]*(pass|fail|needs_followup)' | head -1 | sed -E 's/^verdict:[[:space:]]*//' || true)
-  QA=\$(printf '%s' "\$QA_SEG" | grep -oE 'verdict:[[:space:]]*(pass|fail|blocked)' | head -1 | sed -E 's/^verdict:[[:space:]]*//' || true)
+  # WORKFLOW STATUS fields — extracted only from the WORKFLOW STATUS segment.
+  STATE=\$(field_value "\$WORKFLOW_SEG" "STATE" "[a-z_]+")
+  DONE_MET=\$(field_value "\$WORKFLOW_SEG" "DONE_CRITERIA_MET" "(yes|no)")
+  HANDOFF=\$(field_value "\$WORKFLOW_SEG" "HANDOFF_TARGET" "[A-Za-z0-9_-]+")
+
+  # \`REVIEW_VERDICT\` and \`QA_VERDICT\` are DISTINCT canonical names. Extracting
+  # each from its OWN block segment is belt-and-suspenders — even a stray match
+  # of the other name in the wrong block can't cross-contaminate.
+  REVIEW=\$(field_value "\$REVIEW_SEG" "REVIEW_VERDICT" "(pass|fail|needs_followup)")
+  QA=\$(field_value "\$QA_SEG" "QA_VERDICT" "(pass|fail|blocked)")
 fi
 
 # Compose the line with jq so every field is quoted/escaped correctly and a
@@ -16530,6 +16577,8 @@ if [ "\$HAVE_JQ" = "1" ]; then
   # shellcheck disable=SC2016
   {
     JQ_FILTER='{ts: \$ts, event: \$event, session: \$session, agent: \$agent}'
+    [ -n "\$AGENT_ID" ] && { JQ_ARGS+=(--arg agent_id "\$AGENT_ID"); JQ_FILTER+=' + {agent_id: \$agent_id}'; }
+    [ -n "\$EFFORT" ] && { JQ_ARGS+=(--arg effort "\$EFFORT"); JQ_FILTER+=' + {effort: \$effort}'; }
     [ -n "\$STATE" ] && { JQ_ARGS+=(--arg state "\$STATE"); JQ_FILTER+=' + {state: \$state}'; }
     [ -n "\$DONE_MET" ] && { JQ_ARGS+=(--arg done_criteria_met "\$DONE_MET"); JQ_FILTER+=' + {done_criteria_met: \$done_criteria_met}'; }
     [ -n "\$HANDOFF" ] && { JQ_ARGS+=(--arg handoff_target "\$HANDOFF"); JQ_FILTER+=' + {handoff_target: \$handoff_target}'; }

--- a/templates/core/specflow/logs/README.md
+++ b/templates/core/specflow/logs/README.md
@@ -17,24 +17,39 @@ breaks a dispatch. A line is never rewritten; an agent's *current* state is its
 | --------- | ------------------- | --------------------------------------------- |
 | `ts`      | string (ISO-8601)   | UTC timestamp, e.g. `2026-06-13T11:00:00Z`.   |
 | `event`   | string              | `start` or `stop`.                            |
-| `session` | string              | Session id, or `unknown` if absent.           |
-| `agent`   | string              | Subagent name, or `unknown` if absent.        |
+| `session` | string              | `session_id`, or `unknown` if absent.         |
+| `agent`   | string              | Subagent name from `agent_type` (fallbacks `agent_name`/`subagent_name`/`tool_name`), or `unknown` if absent. |
+
+### Context fields (optional — omit-if-absent)
+
+Captured from the Claude Code event payload when present. `agent_id`
+disambiguates two concurrent agents of the same `agent_type` (e.g. two
+`security-auditor`s); `effort` records the agent's reasoning tier.
+
+| Field      | Type   | Source           | Notes                                            |
+| ---------- | ------ | ---------------- | ------------------------------------------------ |
+| `agent_id` | string | `agent_id`       | Per-dispatch agent id; omitted when absent.      |
+| `effort`   | string | `effort.level`   | `low` · `medium` · `high` · `xhigh`; omitted when absent. |
 
 ### Contract fields (optional — omit-if-absent)
 
-Parsed from the subagent's output text on **`stop`** events when it carries the
-machine-readable contract blocks (`WORKFLOW STATUS` / `REVIEW SUMMARY` /
-`QA SUMMARY`). Each key is present **only** when parsed — never emitted empty,
-never with a garbage value. An absent key means the field was not present in the
-output.
+Parsed from the subagent's final message (`last_assistant_message`, with
+fallbacks `output`/`result`/`response`/`tool_response`/`message`/raw payload) on
+**`stop`** events when it carries the machine-readable contract blocks
+(`WORKFLOW STATUS` / `REVIEW SUMMARY` / `QA SUMMARY`). The canonical field names
+inside those blocks are UPPERCASE (`STATE:`, `DONE_CRITERIA_MET:`,
+`HANDOFF_TARGET:`, `REVIEW_VERDICT:`, `QA_VERDICT:`) and are matched
+case-insensitively. Each key is present **only** when parsed — never emitted
+empty, never with a garbage value. An absent key means the field was not present
+in the output.
 
-| Field               | Type   | Source block      | Allowed values                                                                  |
-| ------------------- | ------ | ----------------- | ------------------------------------------------------------------------------- |
-| `state`             | string | `WORKFLOW STATUS` | `in_progress` · `blocked` · `awaiting_review` · `awaiting_qa` · `awaiting_user` · `done` · `failed` |
-| `done_criteria_met` | string | `WORKFLOW STATUS` | `yes` · `no`                                                                    |
-| `handoff_target`    | string | `WORKFLOW STATUS` | an agent name, or `none`                                                        |
-| `review_verdict`    | string | `REVIEW SUMMARY`  | `pass` · `fail` · `needs_followup`                                              |
-| `qa_verdict`        | string | `QA SUMMARY`      | `pass` · `fail` · `blocked`                                                     |
+| Field               | Type   | Source block / field             | Allowed values                                                                  |
+| ------------------- | ------ | -------------------------------- | ------------------------------------------------------------------------------- |
+| `state`             | string | `WORKFLOW STATUS` › `STATE`             | `in_progress` · `blocked` · `awaiting_review` · `awaiting_qa` · `awaiting_user` · `done` · `failed` |
+| `done_criteria_met` | string | `WORKFLOW STATUS` › `DONE_CRITERIA_MET` | `yes` · `no`                                                                    |
+| `handoff_target`    | string | `WORKFLOW STATUS` › `HANDOFF_TARGET`    | an agent name, or `none`                                                        |
+| `review_verdict`    | string | `REVIEW SUMMARY` › `REVIEW_VERDICT`     | `pass` · `fail` · `needs_followup`                                              |
+| `qa_verdict`        | string | `QA SUMMARY` › `QA_VERDICT`             | `pass` · `fail` · `blocked`                                                     |
 
 ## Examples
 
@@ -47,7 +62,7 @@ Base line (no contract block parsed, or a `start` event):
 Enriched `stop` line (contract block parsed from the output):
 
 ```json
-{"ts":"2026-06-13T11:42:00Z","event":"stop","session":"sess-123","agent":"security-auditor","state":"awaiting_review","done_criteria_met":"yes","handoff_target":"review-coordinator","review_verdict":"fail"}
+{"ts":"2026-06-13T11:42:00Z","event":"stop","session":"sess-123","agent":"security-auditor","agent_id":"abf05f10d169e18fa","effort":"high","state":"awaiting_review","done_criteria_met":"yes","handoff_target":"review-coordinator","review_verdict":"fail"}
 ```
 
 ## Invariants

--- a/templates/harness-specific/claude/hooks/log-subagent.sh
+++ b/templates/harness-specific/claude/hooks/log-subagent.sh
@@ -19,11 +19,23 @@ TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Best-effort field extraction — the exact payload shape varies by
 # Claude Code version; defaults to "unknown" when fields are absent.
+#
+# The agent name lives under `.agent_type` in the real Claude Code
+# SubagentStart/Stop payload (empirically captured, #388); the earlier
+# `.agent_name`/`.subagent_name`/`.tool_name` probes matched nothing and the
+# ledger recorded `agent:"unknown"` for every event. We prefer `.agent_type`
+# and keep the historical keys as version-drift fallbacks.
 HAVE_JQ=0
+AGENT_ID=""
+EFFORT=""
 if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
   HAVE_JQ=1
   SESSION=$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")
-  AGENT=$(printf '%s' "$INPUT" | jq -r '.agent_name // .subagent_name // .tool_name // "unknown"' 2>/dev/null || echo "unknown")
+  AGENT=$(printf '%s' "$INPUT" | jq -r '.agent_type // .agent_name // .subagent_name // .tool_name // "unknown"' 2>/dev/null || echo "unknown")
+  # Optional context (omit-if-absent): `agent_id` disambiguates two concurrent
+  # agents of the same type in `/status-audit`; `effort.level` is cheap context.
+  AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+  EFFORT=$(printf '%s' "$INPUT" | jq -r '.effort.level // ""' 2>/dev/null || echo "")
 else
   SESSION="unknown"
   AGENT="unknown"
@@ -41,11 +53,14 @@ HANDOFF=""
 REVIEW=""
 QA=""
 if [ "$HAVE_JQ" = "1" ] && [ "$EVENT" = "stop" ]; then
-  # The key holding the agent's output text is Claude-Code-version-dependent;
-  # probe the likely candidates and fall back to the raw payload. The first
-  # candidate that yields a non-empty string wins.
+  # The agent's final message — where the end-of-turn contract blocks live — is
+  # carried under `.last_assistant_message` in the real SubagentStop payload
+  # (#388). The earlier `.output`/`.result`/… probes matched nothing, so the
+  # ledger captured zero contract fields. Prefer `.last_assistant_message`,
+  # keep the historical keys as version-drift fallbacks, then fall back to the
+  # raw payload. The first candidate that yields a non-empty string wins.
   OUTPUT=$(printf '%s' "$INPUT" | jq -r \
-    '(.output // .result // .response // .tool_response // .message // "") | if type=="string" then . else tojson end' \
+    '(.last_assistant_message // .output // .result // .response // .tool_response // .message // "") | if type=="string" then . else tojson end' \
     2>/dev/null || echo "")
   if [ -z "$OUTPUT" ]; then
     OUTPUT="$INPUT"
@@ -72,16 +87,33 @@ if [ "$HAVE_JQ" = "1" ] && [ "$EVENT" = "stop" ]; then
   REVIEW_SEG=$(segment "REVIEW SUMMARY")
   QA_SEG=$(segment "QA SUMMARY")
 
-  # WORKFLOW STATUS fields — extracted only from the WORKFLOW STATUS segment.
-  STATE=$(printf '%s' "$WORKFLOW_SEG" | grep -oE 'state:[[:space:]]*[a-z_]+' | head -1 | sed -E 's/^state:[[:space:]]*//' || true)
-  DONE_MET=$(printf '%s' "$WORKFLOW_SEG" | grep -oE 'done_criteria_met:[[:space:]]*(yes|no)' | head -1 | sed -E 's/^done_criteria_met:[[:space:]]*//' || true)
-  HANDOFF=$(printf '%s' "$WORKFLOW_SEG" | grep -oE 'handoff_target:[[:space:]]*[A-Za-z0-9_-]+' | head -1 | sed -E 's/^handoff_target:[[:space:]]*//' || true)
+  # The #378 contract blocks use canonical UPPERCASE field names
+  # (`STATE:` / `DONE_CRITERIA_MET:` / `HANDOFF_TARGET:` / `REVIEW_VERDICT:` /
+  # `QA_VERDICT:`). The earlier lowercase `state:`/`verdict:` greps never
+  # matched a real contract block. We grep the canonical names
+  # CASE-INSENSITIVELY (`-i`) for robustness, then strip the `FIELD:` prefix.
+  # `field_value` lowercases the whole matched token before stripping the prefix
+  # so the case-insensitive sed needs no per-letter alternation; the values
+  # (state names, yes/no, verdicts, agent names) are themselves lowercase.
+  field_value() {
+    # $1 = segment text; $2 = canonical field name; $3 = value charclass/alt.
+    printf '%s' "$1" |
+      grep -ioE "$2:[[:space:]]*$3" |
+      head -1 |
+      tr '[:upper:]' '[:lower:]' |
+      sed -E "s/^[a-z_]+:[[:space:]]*//" || true
+  }
 
-  # `verdict:` appears under both REVIEW SUMMARY and QA SUMMARY; extracting it
-  # from each block's OWN segment is what keeps the two verdicts distinct even
-  # when both blocks (and overlapping value sets like pass/fail) are present.
-  REVIEW=$(printf '%s' "$REVIEW_SEG" | grep -oE 'verdict:[[:space:]]*(pass|fail|needs_followup)' | head -1 | sed -E 's/^verdict:[[:space:]]*//' || true)
-  QA=$(printf '%s' "$QA_SEG" | grep -oE 'verdict:[[:space:]]*(pass|fail|blocked)' | head -1 | sed -E 's/^verdict:[[:space:]]*//' || true)
+  # WORKFLOW STATUS fields — extracted only from the WORKFLOW STATUS segment.
+  STATE=$(field_value "$WORKFLOW_SEG" "STATE" "[a-z_]+")
+  DONE_MET=$(field_value "$WORKFLOW_SEG" "DONE_CRITERIA_MET" "(yes|no)")
+  HANDOFF=$(field_value "$WORKFLOW_SEG" "HANDOFF_TARGET" "[A-Za-z0-9_-]+")
+
+  # `REVIEW_VERDICT` and `QA_VERDICT` are DISTINCT canonical names. Extracting
+  # each from its OWN block segment is belt-and-suspenders — even a stray match
+  # of the other name in the wrong block can't cross-contaminate.
+  REVIEW=$(field_value "$REVIEW_SEG" "REVIEW_VERDICT" "(pass|fail|needs_followup)")
+  QA=$(field_value "$QA_SEG" "QA_VERDICT" "(pass|fail|blocked)")
 fi
 
 # Compose the line with jq so every field is quoted/escaped correctly and a
@@ -96,6 +128,8 @@ if [ "$HAVE_JQ" = "1" ]; then
   # shellcheck disable=SC2016
   {
     JQ_FILTER='{ts: $ts, event: $event, session: $session, agent: $agent}'
+    [ -n "$AGENT_ID" ] && { JQ_ARGS+=(--arg agent_id "$AGENT_ID"); JQ_FILTER+=' + {agent_id: $agent_id}'; }
+    [ -n "$EFFORT" ] && { JQ_ARGS+=(--arg effort "$EFFORT"); JQ_FILTER+=' + {effort: $effort}'; }
     [ -n "$STATE" ] && { JQ_ARGS+=(--arg state "$STATE"); JQ_FILTER+=' + {state: $state}'; }
     [ -n "$DONE_MET" ] && { JQ_ARGS+=(--arg done_criteria_met "$DONE_MET"); JQ_FILTER+=' + {done_criteria_met: $done_criteria_met}'; }
     [ -n "$HANDOFF" ] && { JQ_ARGS+=(--arg handoff_target "$HANDOFF"); JQ_FILTER+=' + {handoff_target: $handoff_target}'; }

--- a/tests/templates/log_subagent_enrichment_test.ts
+++ b/tests/templates/log_subagent_enrichment_test.ts
@@ -2,12 +2,24 @@ import { assert, assertEquals } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 
 /**
- * Hermetic test for the enriched `log-subagent.sh` hook (#381, mechanism C).
+ * Hermetic test for the enriched `log-subagent.sh` hook (#381 mechanism C,
+ * re-anchored in #388 to the empirically-captured real Claude Code payload).
  *
- * The hook is the deterministic data foundation of the status ledger: it parses
- * the OPTIONAL contract fields (`state`, `done_criteria_met`, `handoff_target`,
- * `review_verdict`, `qa_verdict`) out of the subagent's output text and appends
- * them as JSONL keys beside the always-present `{ts, event, session, agent}`.
+ * The hook is the deterministic data foundation of the status ledger. The real
+ * `SubagentStop` payload (captured live, see research.md) names the agent under
+ * `agent_type` and carries the agent's end-of-turn contract blocks under
+ * `last_assistant_message` — NOT the `agent_name`/`output` keys the original
+ * #381 hook (and its test) assumed. That mismatch is why the ledger shipped
+ * inert (`agent:"unknown"`, zero contract fields). These cases are therefore
+ * anchored to the REAL shape; the legacy keys are kept only as explicit
+ * fallback cases.
+ *
+ * The hook parses the OPTIONAL contract fields (`state`, `done_criteria_met`,
+ * `handoff_target`, `review_verdict`, `qa_verdict`) plus the optional
+ * `agent_id`/`effort` context out of the payload and appends them as JSONL keys
+ * beside the always-present `{ts, event, session, agent}`. The contract blocks
+ * use canonical UPPERCASE field names (`STATE:` / `REVIEW_VERDICT:` …) per the
+ * #378 contract; the hook matches them case-insensitively.
  *
  * Each case pipes a synthetic stop-event payload into the hook against a temp
  * cwd (so the hook writes `<temp>/.specflow/logs/agents.jsonl`) and asserts the
@@ -73,22 +85,31 @@ const CONTRACT_KEYS = [
   "qa_verdict",
 ] as const;
 
-Deno.test("stop payload with WORKFLOW STATUS + REVIEW SUMMARY → enriched line", async () => {
-  const output = [
+Deno.test("REAL SubagentStop payload (agent_type + last_assistant_message + UPPERCASE block) → fully enriched line", async () => {
+  // Mirrors the empirically-captured shape: name under `agent_type`, contract
+  // blocks under `last_assistant_message`, canonical UPPERCASE field names.
+  const lastAssistantMessage = [
     "Done with the security pass.",
     "",
-    "WORKFLOW STATUS",
-    "state: awaiting_review",
-    "done_criteria_met: yes",
-    "handoff_target: review-coordinator",
-    "",
     "REVIEW SUMMARY",
-    "verdict: fail",
+    "REVIEW_VERDICT: fail",
+    "",
+    "WORKFLOW STATUS",
+    "STATE: awaiting_review",
+    "DONE_CRITERIA_MET: yes",
+    "HANDOFF_TARGET: review-coordinator",
   ].join("\n");
   const payload = JSON.stringify({
     session_id: "sess-123",
-    agent_name: "security-auditor",
-    output,
+    agent_id: "abf05f10d169e18fa",
+    agent_type: "security-auditor",
+    effort: { level: "high" },
+    permission_mode: "bypassPermissions",
+    hook_event_name: "SubagentStop",
+    stop_hook_active: false,
+    last_assistant_message: lastAssistantMessage,
+    background_tasks: [],
+    session_crons: [],
   });
 
   const { code, line } = await runHook("stop", payload);
@@ -96,7 +117,12 @@ Deno.test("stop payload with WORKFLOW STATUS + REVIEW SUMMARY → enriched line"
   assert(line, "expected an appended JSONL line");
   assertEquals(line.event, "stop");
   assertEquals(line.session, "sess-123");
+  // Name resolved from `agent_type` (not the absent `agent_name`).
   assertEquals(line.agent, "security-auditor");
+  // Optional context fields populated from the real payload.
+  assertEquals(line.agent_id, "abf05f10d169e18fa");
+  assertEquals(line.effort, "high");
+  // Contract fields parsed from `last_assistant_message`, UPPERCASE names.
   assertEquals(line.state, "awaiting_review");
   assertEquals(line.done_criteria_met, "yes");
   assertEquals(line.handoff_target, "review-coordinator");
@@ -109,8 +135,49 @@ Deno.test("stop payload with WORKFLOW STATUS + REVIEW SUMMARY → enriched line"
   assertEquals(typeof line.ts, "string");
 });
 
-Deno.test("stop payload with QA SUMMARY → qa_verdict captured", async () => {
+Deno.test("agent_id / effort omitted when absent from the payload", async () => {
+  const payload = JSON.stringify({
+    session_id: "sess-no-ctx",
+    agent_type: "developer",
+    last_assistant_message: "Just prose, no contract block.",
+  });
+
+  const { code, line } = await runHook("stop", payload);
+  assertEquals(code, 0);
+  assert(line);
+  assertEquals(line.agent, "developer");
+  assert(!("agent_id" in line), "agent_id must be omitted when absent");
+  assert(!("effort" in line), "effort must be omitted when absent");
+});
+
+Deno.test("legacy `.output` key + `agent_name` still probed (version-drift fallback)", async () => {
+  // Older/alternate payload shapes used `agent_name` + `output`. The hook keeps
+  // these as fallbacks behind the real `agent_type` / `last_assistant_message`.
   const output = [
+    "WORKFLOW STATUS",
+    "STATE: blocked",
+    "DONE_CRITERIA_MET: no",
+    "HANDOFF_TARGET: none",
+  ].join("\n");
+  const payload = JSON.stringify({
+    session_id: "sess-legacy",
+    agent_name: "developer",
+    output,
+  });
+
+  const { code, line } = await runHook("stop", payload);
+  assertEquals(code, 0);
+  assert(line);
+  assertEquals(line.agent, "developer");
+  assertEquals(line.state, "blocked");
+  assertEquals(line.done_criteria_met, "no");
+  assertEquals(line.handoff_target, "none");
+});
+
+Deno.test("lowercase contract field names are still captured (case-insensitive match)", async () => {
+  // Defensive: even if an agent emits lowercase field names, the hook's
+  // case-insensitive grep must still populate the ledger.
+  const lastAssistantMessage = [
     "Ran the smoke pass.",
     "",
     "WORKFLOW STATUS",
@@ -119,45 +186,48 @@ Deno.test("stop payload with QA SUMMARY → qa_verdict captured", async () => {
     "handoff_target: none",
     "",
     "QA SUMMARY",
-    "verdict: pass",
+    "qa_verdict: pass",
   ].join("\n");
   const payload = JSON.stringify({
-    session_id: "sess-qa",
-    agent_name: "qa-tester",
-    output,
+    session_id: "sess-lower",
+    agent_type: "qa-tester",
+    last_assistant_message: lastAssistantMessage,
   });
 
   const { code, line } = await runHook("stop", payload);
   assertEquals(code, 0);
   assert(line);
+  assertEquals(line.agent, "qa-tester");
   assertEquals(line.state, "done");
+  assertEquals(line.done_criteria_met, "yes");
   assertEquals(line.handoff_target, "none");
   assertEquals(line.qa_verdict, "pass");
   assert(!("review_verdict" in line), "review_verdict must be omitted");
 });
 
-Deno.test("stop payload with BOTH REVIEW SUMMARY (fail) + QA SUMMARY (pass) → each verdict bound to its own block", async () => {
+Deno.test("dual block REVIEW_VERDICT:fail + QA_VERDICT:pass → each verdict bound to its own block", async () => {
   // Dual-block payload: the review block fails, the QA block passes. The hook
-  // must SEGMENT the output per block so each `verdict:` is read only within
-  // its own block — never cross-contaminated by the other block's verdict.
-  const output = [
+  // must SEGMENT the output per block so each verdict is read only within its
+  // own block — never cross-contaminated. With distinct UPPERCASE names
+  // (REVIEW_VERDICT vs QA_VERDICT) the segmentation is belt-and-suspenders.
+  const lastAssistantMessage = [
     "Wrapping up.",
     "",
-    "WORKFLOW STATUS",
-    "state: awaiting_review",
-    "done_criteria_met: no",
-    "handoff_target: review-coordinator",
-    "",
     "REVIEW SUMMARY",
-    "verdict: fail",
+    "REVIEW_VERDICT: fail",
     "",
     "QA SUMMARY",
-    "verdict: pass",
+    "QA_VERDICT: pass",
+    "",
+    "WORKFLOW STATUS",
+    "STATE: awaiting_review",
+    "DONE_CRITERIA_MET: no",
+    "HANDOFF_TARGET: review-coordinator",
   ].join("\n");
   const payload = JSON.stringify({
     session_id: "sess-dual",
-    agent_name: "review-coordinator",
-    output,
+    agent_type: "review-coordinator",
+    last_assistant_message: lastAssistantMessage,
   });
 
   const { code, line } = await runHook("stop", payload);
@@ -174,8 +244,8 @@ Deno.test("JSON injection via session_id is neutralised → valid JSON, no injec
   const hostile = 'sess","injected":"x';
   const payload = JSON.stringify({
     session_id: hostile,
-    agent_name: "developer",
-    output: "Just prose, no contract block.",
+    agent_type: "developer",
+    last_assistant_message: "Just prose, no contract block.",
   });
 
   const { code, line } = await runHook("stop", payload);
@@ -191,8 +261,8 @@ Deno.test("JSON injection via session_id is neutralised → valid JSON, no injec
 Deno.test("stop payload with no contract block → base four-field line only", async () => {
   const payload = JSON.stringify({
     session_id: "sess-plain",
-    agent_name: "developer",
-    output: "Just some prose with no WORKFLOW STATUS block at all.",
+    agent_type: "developer",
+    last_assistant_message: "Just some prose with no WORKFLOW STATUS block.",
   });
 
   const { code, line } = await runHook("stop", payload);
@@ -205,21 +275,24 @@ Deno.test("stop payload with no contract block → base four-field line only", a
   for (const k of CONTRACT_KEYS) {
     assert(!(k in line), `${k} must be omitted when no block is present`);
   }
-  // Exactly the four base keys.
+  // Exactly the four base keys (agent_id/effort absent here too).
   assertEquals(Object.keys(line).sort(), ["agent", "event", "session", "ts"]);
 });
 
 Deno.test("start event → base line, never enriched", async () => {
+  // SubagentStart carries no last_assistant_message/effort; never enriched.
   const payload = JSON.stringify({
     session_id: "sess-start",
-    agent_name: "developer",
-    output: "WORKFLOW STATUS\nstate: in_progress\ndone_criteria_met: no\nhandoff_target: none",
+    agent_id: "abf05f10d169e18fa",
+    agent_type: "general-purpose",
+    hook_event_name: "SubagentStart",
   });
 
   const { code, line } = await runHook("start", payload);
   assertEquals(code, 0);
   assert(line);
   assertEquals(line.event, "start");
+  assertEquals(line.agent, "general-purpose");
   for (const k of CONTRACT_KEYS) {
     assert(!(k in line), `${k} must be omitted on start events`);
   }
@@ -242,24 +315,4 @@ Deno.test("malformed/non-JSON payload → never aborts, exit 0, valid base line"
   assert(line, "even a malformed payload must produce a valid base line");
   assertEquals(line.event, "stop");
   assertEquals(typeof line.ts, "string");
-});
-
-Deno.test("output under the .result key is also probed", async () => {
-  const output = [
-    "WORKFLOW STATUS",
-    "state: blocked",
-    "done_criteria_met: no",
-    "handoff_target: none",
-  ].join("\n");
-  const payload = JSON.stringify({
-    session_id: "sess-result",
-    agent_name: "developer",
-    result: output,
-  });
-
-  const { code, line } = await runHook("stop", payload);
-  assertEquals(code, 0);
-  assert(line);
-  assertEquals(line.state, "blocked");
-  assertEquals(line.done_criteria_met, "no");
 });


### PR DESCRIPTION
Closes #388 (P1) · follow-up from the epic monorepo#12 dogfood.

The `log-subagent` hook probed payload keys absent from the real Claude Code `SubagentStop` event — the monorepo dogfood showed 219/219 ledger entries `agent:"unknown"` with zero verdicts, so `/status-audit` (mechanism C) was inert. Fixed against the **empirically-captured** payload (`agent_type`, `last_assistant_message`), with canonical UPPERCASE field-name matching (case-insensitive, per-block-segmented) and new optional `agent_id`/`effort` fields.

The test is re-anchored to the **real** payload shape (RED 7/10 → GREEN 10/10) — the old synthetic-shape test agreed with the buggy hook, which is why the bug shipped green. `deno task test` 1003/0; shellcheck clean.

Deferred (non-blocking, MEDIUM): a segmentation-isolation test case + restore a `.result` fallback-key test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)