### PR TITLE
feat(cloud): default login to api.specnaut.com — no prompt, no Convex URL

### DIFF
--- a/src/cli/handlers/cloud_handler.ts
+++ b/src/cli/handlers/cloud_handler.ts
@@ -16,7 +16,11 @@
 import { bold, dim, green, red, yellow } from "@std/fmt/colors";
 import { CloudClient, type CloudColumn, type CloudTask } from "../../domain/cloud/cloud_client.ts";
 import { freshAccessToken, login } from "../../domain/cloud/auth_flow.ts";
-import { readCloudConfig, writeCloudConfig } from "../../domain/cloud/cloud_config.ts";
+import {
+  DEFAULT_CLOUD_API_URL,
+  readCloudConfig,
+  writeCloudConfig,
+} from "../../domain/cloud/cloud_config.ts";
 import { defaultCredentialStore } from "../../infrastructure/credential_store.ts";
 import { openInBrowser } from "../../infrastructure/browser_opener.ts";
 
@@ -42,17 +46,19 @@ function normalizeApiUrl(raw: string): string | null {
 }
 
 /** Where a resolved deployment URL came from — drives the login trust
- *  disclosure (#400). `flag`/`prompt` are explicit user acts; `config` is a
- *  project file the user may not have authored. */
-type ApiUrlSource = "flag" | "config" | "prompt";
+ *  disclosure (#400). `flag` is an explicit user act; `default` is the
+ *  CLI-shipped canonical endpoint; `config` is a project file the user may not
+ *  have authored (the only phishing-relevant source). */
+type ApiUrlSource = "flag" | "config" | "default";
 
 type ResolvedApiUrl = { url: string; source: ApiUrlSource };
 
-/** Resolve the deployment URL: flag → existing config → (login only) prompt,
- *  tagging the source so `runLogin` can disclose it before authenticating. */
+/** Resolve the deployment URL: flag → existing config → the canonical default,
+ *  tagging the source so `runLogin` can disclose it before authenticating.
+ *  Since Specnaut Cloud is a single hosted service, there is always a valid
+ *  target — the only null is a malformed explicit `--api-url` / `api_url`. */
 async function resolveApiUrl(
   explicit: string | null,
-  allowPrompt: boolean,
 ): Promise<ResolvedApiUrl | null> {
   if (explicit) {
     const url = normalizeApiUrl(explicit);
@@ -63,20 +69,13 @@ async function resolveApiUrl(
     const url = normalizeApiUrl(cfg.apiUrl);
     return url ? { url, source: "config" } : null;
   }
-  if (allowPrompt && Deno.stdin.isTerminal()) {
-    const v = prompt("Specnaut Cloud API URL (e.g. https://your-deployment.convex.site):");
-    if (v && v.trim()) {
-      const url = normalizeApiUrl(v);
-      return url ? { url, source: "prompt" } : null;
-    }
-  }
-  return null;
+  return { url: DEFAULT_CLOUD_API_URL, source: "default" };
 }
 
 const URL_SOURCE_LABEL: Record<ApiUrlSource, string> = {
   flag: "--api-url flag",
   config: "project config (.specnaut/backlog-config.yml)",
-  prompt: "entered at prompt",
+  default: "Specnaut Cloud (default)",
 };
 
 /** Human label for where a deployment URL came from (login disclosure, #400). */
@@ -87,8 +86,8 @@ export function urlSourceLabel(source: ApiUrlSource): string {
 /** Whether `login` must confirm before authenticating: only when the URL came
  *  from a project config file AND the user has never authenticated against it.
  *  That is the precise phishing window — a committed `backlog-config.yml`
- *  redirecting login at an attacker host — while an explicit `--api-url`, an
- *  interactively-typed URL, or re-login to a known deployment stay
+ *  redirecting login at an attacker host — while an explicit `--api-url`, the
+ *  CLI-shipped default endpoint, or re-login to a known deployment stay
  *  friction-free (#400). */
 export function loginNeedsTrustConfirm(
   source: ApiUrlSource,
@@ -118,13 +117,9 @@ export async function runCloud(intent: CloudIntent): Promise<number> {
 async function authedSession(
   intent: CloudIntent,
 ): Promise<{ client: CloudClient; token: string } | number> {
-  const resolved = await resolveApiUrl(intent.apiUrl, false);
+  const resolved = await resolveApiUrl(intent.apiUrl);
   if (!resolved) {
-    console.error(
-      red(
-        "error: no Specnaut Cloud API URL (pass --api-url or set api_url in backlog-config.yml).",
-      ),
-    );
+    console.error(red("error: invalid Specnaut Cloud API URL — check --api-url / api_url."));
     return 1;
   }
   const apiUrl = resolved.url;
@@ -233,9 +228,9 @@ async function runLogin(intent: CloudIntent): Promise<number> {
     return 2;
   }
 
-  const resolved = await resolveApiUrl(intent.apiUrl, true);
+  const resolved = await resolveApiUrl(intent.apiUrl);
   if (!resolved) {
-    console.error(red("error: no Specnaut Cloud API URL (pass --api-url <url>)."));
+    console.error(red("error: invalid --api-url — must be a well-formed http(s) URL."));
     return 2;
   }
   const apiUrl = resolved.url;
@@ -368,13 +363,9 @@ async function runToken(intent: CloudIntent): Promise<number> {
     return 0;
   }
 
-  const resolved = await resolveApiUrl(intent.apiUrl, false);
+  const resolved = await resolveApiUrl(intent.apiUrl);
   if (!resolved) {
-    console.error(
-      red(
-        "error: no Specnaut Cloud API URL (pass --api-url or set api_url in backlog-config.yml).",
-      ),
-    );
+    console.error(red("error: invalid Specnaut Cloud API URL — check --api-url / api_url."));
     return 1;
   }
   const apiUrl = resolved.url;
@@ -392,9 +383,9 @@ async function runToken(intent: CloudIntent): Promise<number> {
 }
 
 async function runLogout(intent: CloudIntent): Promise<number> {
-  const resolved = await resolveApiUrl(intent.apiUrl, false);
+  const resolved = await resolveApiUrl(intent.apiUrl);
   if (!resolved) {
-    console.error(red("error: no Specnaut Cloud API URL to log out of."));
+    console.error(red("error: invalid Specnaut Cloud API URL — check --api-url / api_url."));
     return 1;
   }
   const apiUrl = resolved.url;

--- a/src/domain/cloud/cloud_config.ts
+++ b/src/domain/cloud/cloud_config.ts
@@ -5,6 +5,12 @@
 import { parse as parseYaml } from "@std/yaml";
 import type { RemoteConfig } from "./remote_mode.ts";
 
+/** The canonical Specnaut Cloud API endpoint. Specnaut Cloud is a single hosted
+ *  service, so the CLI defaults here — `specnaut cloud login` needs no URL and
+ *  no user ever sees the underlying deployment host. `--api-url` (or an
+ *  `api_url` in `backlog-config.yml`) overrides it for dev / self-hosted use. */
+export const DEFAULT_CLOUD_API_URL = "https://api.specnaut.com";
+
 export type CloudConfig = {
   apiUrl: string;
   projectKey: string;
@@ -22,7 +28,7 @@ export function renderCloudConfig(apiUrl = "", projectKey = ""): string {
     "backend: cloud",
     `api_url: ${
       JSON.stringify(apiUrl)
-    }        # Specnaut Cloud API base, e.g. https://your-deployment.convex.site`,
+    }        # Specnaut Cloud API base (optional; defaults to ${DEFAULT_CLOUD_API_URL})`,
     `project_key: ${JSON.stringify(projectKey)}    # the project's short key, e.g. CLOUD`,
     "",
     "# Remote-control gates (#357) — opt-in. When enabled, a headless agent raises",

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -9308,7 +9308,7 @@ runtime.
 \`\`\`yaml
 # .specnaut/backlog-config.yml
 backend: cloud
-api_url: https://your-deployment.convex.site   # Specnaut Cloud API base
+api_url: https://api.specnaut.com               # optional — defaults to Specnaut Cloud
 project_key: CLOUD                              # the project's short key
 \`\`\`
 

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -266,7 +266,7 @@ runtime.
 ```yaml
 # .specnaut/backlog-config.yml
 backend: cloud
-api_url: https://your-deployment.convex.site   # Specnaut Cloud API base
+api_url: https://api.specnaut.com               # optional — defaults to Specnaut Cloud
 project_key: CLOUD                              # the project's short key
 ```
 

--- a/tests/cli/cloud_login_trust_test.ts
+++ b/tests/cli/cloud_login_trust_test.ts
@@ -7,7 +7,7 @@ Deno.test("urlSourceLabel maps each source to a human label (#400)", () => {
     urlSourceLabel("config"),
     "project config (.specnaut/backlog-config.yml)",
   );
-  assertEquals(urlSourceLabel("prompt"), "entered at prompt");
+  assertEquals(urlSourceLabel("default"), "Specnaut Cloud (default)");
 });
 
 Deno.test("loginNeedsTrustConfirm fires only for a config URL with no existing creds (#400)", () => {
@@ -15,9 +15,11 @@ Deno.test("loginNeedsTrustConfirm fires only for a config URL with no existing c
   assertEquals(loginNeedsTrustConfirm("config", false), true);
   // Already authenticated here before → trusted, no prompt.
   assertEquals(loginNeedsTrustConfirm("config", true), false);
-  // Explicit user acts (typed flag / typed at prompt) are always trusted.
+  // Explicit user act (typed flag) is always trusted.
   assertEquals(loginNeedsTrustConfirm("flag", false), false);
   assertEquals(loginNeedsTrustConfirm("flag", true), false);
-  assertEquals(loginNeedsTrustConfirm("prompt", false), false);
-  assertEquals(loginNeedsTrustConfirm("prompt", true), false);
+  // The CLI-shipped default endpoint is baked into the signed binary, not
+  // attacker-controlled — always trusted, no confirmation.
+  assertEquals(loginNeedsTrustConfirm("default", false), false);
+  assertEquals(loginNeedsTrustConfirm("default", true), false);
 });


### PR DESCRIPTION
## Why

`specnaut cloud login` on a fresh machine prompted for a raw
`https://your-deployment.convex.site` URL. Two problems:

1. **Friction** — Specnaut Cloud is a *single hosted service*. There is no per-user deployment to look up, so asking for a URL is busywork.
2. **Implementation leak** — the prompt literally showed `*.convex.site`, exposing Convex as the backend to every user.

## What

- Resolve the API URL to a canonical default `https://api.specnaut.com` when there's no `--api-url` flag and no `api_url` in `backlog-config.yml`. Login now opens the browser with **zero prompts**.
- Remove the interactive URL prompt entirely.
- `--api-url <url>` and `api_url:` in `backlog-config.yml` stay as escape hatches for dev / self-hosted deployments.
- Scrub the `*.convex.site` example from the config stub + the bundled backlog `SKILL.md`.

## Trust model (#400) — preserved verbatim

The anti-phishing rule is unchanged: a **config-supplied** URL with no prior credentials still requires an explicit confirmation before authenticating. The new `default` source is baked into the signed binary (not attacker-controllable), so it's inherently trusted — same as an explicit `--api-url`. Covered by the updated `cloud_login_trust_test.ts`.

## Agent adoption

`specnaut cloud login` (and `specnaut login`) no longer asks for a deployment URL — it defaults to `https://api.specnaut.com`. If your project's `.specnaut/backlog-config.yml` pins `api_url` to a raw `*.convex.site` host, you can delete that line to use the branded default (keep it only for a dev / self-hosted deployment). No re-login is required; existing credentials keep working.

```prompt
Open `.specnaut/backlog-config.yml` in my project. If it has an `api_url:` line pointing at a `*.convex.site` host under `backend: cloud`, remove that line so the CLI uses its built-in default `https://api.specnaut.com`. Leave `api_url` untouched if it points at a non-Specnaut (dev or self-hosted) deployment. Don't touch `project_key` or any other field.
```

## Tests

Full suite green (1035 passed). Updated the trust + label tests for the `default` source; `cloud token` no-creds guidance still exits 1 as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)