### PR TITLE
fix(release): unblock v1.15.0 pipeline (fmt + plugin preflight + tap slug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,9 +172,9 @@ jobs:
           set -euo pipefail
           # 1. plugin.json must be parseable JSON
           jq -e . plugin/.claude-plugin/plugin.json > /dev/null
-          # 2. Plugin scaffold must contain at minimum the specnaut-auto skill
+          # 2. Plugin scaffold must contain at minimum the specnaut router skill
           # (catches an accidentally truncated plugin/ directory).
-          test -f plugin/skills/specnaut-auto/SKILL.md
+          test -f plugin/skills/specnaut/SKILL.md
           # 3. Hard fail if plugin.json version drifts from deno.json version.
           # The two are kept in lockstep by scripts/bump-version.ts.
           BIN_VERSION=$(jq -r .version deno.json)

--- a/.specnaut/release/postflight.sh
+++ b/.specnaut/release/postflight.sh
@@ -38,7 +38,7 @@ echo "▶ verifying Homebrew tap formula bumped to ${TAG#v}"
 # after the release.yml run completes. We track the soft-warn so the final
 # status differentiates "all green" from "release shipped but tap unverified".
 homebrew_warned=0
-formula_msg="$(gh api repos/mkrlabs/homebrew-tap/commits/main --jq '.commit.message' | head -1)"
+formula_msg="$(gh api repos/specnaut/homebrew-tap/commits/main --jq '.commit.message' | head -1)"
 expected_prefix="chore: bump specnaut to ${TAG#v}"
 if [[ "$formula_msg" != "$expected_prefix"* ]]; then
   echo "⚠ Homebrew formula tip message != '$expected_prefix*': '$formula_msg'"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Pin a version: `VERSION=v0.1.0-alpha.1`. Change install directory: `PREFIX=$HOME
 ### Homebrew
 
 ```bash
-brew tap mkrlabs/tap
+brew tap specnaut/tap
 brew install specnaut
 ```
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,25 +1,26 @@
 # specnaut-plugin — Claude Code plugin for Specnaut
 
-This is the Claude Code plugin distribution of [Specnaut](https://specnaut.com). It ships
-the same slash-commands and sub-agents that the `specnaut` binary scaffolds into projects — just as
-a user-scope plugin instead. `/specnaut specify "<feature>"` auto-chains the full workflow by
-default; pass `--manual` to opt out.
+This is the Claude Code plugin distribution of [Specnaut](https://specnaut.com). It ships the same
+slash-commands and sub-agents that the `specnaut` binary scaffolds into projects — just as a
+user-scope plugin instead. `/specnaut specify "<feature>"` auto-chains the full workflow by default;
+pass `--manual` to opt out.
 
 ## What's in here
 
-| Path                                                                                                                                        | Contents                                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specnaut-plugin`, lockstep with the binary version)         |
-| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specnaut slash-commands — `/specnaut-plugin:specify`, etc.             |
-| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                              |
-| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specnaut-plugin:groom`                                        |
+| Path                                                                                                                                        | Contents                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specnaut-plugin`, lockstep with the binary version) |
+| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specnaut slash-commands — `/specnaut-plugin:specify`, etc.     |
+| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                      |
+| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specnaut-plugin:groom`                                |
 
 The full plugin migration shipped in v0.12.x (issue
-[#73](https://github.com/specnaut/specnaut-cli/issues/73)). When the plugin is installed and the project
-harness is `claude`, `specnaut upgrade` auto-migrates vanilla on-disk agents to the plugin (backs
-them up, then removes them — the plugin serves them going forward). `specnaut check
---project` warns
-about any plugin-covered files that are missing when the plugin is uninstalled.
+[#73](https://github.com/specnaut/specnaut-cli/issues/73)). When the plugin is installed and the
+project harness is `claude`, `specnaut upgrade` auto-migrates vanilla on-disk agents to the plugin
+(backs them up, then removes them — the plugin serves them going forward).
+`specnaut check
+--project` warns about any plugin-covered files that are missing when the plugin is
+uninstalled.
 
 ### Known caveat: handoff IDs
 

--- a/plugin/agents/specnaut-expert.md
+++ b/plugin/agents/specnaut-expert.md
@@ -184,7 +184,7 @@ Frozen at scaffold time. Run the live fetch protocol for anything newer.
 
 Enhanced fork of [`specify` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.com/llms.txt>. Source: <https://github.com/specnaut/specnaut-cli>.
 
-**Install:** `curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash` or `brew tap mkrlabs/tap && brew install specnaut`.
+**Install:** `curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash` or `brew tap specnaut/tap && brew install specnaut`.
 
 **Harnesses:** claude, cursor, codex, windsurf, copilot, opencode, antigravity — all share `templates/core/` content, mapped per-harness by an adapter.
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -7679,7 +7679,7 @@ Frozen at scaffold time. Run the live fetch protocol for anything newer.
 
 Enhanced fork of [\`specify\` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.com/llms.txt>. Source: <https://github.com/specnaut/specnaut-cli>.
 
-**Install:** \`curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash\` or \`brew tap mkrlabs/tap && brew install specnaut\`.
+**Install:** \`curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash\` or \`brew tap specnaut/tap && brew install specnaut\`.
 
 **Harnesses:** claude, cursor, codex, windsurf, copilot, opencode, antigravity — all share \`templates/core/\` content, mapped per-harness by an adapter.
 

--- a/templates/core/agents/specnaut-expert.md
+++ b/templates/core/agents/specnaut-expert.md
@@ -184,7 +184,7 @@ Frozen at scaffold time. Run the live fetch protocol for anything newer.
 
 Enhanced fork of [`specify` CLI](https://github.com/github/spec-kit), distributed as a single native binary. Scaffolds AI harness files — SpecKit slash-commands, spec/plan/tasks templates, a constitution, sub-agents, and a backlog system — into an existing project in one command. Does **not** call any LLM; the user's AI harness reads the generated files. Docs: <https://specnaut.com/llms.txt>. Source: <https://github.com/specnaut/specnaut-cli>.
 
-**Install:** `curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash` or `brew tap mkrlabs/tap && brew install specnaut`.
+**Install:** `curl -fsSL https://raw.githubusercontent.com/specnaut/specnaut-cli/main/install.sh | bash` or `brew tap specnaut/tap && brew install specnaut`.
 
 **Harnesses:** claude, cursor, codex, windsurf, copilot, opencode, antigravity — all share `templates/core/` content, mapped per-harness by an adapter.
 


### PR DESCRIPTION
Pre-release hardening for the **v1.15.0** minor bump. A `devops-sre` advisory + the release preflight surfaced blockers on `main` after #406/#410/#411/#412.

## Release blockers fixed

1. **CI red on `main` (`fmt:check`)** — removing the specnaut-auto table row (#411) + URL edits (#412) left `plugin/README.md` unformatted (repo-wide `deno fmt --check` failed in `lint-test`). Reformatted; whole repo is `deno fmt --check` clean (358 files).
2. **`release.yml` Plugin pre-flight would fail on tag push** — it hard-checked `plugin/skills/specnaut-auto/SKILL.md` (deleted in #411) under `set -euo pipefail`. This only runs on a tag, so it merged invisibly. Repointed the scaffold-integrity sentinel at `plugin/skills/specnaut/SKILL.md` (the router — the real minimum-scaffold file).

## Correctness fixes bundled in

3. **Homebrew tap slug** — `brew tap mkrlabs/tap` was stale (real tap is `specnaut/homebrew-tap` per `scripts/bump-tap-formula.ts`) and shipped inside the binary via the bundled `specnaut-expert` agent. Retargeted to `brew tap specnaut/tap` in README + agent template (+ plugin mirror); bundle regenerated.
4. **`postflight.sh`** queried `mkrlabs/homebrew-tap` (worked only via GitHub's org-rename redirect) → `specnaut/homebrew-tap`.

## Flagged, not changed (out of scope / uncertain)

- `.cursor-plugin/plugin.json` `author.url` still `github.com/mkrlabs` (author identity, not an install/repo URL).
- `WIKI_SSH_KEY` is listed as a release prerequisite but unused in any workflow/script (orphaned).
- `plugin/README.md` `/plugin install specnaut/specnaut-cli-plugin` → 404 (plugin distribution slug needs confirmation).

## Tests

Full suite green **1035/0**; `fmt`/`lint`/`check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)