### PR TITLE
ci(release): decouple publish steps so one failure can't skip the rest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
         # (the token reaches `gh` via subprocess env inheritance regardless).
         run: deno run --allow-read --allow-write --allow-run --allow-env scripts/gen-changelog.ts --strict
       - name: Create release
+        id: release
         uses: softprops/action-gh-release@v3
         with:
           files: |
@@ -245,13 +246,22 @@ jobs:
             dist/specnaut-windows-x64.exe
             dist/specnaut-windows-x64.exe.sha256
           body_path: dist/release-notes.md
-      - name: Bump mkrlabs/homebrew-tap formula
+      # The three publish steps below (tap / Codex / marketplace) each run
+      # INDEPENDENTLY: gated only on the release having been created, never on
+      # each other. A failure in one (e.g. an expired HOMEBREW_TAP_TOKEN) no
+      # longer skips the others — the job still ends red so the failure is
+      # noticed and fixed, but every distribution channel that *can* publish
+      # does. (Hardening after v1.14.0, where a tap-token 403 skipped both
+      # syncs — see specnaut-cli#402.)
+      - name: Bump specnaut/homebrew-tap formula
+        if: ${{ !cancelled() && steps.release.outcome == 'success' }}
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           deno run --allow-read --allow-write --allow-run --allow-env \
             scripts/bump-tap-formula.ts
       - name: Sync to Codex marketplace fork (#277 / B1)
+        if: ${{ !cancelled() && steps.release.outcome == 'success' }}
         # Mirrors the Specnaut plugin content into
         # `mkrlabs/plugins:plugins/specnaut/`. A human rebases that
         # fork's PR into upstream `openai/plugins` for the actual
@@ -272,6 +282,7 @@ jobs:
           fi
           exit "${rc:-0}"
       - name: Sync to Specnaut marketplace catalog (#281 / B5)
+        if: ${{ !cancelled() && steps.release.outcome == 'success' }}
         # Bumps `.claude-plugin/marketplace.json` in
         # `specnaut/specnaut-marketplace` (the shared marketplace
         # catalog serving both Claude Code AND Copilot CLI users via


### PR DESCRIPTION
## Why
On **v1.14.0** an expired `HOMEBREW_TAP_TOKEN` made the *Bump homebrew-tap formula* step `403`. Because the **tap → Codex-sync → marketplace-sync** steps are sequential in the same `build` job, the tap failure **skipped both syncs** — `mkrlabs/plugins` and `mkrlabs/specnaut-marketplace` were left a version behind (only `brew` was hand-fixed). And the published release is immutable, so re-running the job can't recover it (the *Create release* step fails re-uploading assets).

## What
- `Create release` gets `id: release`.
- The three publish steps (tap / Codex / marketplace) each gated on `if: ${{ !cancelled() && steps.release.outcome == 'success' }}` → they run **independently**. A failure in one no longer skips the others; the job still ends **red** on any failure (so a broken token is still surfaced and fixed), but every channel that *can* publish does.
- Fixes the stale step label `mkrlabs/homebrew-tap` → `specnaut/homebrew-tap` (the script's `REPO` const targets `specnaut/homebrew-tap`).

## Behaviour after this
| Scenario | Before | After |
|---|---|---|
| tap token 403 | tap fails → **both syncs skipped** | tap fails (job red) → **Codex + marketplace still publish** |
| Create-release fails | everything after skips | publish steps skip (correct — nothing to publish) |
| all healthy | all publish | all publish |

## Verification
Workflow YAML parses; `deno fmt --check` clean (358 files). The full behaviour is confirmed on the next release (CI workflow changes only run on tag push). Hardening after #402 (the token rotation, already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)