### PR TITLE
fix: grant unscoped --allow-net so cloud login never prompts

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -15,20 +15,23 @@ const TARGETS: Target[] = [
   { triple: "x86_64-pc-windows-msvc", outName: "specnaut-windows-x64.exe" },
 ];
 
-// Permissions baked into the binary. `--allow-net` is required by
-// `specnaut self-update` to reach api.github.com (release lookup) and the
-// release download hosts. github.com 302-redirects release-asset downloads
-// to release-assets.githubusercontent.com — both must be in the allowlist
-// or Deno prompts the user at runtime, defeating the point of a compiled
-// binary. objects.githubusercontent.com / codeload.github.com are kept as
-// belt-and-braces for any redirect path GitHub may use historically or in
-// the future.
+// Permissions baked into the binary. `--allow-net` is unscoped (no host
+// allowlist) on purpose: the Cloud backend (`specnaut cloud login`, backlog
+// sync) talks to a USER-CONFIGURABLE API host — the `api.specnaut.com`
+// default, an `--api-url` flag for dev / self-hosted, or an `api_url` in
+// `.specnaut/backlog-config.yml`. A compile-time host allowlist cannot know
+// those, so any scoped list makes Deno prompt at runtime for every non-listed
+// host (the exact UX we're removing). Scoping also buys almost nothing here:
+// the binary already ships `--allow-run` + `--allow-ffi` + full read/write, so
+// a tampered binary could exfiltrate via a subprocess regardless — the net
+// allowlist was never a real trust boundary. self-update (api.github.com +
+// the release-asset redirect hosts) is covered by the same open grant.
 const PERMISSIONS = [
   "--allow-read",
   "--allow-write",
   "--allow-run",
   "--allow-env",
-  "--allow-net=api.github.com,github.com,release-assets.githubusercontent.com,objects.githubusercontent.com,codeload.github.com",
+  "--allow-net",
   // OS-native keychain for Cloud credentials (#360) reaches the platform secret
   // store via Deno FFI. If withheld, the keychain backends throw
   // PermissionDenied and credential storage degrades to the 0600 file fallback.


### PR DESCRIPTION
## What

The compiled binary baked a **host-scoped** `--allow-net` (GitHub hosts only, for `self-update`). `specnaut cloud login` fetches the **user-configurable** Cloud API host — `api.specnaut.com` (default), `--api-url` (dev/self-hosted), or `api_url` in `.specnaut/backlog-config.yml` — none of which are in the allowlist, so Deno raised its runtime permission gate:

```
⚠️ Deno requests net access to "api.specnaut.com:443".
Allow? [y/n/A]
```

That's a broken first-run UX for the flagship Cloud onboarding.

## Fix

Drop the host scope — bake plain `--allow-net`.

- A compile-time host allowlist **cannot** enumerate a user-configurable host, so any scoped list guarantees a prompt for dev/self-hosted/default users.
- Scoping was never a real trust boundary here: the binary already ships `--allow-run` + `--allow-ffi` + full `--allow-read/write`, so a tampered binary could exfiltrate via a subprocess regardless.
- `self-update` (api.github.com + release-asset redirect hosts) is covered by the same open grant.

Only `scripts/build.ts` changes; the comment now documents the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)