### PR TITLE
docs: rebrand stale `specflow <cmd>` refs in JSDoc to `specnaut`

### DIFF
--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -36,7 +36,7 @@ export type InitResult =
     conflicts: string[];
     /**
      * True when a `.specnaut/installed.lock` already exists at the target —
-     * lets the CLI suggest `specflow upgrade` instead of `--force` for
+     * lets the CLI suggest `specnaut upgrade` instead of `--force` for
      * projects that were previously initialised by Specnaut.
      */
     lockExists: boolean;
@@ -78,7 +78,7 @@ export type InitProjectInput = {
    * Destination paths to leave untouched on a forced refresh — the
    * maintainer's preserve declarations (`.specnaut/preserve.yml`, spec 011 /
    * issue #367). These are removed from the WRITE set only; they STAY
-   * lock-tracked (FR-012) so `specflow diff` and future upgrades still
+   * lock-tracked (FR-012) so `specnaut diff` and future upgrades still
    * compare them. Absent/empty ⇒ today's behaviour (FR-011). The handler
    * resolves the set (and validates membership / `--reset-preserved`); the
    * use case never reads the manifest or any CLI flag.

--- a/src/cli/handlers/diff_handler.ts
+++ b/src/cli/handlers/diff_handler.ts
@@ -14,7 +14,7 @@ export type DiffIntent = {
 };
 
 /**
- * `specflow diff` (spec 011 / issue #367, US2) — render, read-only, how each
+ * `specnaut diff` (spec 011 / issue #367, US2) — render, read-only, how each
  * managed file on disk diverges from the bundled original for the installed
  * templates version (FR-006).
  *

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -117,7 +117,7 @@ export type Intent =
   }
   | {
     /**
-     * `specflow diff` (spec 011 / issue #367, US2) — read-only divergence view:
+     * `specnaut diff` (spec 011 / issue #367, US2) — read-only divergence view:
      * show how each managed file on disk differs from the bundled original for
      * the installed templates version. Mutates nothing.
      */
@@ -141,7 +141,7 @@ export type Intent =
     apiUrl: string | null;
   }
   | {
-    /** `specflow gate <status|raise|cancel>` (#358) — the non-interactive bridge
+    /** `specnaut gate <status|raise|cancel>` (#358) — the non-interactive bridge
      *  a skill phase uses to raise a remote-control gate. See gate_handler.ts. */
     kind: "gate";
     sub: "status" | "raise" | "cancel";

--- a/src/domain/merge_block.ts
+++ b/src/domain/merge_block.ts
@@ -2,7 +2,7 @@
  * Append-block helpers for `mergeable-project-root` files (e.g. `.gitignore`).
  *
  * A merge block is a labeled section in an otherwise user-owned file that
- * Specflow can write, replace, or read back without touching surrounding
+ * Specnaut can write, replace, or read back without touching surrounding
  * lines. The fence markers are stable so future runs (init re-run, upgrade)
  * can find and replace the block in place.
  *


### PR DESCRIPTION
Follow-up to #396. The descoped internal JSDoc command refs (`specflow upgrade`/`diff`/`gate`, plus one merge_block module-doc line) → `specnaut`.

Remaining `specflow` in src/ is intentional machinery/contract (deprecation detector, .specflow→.specnaut migrator, env/credentials/keychain fallbacks, legacy merge-fence, frozen `specflow-cli` OAuth id) — must name the old brand to function.

Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)