### PR TITLE
ci(codeql): scan main on push so fixed alerts auto-close

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,12 @@
 name: codeql
 
 on:
+  # Analyse the default branch on every merge so the Security tab reflects
+  # main's true state and fixed alerts auto-close (without a push trigger,
+  # CodeQL never re-scans main on merge and stale alerts linger until the
+  # weekly schedule — GitHub warns about exactly this).
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Why

While fixing the `js/incomplete-sanitization` alert (#418), the alert didn't auto-close on merge — I had to `workflow_dispatch` a CodeQL run by hand. Root cause: `codeql.yml` triggered only on `pull_request` / `schedule` / `workflow_dispatch`, **never on push to `main`**. So a fix merged to main never re-scanned the default branch, and resolved findings lingered in the Security tab until the weekly Monday cron. GitHub's own run annotation flags exactly this: *"Please specify an on.push hook to analyze and see code scanning alerts from the default branch."*

## What

Add `push: branches: [main]`. Now every merge re-scans main and fixed alerts flip to `fixed` automatically — no manual dispatch, and the Security tab always reflects main's true state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)