### PR TITLE
fix(security): complete Markdown-cell escaping in groom-inbox (CodeQL js/incomplete-sanitization)

### DIFF
--- a/scripts/gh-issues/groom-inbox.ts
+++ b/scripts/gh-issues/groom-inbox.ts
@@ -70,6 +70,14 @@ function trim(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
 }
 
+/** Escape a value for a GitHub-flavoured Markdown table cell. Escape `\` FIRST,
+ *  then `|` — escaping `|` alone is incomplete (a backslash in the input would
+ *  otherwise consume the escape and let a `|` break the column). Always trim the
+ *  RAW string before escaping so truncation can't split an escape sequence. */
+function escapeMdCell(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
 if (import.meta.main) {
   const [inbox, pool] = await Promise.all([fetchInbox(), fetchPool()]);
 
@@ -94,7 +102,7 @@ if (import.meta.main) {
     const likely = candidates.find((c) => c.bucket === "likely-dupe");
     const action = likely ? `mark-dupe of #${likely.number}?` : "promote (P3/M)";
     const day = issue.createdAt.slice(0, 10);
-    const title = trim(issue.title.replace(/\|/g, "\\|"), 60);
+    const title = escapeMdCell(trim(issue.title, 60));
     console.log(`| ${issue.number} | ${title} | ${day} | ${dupeCol} | ${action} |`);
   }
 


### PR DESCRIPTION
## What

Closes the open CodeQL alert **`js/incomplete-sanitization` (high)** at `scripts/gh-issues/groom-inbox.ts:97`.

`issue.title.replace(/\|/g, "\\|")` escaped `|` but not the backslash first. A crafted issue title containing `\|` defeated the escaping — the `\\` renders as a literal backslash in GFM and consumes the escape, leaving `|` as a live column delimiter that desyncs the Markdown table. Truncation also ran *before* escaping, which could split a freshly-inserted escape sequence at the 60-char boundary.

## Fix

Per `security-auditor` triage of the alert:
- new `escapeMdCell()` helper escapes `\` **first**, then `|`;
- truncate the **raw** title first, then escape — so no escape sequence is ever split.

```
- const title = trim(issue.title.replace(/\|/g, "\\|"), 60);
+ const title = escapeMdCell(trim(issue.title, 60));
```

## Severity note

`groom-inbox.ts` is a maintainer-facing dev script that only writes a triage table to the console — worst case is a garbled table, not an injection into an executable/rendered sink. The auditor rated the **true** impact **Low** (CodeQL's "high" is overstated for this console-only sink), but the fix is trivial and clears the alert on the public repo. The auditor confirmed this is the only untrusted-field-into-Markdown-cell instance in the file.

## Validation

`deno check` / `deno lint` / `deno fmt --check` clean. Escape order verified: input `a\|b` → `a\\\|b`, which renders literally with no column break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)