### PR TITLE
feat(cloud): `specnaut login` alias + `cloud orgs` / `cloud board` (#398)

### DIFF
--- a/.specnaut/specs/019-cli-login-orgs-board/spec.md
+++ b/.specnaut/specs/019-cli-login-orgs-board/spec.md
@@ -1,101 +1,90 @@
 # Feature Spec: `specnaut login` + `cloud orgs` / `cloud board`
 
-**Issue**: specnaut-cli#398 (child of epic specnaut-monorepo#14 — `specnaut login`)
-**Status**: draft → implementing
-**Half**: CLI (`apps/specnaut-cli`, public OSS)
+**Issue**: specnaut-cli#398 (child of epic specnaut-monorepo#14 — `specnaut login`) **Status**:
+draft → implementing **Half**: CLI (`apps/specnaut-cli`, public OSS)
 
 ## Summary
 
 The CLI already has the full Specnaut Cloud auth foundation (`specnaut cloud
-login/token/logout`: device-auth browser flow, OS-keychain credential storage,
-transparent refresh, interactive project selection). This feature adds the last
-ergonomic pieces of the `specnaut login` epic:
+login/token/logout`:
+device-auth browser flow, OS-keychain credential storage, transparent refresh, interactive project
+selection). This feature adds the last ergonomic pieces of the `specnaut login` epic:
 
-1. **`specnaut login`** — a top-level alias for `specnaut cloud login` (the verb
-   users reach for first, à la `gh auth login`).
-2. **`specnaut cloud orgs`** — list the organizations the authenticated account
-   belongs to, flagging the active one.
-3. **`specnaut cloud board`** — show the linked project's board: tasks grouped
-   by column.
+1. **`specnaut login`** — a top-level alias for `specnaut cloud login` (the verb users reach for
+   first, à la `gh auth login`).
+2. **`specnaut cloud orgs`** — list the organizations the authenticated account belongs to, flagging
+   the active one.
+3. **`specnaut cloud board`** — show the linked project's board: tasks grouped by column.
 
-All three consume only the versioned `/api/v1` HTTP contract (the sole OSS↔Cloud
-coupling): `orgs` calls the new `GET /api/v1/orgs` (cloud#145); `board` calls the
-existing `GET /api/v1/columns?projectKey=` + `GET /api/v1/tasks?projectKey=`.
+All three consume only the versioned `/api/v1` HTTP contract (the sole OSS↔Cloud coupling): `orgs`
+calls the new `GET /api/v1/orgs` (cloud#145); `board` calls the existing
+`GET /api/v1/columns?projectKey=` + `GET /api/v1/tasks?projectKey=`.
 
 ## User Scenarios & Testing
 
-- **Login alias**: `specnaut login` behaves identically to `specnaut cloud login`
-  (same device flow, same project binding).
-- **Orgs**: an authenticated user runs `specnaut cloud orgs` and sees each org
-  they belong to with its role; the active org is marked.
-- **Board**: in a project linked via `backlog-config.yml`, `specnaut cloud board`
-  prints the columns in order, each with its tasks (`#number title [priority
+- **Login alias**: `specnaut login` behaves identically to `specnaut cloud login` (same device flow,
+  same project binding).
+- **Orgs**: an authenticated user runs `specnaut cloud orgs` and sees each org they belong to with
+  its role; the active org is marked.
+- **Board**: in a project linked via `backlog-config.yml`, `specnaut cloud board` prints the columns
+  in order, each with its tasks (`#number title [priority
   size]`).
-- **Not authenticated**: `orgs`/`board` print a clear "run `specnaut login`"
-  hint and exit non-zero — never a stack trace, never a leaked token.
-- **No project linked**: `board` explains there's no linked project and exits
-  non-zero.
+- **Not authenticated**: `orgs`/`board` print a clear "run `specnaut login`" hint and exit non-zero
+  — never a stack trace, never a leaked token.
+- **No project linked**: `board` explains there's no linked project and exits non-zero.
 
 ## Functional Requirements
 
-- **FR1** — `specnaut login [--api-url <url>]` parses to the same intent as
-  `specnaut cloud login` and runs the identical handler.
-- **FR2** — `specnaut cloud orgs` resolves the deployment URL + a fresh access
-  token (no prompt), calls `GET /api/v1/orgs`, and renders the list; empty list →
-  a friendly "No organizations." message, exit 0.
-- **FR3** — `specnaut cloud board` requires a linked `projectKey` (from
-  `backlog-config.yml`); it fetches columns + tasks concurrently and renders the
-  board grouped by column, columns sorted by `order`.
-- **FR4** — Both read commands share one auth path (`authedSession`): missing
-  URL or missing/expired credentials → guidance + non-zero exit, no token leak.
+- **FR1** — `specnaut login [--api-url <url>]` parses to the same intent as `specnaut cloud login`
+  and runs the identical handler.
+- **FR2** — `specnaut cloud orgs` resolves the deployment URL + a fresh access token (no prompt),
+  calls `GET /api/v1/orgs`, and renders the list; empty list → a friendly "No organizations."
+  message, exit 0.
+- **FR3** — `specnaut cloud board` requires a linked `projectKey` (from `backlog-config.yml`); it
+  fetches columns + tasks concurrently and renders the board grouped by column, columns sorted by
+  `order`.
+- **FR4** — Both read commands share one auth path (`authedSession`): missing URL or missing/expired
+  credentials → guidance + non-zero exit, no token leak.
 
 ## Success Criteria
 
 - `specnaut login` works as a drop-in for `specnaut cloud login`.
-- A user can list their orgs and view a project board without leaving the
-  terminal, in one command each.
+- A user can list their orgs and view a project board without leaving the terminal, in one command
+  each.
 - New commands appear in `--help`.
 
 ## Security (epic #14 focus)
 
-- **Token never leaks**: the bearer access token travels only in the
-  `Authorization` header (shared `getJson` helper); it is never logged, printed,
-  or placed in a URL/querystring, and never appears in error messages (those
-  carry only the server's error body).
-- **URL safety**: the deployment URL flows through the existing
-  `normalizeApiUrl()` (rejects non-`http(s)` schemes) — same guard as the
-  pre-existing auth commands; no new SSRF surface.
-- **Query-injection safe**: `projectKey` is `encodeURIComponent`-escaped before
-  it reaches the `?projectKey=` querystrings.
-- **Terminal-escape hardening**: server-provided display strings (org name/slug,
-  column name, task title) are stripped of control / non-printable characters
-  before printing, so a hostile or misconfigured API can't inject ANSI/OSC escape
-  sequences into the user's console (`cloud_client.ts:cleanText`).
-- **Boundary**: no private-half identifier, type, or secret enters the public
-  CLI — only the documented `/api/v1` wire shapes (`CloudOrg`, `CloudColumn`,
-  `CloudTask`). The frozen `specflow-cli` OAuth client id is a contract string,
-  intentionally unchanged.
+- **Token never leaks**: the bearer access token travels only in the `Authorization` header (shared
+  `getJson` helper); it is never logged, printed, or placed in a URL/querystring, and never appears
+  in error messages (those carry only the server's error body).
+- **URL safety**: the deployment URL flows through the existing `normalizeApiUrl()` (rejects
+  non-`http(s)` schemes) — same guard as the pre-existing auth commands; no new SSRF surface.
+- **Query-injection safe**: `projectKey` is `encodeURIComponent`-escaped before it reaches the
+  `?projectKey=` querystrings.
+- **Terminal-escape hardening**: server-provided display strings (org name/slug, column name, task
+  title) are stripped of control / non-printable characters before printing, so a hostile or
+  misconfigured API can't inject ANSI/OSC escape sequences into the user's console
+  (`cloud_client.ts:cleanText`).
+- **Boundary**: no private-half identifier, type, or secret enters the public CLI — only the
+  documented `/api/v1` wire shapes (`CloudOrg`, `CloudColumn`, `CloudTask`). The frozen
+  `specflow-cli` OAuth client id is a contract string, intentionally unchanged.
 
 ## Domain Model
 
 - **Bounded context**: the CLI's Specnaut Cloud client + command surface.
-- **Ubiquitous language**: *session* = a resolved (apiUrl, fresh access token)
-  pair; *active org* = the org the token is bound to; *linked project* = the
-  `projectKey` in `backlog-config.yml`.
-- **Value objects**: `CloudOrg { slug, name, role, isActive }`,
-  `CloudColumn { id, name, order }`,
+- **Ubiquitous language**: _session_ = a resolved (apiUrl, fresh access token) pair; _active org_ =
+  the org the token is bound to; _linked project_ = the `projectKey` in `backlog-config.yml`.
+- **Value objects**: `CloudOrg { slug, name, role, isActive }`, `CloudColumn { id, name, order }`,
   `CloudTask { number, title, columnId, priority, size }`.
-- **Invariants**: read commands never run without a valid token; the token is
-  never emitted to stdout/stderr; rendered server text contains no control
-  characters.
-- **Out of scope**: mutating the board from the CLI; switching the active org
-  over the API; a machine-readable `--json` output mode (the CLI has none today;
-  a follow-up if scripts need it).
+- **Invariants**: read commands never run without a valid token; the token is never emitted to
+  stdout/stderr; rendered server text contains no control characters.
+- **Out of scope**: mutating the board from the CLI; switching the active org over the API; a
+  machine-readable `--json` output mode (the CLI has none today; a follow-up if scripts need it).
 
 ## Notes
 
-Known follow-up (pre-existing, not introduced here; flagged by the security
-review): a malicious `backlog-config.yml` can redirect the bearer token to an
-attacker `https://` host — the same surface as the existing `login`/`token`
-commands. Hardening (e.g. warn when the configured URL changes from the last
-authenticated one) is a separate backlog item.
+Known follow-up (pre-existing, not introduced here; flagged by the security review): a malicious
+`backlog-config.yml` can redirect the bearer token to an attacker `https://` host — the same surface
+as the existing `login`/`token` commands. Hardening (e.g. warn when the configured URL changes from
+the last authenticated one) is a separate backlog item.

--- a/.specnaut/specs/019-cli-login-orgs-board/spec.md
+++ b/.specnaut/specs/019-cli-login-orgs-board/spec.md
@@ -1,0 +1,101 @@
+# Feature Spec: `specnaut login` + `cloud orgs` / `cloud board`
+
+**Issue**: specnaut-cli#398 (child of epic specnaut-monorepo#14 — `specnaut login`)
+**Status**: draft → implementing
+**Half**: CLI (`apps/specnaut-cli`, public OSS)
+
+## Summary
+
+The CLI already has the full Specnaut Cloud auth foundation (`specnaut cloud
+login/token/logout`: device-auth browser flow, OS-keychain credential storage,
+transparent refresh, interactive project selection). This feature adds the last
+ergonomic pieces of the `specnaut login` epic:
+
+1. **`specnaut login`** — a top-level alias for `specnaut cloud login` (the verb
+   users reach for first, à la `gh auth login`).
+2. **`specnaut cloud orgs`** — list the organizations the authenticated account
+   belongs to, flagging the active one.
+3. **`specnaut cloud board`** — show the linked project's board: tasks grouped
+   by column.
+
+All three consume only the versioned `/api/v1` HTTP contract (the sole OSS↔Cloud
+coupling): `orgs` calls the new `GET /api/v1/orgs` (cloud#145); `board` calls the
+existing `GET /api/v1/columns?projectKey=` + `GET /api/v1/tasks?projectKey=`.
+
+## User Scenarios & Testing
+
+- **Login alias**: `specnaut login` behaves identically to `specnaut cloud login`
+  (same device flow, same project binding).
+- **Orgs**: an authenticated user runs `specnaut cloud orgs` and sees each org
+  they belong to with its role; the active org is marked.
+- **Board**: in a project linked via `backlog-config.yml`, `specnaut cloud board`
+  prints the columns in order, each with its tasks (`#number title [priority
+  size]`).
+- **Not authenticated**: `orgs`/`board` print a clear "run `specnaut login`"
+  hint and exit non-zero — never a stack trace, never a leaked token.
+- **No project linked**: `board` explains there's no linked project and exits
+  non-zero.
+
+## Functional Requirements
+
+- **FR1** — `specnaut login [--api-url <url>]` parses to the same intent as
+  `specnaut cloud login` and runs the identical handler.
+- **FR2** — `specnaut cloud orgs` resolves the deployment URL + a fresh access
+  token (no prompt), calls `GET /api/v1/orgs`, and renders the list; empty list →
+  a friendly "No organizations." message, exit 0.
+- **FR3** — `specnaut cloud board` requires a linked `projectKey` (from
+  `backlog-config.yml`); it fetches columns + tasks concurrently and renders the
+  board grouped by column, columns sorted by `order`.
+- **FR4** — Both read commands share one auth path (`authedSession`): missing
+  URL or missing/expired credentials → guidance + non-zero exit, no token leak.
+
+## Success Criteria
+
+- `specnaut login` works as a drop-in for `specnaut cloud login`.
+- A user can list their orgs and view a project board without leaving the
+  terminal, in one command each.
+- New commands appear in `--help`.
+
+## Security (epic #14 focus)
+
+- **Token never leaks**: the bearer access token travels only in the
+  `Authorization` header (shared `getJson` helper); it is never logged, printed,
+  or placed in a URL/querystring, and never appears in error messages (those
+  carry only the server's error body).
+- **URL safety**: the deployment URL flows through the existing
+  `normalizeApiUrl()` (rejects non-`http(s)` schemes) — same guard as the
+  pre-existing auth commands; no new SSRF surface.
+- **Query-injection safe**: `projectKey` is `encodeURIComponent`-escaped before
+  it reaches the `?projectKey=` querystrings.
+- **Terminal-escape hardening**: server-provided display strings (org name/slug,
+  column name, task title) are stripped of control / non-printable characters
+  before printing, so a hostile or misconfigured API can't inject ANSI/OSC escape
+  sequences into the user's console (`cloud_client.ts:cleanText`).
+- **Boundary**: no private-half identifier, type, or secret enters the public
+  CLI — only the documented `/api/v1` wire shapes (`CloudOrg`, `CloudColumn`,
+  `CloudTask`). The frozen `specflow-cli` OAuth client id is a contract string,
+  intentionally unchanged.
+
+## Domain Model
+
+- **Bounded context**: the CLI's Specnaut Cloud client + command surface.
+- **Ubiquitous language**: *session* = a resolved (apiUrl, fresh access token)
+  pair; *active org* = the org the token is bound to; *linked project* = the
+  `projectKey` in `backlog-config.yml`.
+- **Value objects**: `CloudOrg { slug, name, role, isActive }`,
+  `CloudColumn { id, name, order }`,
+  `CloudTask { number, title, columnId, priority, size }`.
+- **Invariants**: read commands never run without a valid token; the token is
+  never emitted to stdout/stderr; rendered server text contains no control
+  characters.
+- **Out of scope**: mutating the board from the CLI; switching the active org
+  over the API; a machine-readable `--json` output mode (the CLI has none today;
+  a follow-up if scripts need it).
+
+## Notes
+
+Known follow-up (pre-existing, not introduced here; flagged by the security
+review): a malicious `backlog-config.yml` can redirect the bearer token to an
+attacker `https://` host — the same surface as the existing `login`/`token`
+commands. Hardening (e.g. warn when the configured URL changes from the last
+authenticated one) is a separate backlog item.

--- a/src/cli/handlers/cloud_handler.ts
+++ b/src/cli/handlers/cloud_handler.ts
@@ -1,17 +1,20 @@
-// `specnaut cloud <login|token|logout>` (#353) — the CLI side of the Specnaut
-// Cloud backlog backend's interactive auth.
+// `specnaut cloud <login|token|logout|orgs|board>` (#353, #398) — the CLI side
+// of the Specnaut Cloud backlog backend's interactive auth + read commands.
 //
 //   login   device-authorization browser flow → stores credentials securely,
 //           then binds the project to a Cloud project (select or create) and
-//           writes .specnaut/backlog-config.yml.
+//           writes .specnaut/backlog-config.yml. Also reachable as the
+//           top-level `specnaut login` alias.
 //   token   prints a fresh access token to stdout (refreshing transparently);
 //           used by the bundled cloud/*.sh scripts. Honors SPECNAUT_CLOUD_TOKEN
 //           (legacy SPECFLOW_CLOUD_TOKEN as a fallback) as a headless / CI
 //           escape hatch.
 //   logout  removes the stored credentials for the deployment.
+//   orgs    lists the account's organizations (active one flagged).
+//   board   shows the linked project's board, tasks grouped by column.
 
 import { bold, dim, green, red, yellow } from "@std/fmt/colors";
-import { CloudClient } from "../../domain/cloud/cloud_client.ts";
+import { CloudClient, type CloudColumn, type CloudTask } from "../../domain/cloud/cloud_client.ts";
 import { freshAccessToken, login } from "../../domain/cloud/auth_flow.ts";
 import { readCloudConfig, writeCloudConfig } from "../../domain/cloud/cloud_config.ts";
 import { defaultCredentialStore } from "../../infrastructure/credential_store.ts";
@@ -19,7 +22,7 @@ import { openInBrowser } from "../../infrastructure/browser_opener.ts";
 
 export type CloudIntent = {
   kind: "cloud";
-  sub: "login" | "token" | "logout";
+  sub: "login" | "token" | "logout" | "orgs" | "board";
   apiUrl: string | null;
 };
 
@@ -61,6 +64,119 @@ export async function runCloud(intent: CloudIntent): Promise<number> {
       return await runToken(intent);
     case "logout":
       return await runLogout(intent);
+    case "orgs":
+      return await runOrgs(intent);
+    case "board":
+      return await runBoard(intent);
+  }
+}
+
+/** Resolve the deployment URL (no prompt) + a fresh access token for the
+ *  read commands, or print guidance and return a non-zero exit code. The token
+ *  is obtained via the keychain-backed refresh flow and never printed. */
+async function authedSession(
+  intent: CloudIntent,
+): Promise<{ client: CloudClient; token: string } | number> {
+  const apiUrl = await resolveApiUrl(intent.apiUrl, false);
+  if (!apiUrl) {
+    console.error(
+      red(
+        "error: no Specnaut Cloud API URL (pass --api-url or set api_url in backlog-config.yml).",
+      ),
+    );
+    return 1;
+  }
+  const client = new CloudClient(apiUrl);
+  const store = defaultCredentialStore();
+  const token = await freshAccessToken({ apiUrl, client, store, now: () => Date.now() });
+  if (!token) {
+    console.error(red("error: not authenticated with Specnaut Cloud."));
+    console.error(dim("  run `specnaut login` (or set SPECNAUT_CLOUD_TOKEN)."));
+    return 1;
+  }
+  return { client, token };
+}
+
+async function runOrgs(intent: CloudIntent): Promise<number> {
+  const session = await authedSession(intent);
+  if (typeof session === "number") return session;
+
+  let orgs;
+  try {
+    orgs = await session.client.listOrgs(session.token);
+  } catch (e) {
+    console.error(red(`error: ${e instanceof Error ? e.message : String(e)}`));
+    return 1;
+  }
+
+  if (orgs.length === 0) {
+    console.log(dim("No organizations."));
+    return 0;
+  }
+  console.log(bold("Your organizations:"));
+  for (const o of orgs) {
+    const marker = o.isActive ? green("●") : dim("○");
+    const active = o.isActive ? green(" (active)") : "";
+    console.log(`  ${marker} ${bold(o.name)} ${dim(o.slug)} — ${o.role}${active}`);
+  }
+  return 0;
+}
+
+async function runBoard(intent: CloudIntent): Promise<number> {
+  const cfg = await readCloudConfig(Deno.cwd());
+  const projectKey = cfg?.projectKey;
+  if (!projectKey) {
+    console.error(red("error: no project linked here."));
+    console.error(
+      dim("  run `specnaut login` to select a project, or `cd` into a linked project."),
+    );
+    return 1;
+  }
+
+  const session = await authedSession(intent);
+  if (typeof session === "number") return session;
+
+  let columns: CloudColumn[];
+  let tasks: CloudTask[];
+  try {
+    [columns, tasks] = await Promise.all([
+      session.client.listColumns(session.token, projectKey),
+      session.client.listTasks(session.token, projectKey),
+    ]);
+  } catch (e) {
+    console.error(red(`error: ${e instanceof Error ? e.message : String(e)}`));
+    return 1;
+  }
+
+  renderBoard(projectKey, columns, tasks);
+  return 0;
+}
+
+/** Print the board: columns in order, each followed by its tasks. */
+function renderBoard(
+  projectKey: string,
+  columns: CloudColumn[],
+  tasks: CloudTask[],
+): void {
+  const byColumn = new Map<string, CloudTask[]>();
+  for (const t of tasks) {
+    const list = byColumn.get(t.columnId) ?? [];
+    list.push(t);
+    byColumn.set(t.columnId, list);
+  }
+
+  console.log(bold(`Board — ${projectKey}`));
+  for (const col of [...columns].sort((a, b) => a.order - b.order)) {
+    const colTasks = byColumn.get(col.id) ?? [];
+    console.log(`\n${bold(col.name)} ${dim(`(${colTasks.length})`)}`);
+    if (colTasks.length === 0) {
+      console.log(dim("  —"));
+      continue;
+    }
+    for (const t of colTasks) {
+      const meta = [t.priority, t.size].filter(Boolean).join(" ");
+      console.log(`  ${dim(`#${t.number}`)} ${t.title}${meta ? dim(`  [${meta}]`) : ""}`);
+    }
   }
 }
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -15,10 +15,15 @@ ${bold("Usage:")}
   specnaut reconcile --status         List files pending post-upgrade reconciliation
   specnaut reconcile <path> --accept-upstream | --accept-current
                                       Resolve a preserved file after upgrade
+  specnaut login [--api-url <url>]    Authenticate with Specnaut Cloud (alias for "cloud login")
   specnaut cloud login [--api-url <url>]
                                       Authenticate with Specnaut Cloud (browser device flow) and link a project
   specnaut cloud logout [--api-url <url>]
                                       Remove stored Specnaut Cloud credentials
+  specnaut cloud orgs [--api-url <url>]
+                                      List the organizations your account belongs to
+  specnaut cloud board [--api-url <url>]
+                                      Show the linked project's board (tasks grouped by column)
   specnaut --version, -v              Print version
   specnaut --help, -h                 Show this help
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -135,8 +135,10 @@ export type Intent =
   | {
     kind: "cloud";
     /** Subcommand: `login` (interactive device auth), `token` (print a fresh
-     *  access token for the scripts), `logout` (clear stored credentials). */
-    sub: "login" | "token" | "logout";
+     *  access token for the scripts), `logout` (clear stored credentials),
+     *  `orgs` (list the account's organizations), `board` (show the linked
+     *  project's board). */
+    sub: "login" | "token" | "logout" | "orgs" | "board";
     /** `--api-url` override; null = read from backlog-config.yml / prompt. */
     apiUrl: string | null;
   }
@@ -310,10 +312,23 @@ export function parseArgs(argv: string[]): Intent {
     };
   }
 
+  // `specnaut login` — top-level alias for `specnaut cloud login` (#398), the
+  // verb users reach for first (à la `gh auth login`).
+  if (command === "login") {
+    const apiUrl = typeof parsed["api-url"] === "string" ? parsed["api-url"] : null;
+    return { kind: "cloud", sub: "login", apiUrl };
+  }
+
   if (command === "cloud") {
     const sub = rest[0];
     const apiUrl = typeof parsed["api-url"] === "string" ? parsed["api-url"] : null;
-    if (sub === "login" || sub === "token" || sub === "logout") {
+    if (
+      sub === "login" ||
+      sub === "token" ||
+      sub === "logout" ||
+      sub === "orgs" ||
+      sub === "board"
+    ) {
       return { kind: "cloud", sub, apiUrl };
     }
     return { kind: "unknown", received: `cloud ${sub ?? ""}`.trim() };

--- a/src/domain/cloud/cloud_client.ts
+++ b/src/domain/cloud/cloud_client.ts
@@ -26,6 +26,26 @@ export type RefreshResult =
 
 export type CloudProject = { key: string; name: string; role: string };
 
+/** An org the authenticated account belongs to (`GET /api/v1/orgs`, #398).
+ *  Identified by its public `slug`; `isActive` marks the org the current
+ *  session/token is bound to. */
+export type CloudOrg = {
+  slug: string;
+  name: string;
+  role: string;
+  isActive: boolean;
+};
+
+export type CloudColumn = { id: string; name: string; order: number };
+
+export type CloudTask = {
+  number: number;
+  title: string;
+  columnId: string;
+  priority: string | null;
+  size: string | null;
+};
+
 export type FetchFn = typeof fetch;
 
 export class CloudApiError extends Error {
@@ -57,6 +77,24 @@ export class CloudClient {
       body: JSON.stringify(body ?? {}),
     });
     return { status: res.status, json: await readJson(res) };
+  }
+
+  /** Authenticated GET → parsed body, throwing CloudApiError on non-200. The
+   *  bearer token only ever travels in the Authorization header (never logged,
+   *  never in the URL/querystring). */
+  private async getJson(
+    path: string,
+    accessToken: string,
+    failMsg: string,
+  ): Promise<Record<string, unknown>> {
+    const res = await this.fetchFn(`${this.base}${path}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const json = await readJson(res);
+    if (res.status !== 200) {
+      throw new CloudApiError(res.status, strField(json, "error") ?? failMsg);
+    }
+    return json;
   }
 
   // `specflow-cli` is the frozen OAuth device-client id the Cloud backend
@@ -115,17 +153,60 @@ export class CloudClient {
   }
 
   async listProjects(accessToken: string): Promise<CloudProject[]> {
-    const res = await this.fetchFn(`${this.base}/projects`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    const json = await readJson(res);
-    if (res.status !== 200) {
-      throw new CloudApiError(res.status, strField(json, "error") ?? "list projects failed");
-    }
+    const json = await this.getJson("/projects", accessToken, "list projects failed");
     const raw = Array.isArray(json.projects) ? json.projects : [];
     return raw.map((p) => {
       const o = p as Record<string, unknown>;
       return { key: String(o.key), name: String(o.name), role: String(o.role ?? "") };
+    });
+  }
+
+  /** The orgs the authenticated account belongs to (`specnaut cloud orgs`). */
+  async listOrgs(accessToken: string): Promise<CloudOrg[]> {
+    const json = await this.getJson("/orgs", accessToken, "list orgs failed");
+    const raw = Array.isArray(json.orgs) ? json.orgs : [];
+    return raw.map((o) => {
+      const r = o as Record<string, unknown>;
+      return {
+        slug: cleanText(r.slug),
+        name: cleanText(r.name),
+        role: cleanText(r.role),
+        isActive: Boolean(r.isActive),
+      };
+    });
+  }
+
+  /** The board's columns for a project (`specnaut cloud board`). */
+  async listColumns(accessToken: string, projectKey: string): Promise<CloudColumn[]> {
+    const json = await this.getJson(
+      `/columns?projectKey=${encodeURIComponent(projectKey)}`,
+      accessToken,
+      "list columns failed",
+    );
+    const raw = Array.isArray(json.columns) ? json.columns : [];
+    return raw.map((c) => {
+      const o = c as Record<string, unknown>;
+      return { id: String(o.id), name: cleanText(o.name), order: Number(o.order ?? 0) };
+    });
+  }
+
+  /** The project's tasks (`specnaut cloud board`). */
+  async listTasks(accessToken: string, projectKey: string): Promise<CloudTask[]> {
+    const json = await this.getJson(
+      `/tasks?projectKey=${encodeURIComponent(projectKey)}`,
+      accessToken,
+      "list tasks failed",
+    );
+    const raw = Array.isArray(json.tasks) ? json.tasks : [];
+    return raw.map((t) => {
+      const o = t as Record<string, unknown>;
+      return {
+        number: Number(o.number ?? 0),
+        title: cleanText(o.title),
+        columnId: String(o.columnId ?? ""),
+        priority: typeof o.priority === "string" ? o.priority : null,
+        size: typeof o.size === "string" ? o.size : null,
+      };
     });
   }
 
@@ -154,6 +235,15 @@ async function readJson(res: Response): Promise<Record<string, unknown>> {
 function strField(json: Record<string, unknown>, key: string): string | null {
   const v = json[key];
   return typeof v === "string" ? v : null;
+}
+
+/** Coerce a server value to a string with control / non-printable characters
+ *  stripped, so hostile or misconfigured API output can't inject terminal
+ *  escape sequences (ANSI / OSC) when the CLI prints org names, board column
+ *  names, or task titles (#398 hardening). */
+function cleanText(v: unknown): string {
+  // deno-lint-ignore no-control-regex
+  return String(v ?? "").replace(/[\x00-\x1f\x7f]/g, "");
 }
 
 /** Clamp a (possibly NaN) number into [lo, hi], falling back to lo. */

--- a/tests/cli/cloud_parser_test.ts
+++ b/tests/cli/cloud_parser_test.ts
@@ -33,6 +33,38 @@ Deno.test("parseArgs: cloud logout", () => {
   });
 });
 
+Deno.test("parseArgs: cloud orgs", () => {
+  assertEquals(parseArgs(["cloud", "orgs"]), {
+    kind: "cloud",
+    sub: "orgs",
+    apiUrl: null,
+  });
+});
+
+Deno.test("parseArgs: cloud board --api-url", () => {
+  assertEquals(parseArgs(["cloud", "board", "--api-url", "https://x.convex.site"]), {
+    kind: "cloud",
+    sub: "board",
+    apiUrl: "https://x.convex.site",
+  });
+});
+
+Deno.test("parseArgs: top-level `login` is an alias for `cloud login`", () => {
+  assertEquals(parseArgs(["login"]), {
+    kind: "cloud",
+    sub: "login",
+    apiUrl: null,
+  });
+});
+
+Deno.test("parseArgs: top-level `login --api-url`", () => {
+  assertEquals(parseArgs(["login", "--api-url", "https://x.convex.site"]), {
+    kind: "cloud",
+    sub: "login",
+    apiUrl: "https://x.convex.site",
+  });
+});
+
 Deno.test("parseArgs: unknown cloud subcommand → unknown", () => {
   assertEquals(parseArgs(["cloud", "wat"]), { kind: "unknown", received: "cloud wat" });
 });

--- a/tests/domain/cloud_client_test.ts
+++ b/tests/domain/cloud_client_test.ts
@@ -118,3 +118,69 @@ Deno.test("createProject surfaces a conflict as CloudApiError", async () => {
     "already exists",
   );
 });
+
+Deno.test("listOrgs sends the bearer token and parses the array (#398)", async () => {
+  const { fn, calls } = fakeFetch(200, {
+    ok: true,
+    orgs: [
+      { slug: "acme", name: "Acme", role: "owner", isActive: true },
+      { slug: "beta", name: "Beta", role: "member", isActive: false },
+    ],
+  });
+  const out = await new CloudClient(API, fn).listOrgs("AT");
+  assertEquals(calls[0].url, `${API}/api/v1/orgs`);
+  assertEquals(calls[0].method, "GET");
+  assertEquals(calls[0].auth, "Bearer AT");
+  assertEquals(out, [
+    { slug: "acme", name: "Acme", role: "owner", isActive: true },
+    { slug: "beta", name: "Beta", role: "member", isActive: false },
+  ]);
+});
+
+Deno.test("listOrgs surfaces a 401 as CloudApiError (#398)", async () => {
+  const { fn } = fakeFetch(401, { error: "unauthorized" });
+  await assertRejects(
+    () => new CloudClient(API, fn).listOrgs("BAD"),
+    CloudApiError,
+    "unauthorized",
+  );
+});
+
+Deno.test("list* strips terminal control characters from server strings (#398 hardening)", async () => {
+  const { fn } = fakeFetch(200, {
+    ok: true,
+    // A hostile/misconfigured API returns ANSI escape + BEL in the org name.
+    orgs: [{ slug: "ok", name: "Acme\x1b[31m\x07", role: "owner", isActive: true }],
+  });
+  const out = await new CloudClient(API, fn).listOrgs("AT");
+  // ESC (\x1b) and BEL (\x07) stripped; printable chars preserved.
+  assertEquals(out[0].name, "Acme[31m");
+});
+
+Deno.test("listColumns passes projectKey in the querystring (#398)", async () => {
+  const { fn, calls } = fakeFetch(200, {
+    ok: true,
+    columns: [{ id: "c1", name: "Todo", order: 1 }],
+  });
+  const out = await new CloudClient(API, fn).listColumns("AT", "CLOUD");
+  assertEquals(calls[0].url, `${API}/api/v1/columns?projectKey=CLOUD`);
+  assertEquals(calls[0].auth, "Bearer AT");
+  assertEquals(out, [{ id: "c1", name: "Todo", order: 1 }]);
+});
+
+Deno.test("listTasks parses tasks and tolerates missing priority/size (#398)", async () => {
+  const { fn, calls } = fakeFetch(200, {
+    ok: true,
+    tasks: [
+      { number: 12, title: "Ship it", columnId: "c1", priority: "p1", size: "m" },
+      { number: 13, title: "No meta", columnId: "c2" },
+    ],
+  });
+  const out = await new CloudClient(API, fn).listTasks("AT", "CLOUD");
+  assertEquals(calls[0].url, `${API}/api/v1/tasks?projectKey=CLOUD`);
+  assertEquals(calls[0].auth, "Bearer AT");
+  assertEquals(out, [
+    { number: 12, title: "Ship it", columnId: "c1", priority: "p1", size: "m" },
+    { number: 13, title: "No meta", columnId: "c2", priority: null, size: null },
+  ]);
+});


### PR DESCRIPTION
Closes #398 (child of epic specnaut-monorepo#14 — `specnaut login`).

## What
Completes the `specnaut login` epic on top of the CLI's existing Cloud auth foundation (device-auth browser flow + OS keychain + transparent refresh + project selection):

- **`specnaut login`** — top-level alias for `specnaut cloud login` (à la `gh auth login`).
- **`specnaut cloud orgs`** — lists the account's organizations, active one flagged → new `GET /api/v1/orgs` (specnaut-cloud#145).
- **`specnaut cloud board`** — renders the linked project's board (tasks grouped by column) → existing `GET /api/v1/columns?projectKey=` + `GET /api/v1/tasks?projectKey=`.

`CloudClient` gains `listOrgs` / `listColumns` / `listTasks` on a shared authed `getJson` helper (`listProjects` refactored onto it). Help text + spec (`.specnaut/specs/019-cli-login-orgs-board/`) updated.

## Security (epic #14 focus)
- **Token never leaks**: bearer token travels only in the `Authorization` header (shared `getJson`) — never logged, never in a URL/querystring, never in an error message.
- **Injection-safe**: `projectKey` is `encodeURIComponent`-escaped into the querystrings.
- **URL safety**: deployment URL flows through the existing `normalizeApiUrl()` (http(s)-only) — same guard as the pre-existing auth commands, no new SSRF surface.
- **Terminal-escape hardening**: server-provided display strings (org name/slug, column name, task title) are stripped of control chars (`cleanText`) so a hostile/misconfigured API can't inject ANSI/OSC escapes into the console.
- **Boundary**: no private-half identifier enters the public CLI — only the documented `/api/v1` wire shapes.

Reviewed by `security-auditor`: **0 critical/high**. One Medium (token-redirect via a malicious `backlog-config.yml`) is **pre-existing** — shared with `login`/`token`, not a regression — noted as a follow-up hardening item. One Low (terminal-escape) **fixed here**.

## Depends on
specnaut-cloud#145 (`GET /api/v1/orgs`) — merged.

## Verification
`deno task lint` + `deno task check` clean · `deno task test` **1034/1034** · runtime smoke of `cloud orgs` / `cloud board` / `--help` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Agent adoption

`specnaut login` is now a top-level alias for `specnaut cloud login`, and two new read-only commands landed: `specnaut cloud orgs` (list the organizations your account belongs to) and `specnaut cloud board` (view the linked project's board, tasks grouped by column). If your project docs or agent rules point users at `specnaut cloud login` for Cloud auth, mention the shorter `specnaut login`, and surface the new read commands where a quick "what's on my board?" check helps.

```prompt
Audit my project for references to Specnaut Cloud auth in:
  - `.claude/agents/*.md`, `.claude/skills/**/*.md`
  - `AGENTS.md`, `CLAUDE.md`, `README.md`

Where `specnaut cloud login` is mentioned, add a note that `specnaut login` is a
shorter top-level alias. Where it helps, mention the new read commands
`specnaut cloud orgs` (list your organizations) and `specnaut cloud board`
(show the linked project's board). Open a PR with the changes.
```