### PR TITLE
fix(code-audit): harden collect-audit-scope.sh (#389, #390, #391)

### DIFF
--- a/.specflow/feature.json
+++ b/.specflow/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specflow/specs/017-hook-payload-fix",
-  "linked_issue": 388,
+  "feature_directory": ".specflow/specs/018-scope-script-hardening",
+  "linked_issue": 389,
   "workflow_shape": "full"
 }

--- a/.specflow/specs/013-code-audit/contracts/scope-signals.md
+++ b/.specflow/specs/013-code-audit/contracts/scope-signals.md
@@ -14,11 +14,24 @@ FILES:
 <path>                 (one per line; the changed/tracked files in scope)
 TOTAL_FILES: <integer>
 CATEGORY SIGNALS
-FRONTEND_COUNT: <integer>
-TEST_COUNT: <integer>
-DEP_COUNT: <integer>
-INFRA_COUNT: <integer>
+FRONTEND_COUNT: <integer>   # GATING — > 0 deploys the accessibility seat
+TEST_COUNT: <integer>       # INFORMATIONAL — context only, no seat consumes it
+DEP_COUNT: <integer>        # GATING — > 0 deploys the dependency seat
+INFRA_COUNT: <integer>      # INFORMATIONAL — context only, no seat consumes it
 ```
+
+## Signal intent — gating vs informational
+
+The four CATEGORY SIGNALS split into two roles. All four are **always emitted**;
+the distinction is whether a seat reads them:
+
+- **Gating signals** select an auditor seat:
+  - `FRONTEND_COUNT > 0` → deploy the **accessibility** seat (`a11y-auditor`).
+  - `DEP_COUNT > 0` → deploy the **dependency** seat (`dependency-auditor`).
+- **Informational signals** describe the scope but gate nothing:
+  - `TEST_COUNT` and `INFRA_COUNT` are context only — there is no test/coverage
+    or infra auditor seat, by design. They are not orphaned bugs; they round out
+    the scope picture for the maintainer reading the block.
 
 ## Rules
 
@@ -26,7 +39,9 @@ INFRA_COUNT: <integer>
   (default 20; `--last <n>` overrides).
 - Argument validation (exit 2 with a clear `error:` on stderr, no block, before any git call):
   - `--last <n>` MUST be a positive integer (`^[0-9]+$` and ≥ 1).
-  - `--range <a>..<b>` MUST match `^[^.]+\.\.[^.]+$`.
+  - `--range <a>..<b>` MUST match `^[A-Za-z0-9._/@^~-]+\.\.[A-Za-z0-9._/@^~-]+$`
+    (each endpoint restricted to a git-ref-name allowlist around a single two-dot
+    `..`; three-dot ranges, shell metacharacters, and whitespace are rejected).
   - `--path` / `--range` present with an empty argument is an error (no silent fall-through to
     auto-scope).
 - `--path` resolving to zero tracked files emits a `warning:` on stderr (the scope is still produced

--- a/.specflow/specs/018-scope-script-hardening/checklists/requirements.md
+++ b/.specflow/specs/018-scope-script-hardening/checklists/requirements.md
@@ -1,0 +1,17 @@
+# Specification Quality Checklist: collect-audit-scope.sh hardening
+
+**Created**: 2026-06-13 · **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation detail beyond the necessary script facts · [x] User value focused · [x] Mandatory sections complete
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers · [x] Testable, unambiguous · [x] Measurable SCs
+- [x] Acceptance scenarios + edge cases · [x] Scope bounded; assumptions identified
+
+## Feature Readiness
+- [x] FRs have acceptance criteria · [x] Scenarios cover flows · [x] No speculative scope
+
+## Notes
+Batches 3 dogfood follow-ups (#389/#390/#391), all on collect-audit-scope.sh. #389 resolves by docs
+(the #379 contract requires emitting all four signals). No open markers.

--- a/.specflow/specs/018-scope-script-hardening/spec.md
+++ b/.specflow/specs/018-scope-script-hardening/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: collect-audit-scope.sh hardening (orphan signals · input validation · perf)
+
+**Feature Branch**: `018-scope-script-hardening`
+**Created**: 2026-06-13
+**Status**: Draft
+**Input**: User description: "Batch the three small hardening follow-ups from the epic monorepo#12 dogfood, all on collect-audit-scope.sh: #389 (clarify the orphan INFRA_COUNT/TEST_COUNT signals), #390 (validate --path/--range input), #391 (perf micro-opts: dedupe git rev-list, single-pass category counting)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Clear which signals gate seats (#389) (Priority: P2)
+
+A maintainer reading the scope block or the `/code-audit` skill understands that `FRONTEND_COUNT` and `DEP_COUNT` gate seats (accessibility, dependency) while `TEST_COUNT` and `INFRA_COUNT` are **informational context only** — not orphaned bugs. The four signals stay in the output (the #379 scope-signals contract requires all four), but the docs label which gate and which inform.
+
+**Why this priority**: The dogfood flagged the two non-gating signals as confusing "orphans". The contract requires emitting all four, so the fix is to document intent, not remove them.
+
+**Acceptance Scenarios**:
+1. **Given** the `/code-audit` SKILL.md seat table, **When** read, **Then** it notes `TEST_COUNT`/`INFRA_COUNT` are informational (no seat consumes them; FRONTEND/DEP gate a11y/dependency).
+2. **Given** `scope-signals.md`, **When** read, **Then** it labels each signal gating-vs-informational.
+3. **Given** the script output, **When** run, **Then** all four signals are still emitted (no contract break).
+
+---
+
+### User Story 2 - Reject malformed/unsafe scope arguments (#390) (Priority: P2)
+
+`--path` rejects absolute paths and `..` traversal before touching git; `--range` accepts only git-ref-name-shaped values (not arbitrary strings with shell metacharacters). Both fail fast with a clear `error:` and exit non-zero rather than silently producing an empty or misleading scope.
+
+**Why this priority**: Defensive hardening of the only external inputs the script takes; prevents confusing empty scopes and tightens an input boundary.
+
+**Acceptance Scenarios**:
+1. **Given** `--path /etc` or `--path ../../x`, **When** parsed, **Then** the script errors (`--path must be a relative path inside the repo`) and exits non-zero, no block emitted.
+2. **Given** `--range 'a b;rm'` (metacharacters), **When** parsed, **Then** the script errors (range must be ref-name-shaped) and exits non-zero.
+3. **Given** a valid `--path src/x` or `--range v1.0..HEAD`, **When** parsed, **Then** it resolves normally.
+
+---
+
+### User Story 3 - Avoid redundant work (#391) (Priority: P3)
+
+The script computes the unpushed-commit count once (not twice) and classifies files in a single pass over the file list (not four passes). Behaviour is identical; only the redundant work is removed.
+
+**Why this priority**: Pure micro-optimization; lowest priority. Bounded impact, but free correctness-preserving cleanup.
+
+**Acceptance Scenarios**:
+1. **Given** the unpushed-scope branch, **When** resolved, **Then** `git rev-list --count origin/main..HEAD` runs once.
+2. **Given** any scope, **When** category signals are computed, **Then** the file list is walked once and all four counters incremented together; the emitted counts are unchanged from the previous implementation.
+
+---
+
+### Edge Cases
+- `--path .` or a valid nested relative path → allowed (only absolute + `..` rejected).
+- `--range` with three dots (`a...b`) → rejected (only two-dot ranges, as before).
+- Empty/zero-file scope after a valid `--path` → still emits `TOTAL_FILES: 0` (unchanged).
+- The single-pass classifier must produce byte-identical counts to the four-pass version on the same input (regression-guarded by the existing scope tests).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+- **FR-001** (#389): Keep emitting all four CATEGORY SIGNALS (contract-required). Document — in the `/code-audit` SKILL.md seat table and in `contracts/scope-signals.md` — that `FRONTEND_COUNT` gates accessibility and `DEP_COUNT` gates dependency, while `TEST_COUNT`/`INFRA_COUNT` are informational context (no seat). Add a one-line in-script comment to the same effect.
+- **FR-002** (#390): Validate `--path` before use — reject a value that is absolute (leading `/`) or contains a `..` segment, with `error: --path must be a relative path inside the repo (got: <v>)` and a non-zero exit, before any git call.
+- **FR-003** (#390): Tighten `--range` validation to a git-ref-name allowlist (reject shell metacharacters / spaces); keep the existing two-dot-only rule and the clear error + non-zero exit.
+- **FR-004** (#391): Compute the unpushed-commit count once and reuse it (no duplicate `git rev-list --count`).
+- **FR-005** (#391): Classify files into the four category counters in a single pass over the file list (replace the four serial `count_matches` calls), producing identical counts.
+- **FR-006**: No behavioural regression — the scope block format, the resolution-priority order, the signal values, the git-repo guard, the `TOTAL_FILES: 0` distinct case, and `set -euo pipefail` + exit codes are all unchanged except where a new validation adds an explicit error path.
+- **FR-007**: The change ships through the bundle (`init`/`upgrade`); existing `collect_audit_scope_test.ts` stays green and gains cases for the new `--path`/`--range` rejections.
+
+## Key Entities
+- **Scope argument**: `--path` / `--range` / `--last` (validation tightened on the first two).
+- **Category signal**: gating (`FRONTEND_COUNT`, `DEP_COUNT`) vs informational (`TEST_COUNT`, `INFRA_COUNT`).
+
+## Domain Model *(mandatory)*
+
+**Bounded context:** Audit-scope resolution (the `collect-audit-scope.sh` script) — hardening pass, no new behaviour.
+
+**Vocabulary:** **Gating signal** (governs a seat) vs **Informational signal** (context only); **Scope argument** (the validated inputs).
+
+**Entities:** *Scope script* — existing; this pass tightens input validation, dedups work, and clarifies signal intent.
+
+**Value objects:** *CategorySignals(frontend[gating], dep[gating], test[info], infra[info])*; *ScopeArg(path|range|last)* with validation rules.
+
+**Invariants:**
+- All four CATEGORY SIGNALS are always emitted (contract from #379).
+- Single-pass classification yields identical counts to the prior four-pass version.
+- `--path` is relative + no `..`; `--range` is ref-name-shaped + two-dot only.
+- Resolution priority, scope-block format, git-repo guard, exit-0-on-empty-scope, `set -euo pipefail` unchanged.
+
+**Out of scope:** adding an infra/coverage audit seat (no such agent exists; not warranted); changing the scope-block schema; touching `/code-audit`'s dispatch/synthesis logic.
+
+## Success Criteria *(mandatory)*
+- **SC-001**: All four signals still emitted; SKILL.md + scope-signals.md + an in-script comment label gating vs informational. (#389)
+- **SC-002**: `--path` absolute/`..` and `--range` metacharacter inputs are rejected with a clear error + non-zero exit; valid inputs resolve unchanged — test-verified. (#390)
+- **SC-003**: Unpushed count computed once; file classification is a single pass; the scope tests confirm unchanged counts. (#391)
+- **SC-004**: `deno task test` green (existing scope tests + new rejection cases); `shellcheck` clean.
+
+## Assumptions
+- All three issues touch `collect-audit-scope.sh`; batching them in one pass is lower-risk than three separate edits to the same file.
+- `#389` resolves by documentation (the #379 contract mandates emitting all four signals, so removal is not an option); the confusion is "which gate?", answered by labeling.
+- The single-pass classifier (#391) must be regression-guarded by asserting the same counts on a fixture the four-pass version produced — the existing `collect_audit_scope_test.ts` already asserts FRONTEND/TEST/DEP/INFRA counts.

--- a/.specflow/specs/018-scope-script-hardening/tasks.md
+++ b/.specflow/specs/018-scope-script-hardening/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: collect-audit-scope.sh hardening (#389 · #390 · #391)
+
+**Feature**: `018-scope-script-hardening` | **Branch**: `018-scope-script-hardening` | **Issues**: mkrlabs/specflow#389, #390, #391
+**Inputs**: [spec.md](./spec.md). Target file: `templates/harness-specific/claude/...`? NO — `templates/core/skills/code-audit/scripts/collect-audit-scope.sh` (+ its SKILL.md + the spec-013 scope-signals contract doc).
+
+All three issues touch the same scope script. TDD where a behaviour changes (the `--path`/`--range` rejections); the perf changes are regression-guarded by the existing count assertions.
+
+## Phase 1: #390 input validation (TDD)
+- [ ] T001 Add failing cases to `tests/templates/collect_audit_scope_test.ts`: `--path /etc` and `--path ../x` → non-zero exit + `error:` on stderr, no scope block; `--range 'a b;rm'` (and `--range a...b`) → non-zero exit + error; valid `--path src` and `--range <a>..<b>` still resolve. (Confirm RED first.)
+- [ ] T002 In `collect-audit-scope.sh`, before any git call: reject `--path` that is absolute (`/*`) or contains a `..` path segment (`error: --path must be a relative path inside the repo (got: <v>)`, exit 2); tighten `--range` to a git-ref-name allowlist (e.g. only `[A-Za-z0-9._/@^~-]` around the single `..`), keeping the two-dot-only rule + clear error + exit 2. Make T001 GREEN.
+
+## Phase 2: #391 perf micro-opts (regression-guarded)
+- [ ] T003 Dedupe the unpushed-count: capture `local_count="$(git rev-list --count origin/main..HEAD …)"` once and test `$local_count` in the guard (no second `git rev-list`).
+- [ ] T004 Replace the four serial `count_matches` calls with a SINGLE pass over the file list that increments all four category counters together. The emitted FRONTEND/TEST/DEP/INFRA counts MUST be byte-identical to before — the existing `collect_audit_scope_test.ts` count assertions (incl. the `INFRA_COUNT: 1` and exact `TOTAL_FILES` cases) are the regression guard; keep them green.
+
+## Phase 3: #389 signal-intent docs
+- [ ] T005 Keep emitting all four signals (contract). Document gating-vs-informational in three places: (a) `templates/core/skills/code-audit/SKILL.md` seat table — note FRONTEND_COUNT→accessibility, DEP_COUNT→dependency gate; TEST_COUNT/INFRA_COUNT informational (no seat); (b) `.specflow/specs/013-code-audit/contracts/scope-signals.md` — label each signal; (c) a one-line comment in the script above the CATEGORY SIGNALS emission.
+
+## Phase 4: distribution + validate
+- [ ] T006 `deno task bundle` (regenerate so the embedded skill carries the updated script + SKILL.md). Re-mirror to `plugin/skills/code-audit/` IF a mirrored file changed — NOTE: code-audit is script-backed and NOT in plugin/ (confirmed in #379), so only the SKILL.md mirror matters; verify whether code-audit/SKILL.md is in plugin/ (it is not) → no plugin change. No new skill folder → init counts unchanged.
+- [ ] T007 `deno task test` GREEN (existing + new rejection cases); `shellcheck collect-audit-scope.sh` clean; `deno fmt`+`deno lint` on touched TS. Manually run the script with a valid `--path`, an invalid `--path /etc`, and `--last 3`; confirm behaviour.
+
+## Dependencies
+- T001→T002 (TDD). T003/T004 independent (same file — sequence to avoid conflict). T005 docs. T006 after T002/T004. All small.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11650,10 +11650,18 @@ zero, and record the skip with its reason in the report's \`### Scope\` line.
 | Architecture  | architecture-auditor  | scope non-empty (always)               |
 | Security      | security-auditor      | scope non-empty (always)               |
 | Performance   | performance-auditor   | scope non-empty (always)               |
-| Accessibility | a11y-auditor          | \`FRONTEND_COUNT > 0\`                    |
-| Dependency    | dependency-auditor    | \`DEP_COUNT > 0\`                         |
+| Accessibility | a11y-auditor          | \`FRONTEND_COUNT > 0\` (gating signal)   |
+| Dependency    | dependency-auditor    | \`DEP_COUNT > 0\` (gating signal)        |
 
 These are the **existing** auditor agents — this skill defines no new agents.
+
+**Gating vs informational signals.** Only \`FRONTEND_COUNT\` and \`DEP_COUNT\`
+**gate** a seat (accessibility and dependency, respectively). \`TEST_COUNT\` and
+\`INFRA_COUNT\` are **informational context only** — no seat consumes them, and
+there is intentionally no test/coverage or infra seat (no such auditor agent
+exists). All four counts are always emitted (the scope-signals contract requires
+it); the two informational ones simply describe the scope, they do not select
+seats.
 
 ## Step 4 — Dispatch all selected seats IN PARALLEL (one message)
 
@@ -11758,6 +11766,9 @@ LAST_N=20
 
 usage() {
   echo "usage: collect-audit-scope.sh [--path <subtree> | --range <a>..<b>] [--last <n>]" >&2
+  # Known limitation: the --range allowlist excludes '{' '}', so stash refs of
+  # the form 'stash@{N}' are not accepted as range endpoints.
+  echo "note: stash refs (stash@{N}) are not valid --range endpoints" >&2
 }
 
 while [ \$# -gt 0 ]; do
@@ -11769,6 +11780,17 @@ while [ \$# -gt 0 ]; do
         usage
         exit 2
       fi
+      # Reject anything that escapes the repo root before any git call: an
+      # absolute path (leading '/') or any '..' path segment lets the caller
+      # point the scope outside the working tree. Only relative, in-tree
+      # subtrees are valid scope arguments.
+      case "\$PATH_ARG" in
+        /* | ../* | */../* | */.. | ..)
+          echo "error: --path must be a relative path inside the repo (got: \$PATH_ARG)" >&2
+          usage
+          exit 2
+          ;;
+      esac
       shift 2
       ;;
     --range)
@@ -11778,23 +11800,19 @@ while [ \$# -gt 0 ]; do
         usage
         exit 2
       fi
-      # Validate the range shape (<a>..<b>, no dots inside either ref) before
-      # handing it to git — a malformed range must error, not silently fall
-      # through to auto-scope.
-      case "\$RANGE_ARG" in
-        *..*)
-          if ! printf '%s' "\$RANGE_ARG" | grep -Eq '^[^.]+\\.\\.[^.]+\$'; then
-            echo "error: --range must match <a>..<b> (got: \$RANGE_ARG)" >&2
-            usage
-            exit 2
-          fi
-          ;;
-        *)
-          echo "error: --range must match <a>..<b> (got: \$RANGE_ARG)" >&2
-          usage
-          exit 2
-          ;;
-      esac
+      # Validate the range shape before handing it to git — a malformed range
+      # must error, not silently fall through to auto-scope. Two endpoints,
+      # each restricted to a git-ref-name allowlist ([A-Za-z0-9._/@^~-]), around
+      # a single two-dot '..'. This rejects three-dot ranges, shell
+      # metacharacters, and whitespace (so a value can never become a shell
+      # injection or a misleading empty scope). The '.' is allowed inside a ref
+      # (tags like v1.0) but the '..' separator must be exactly two dots.
+      if ! printf '%s' "\$RANGE_ARG" | grep -Eq '^[A-Za-z0-9._/@^~-]+\\.\\.[A-Za-z0-9._/@^~-]+\$' ||
+        printf '%s' "\$RANGE_ARG" | grep -Eq '\\.\\.\\.'; then
+        echo "error: --range must match <a>..<b> with ref-name-shaped endpoints (got: \$RANGE_ARG)" >&2
+        usage
+        exit 2
+      fi
       shift 2
       ;;
     --last)
@@ -11826,32 +11844,62 @@ SCOPE_LABEL=""
 COMMITS=""
 FILES=""
 
-# Counts a newline-separated file list against a glob, printing the integer.
-# Tolerates an empty list (prints 0). Matching is case-insensitive on the
-# basename / path so heuristic globs stay "good enough to pick seats".
-count_matches() {
-  local list="\$1"
+# Classifies a newline-separated file list into the four CATEGORY SIGNAL
+# counters in a SINGLE pass over the list. Each file is tested against every
+# category's glob set independently (a file can count toward more than one
+# category, e.g. a frontend test file). Sets FRONTEND_COUNT / TEST_COUNT /
+# DEP_COUNT / INFRA_COUNT. The globs are heuristic (research.md Decision 1):
+# good enough to pick which auditor seats run. Walking the list once instead of
+# four times is purely a perf optimization — the per-category counts are
+# identical to testing each category in its own pass.
+#
+# matches_any <file> <glob...> — 0 if the file matches any of the globs.
+matches_any() {
+  local f="\$1"
   shift
-  local n=0
+  local pat
+  for pat in "\$@"; do
+    # shellcheck disable=SC2254
+    case "\$f" in
+      \$pat) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+classify_files() {
+  local list="\$1"
+  FRONTEND_COUNT=0
+  TEST_COUNT=0
+  DEP_COUNT=0
+  INFRA_COUNT=0
   local f
   while IFS= read -r f; do
     [ -z "\$f" ] && continue
-    local matched=0
-    local pat
-    for pat in "\$@"; do
-      # shellcheck disable=SC2254
-      case "\$f" in
-        \$pat)
-          matched=1
-          break
-          ;;
-      esac
-    done
-    [ "\$matched" -eq 1 ] && n=\$((n + 1))
+    # \`matches_any … && COUNT=\$((…))\` relies on \`set -e\` NOT aborting on a
+    # failed \`&&\` compound list (a non-match is expected, not an error). This is
+    # bash semantics; a future shebang switch to /bin/sh would need an explicit
+    # \`if matches_any …; then COUNT=…; fi\` rewrite to stay safe.
+    matches_any "\$f" \\
+      '*.tsx' '*.jsx' '*.vue' '*.svelte' '*.css' '*.scss' '*inertia*' '*frontend*' '*components*' &&
+      FRONTEND_COUNT=\$((FRONTEND_COUNT + 1))
+    matches_any "\$f" \\
+      '*_test.*' '*.test.*' '*.spec.*' 'tests/*' '*/tests/*' '*/test/*' '*__tests__*' &&
+      TEST_COUNT=\$((TEST_COUNT + 1))
+    matches_any "\$f" \\
+      'package.json' '*/package.json' 'deno.json' '*/deno.json' 'deno.jsonc' '*.lock' \\
+      'Cargo.toml' 'pyproject.toml' 'go.mod' 'composer.json' 'Gemfile' 'requirements.txt' &&
+      DEP_COUNT=\$((DEP_COUNT + 1))
+    matches_any "\$f" \\
+      'Dockerfile' '*/Dockerfile' '*.tf' '*.pulumi.*' 'k8s/*' '*/k8s/*' \\
+      '.github/workflows/*' '*.yaml' '*.yml' &&
+      INFRA_COUNT=\$((INFRA_COUNT + 1))
   done <<EOF
 \$list
 EOF
-  printf '%s' "\$n"
+  # A trailing non-match leaves \$? non-zero; return 0 so \`set -e\` doesn't abort
+  # (the function's job is to set the four counters, not to report a status).
+  return 0
 }
 
 if [ -n "\$PATH_ARG" ]; then
@@ -11866,12 +11914,15 @@ if [ -n "\$PATH_ARG" ]; then
 elif [ -n "\$RANGE_ARG" ]; then
   SCOPE="range"
   SCOPE_LABEL="\$RANGE_ARG"
-  FILES="\$(git diff --name-only "\$RANGE_ARG" 2>/dev/null || true)"
-  COMMITS="\$(git log --oneline "\$RANGE_ARG" 2>/dev/null || true)"
+  # Trailing \`--\` ends option/revision parsing so a ref-shaped value can never
+  # be mistaken for a pathspec (matches the \`git ls-files --\` call above).
+  FILES="\$(git diff --name-only "\$RANGE_ARG" -- 2>/dev/null || true)"
+  COMMITS="\$(git log --oneline "\$RANGE_ARG" -- 2>/dev/null || true)"
 elif git rev-parse --verify --quiet origin/main >/dev/null 2>&1 &&
-  [ "\$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)" -gt 0 ]; then
+  local_count="\$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)" &&
+  [ "\$local_count" -gt 0 ]; then
+  # Reuse the count captured in the guard rather than running rev-list twice.
   SCOPE="unpushed"
-  local_count="\$(git rev-list --count origin/main..HEAD)"
   SCOPE_LABEL="origin/main..HEAD (\${local_count} commits)"
   FILES="\$(git diff --name-only origin/main..HEAD 2>/dev/null || true)"
   COMMITS="\$(git log --oneline origin/main..HEAD 2>/dev/null || true)"
@@ -11909,16 +11960,11 @@ else
 fi
 
 # CATEGORY SIGNALS — heuristic path/extension globs (research.md Decision 1).
-FRONTEND_COUNT="\$(count_matches "\$FILES" \\
-  '*.tsx' '*.jsx' '*.vue' '*.svelte' '*.css' '*.scss' '*inertia*' '*frontend*' '*components*')"
-TEST_COUNT="\$(count_matches "\$FILES" \\
-  '*_test.*' '*.test.*' '*.spec.*' 'tests/*' '*/tests/*' '*/test/*' '*__tests__*')"
-DEP_COUNT="\$(count_matches "\$FILES" \\
-  'package.json' '*/package.json' 'deno.json' '*/deno.json' 'deno.jsonc' '*.lock' \\
-  'Cargo.toml' 'pyproject.toml' 'go.mod' 'composer.json' 'Gemfile' 'requirements.txt')"
-INFRA_COUNT="\$(count_matches "\$FILES" \\
-  'Dockerfile' '*/Dockerfile' '*.tf' '*.pulumi.*' 'k8s/*' '*/k8s/*' \\
-  '.github/workflows/*' '*.yaml' '*.yml')"
+# Signal intent (contract: contracts/scope-signals.md): FRONTEND_COUNT and
+# DEP_COUNT are GATING (they decide whether the accessibility and dependency
+# seats run); TEST_COUNT and INFRA_COUNT are INFORMATIONAL only (no seat
+# consumes them) — all four are always emitted per the #379 contract.
+classify_files "\$FILES"
 
 # Emit the fixed block.
 echo "CODE-AUDIT SCOPE"

--- a/templates/core/skills/code-audit/SKILL.md
+++ b/templates/core/skills/code-audit/SKILL.md
@@ -53,10 +53,18 @@ zero, and record the skip with its reason in the report's `### Scope` line.
 | Architecture  | architecture-auditor  | scope non-empty (always)               |
 | Security      | security-auditor      | scope non-empty (always)               |
 | Performance   | performance-auditor   | scope non-empty (always)               |
-| Accessibility | a11y-auditor          | `FRONTEND_COUNT > 0`                    |
-| Dependency    | dependency-auditor    | `DEP_COUNT > 0`                         |
+| Accessibility | a11y-auditor          | `FRONTEND_COUNT > 0` (gating signal)   |
+| Dependency    | dependency-auditor    | `DEP_COUNT > 0` (gating signal)        |
 
 These are the **existing** auditor agents — this skill defines no new agents.
+
+**Gating vs informational signals.** Only `FRONTEND_COUNT` and `DEP_COUNT`
+**gate** a seat (accessibility and dependency, respectively). `TEST_COUNT` and
+`INFRA_COUNT` are **informational context only** — no seat consumes them, and
+there is intentionally no test/coverage or infra seat (no such auditor agent
+exists). All four counts are always emitted (the scope-signals contract requires
+it); the two informational ones simply describe the scope, they do not select
+seats.
 
 ## Step 4 — Dispatch all selected seats IN PARALLEL (one message)
 

--- a/templates/core/skills/code-audit/scripts/collect-audit-scope.sh
+++ b/templates/core/skills/code-audit/scripts/collect-audit-scope.sh
@@ -25,6 +25,9 @@ LAST_N=20
 
 usage() {
   echo "usage: collect-audit-scope.sh [--path <subtree> | --range <a>..<b>] [--last <n>]" >&2
+  # Known limitation: the --range allowlist excludes '{' '}', so stash refs of
+  # the form 'stash@{N}' are not accepted as range endpoints.
+  echo "note: stash refs (stash@{N}) are not valid --range endpoints" >&2
 }
 
 while [ $# -gt 0 ]; do
@@ -36,6 +39,17 @@ while [ $# -gt 0 ]; do
         usage
         exit 2
       fi
+      # Reject anything that escapes the repo root before any git call: an
+      # absolute path (leading '/') or any '..' path segment lets the caller
+      # point the scope outside the working tree. Only relative, in-tree
+      # subtrees are valid scope arguments.
+      case "$PATH_ARG" in
+        /* | ../* | */../* | */.. | ..)
+          echo "error: --path must be a relative path inside the repo (got: $PATH_ARG)" >&2
+          usage
+          exit 2
+          ;;
+      esac
       shift 2
       ;;
     --range)
@@ -45,23 +59,19 @@ while [ $# -gt 0 ]; do
         usage
         exit 2
       fi
-      # Validate the range shape (<a>..<b>, no dots inside either ref) before
-      # handing it to git — a malformed range must error, not silently fall
-      # through to auto-scope.
-      case "$RANGE_ARG" in
-        *..*)
-          if ! printf '%s' "$RANGE_ARG" | grep -Eq '^[^.]+\.\.[^.]+$'; then
-            echo "error: --range must match <a>..<b> (got: $RANGE_ARG)" >&2
-            usage
-            exit 2
-          fi
-          ;;
-        *)
-          echo "error: --range must match <a>..<b> (got: $RANGE_ARG)" >&2
-          usage
-          exit 2
-          ;;
-      esac
+      # Validate the range shape before handing it to git — a malformed range
+      # must error, not silently fall through to auto-scope. Two endpoints,
+      # each restricted to a git-ref-name allowlist ([A-Za-z0-9._/@^~-]), around
+      # a single two-dot '..'. This rejects three-dot ranges, shell
+      # metacharacters, and whitespace (so a value can never become a shell
+      # injection or a misleading empty scope). The '.' is allowed inside a ref
+      # (tags like v1.0) but the '..' separator must be exactly two dots.
+      if ! printf '%s' "$RANGE_ARG" | grep -Eq '^[A-Za-z0-9._/@^~-]+\.\.[A-Za-z0-9._/@^~-]+$' ||
+        printf '%s' "$RANGE_ARG" | grep -Eq '\.\.\.'; then
+        echo "error: --range must match <a>..<b> with ref-name-shaped endpoints (got: $RANGE_ARG)" >&2
+        usage
+        exit 2
+      fi
       shift 2
       ;;
     --last)
@@ -93,32 +103,62 @@ SCOPE_LABEL=""
 COMMITS=""
 FILES=""
 
-# Counts a newline-separated file list against a glob, printing the integer.
-# Tolerates an empty list (prints 0). Matching is case-insensitive on the
-# basename / path so heuristic globs stay "good enough to pick seats".
-count_matches() {
-  local list="$1"
+# Classifies a newline-separated file list into the four CATEGORY SIGNAL
+# counters in a SINGLE pass over the list. Each file is tested against every
+# category's glob set independently (a file can count toward more than one
+# category, e.g. a frontend test file). Sets FRONTEND_COUNT / TEST_COUNT /
+# DEP_COUNT / INFRA_COUNT. The globs are heuristic (research.md Decision 1):
+# good enough to pick which auditor seats run. Walking the list once instead of
+# four times is purely a perf optimization — the per-category counts are
+# identical to testing each category in its own pass.
+#
+# matches_any <file> <glob...> — 0 if the file matches any of the globs.
+matches_any() {
+  local f="$1"
   shift
-  local n=0
+  local pat
+  for pat in "$@"; do
+    # shellcheck disable=SC2254
+    case "$f" in
+      $pat) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+classify_files() {
+  local list="$1"
+  FRONTEND_COUNT=0
+  TEST_COUNT=0
+  DEP_COUNT=0
+  INFRA_COUNT=0
   local f
   while IFS= read -r f; do
     [ -z "$f" ] && continue
-    local matched=0
-    local pat
-    for pat in "$@"; do
-      # shellcheck disable=SC2254
-      case "$f" in
-        $pat)
-          matched=1
-          break
-          ;;
-      esac
-    done
-    [ "$matched" -eq 1 ] && n=$((n + 1))
+    # `matches_any … && COUNT=$((…))` relies on `set -e` NOT aborting on a
+    # failed `&&` compound list (a non-match is expected, not an error). This is
+    # bash semantics; a future shebang switch to /bin/sh would need an explicit
+    # `if matches_any …; then COUNT=…; fi` rewrite to stay safe.
+    matches_any "$f" \
+      '*.tsx' '*.jsx' '*.vue' '*.svelte' '*.css' '*.scss' '*inertia*' '*frontend*' '*components*' &&
+      FRONTEND_COUNT=$((FRONTEND_COUNT + 1))
+    matches_any "$f" \
+      '*_test.*' '*.test.*' '*.spec.*' 'tests/*' '*/tests/*' '*/test/*' '*__tests__*' &&
+      TEST_COUNT=$((TEST_COUNT + 1))
+    matches_any "$f" \
+      'package.json' '*/package.json' 'deno.json' '*/deno.json' 'deno.jsonc' '*.lock' \
+      'Cargo.toml' 'pyproject.toml' 'go.mod' 'composer.json' 'Gemfile' 'requirements.txt' &&
+      DEP_COUNT=$((DEP_COUNT + 1))
+    matches_any "$f" \
+      'Dockerfile' '*/Dockerfile' '*.tf' '*.pulumi.*' 'k8s/*' '*/k8s/*' \
+      '.github/workflows/*' '*.yaml' '*.yml' &&
+      INFRA_COUNT=$((INFRA_COUNT + 1))
   done <<EOF
 $list
 EOF
-  printf '%s' "$n"
+  # A trailing non-match leaves $? non-zero; return 0 so `set -e` doesn't abort
+  # (the function's job is to set the four counters, not to report a status).
+  return 0
 }
 
 if [ -n "$PATH_ARG" ]; then
@@ -133,12 +173,15 @@ if [ -n "$PATH_ARG" ]; then
 elif [ -n "$RANGE_ARG" ]; then
   SCOPE="range"
   SCOPE_LABEL="$RANGE_ARG"
-  FILES="$(git diff --name-only "$RANGE_ARG" 2>/dev/null || true)"
-  COMMITS="$(git log --oneline "$RANGE_ARG" 2>/dev/null || true)"
+  # Trailing `--` ends option/revision parsing so a ref-shaped value can never
+  # be mistaken for a pathspec (matches the `git ls-files --` call above).
+  FILES="$(git diff --name-only "$RANGE_ARG" -- 2>/dev/null || true)"
+  COMMITS="$(git log --oneline "$RANGE_ARG" -- 2>/dev/null || true)"
 elif git rev-parse --verify --quiet origin/main >/dev/null 2>&1 &&
-  [ "$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)" -gt 0 ]; then
+  local_count="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)" &&
+  [ "$local_count" -gt 0 ]; then
+  # Reuse the count captured in the guard rather than running rev-list twice.
   SCOPE="unpushed"
-  local_count="$(git rev-list --count origin/main..HEAD)"
   SCOPE_LABEL="origin/main..HEAD (${local_count} commits)"
   FILES="$(git diff --name-only origin/main..HEAD 2>/dev/null || true)"
   COMMITS="$(git log --oneline origin/main..HEAD 2>/dev/null || true)"
@@ -176,16 +219,11 @@ else
 fi
 
 # CATEGORY SIGNALS — heuristic path/extension globs (research.md Decision 1).
-FRONTEND_COUNT="$(count_matches "$FILES" \
-  '*.tsx' '*.jsx' '*.vue' '*.svelte' '*.css' '*.scss' '*inertia*' '*frontend*' '*components*')"
-TEST_COUNT="$(count_matches "$FILES" \
-  '*_test.*' '*.test.*' '*.spec.*' 'tests/*' '*/tests/*' '*/test/*' '*__tests__*')"
-DEP_COUNT="$(count_matches "$FILES" \
-  'package.json' '*/package.json' 'deno.json' '*/deno.json' 'deno.jsonc' '*.lock' \
-  'Cargo.toml' 'pyproject.toml' 'go.mod' 'composer.json' 'Gemfile' 'requirements.txt')"
-INFRA_COUNT="$(count_matches "$FILES" \
-  'Dockerfile' '*/Dockerfile' '*.tf' '*.pulumi.*' 'k8s/*' '*/k8s/*' \
-  '.github/workflows/*' '*.yaml' '*.yml')"
+# Signal intent (contract: contracts/scope-signals.md): FRONTEND_COUNT and
+# DEP_COUNT are GATING (they decide whether the accessibility and dependency
+# seats run); TEST_COUNT and INFRA_COUNT are INFORMATIONAL only (no seat
+# consumes them) — all four are always emitted per the #379 contract.
+classify_files "$FILES"
 
 # Emit the fixed block.
 echo "CODE-AUDIT SCOPE"

--- a/tests/templates/collect_audit_scope_test.ts
+++ b/tests/templates/collect_audit_scope_test.ts
@@ -307,3 +307,104 @@ Deno.test("collect-audit-scope rejects a malformed --range with exit 2", async (
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("collect-audit-scope rejects an absolute --path with exit 2 (no git call)", async () => {
+  const dir = await fixtureRepo();
+  try {
+    const r = await scope(dir, ["--path", "/etc"]);
+    assertEquals(r.code, 2);
+    assertStringIncludes(r.stderr, "relative path inside the repo");
+    assert(!r.stdout.includes("CODE-AUDIT SCOPE"), "no block on the validation-error path");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collect-audit-scope rejects a --path with a .. segment (traversal) with exit 2", async () => {
+  const dir = await fixtureRepo();
+  try {
+    const r = await scope(dir, ["--path", "../x"]);
+    assertEquals(r.code, 2);
+    assertStringIncludes(r.stderr, "relative path inside the repo");
+    assert(!r.stdout.includes("CODE-AUDIT SCOPE"), "no block on the validation-error path");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collect-audit-scope rejects a --path with a middle .. segment (traversal) with exit 2", async () => {
+  const dir = await fixtureRepo();
+  try {
+    // `foo/../etc` exercises the `*/../*` guard arm — the actual security guard
+    // against mid-path traversal, distinct from the leading-`..` case above.
+    const r = await scope(dir, ["--path", "foo/../etc"]);
+    assertEquals(r.code, 2);
+    assertStringIncludes(r.stderr, "relative path inside the repo");
+    assert(!r.stdout.includes("CODE-AUDIT SCOPE"), "no block on the validation-error path");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collect-audit-scope rejects a --range with shell metacharacters with exit 2", async () => {
+  const dir = await fixtureRepo();
+  try {
+    const r = await scope(dir, ["--range", "a b;rm"]);
+    assertEquals(r.code, 2);
+    // Assert the SPECIFIC range-rejection message so the test can't pass on an
+    // unrelated exit-2 path (e.g. an arg-parse error).
+    assertStringIncludes(r.stderr, "--range must match <a>..<b>");
+    assert(!r.stdout.includes("CODE-AUDIT SCOPE"), "no block on the validation-error path");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collect-audit-scope rejects a three-dot --range (a...b) with exit 2", async () => {
+  const dir = await fixtureRepo();
+  try {
+    const r = await scope(dir, ["--range", "a...b"]);
+    assertEquals(r.code, 2);
+    // Assert the SPECIFIC range-rejection message — without this the test would
+    // pass if the script exited 2 for any other reason (HIGH review finding).
+    assertStringIncludes(r.stderr, "--range must match <a>..<b>");
+    assert(!r.stdout.includes("CODE-AUDIT SCOPE"), "no block on the validation-error path");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collect-audit-scope: a valid relative --path does NOT trip the traversal guard", async () => {
+  const dir = await fixtureRepo();
+  try {
+    // Resolution itself is covered by "scopes to a subtree"; this test asserts
+    // the NEGATIVE — a legitimate relative subtree never hits the path guard.
+    const r = await scope(dir, ["--path", "src"]);
+    assertEquals(r.code, 0, r.stderr);
+    assert(
+      !r.stderr.includes("relative path inside the repo"),
+      "the traversal guard must not fire on a valid relative subtree",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collect-audit-scope: a valid two-dot --range does NOT trip the range guard", async () => {
+  const dir = await fixtureRepo();
+  try {
+    await Deno.writeTextFile(`${dir}/src/added.ts`, "export const added = 1;\n");
+    await git(["add", "."], dir);
+    await git(["commit", "-m", "feat: added"], dir);
+    // Resolution itself is covered by "scopes to an explicit commit range"; this
+    // test asserts the NEGATIVE — a well-formed two-dot range clears the guard.
+    const r = await scope(dir, ["--range", "HEAD~1..HEAD"]);
+    assertEquals(r.code, 0, r.stderr);
+    assert(
+      !r.stderr.includes("--range must match <a>..<b>"),
+      "the range guard must not fire on a valid two-dot range",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Batches the three dogfood follow-ups on `collect-audit-scope.sh`, all closed by this PR.

- **#390** — `--path` rejects absolute/`..` traversal; `--range` tightened to a git-ref-name allowlist (`^[A-Za-z0-9._/@^~-]+\.\.[A-Za-z0-9._/@^~-]+$`), before any git call, with a clear error + exit 2. Tests assert the specific messages + the mid-path (`foo/../etc`) guard.
- **#391** — unpushed count computed once; single-pass file classification (counts byte-identical, regression-guarded by the existing count assertions).
- **#389** — all four CATEGORY SIGNALS still emitted (the #379 contract requires them); docs now label FRONTEND/DEP as seat-gating and TEST/INFRA as informational (SKILL.md + scope-signals.md + in-script comment).

`deno task test` 1010/0; shellcheck + lint + fmt clean. Review gate cleared (no correctness/security defect; one fix cycle hardened test assertions + the contract-regex doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)