### PR TITLE
fix(init): don't nudge cloud login twice when the cloud backend is picked

### DIFF
--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -568,7 +568,11 @@ export async function runInit(intent: InitIntent): Promise<number> {
   console.log(`  4. Use ${bold('/backlog add "<task title>"')} for follow-up work`);
 
   // Specnaut Cloud funnel: point CLI users at the hosted product once they've
-  // scaffolded — run headless + remote-control the agent's checkpoints.
+  // scaffolded — run headless + remote-control the agent's checkpoints. The
+  // headless/remote pitch is worth showing regardless of backend, but when the
+  // user already picked the cloud backlog backend the cloud strategy has already
+  // emitted the `specnaut cloud login` CTA — so we drop the duplicate login line
+  // here and just point at the site, keeping the call-to-action to once (#407).
   console.log(
     `\n${cyan("✦ Specnaut Cloud")} — run Specnaut headless and answer your agent from your phone:`,
   );
@@ -578,7 +582,11 @@ export async function runInit(intent: InitIntent): Promise<number> {
     ),
   );
   console.log(
-    `     Start free: ${bold("specnaut cloud login")} ${dim("·")} ${cyan("https://specnaut.com")}`,
+    backlogBackend === "cloud"
+      ? `     Learn more: ${cyan("https://specnaut.com")}`
+      : `     Start free: ${bold("specnaut cloud login")} ${dim("·")} ${
+        cyan("https://specnaut.com")
+      }`,
   );
   return 0;
 }

--- a/tests/integration/init_backlog_test.ts
+++ b/tests/integration/init_backlog_test.ts
@@ -75,6 +75,11 @@ Deno.test("init --backlog local renders the local backlog skill", async () => {
       join(parent, "demo/.specnaut/installed.lock"),
     );
     assertStringIncludes(lock, "backlog_backend: local");
+
+    // #407: for a non-cloud backend, the Cloud funnel keeps its full
+    // "Start free: specnaut cloud login" call-to-action (genuine upsell).
+    assertStringIncludes(r.stdout, "Start free:");
+    assertStringIncludes(r.stdout, "specnaut cloud login");
   });
 });
 
@@ -184,6 +189,14 @@ Deno.test("init --backlog cloud renders the cloud skill + writes config stub (no
       join(parent, "demo/.specnaut/installed.lock"),
     );
     assertStringIncludes(lock, "backlog_backend: cloud");
+
+    // #407: with the cloud backend, the login CTA must appear exactly once —
+    // the cloud strategy already prints `specnaut cloud login`, so the Cloud
+    // funnel footer drops its duplicate "Start free: specnaut cloud login"
+    // line and just links the site instead.
+    assertEquals(r.stdout.includes("Start free:"), false);
+    assertStringIncludes(r.stdout, "Learn more:");
+    assertEquals(r.stdout.split("specnaut cloud login").length - 1, 1);
   });
 });
 


### PR DESCRIPTION
Closes #407.

## What

Since #406 made Specnaut Cloud the default backlog backend, the common `specnaut init` path printed the `specnaut cloud login` call-to-action **twice**:
1. From the cloud strategy's `initConfigMessages` — `next: run \`specnaut cloud login\` …`
2. From the unconditional Specnaut Cloud funnel footer — `Start free: specnaut cloud login · https://specnaut.com`

This dedups it: when the resolved backlog backend is `cloud`, the funnel keeps its headless/remote-control value pitch (distinct from the backlog CTA) but drops the duplicate login line, linking the site instead. Non-cloud backends keep the full upsell.

## Real output

**cloud backend:**
```
  next: run `specnaut cloud login` to authenticate and link a Cloud project
✦ Specnaut Cloud — run Specnaut headless and answer your agent from your phone:
     Learn more: https://specnaut.com
```
→ `specnaut cloud login` appears exactly once.

**local (and other non-cloud) backends — unchanged:**
```
✦ Specnaut Cloud — run Specnaut headless and answer your agent from your phone:
     Start free: specnaut cloud login · https://specnaut.com
```

## Tests

- `init --backlog cloud`: asserts no `Start free:` line, a `Learn more:` line, and exactly one `specnaut cloud login` in stdout.
- `init --backlog local`: asserts the full `Start free: specnaut cloud login` upsell still renders.
- Full suite green: **1036 passed / 0 failed**; `deno fmt`/`lint`/`check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)