### PR TITLE
fix(templates): retarget stale mkrlabs/specnaut + makerlabs.dev URLs to canonical

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "noreply@anthropic.com",
     "url": "https://github.com/mkrlabs"
   },
-  "homepage": "https://specnaut.makerlabs.dev",
-  "repository": "https://github.com/mkrlabs/specnaut",
+  "homepage": "https://specnaut.com",
+  "repository": "https://github.com/specnaut/specnaut-cli",
   "license": "MIT",
   "keywords": [
     "skills",
@@ -33,7 +33,7 @@
       "Review the changes I just made.",
       "Run a backlog grooming pass."
     ],
-    "websiteURL": "https://specnaut.makerlabs.dev",
+    "websiteURL": "https://specnaut.com",
     "brandColor": "#0d6efd",
     "composerIcon": "./assets/composer-icon.svg",
     "logo": "./assets/logo.svg",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -7,8 +7,8 @@
     "name": "MakerLabs",
     "url": "https://github.com/mkrlabs"
   },
-  "homepage": "https://specnaut.makerlabs.dev",
-  "repository": "https://github.com/mkrlabs/specnaut",
+  "homepage": "https://specnaut.com",
+  "repository": "https://github.com/specnaut/specnaut-cli",
   "license": "MIT",
   "keywords": [
     "skills",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "MakerLabs"
   },
-  "homepage": "https://specnaut.makerlabs.dev",
-  "repository": "https://github.com/mkrlabs/specnaut",
+  "homepage": "https://specnaut.com",
+  "repository": "https://github.com/specnaut/specnaut-cli",
   "license": "MIT"
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # specnaut-plugin — Claude Code plugin for Specnaut
 
-This is the Claude Code plugin distribution of [Specnaut](https://specnaut.makerlabs.dev). It ships
+This is the Claude Code plugin distribution of [Specnaut](https://specnaut.com). It ships
 the same slash-commands and sub-agents that the `specnaut` binary scaffolds into projects — just as
 a user-scope plugin instead. `/specnaut specify "<feature>"` auto-chains the full workflow by
 default; pass `--manual` to opt out.
@@ -15,7 +15,7 @@ default; pass `--manual` to opt out.
 | `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specnaut-plugin:groom`                                        |
 
 The full plugin migration shipped in v0.12.x (issue
-[#73](https://github.com/mkrlabs/specnaut/issues/73)). When the plugin is installed and the project
+[#73](https://github.com/specnaut/specnaut-cli/issues/73)). When the plugin is installed and the project
 harness is `claude`, `specnaut upgrade` auto-migrates vanilla on-disk agents to the plugin (backs
 them up, then removes them — the plugin serves them going forward). `specnaut check
 --project` warns
@@ -43,7 +43,7 @@ discoverability layer, not the polished workflow. Handoff rewriting is a known f
 ## Install
 
 ```bash
-/plugin install mkrlabs/specnaut-plugin
+/plugin install specnaut/specnaut-cli-plugin
 ```
 
 ## Local development

--- a/plugin/agents/specnaut-expert.md
+++ b/plugin/agents/specnaut-expert.md
@@ -44,12 +44,12 @@ news on demand. You do not modify code; you serve knowledge.
 
 For "what's new" / version-delta questions only:
 
-1. Fetch `https://specnaut.makerlabs.dev/llms.txt` — the canonical
+1. Fetch `https://specnaut.com/llms.txt` — the canonical
    current docs.
 2. If you also need release notes, fetch
-   `https://api.github.com/repos/mkrlabs/specnaut/releases/latest`
+   `https://api.github.com/repos/specnaut/specnaut-cli/releases/latest`
    and extract `tag_name` + `body`. For a range, hit
-   `https://api.github.com/repos/mkrlabs/specnaut/releases` and
+   `https://api.github.com/repos/specnaut/specnaut-cli/releases` and
    filter the `tag_name` list.
 3. If both fail (no network, no `WebFetch` capability), fall back to
    the vendored snapshot below and explicitly say:
@@ -72,7 +72,7 @@ match those triggers — silence beats noise.
 
 1. Read `.specnaut/installed.lock` and extract the `templates_version`
    field. If the file is absent or unreadable, skip silently.
-2. `WebFetch` `https://specnaut.makerlabs.dev/version.json`. Expect
+2. `WebFetch` `https://specnaut.com/version.json`. Expect
    `{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}`. On any
    failure (non-200, network error, malformed JSON), skip silently
    — never surface the error to the user.
@@ -118,7 +118,7 @@ sections above.
 `~/.config/gh/`. Email addresses NOT scrubbed — tell the user to review.
 
 **Surface**: generate
-`https://github.com/mkrlabs/specnaut/issues/new?title=…&body=…&labels=bug,from%3Aspecnaut-expert`
+`https://github.com/specnaut/specnaut-cli/issues/new?title=…&body=…&labels=bug,from%3Aspecnaut-expert`
 URL-encoded. The label gates the maintainer triage inbox. If the raw
 body exceeds **3000 chars**, present a fenced code block and ask the
 user to paste it into a fresh `issues/new` form.
@@ -141,7 +141,7 @@ Read `.specnaut/upgrade-pending.json`. If absent, respond:
 
 ### 2. Fetch release bodies
 
-For each tag in `(marker.from, marker.to]`: `WebFetch https://api.github.com/repos/mkrlabs/specnaut/releases/tags/v<TAG>`, extract `body`, parse the `### Adoption guide` section (entries: `**#NUM — Title**` / prose / ` ```prompt ` block). Build `adoption = [{version, prNum, title, prose, prompt}]`.
+For each tag in `(marker.from, marker.to]`: `WebFetch https://api.github.com/repos/specnaut/specnaut-cli/releases/tags/v<TAG>`, extract `body`, parse the `### Adoption guide` section (entries: `**#NUM — Title**` / prose / ` ```prompt ` block). Build `adoption = [{version, prNum, title, prose, prompt}]`.
 
 API failure fallback: use vendored snapshot for high-level guidance; warn "Couldn't fetch release notes; high-level adoption guidance only."
 
@@ -182,9 +182,9 @@ Frozen at scaffold time. Run the live fetch protocol for anything newer.
 
 ### What Specnaut is
 
-Enhanced fork of [`specify` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.makerlabs.dev/llms.txt>. Source: <https://github.com/mkrlabs/specnaut>.
+Enhanced fork of [`specify` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.com/llms.txt>. Source: <https://github.com/specnaut/specnaut-cli>.
 
-**Install:** `curl -fsSL https://raw.githubusercontent.com/mkrlabs/specnaut/main/install.sh | bash` or `brew tap mkrlabs/tap && brew install specnaut`.
+**Install:** `curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash` or `brew tap mkrlabs/tap && brew install specnaut`.
 
 **Harnesses:** claude, cursor, codex, windsurf, copilot, opencode, antigravity — all share `templates/core/` content, mapped per-harness by an adapter.
 

--- a/plugin/skills/using-specnaut/references/copilot-tools.md
+++ b/plugin/skills/using-specnaut/references/copilot-tools.md
@@ -28,13 +28,13 @@ maps each Claude Code tool to its GitHub Copilot CLI equivalent.
 Copilot CLI distributes plugins through a **marketplace repository** — a
 separate GitHub repo registered with `copilot plugin marketplace add`.
 The Specnaut marketplace (see issue #281) lives at
-`mkrlabs/specnaut-marketplace` (planned) and registers Specnaut as
+`specnaut/specnaut-cli-marketplace` (planned) and registers Specnaut as
 `specnaut@specnaut-marketplace`.
 
 Install flow for end users:
 
 ```bash
-copilot plugin marketplace add mkrlabs/specnaut-marketplace
+copilot plugin marketplace add specnaut/specnaut-cli-marketplace
 copilot plugin install specnaut@specnaut-marketplace
 ```
 

--- a/plugin/skills/using-specnaut/references/opencode-tools.md
+++ b/plugin/skills/using-specnaut/references/opencode-tools.md
@@ -56,7 +56,7 @@ Add to the user's `opencode.json`:
 ```json
 {
   "plugin": [
-    "specnaut@git+https://github.com/mkrlabs/specnaut.git"
+    "specnaut@git+https://github.com/specnaut/specnaut-cli.git"
   ]
 }
 ```

--- a/scripts/gh-issues/dedupe.ts
+++ b/scripts/gh-issues/dedupe.ts
@@ -5,7 +5,7 @@
 
 import { findCandidates, type IssueRef } from "./_dedupe_heuristic.ts";
 
-const REPO = "mkrlabs/specnaut";
+const REPO = "specnaut/specnaut-cli";
 
 async function ghJson<T>(args: string[]): Promise<T> {
   const cmd = new Deno.Command("gh", { args, stdout: "piped", stderr: "piped" });

--- a/scripts/gh-issues/groom-inbox.ts
+++ b/scripts/gh-issues/groom-inbox.ts
@@ -7,7 +7,7 @@
 
 import { findCandidates, type IssueRef } from "./_dedupe_heuristic.ts";
 
-const REPO = "mkrlabs/specnaut";
+const REPO = "specnaut/specnaut-cli";
 const INBOUND_LABEL = "from:specnaut-expert";
 
 type GhIssue = IssueRef & { createdAt: string };

--- a/scripts/gh-issues/list.ts
+++ b/scripts/gh-issues/list.ts
@@ -5,7 +5,7 @@
 //
 // Usage: deno run --allow-run list.ts
 
-const REPO = "mkrlabs/specnaut";
+const REPO = "specnaut/specnaut-cli";
 const LABEL = "from:specnaut-expert";
 
 type GhIssue = {

--- a/scripts/gh-issues/promote.ts
+++ b/scripts/gh-issues/promote.ts
@@ -9,7 +9,7 @@
 //   4. set-field.sh <num> Size <S>      (same fallback contract)
 //   5. Public thank-you comment on the issue.
 
-const REPO = "mkrlabs/specnaut";
+const REPO = "specnaut/specnaut-cli";
 const BACKLOG_DIR = ".claude/skills/backlog/scripts";
 
 const PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);

--- a/scripts/gh-issues/reject.ts
+++ b/scripts/gh-issues/reject.ts
@@ -6,7 +6,7 @@
 // Hard contract: this script never closes anything. Closure goes
 // through Kevin's explicit approval.
 
-const REPO = "mkrlabs/specnaut";
+const REPO = "specnaut/specnaut-cli";
 
 export type RejectArgs = { num: number; reason: string };
 

--- a/scripts/groom-backlog-local.sh
+++ b/scripts/groom-backlog-local.sh
@@ -22,7 +22,7 @@ mkdir -p "$LOG_DIR"
 # Make sure gh + claude are on PATH when launched from a non-login shell.
 export PATH="/opt/homebrew/bin:/usr/local/bin:/Applications/cmux.app/Contents/Resources/bin:$PATH"
 
-PROMPT='You are running as a scheduled grooming routine for the Specnaut project. Your job: clarify any items currently in the Backlog column of GitHub Project #4 (mkrlabs/specnaut), following the Product Owner contract defined at .claude/agents/product-owner.md.
+PROMPT='You are running as a scheduled grooming routine for the Specnaut project. Your job: clarify any items currently in the Backlog column of GitHub Project #4 (specnaut/specnaut-cli), following the Product Owner contract defined at .claude/agents/product-owner.md.
 
 Steps:
 1. Run `.claude/skills/backlog/scripts/list.sh --repo specnaut Backlog` to list current Backlog items.

--- a/scripts/triage-pr-local.sh
+++ b/scripts/triage-pr-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Local launchd-fired PR triage run.
 #
-# Looks for open PRs on mkrlabs/specnaut that don't have a 🤖 marker review
+# Looks for open PRs on specnaut/specnaut-cli that don't have a 🤖 marker review
 # yet, and fires `claude -p` headless to review the diff against project
 # conventions. The review is posted as a PR comment, not a blocking review.
 #
@@ -25,7 +25,7 @@ echo "=== specnaut-triage-pr START $(date -Iseconds) (cwd=$REPO_ROOT) ==="
 # Cheap precheck: if no open PR needs triage, exit immediately. Most fires
 # will hit this no-op path so the routine costs ~nothing when the board is
 # calm.
-NEEDS_TRIAGE=$(gh pr list --repo mkrlabs/specnaut --state open --json number,comments \
+NEEDS_TRIAGE=$(gh pr list --repo specnaut/specnaut-cli --state open --json number,comments \
   --jq '[.[] | select(([.comments[] | select(.body | startswith("🤖 specnaut-triage-pr review:"))] | length) == 0) | .number] | join(",")')
 
 if [[ -z "$NEEDS_TRIAGE" ]]; then
@@ -36,21 +36,21 @@ fi
 
 echo "PRs needing triage: $NEEDS_TRIAGE"
 
-PROMPT="You are running as a scheduled PR triage routine for the Specnaut project. Your job: review any open PRs on mkrlabs/specnaut that don't yet have a triage review, and post a structured review comment.
+PROMPT="You are running as a scheduled PR triage routine for the Specnaut project. Your job: review any open PRs on specnaut/specnaut-cli that don't yet have a triage review, and post a structured review comment.
 
 Open PR numbers needing review (comma-separated): $NEEDS_TRIAGE
 
 For each PR number:
 
-1. \`gh pr view <num> --repo mkrlabs/specnaut --json title,body,headRefName,baseRefName,additions,deletions,changedFiles,files\` to get metadata.
-2. \`gh pr diff <num> --repo mkrlabs/specnaut\` to read the full diff.
+1. \`gh pr view <num> --repo specnaut/specnaut-cli --json title,body,headRefName,baseRefName,additions,deletions,changedFiles,files\` to get metadata.
+2. \`gh pr diff <num> --repo specnaut/specnaut-cli\` to read the full diff.
 3. Cross-reference against project conventions:
    - \`AGENTS.md\` — project vision, locked decisions, hexagonal layering rules
    - \`.claude/agents/architect.md\` — architectural patterns (the architect agent's contract)
    - \`CLAUDE.md\` — collaboration rules
 4. For non-trivial changes that touch boundaries (new ports, new harnesses, changes to template bundling, install/release flow), dispatch the \`architect\` subagent for a design opinion.
 
-Then post ONE review comment per PR via \`gh pr comment <num> --repo mkrlabs/specnaut --body \"<review>\"\` with this exact structure (always include the marker prefix on the FIRST line):
+Then post ONE review comment per PR via \`gh pr comment <num> --repo specnaut/specnaut-cli --body \"<review>\"\` with this exact structure (always include the marker prefix on the FIRST line):
 
 \`\`\`
 🤖 specnaut-triage-pr review:

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -7539,12 +7539,12 @@ news on demand. You do not modify code; you serve knowledge.
 
 For "what's new" / version-delta questions only:
 
-1. Fetch \`https://specnaut.makerlabs.dev/llms.txt\` — the canonical
+1. Fetch \`https://specnaut.com/llms.txt\` — the canonical
    current docs.
 2. If you also need release notes, fetch
-   \`https://api.github.com/repos/mkrlabs/specnaut/releases/latest\`
+   \`https://api.github.com/repos/specnaut/specnaut-cli/releases/latest\`
    and extract \`tag_name\` + \`body\`. For a range, hit
-   \`https://api.github.com/repos/mkrlabs/specnaut/releases\` and
+   \`https://api.github.com/repos/specnaut/specnaut-cli/releases\` and
    filter the \`tag_name\` list.
 3. If both fail (no network, no \`WebFetch\` capability), fall back to
    the vendored snapshot below and explicitly say:
@@ -7567,7 +7567,7 @@ match those triggers — silence beats noise.
 
 1. Read \`.specnaut/installed.lock\` and extract the \`templates_version\`
    field. If the file is absent or unreadable, skip silently.
-2. \`WebFetch\` \`https://specnaut.makerlabs.dev/version.json\`. Expect
+2. \`WebFetch\` \`https://specnaut.com/version.json\`. Expect
    \`{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}\`. On any
    failure (non-200, network error, malformed JSON), skip silently
    — never surface the error to the user.
@@ -7613,7 +7613,7 @@ sections above.
 \`~/.config/gh/\`. Email addresses NOT scrubbed — tell the user to review.
 
 **Surface**: generate
-\`https://github.com/mkrlabs/specnaut/issues/new?title=…&body=…&labels=bug,from%3Aspecnaut-expert\`
+\`https://github.com/specnaut/specnaut-cli/issues/new?title=…&body=…&labels=bug,from%3Aspecnaut-expert\`
 URL-encoded. The label gates the maintainer triage inbox. If the raw
 body exceeds **3000 chars**, present a fenced code block and ask the
 user to paste it into a fresh \`issues/new\` form.
@@ -7636,7 +7636,7 @@ Read \`.specnaut/upgrade-pending.json\`. If absent, respond:
 
 ### 2. Fetch release bodies
 
-For each tag in \`(marker.from, marker.to]\`: \`WebFetch https://api.github.com/repos/mkrlabs/specnaut/releases/tags/v<TAG>\`, extract \`body\`, parse the \`### Adoption guide\` section (entries: \`**#NUM — Title**\` / prose / \` \`\`\`prompt \` block). Build \`adoption = [{version, prNum, title, prose, prompt}]\`.
+For each tag in \`(marker.from, marker.to]\`: \`WebFetch https://api.github.com/repos/specnaut/specnaut-cli/releases/tags/v<TAG>\`, extract \`body\`, parse the \`### Adoption guide\` section (entries: \`**#NUM — Title**\` / prose / \` \`\`\`prompt \` block). Build \`adoption = [{version, prNum, title, prose, prompt}]\`.
 
 API failure fallback: use vendored snapshot for high-level guidance; warn "Couldn't fetch release notes; high-level adoption guidance only."
 
@@ -7677,9 +7677,9 @@ Frozen at scaffold time. Run the live fetch protocol for anything newer.
 
 ### What Specnaut is
 
-Enhanced fork of [\`specify\` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.makerlabs.dev/llms.txt>. Source: <https://github.com/mkrlabs/specnaut>.
+Enhanced fork of [\`specify\` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.com/llms.txt>. Source: <https://github.com/specnaut/specnaut-cli>.
 
-**Install:** \`curl -fsSL https://raw.githubusercontent.com/mkrlabs/specnaut/main/install.sh | bash\` or \`brew tap mkrlabs/tap && brew install specnaut\`.
+**Install:** \`curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash\` or \`brew tap mkrlabs/tap && brew install specnaut\`.
 
 **Harnesses:** claude, cursor, codex, windsurf, copilot, opencode, antigravity — all share \`templates/core/\` content, mapped per-harness by an adapter.
 

--- a/templates/core/agents/specnaut-expert.md
+++ b/templates/core/agents/specnaut-expert.md
@@ -44,12 +44,12 @@ news on demand. You do not modify code; you serve knowledge.
 
 For "what's new" / version-delta questions only:
 
-1. Fetch `https://specnaut.makerlabs.dev/llms.txt` — the canonical
+1. Fetch `https://specnaut.com/llms.txt` — the canonical
    current docs.
 2. If you also need release notes, fetch
-   `https://api.github.com/repos/mkrlabs/specnaut/releases/latest`
+   `https://api.github.com/repos/specnaut/specnaut-cli/releases/latest`
    and extract `tag_name` + `body`. For a range, hit
-   `https://api.github.com/repos/mkrlabs/specnaut/releases` and
+   `https://api.github.com/repos/specnaut/specnaut-cli/releases` and
    filter the `tag_name` list.
 3. If both fail (no network, no `WebFetch` capability), fall back to
    the vendored snapshot below and explicitly say:
@@ -72,7 +72,7 @@ match those triggers — silence beats noise.
 
 1. Read `.specnaut/installed.lock` and extract the `templates_version`
    field. If the file is absent or unreadable, skip silently.
-2. `WebFetch` `https://specnaut.makerlabs.dev/version.json`. Expect
+2. `WebFetch` `https://specnaut.com/version.json`. Expect
    `{"version": "X.Y.Z", "released_at": "YYYY-MM-DD"}`. On any
    failure (non-200, network error, malformed JSON), skip silently
    — never surface the error to the user.
@@ -118,7 +118,7 @@ sections above.
 `~/.config/gh/`. Email addresses NOT scrubbed — tell the user to review.
 
 **Surface**: generate
-`https://github.com/mkrlabs/specnaut/issues/new?title=…&body=…&labels=bug,from%3Aspecnaut-expert`
+`https://github.com/specnaut/specnaut-cli/issues/new?title=…&body=…&labels=bug,from%3Aspecnaut-expert`
 URL-encoded. The label gates the maintainer triage inbox. If the raw
 body exceeds **3000 chars**, present a fenced code block and ask the
 user to paste it into a fresh `issues/new` form.
@@ -141,7 +141,7 @@ Read `.specnaut/upgrade-pending.json`. If absent, respond:
 
 ### 2. Fetch release bodies
 
-For each tag in `(marker.from, marker.to]`: `WebFetch https://api.github.com/repos/mkrlabs/specnaut/releases/tags/v<TAG>`, extract `body`, parse the `### Adoption guide` section (entries: `**#NUM — Title**` / prose / ` ```prompt ` block). Build `adoption = [{version, prNum, title, prose, prompt}]`.
+For each tag in `(marker.from, marker.to]`: `WebFetch https://api.github.com/repos/specnaut/specnaut-cli/releases/tags/v<TAG>`, extract `body`, parse the `### Adoption guide` section (entries: `**#NUM — Title**` / prose / ` ```prompt ` block). Build `adoption = [{version, prNum, title, prose, prompt}]`.
 
 API failure fallback: use vendored snapshot for high-level guidance; warn "Couldn't fetch release notes; high-level adoption guidance only."
 
@@ -182,9 +182,9 @@ Frozen at scaffold time. Run the live fetch protocol for anything newer.
 
 ### What Specnaut is
 
-Enhanced fork of [`specify` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.makerlabs.dev/llms.txt>. Source: <https://github.com/mkrlabs/specnaut>.
+Enhanced fork of [`specify` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.com/llms.txt>. Source: <https://github.com/specnaut/specnaut-cli>.
 
-**Install:** `curl -fsSL https://raw.githubusercontent.com/mkrlabs/specnaut/main/install.sh | bash` or `brew tap mkrlabs/tap && brew install specnaut`.
+**Install:** `curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash` or `brew tap mkrlabs/tap && brew install specnaut`.
 
 **Harnesses:** claude, cursor, codex, windsurf, copilot, opencode, antigravity — all share `templates/core/` content, mapped per-harness by an adapter.
 

--- a/templates/core/skills/using-specnaut/references/copilot-tools.md
+++ b/templates/core/skills/using-specnaut/references/copilot-tools.md
@@ -28,13 +28,13 @@ maps each Claude Code tool to its GitHub Copilot CLI equivalent.
 Copilot CLI distributes plugins through a **marketplace repository** — a
 separate GitHub repo registered with `copilot plugin marketplace add`.
 The Specnaut marketplace (see issue #281) lives at
-`mkrlabs/specnaut-marketplace` (planned) and registers Specnaut as
+`specnaut/specnaut-cli-marketplace` (planned) and registers Specnaut as
 `specnaut@specnaut-marketplace`.
 
 Install flow for end users:
 
 ```bash
-copilot plugin marketplace add mkrlabs/specnaut-marketplace
+copilot plugin marketplace add specnaut/specnaut-cli-marketplace
 copilot plugin install specnaut@specnaut-marketplace
 ```
 

--- a/templates/core/skills/using-specnaut/references/opencode-tools.md
+++ b/templates/core/skills/using-specnaut/references/opencode-tools.md
@@ -56,7 +56,7 @@ Add to the user's `opencode.json`:
 ```json
 {
   "plugin": [
-    "specnaut@git+https://github.com/mkrlabs/specnaut.git"
+    "specnaut@git+https://github.com/specnaut/specnaut-cli.git"
   ]
 }
 ```


### PR DESCRIPTION
Closes #408.

## What

The SpecFlow→SpecNaut repo/domain rebrand left stale references to the old **`mkrlabs/specnaut`** GitHub repo and the **`specnaut.makerlabs.dev`** docs domain scattered across the codebase. A scaffolded `specnaut-expert` agent pointed users' bug reports (`issues/new`), release-note fetches, and install links at the wrong repo/host.

Discovered via the now-working `smoke-features.sh` (`issues/new URL pre-fill present` was failing).

## Changes (targeted, safe string swaps)

- `github.com/mkrlabs/specnaut` → `github.com/specnaut/specnaut-cli` — repo, API (`/releases`, `/releases/latest`, `/releases/tags`), `issues/new`, `install.sh`, OpenCode `git+https` URL. The `-plugin` / `-marketplace` suffixes map correctly to `specnaut/specnaut-cli-plugin` / `specnaut/specnaut-cli-marketplace`.
- `specnaut.makerlabs.dev` → `specnaut.com` — docs, `llms.txt`, `version.json`.
- Plugin manifests (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`) — `homepage` + `repository`.
- Maintainer scripts (`scripts/gh-issues/*`, `groom-backlog-local.sh`, `triage-pr-local.sh`) — repo constants.
- Regenerated `templates_bundle.ts`; core + plugin mirror stay byte-identical (plugin-sync test passes).

## Deliberately left intact

- **`brew tap mkrlabs/tap`** — the Homebrew tap was *not* renamed (the canonical `README.md` still uses `mkrlabs/tap`). The targeted `mkrlabs/specnaut` swap leaves it untouched.

## Known follow-up (not a URL, out of scope)

- `scripts/groom-backlog-local.sh` still says "GitHub Project #4" — the project number wasn't verified here (the repo ref is fixed). Flagging for a maintainer pass.

## Tests

Full suite green: **1035 passed / 0 failed**; `fmt`/`lint`/`check` clean. `smoke-features.sh` is now fully green (the companion `version.json` assertion was updated in the monorepo test-sandbox skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)