### PR TITLE
fix(release): make marketplace/codex sync push failures non-blocking

### DIFF
--- a/scripts/sync-to-codex-plugin.sh
+++ b/scripts/sync-to-codex-plugin.sh
@@ -23,8 +23,9 @@
 # Exit codes:
 #   0   success (or "no changes — sync skipped" — the script bails
 #       early if rsync produces an empty diff in the destination)
-#   2   missing GH_TOKEN — emit ::warning:: and exit 0 in release.yml
-#       (mirrors the HOMEBREW_TAP_TOKEN-missing pattern)
+#   2   non-blocking skip — missing GH_TOKEN, OR the push was denied (token
+#       lacks write access / fork not provisioned). Emits ::warning:: and is
+#       mapped to exit 0 in release.yml (mirrors the HOMEBREW_TAP_TOKEN pattern)
 #   1   unexpected error
 set -euo pipefail
 
@@ -156,7 +157,15 @@ fi
 git checkout -b "$BRANCH"
 git add -A
 git commit -m "$TITLE"
-git push -u origin "$BRANCH"
+# The push can be denied (HTTP 403) when the sync token lacks write access to
+# the fork, or the fork isn't provisioned yet (see specnaut-cli#298–#300). That
+# is an external-provisioning gap, not a release defect — treat it as a
+# non-blocking skip (exit 2 → the release.yml wrapper maps it to exit 0) rather
+# than letting `set -e` red the whole release build.
+if ! git push -u origin "$BRANCH"; then
+  echo "::warning::Codex sync: push to $FORK was denied — the sync token lacks write access, or the fork isn't provisioned yet (specnaut-cli#298–#300). The release itself is unaffected; skipping this best-effort publish." >&2
+  exit 2
+fi
 
 create_pr_idempotent "$FORK" "$BRANCH" "$TITLE" "$BODY"
 

--- a/scripts/sync-to-marketplace.sh
+++ b/scripts/sync-to-marketplace.sh
@@ -31,8 +31,10 @@
 # Exit codes:
 #   0   success (or "no changes — sync skipped" if the catalog is
 #       already in sync with the current version)
-#   2   missing GH_TOKEN — emit ::warning:: and exit 0 in release.yml
-#       (mirrors the HOMEBREW_TAP_TOKEN / CODEX_SYNC_TOKEN pattern)
+#   2   non-blocking skip — missing GH_TOKEN, OR the push was denied (token
+#       lacks write access / catalog repo not provisioned). Emits ::warning::
+#       and is mapped to exit 0 in release.yml (mirrors the HOMEBREW_TAP_TOKEN /
+#       CODEX_SYNC_TOKEN pattern)
 #   1   unexpected error
 set -euo pipefail
 
@@ -137,7 +139,15 @@ fi
 git checkout -b "$BRANCH"
 git add "$CATALOG"
 git commit -m "$TITLE"
-git push -u origin "$BRANCH"
+# The push can be denied (HTTP 403) when the sync token lacks write access to
+# the catalog repo, or it isn't provisioned yet (see specnaut-cli#309–#310).
+# That is an external-provisioning gap, not a release defect — treat it as a
+# non-blocking skip (exit 2 → the release.yml wrapper maps it to exit 0) rather
+# than letting `set -e` red the whole release build.
+if ! git push -u origin "$BRANCH"; then
+  echo "::warning::Marketplace sync: push to $MARKETPLACE was denied — the sync token lacks write access, or the catalog repo isn't provisioned yet (specnaut-cli#309–#310). The release itself is unaffected; skipping this best-effort publish." >&2
+  exit 2
+fi
 
 create_pr_idempotent "$MARKETPLACE" "$BRANCH" "$TITLE" "$BODY"
 


### PR DESCRIPTION
## Problem

The release `build` job has gone **red on every tag** (v1.14.0, v1.14.1, and just now v1.15.0) — [example failing job](https://github.com/specnaut/specnaut-cli/actions/runs/29159220091/job/86561313620).

Root cause (from the v1.15.0 log): the "Sync to Codex marketplace fork" step clones `specnaut/specnaut-plugins` (read OK), rsyncs, commits, then **`git push` fails with HTTP 403**:

```
remote: Permission to specnaut/specnaut-plugins.git denied to kevinkod.
fatal: unable to access '.../specnaut-plugins.git/': The requested URL returned error: 403
##[error]Process completed with exit code 128.
```

The token authenticates as a user without push access to the fork/catalog repo. Under `set -euo pipefail` the script dies with exit 128; the `release.yml` wrapper only maps exit **2** (missing token) to a non-blocking skip, so 128 propagated and failed the whole build — **even though the binaries, the GitHub Release, and the Homebrew tap bump had all already succeeded** upstream of these best-effort publish steps.

## Fix

These syncs are gated on external fork/token provisioning (#298–#300, #309–#310); a push denial is an infra gap, not a release defect. Catch the push failure in both `sync-to-codex-plugin.sh` and `sync-to-marketplace.sh`, emit a `::warning::`, and `exit 2` — the established non-blocking sentinel the workflow already maps to exit 0. Genuine unexpected errors (`exit 1`) still fail the job, so real bugs aren't masked.

Verified the control flow locally: `if ! git push` under `set -e` exits **2** (not 128) and skips the follow-on PR step.

## Not fixed here (needs org action)

To make the sync actually **publish** (not just skip cleanly), the sync token needs push access to `specnaut/specnaut-plugins` + the marketplace catalog repo — a permissions/provisioning task on the specnaut org, tracked by #298–#300 / #309–#310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)