### PR TITLE
feat(init): default the backlog picker to Specnaut Cloud (recommended)

### DIFF
--- a/src/cli/backlog_picker.ts
+++ b/src/cli/backlog_picker.ts
@@ -6,7 +6,19 @@ import {
 } from "../domain/backlog_strategies/kanban_url_parser.ts";
 import { selectInteractive, type SelectIO } from "./select.ts";
 
-export const DEFAULT_BACKLOG_BACKEND: BacklogBackend = "local";
+export const DEFAULT_BACKLOG_BACKEND: BacklogBackend = "cloud";
+
+/** Suffix on the default backend's line — signals it's the recommended pick. */
+const RECOMMENDED_MARKER = " — recommended (default)";
+
+/**
+ * One-line "why this is the recommended default" note, shown once above the
+ * choices for whichever backend is the default. Keyed by backend so it stays
+ * correct if the default ever moves.
+ */
+const DEFAULT_BACKEND_NOTE: Partial<Record<BacklogBackend, string>> = {
+  cloud: "Specnaut Cloud: hosted online Kanban — shareable, real-time, no local file upkeep.",
+};
 
 export type BacklogPickerIO = {
   readLine: () => string | null;
@@ -18,9 +30,11 @@ export function pickBacklogBackend(io: BacklogPickerIO): BacklogBackend {
   io.log("Choose your backlog backend (press Enter for default):");
   for (let i = 0; i < BACKLOG_STRATEGIES.length; i++) {
     const s = BACKLOG_STRATEGIES[i];
-    const marker = s.key === DEFAULT_BACKLOG_BACKEND ? " (default)" : "";
+    const marker = s.key === DEFAULT_BACKLOG_BACKEND ? RECOMMENDED_MARKER : "";
     io.log(`  ${i + 1}) ${s.displayName}${marker}`);
   }
+  const note = DEFAULT_BACKEND_NOTE[DEFAULT_BACKLOG_BACKEND];
+  if (note) io.log(`  ↳ ${note}`);
   while (true) {
     const raw = (io.readLine() ?? "").trim();
     if (raw === "") return DEFAULT_BACKLOG_BACKEND;
@@ -46,8 +60,14 @@ export async function pickBacklogBackendInteractive(
   );
   const items = BACKLOG_STRATEGIES.map((s) => ({
     key: s.key,
-    label: s.key === DEFAULT_BACKLOG_BACKEND ? `${s.displayName} (default)` : s.displayName,
+    label: s.key === DEFAULT_BACKLOG_BACKEND
+      ? `${s.displayName}${RECOMMENDED_MARKER}`
+      : s.displayName,
   }));
+  // Printed once above the menu; the picker's redraw only rewinds over the
+  // menu frame, so this benefit line stays put.
+  const note = DEFAULT_BACKEND_NOTE[DEFAULT_BACKLOG_BACKEND];
+  if (note) io.write(`  ↳ ${note}\n`);
   return await selectInteractive(
     items,
     defaultIdx >= 0 ? defaultIdx : 0,

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -16,7 +16,10 @@ import {
 import { makeStdinSelectIO } from "../select.ts";
 import type { BacklogBackend, VersionScheme } from "../../domain/installed_lock.ts";
 import { detectVersionScheme } from "../../domain/project_detection.ts";
-import { findBacklogStrategy } from "../../domain/backlog_strategies/registry.ts";
+import {
+  BACKLOG_STRATEGIES,
+  findBacklogStrategy,
+} from "../../domain/backlog_strategies/registry.ts";
 import {
   type ParsedKanbanURL,
   parseKanbanURL,
@@ -86,7 +89,7 @@ async function resolveBacklogBackend(
   if (explicit !== null) return explicit;
   if (!Deno.stdin.isTerminal()) {
     return pickBacklogBackend({
-      readLine: () => prompt("Choose [1-3]:"),
+      readLine: () => prompt(`Choose [1-${BACKLOG_STRATEGIES.length}]:`),
       log: (s) => console.log(s),
       errLog: (s) => console.error(red(s)),
     });

--- a/src/domain/backlog_strategies/registry.ts
+++ b/src/domain/backlog_strategies/registry.ts
@@ -5,11 +5,13 @@ import { GithubBacklogStrategy } from "./github.ts";
 import { GitlabBacklogStrategy } from "./gitlab.ts";
 import { CloudBacklogStrategy } from "./cloud.ts";
 
+// Order drives the picker: Specnaut Cloud is listed first and is the
+// recommended default (see DEFAULT_BACKLOG_BACKEND in cli/backlog_picker.ts).
 export const BACKLOG_STRATEGIES: ReadonlyArray<BacklogBackendStrategy> = [
+  new CloudBacklogStrategy(),
   new LocalBacklogStrategy(),
   new GithubBacklogStrategy(),
   new GitlabBacklogStrategy(),
-  new CloudBacklogStrategy(),
 ];
 
 /**

--- a/tests/cli/backlog_picker_test.ts
+++ b/tests/cli/backlog_picker_test.ts
@@ -34,53 +34,57 @@ function fakeIO(answers: ReadonlyArray<string | null>) {
   };
 }
 
-Deno.test("pickBacklogBackend defaults to local on empty input", () => {
+Deno.test("pickBacklogBackend defaults to cloud on empty input", () => {
   const { io, log } = fakeIO([""]);
-  assertEquals(pickBacklogBackend(io), "local");
-  assertEquals(DEFAULT_BACKLOG_BACKEND, "local");
-  // Lists both backends
+  assertEquals(pickBacklogBackend(io), "cloud");
+  assertEquals(DEFAULT_BACKLOG_BACKEND, "cloud");
   const all = log.join("\n");
+  // Cloud is listed first, marked recommended (default), with a benefit note;
+  // the other backends remain listed.
+  assertEquals(all.includes("Specnaut Cloud"), true);
+  assertEquals(all.includes("recommended (default)"), true);
+  assertEquals(all.includes("hosted online Kanban"), true);
   assertEquals(all.includes("Local Markdown"), true);
   assertEquals(all.includes("GitHub"), true);
 });
 
-Deno.test("pickBacklogBackend picks 1 for local", () => {
+Deno.test("pickBacklogBackend picks 1 for cloud (listed first)", () => {
   const { io } = fakeIO(["1"]);
+  assertEquals(pickBacklogBackend(io), "cloud");
+});
+
+Deno.test("pickBacklogBackend picks 2 for local", () => {
+  const { io } = fakeIO(["2"]);
   assertEquals(pickBacklogBackend(io), "local");
 });
 
-Deno.test("pickBacklogBackend picks 2 for github", () => {
-  const { io } = fakeIO(["2"]);
+Deno.test("pickBacklogBackend picks 3 for github", () => {
+  const { io } = fakeIO(["3"]);
   assertEquals(pickBacklogBackend(io), "github");
 });
 
-Deno.test("pickBacklogBackend picks 3 for gitlab", () => {
-  const { io } = fakeIO(["3"]);
-  assertEquals(pickBacklogBackend(io), "gitlab");
-});
-
-Deno.test("pickBacklogBackend picks 4 for cloud", () => {
+Deno.test("pickBacklogBackend picks 4 for gitlab", () => {
   const { io } = fakeIO(["4"]);
-  assertEquals(pickBacklogBackend(io), "cloud");
+  assertEquals(pickBacklogBackend(io), "gitlab");
 });
 
 Deno.test("pickBacklogBackend re-prompts on invalid input", () => {
   const { io, errLog } = fakeIO(["999", "bad", "1"]);
-  assertEquals(pickBacklogBackend(io), "local");
+  assertEquals(pickBacklogBackend(io), "cloud");
   assertEquals(errLog.length, 2);
 });
 
-Deno.test("pickBacklogBackendInteractive returns 'local' on Enter (default)", async () => {
+Deno.test("pickBacklogBackendInteractive returns 'cloud' on Enter (default)", async () => {
   const io = scriptedIO([new Uint8Array([0x0d])]);
-  assertEquals(await pickBacklogBackendInteractive(io), "local");
+  assertEquals(await pickBacklogBackendInteractive(io), "cloud");
 });
 
-Deno.test("pickBacklogBackendInteractive returns 'github' after one arrow-down + space", async () => {
+Deno.test("pickBacklogBackendInteractive returns 'local' after one arrow-down + space", async () => {
   const io = scriptedIO([
     new Uint8Array([0x1b, 0x5b, 0x42]),
     new Uint8Array([0x20]),
   ]);
-  assertEquals(await pickBacklogBackendInteractive(io), "github");
+  assertEquals(await pickBacklogBackendInteractive(io), "local");
 });
 
 Deno.test("pickBacklogBackendInteractive returns null on Ctrl-C cancel", async () => {

--- a/tests/cli/handlers/upgrade_handler_test.ts
+++ b/tests/cli/handlers/upgrade_handler_test.ts
@@ -45,7 +45,12 @@ async function initializedParentManagedChild(): Promise<{ root: string; child: s
     join(parent, "deno.json"),
     JSON.stringify({ workspace: ["./child"] }, null, 2),
   );
-  const { code, stderr } = await runSpecnaut(["init", "--here", "--no-git"], { cwd: child });
+  // Pin the starting backend explicitly so this switch scenario (local → github)
+  // is independent of the picker's default (which is `cloud`).
+  const { code, stderr } = await runSpecnaut(
+    ["init", "--here", "--no-git", "--backlog", "local"],
+    { cwd: child },
+  );
   assertEquals(code, 0, `init precondition failed: ${stderr}`);
   return { root, child };
 }


### PR DESCRIPTION
Closes #405.

## What

Makes **Specnaut Cloud** the recommended default in the `specnaut init` backlog-backend picker, to surface the hosted online Kanban at the exact moment of choice.

- **Cloud listed first** and marked `— recommended (default)` in **both** pickers (line-based `pickBacklogBackend` + arrow-key `pickBacklogBackendInteractive`).
- **Enter / non-interactive default → Cloud** (`DEFAULT_BACKLOG_BACKEND = "cloud"`).
- **One-line benefit note** printed above the choices (`↳ Specnaut Cloud: hosted online Kanban — shareable, real-time, no local file upkeep.`), so the default is an informed choice, not a silent flip.
- **Local / GitHub / GitLab remain fully selectable**, unchanged once chosen.
- Marker + note are keyed by backend (`RECOMMENDED_MARKER`, `DEFAULT_BACKEND_NOTE`) so the copy tracks the default if it ever moves.
- Drive-by fix: the non-interactive prompt said `Choose [1-3]` with 4 backends — now derives the count from the registry.

## Real picker output

```
Choose your backlog backend (press Enter for default):
  1) Specnaut Cloud (real-time API — browser login) — recommended (default)
  2) Local Markdown files (.specnaut/backlog/)
  3) GitHub Issues + Project (requires gh CLI)
  4) GitLab Issues + scoped Status labels (requires glab CLI)
  ↳ Specnaut Cloud: hosted online Kanban — shareable, real-time, no local file upkeep.
```
Empty stdin → `backlog_backend: cloud` in the resulting lock. ✔

## Tests

- Picker unit tests updated for the new default + order.
- Parent-managed backend-switch test pins `--backlog local` so it's independent of the picker default.
- Full suite green: **1036 passed / 0 failed**; `deno fmt --check`, `deno lint`, `deno check` all clean.

## Out of scope / follow-up

- The Cloud backend itself is unchanged (assumed working — `--backlog cloud` already wired it).
- **Docs drift**: `apps/specnaut-web/docs/llms.md` still lists `local` as the default (lines ~232/236). Deliberately deferred per the issue notes — it deploys independently, so it should be updated **when this ships in a released CLI**, not before (else the docs claim cloud-default ahead of the binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)