### PR TITLE
feat: arrow-key project picker + auto-generated key on cloud login

### DIFF
--- a/src/cli/handlers/cloud_handler.ts
+++ b/src/cli/handlers/cloud_handler.ts
@@ -14,7 +14,12 @@
 //   board   shows the linked project's board, tasks grouped by column.
 
 import { bold, dim, green, red, yellow } from "@std/fmt/colors";
-import { CloudClient, type CloudColumn, type CloudTask } from "../../domain/cloud/cloud_client.ts";
+import {
+  CloudClient,
+  type CloudColumn,
+  type CloudProject,
+  type CloudTask,
+} from "../../domain/cloud/cloud_client.ts";
 import { freshAccessToken, login } from "../../domain/cloud/auth_flow.ts";
 import {
   DEFAULT_CLOUD_API_URL,
@@ -23,6 +28,8 @@ import {
 } from "../../domain/cloud/cloud_config.ts";
 import { defaultCredentialStore } from "../../infrastructure/credential_store.ts";
 import { openInBrowser } from "../../infrastructure/browser_opener.ts";
+import { makeStdinSelectIO, type SelectItem, selectInteractive } from "../select.ts";
+import { generateProjectKey } from "../../domain/cloud/project_key.ts";
 
 export type CloudIntent = {
   kind: "cloud";
@@ -321,37 +328,85 @@ async function runLogin(intent: CloudIntent): Promise<number> {
   return 0;
 }
 
-/** Interactive project selection or inline creation. Returns the chosen key. */
+/** One entry in the project picker: an existing project, or "create new". */
+export type ProjectChoice = { kind: "pick"; key: string } | { kind: "create" };
+
+/**
+ * Build the unified picker list — every accessible project followed by a
+ * "create a new project" row — as `SelectItem`s. Pure (no I/O) so the label
+ * shape and ordering are unit-testable.
+ */
+export function buildProjectChoices(
+  projects: ReadonlyArray<CloudProject>,
+): SelectItem<ProjectChoice>[] {
+  const items: SelectItem<ProjectChoice>[] = projects.map((p) => ({
+    key: { kind: "pick", key: p.key },
+    label: `${bold(p.key)} — ${p.name}${p.role ? dim(` (${p.role})`) : ""}`,
+  }));
+  items.push({ key: { kind: "create" }, label: green("+ Create a new project") });
+  return items;
+}
+
+/**
+ * Bind the project after login: one arrow-key list of the account's projects
+ * plus a "create new" row (↑/↓ + enter). Picking a project returns its key;
+ * picking "create" asks only for a NAME and derives the key automatically.
+ * Returns the chosen key, or null if the user cancelled (Ctrl-C / ESC).
+ */
 async function chooseProject(
   client: CloudClient,
   token: string,
 ): Promise<string | null> {
   const projects = await client.listProjects(token);
+  const header = projects.length > 0
+    ? "\nSelect a Cloud project or create one (↑/↓ to move, enter to select):"
+    : "\nNo Cloud projects yet — press enter to create your first:";
 
-  if (projects.length > 0) {
-    console.log("\nYour Cloud projects:");
-    projects.forEach((p, i) => {
-      console.log(`  ${i + 1}) ${bold(p.key)} — ${p.name}${p.role ? dim(` (${p.role})`) : ""}`);
-    });
-    console.log(`  n) create a new project`);
-    const choice = (prompt("Select [1-" + projects.length + "] or 'n':") ?? "").trim();
-    if (choice && choice !== "n" && choice !== "N") {
-      const idx = Number(choice) - 1;
-      if (Number.isInteger(idx) && idx >= 0 && idx < projects.length) {
-        return projects[idx].key;
+  const picked = await selectInteractive(
+    buildProjectChoices(projects),
+    0,
+    makeStdinSelectIO(),
+    header,
+  );
+  if (picked === null) return null; // cancelled — caller reports "aborted"
+  if (picked.kind === "pick") return picked.key;
+
+  return await createProjectFromName(client, token, projects.map((p) => p.key));
+}
+
+/**
+ * Create a project from a human name alone: derive a valid key via
+ * {@link generateProjectKey}, deduping against the keys we already know. If a
+ * concurrent create stole the key between our list and our write, the server
+ * rejects it with "already exists" — we add it to the taken set and retry with
+ * the next suffix. Returns the created key, or null if the user gave no name.
+ */
+async function createProjectFromName(
+  client: CloudClient,
+  token: string,
+  existingKeys: ReadonlyArray<string>,
+): Promise<string | null> {
+  const name = (prompt("Project name:") ?? "").trim();
+  if (!name) return null;
+
+  const taken = new Set(existingKeys);
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const key = generateProjectKey(name, taken);
+    try {
+      const created = await client.createProject(token, key, name);
+      console.log(green(`✓ created project ${bold(created.name)} ${dim(`(key ${created.key})`)}`));
+      return created.key;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/already exists/i.test(msg)) {
+        taken.add(key); // race: someone took this key — bump the suffix and retry
+        continue;
       }
-      console.error(yellow("  not a valid choice — creating a new project instead."));
+      throw e;
     }
-  } else {
-    console.log(dim("\nNo Cloud projects yet — let's create one."));
   }
-
-  const key = (prompt("New project key (2–10 uppercase, e.g. CLOUD):") ?? "").trim();
-  if (!key) return null;
-  const name = (prompt("Project name:") ?? "").trim() || key;
-  const created = await client.createProject(token, key, name);
-  console.log(green(`✓ created project ${bold(created.key)}`));
-  return created.key;
+  console.error(red("error: couldn't find a free project key — please retry."));
+  return null;
 }
 
 async function runToken(intent: CloudIntent): Promise<number> {

--- a/src/cli/handlers/cloud_handler.ts
+++ b/src/cli/handlers/cloud_handler.ts
@@ -28,7 +28,7 @@ import {
 } from "../../domain/cloud/cloud_config.ts";
 import { defaultCredentialStore } from "../../infrastructure/credential_store.ts";
 import { openInBrowser } from "../../infrastructure/browser_opener.ts";
-import { makeStdinSelectIO, type SelectItem, selectInteractive } from "../select.ts";
+import { makeStdinSelectIO, selectInteractive, type SelectItem } from "../select.ts";
 import { generateProjectKey } from "../../domain/cloud/project_key.ts";
 
 export type CloudIntent = {

--- a/src/domain/cloud/project_key.ts
+++ b/src/domain/cloud/project_key.ts
@@ -1,0 +1,49 @@
+// Derive a Cloud project **key** from a human project **name** (#417 UX).
+//
+// The key is the task-number prefix (e.g. `CLOUD` → CLOUD-12), so the server
+// constrains it to `/^[A-Z][A-Z0-9]{1,9}$/` — 2–10 chars, uppercase
+// letters/digits, first char a letter, unique per org. Rather than make the
+// user hand-craft that (the old "New project key (2–10 uppercase)" prompt that
+// tripped everyone up), we slugify the name they already typed and append a
+// numeric suffix when the slug is taken.
+
+export const MAX_KEY_LEN = 10;
+const MIN_KEY_LEN = 2;
+/** Used when the name has no usable letters/digits at all (e.g. "!!!"). */
+const FALLBACK_BASE = "PROJECT";
+
+/**
+ * Slugify a name into a *candidate* key base — uppercase, `[A-Z0-9]` only,
+ * first char forced to a letter (leading digits dropped, since the key must
+ * start `[A-Z]`), padded to the 2-char minimum and clamped to `MAX_KEY_LEN`.
+ * Does NOT dedupe — that's `generateProjectKey`'s job.
+ */
+export function slugifyKeyBase(name: string): string {
+  let base = name.toUpperCase().replace(/[^A-Z0-9]/g, "").replace(/^[0-9]+/, "");
+  if (base.length < MIN_KEY_LEN) base = (base + FALLBACK_BASE);
+  return base.slice(0, MAX_KEY_LEN);
+}
+
+/**
+ * Turn a project name into a valid, currently-free key. Slugifies the name,
+ * then — if that base collides with an existing key (case-insensitive) —
+ * appends the smallest integer suffix ≥ 2 that fits inside `MAX_KEY_LEN`
+ * (truncating the base as needed so `base+suffix` never exceeds the cap):
+ * `PHOTOSHOP` → `PHOTOSHOP2` → `PHOTOSHOP3` … The result always satisfies the
+ * server regex.
+ */
+export function generateProjectKey(name: string, existing: Iterable<string>): string {
+  const taken = new Set<string>();
+  for (const k of existing) taken.add(k.toUpperCase());
+
+  const base = slugifyKeyBase(name);
+  if (!taken.has(base)) return base;
+
+  for (let i = 2; i < 100000; i++) {
+    const suffix = String(i);
+    const candidate = base.slice(0, MAX_KEY_LEN - suffix.length) + suffix;
+    if (!taken.has(candidate)) return candidate;
+  }
+  // Unreachable in practice (99998 collisions on one slug); keep the type total.
+  return base;
+}

--- a/src/domain/cloud/project_key.ts
+++ b/src/domain/cloud/project_key.ts
@@ -20,7 +20,7 @@ const FALLBACK_BASE = "PROJECT";
  */
 export function slugifyKeyBase(name: string): string {
   let base = name.toUpperCase().replace(/[^A-Z0-9]/g, "").replace(/^[0-9]+/, "");
-  if (base.length < MIN_KEY_LEN) base = (base + FALLBACK_BASE);
+  if (base.length < MIN_KEY_LEN) base = base + FALLBACK_BASE;
   return base.slice(0, MAX_KEY_LEN);
 }
 

--- a/tests/cli/cloud_project_choices_test.ts
+++ b/tests/cli/cloud_project_choices_test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "@std/assert";
+import { buildProjectChoices } from "../../src/cli/handlers/cloud_handler.ts";
+import type { CloudProject } from "../../src/domain/cloud/cloud_client.ts";
+
+const P = (key: string, name: string, role = ""): CloudProject => ({ key, name, role });
+
+Deno.test("buildProjectChoices lists every project then a create row", () => {
+  const items = buildProjectChoices([P("TASK", "My Project", "owner"), P("CLOUD", "Cloud")]);
+  assertEquals(items.length, 3);
+  assertEquals(items[0].key, { kind: "pick", key: "TASK" });
+  assertEquals(items[1].key, { kind: "pick", key: "CLOUD" });
+  assertEquals(items[2].key, { kind: "create" });
+});
+
+Deno.test("buildProjectChoices always ends with a create row, even with no projects", () => {
+  const items = buildProjectChoices([]);
+  assertEquals(items.length, 1);
+  assertEquals(items[0].key, { kind: "create" });
+});
+
+Deno.test("buildProjectChoices labels carry the key, name and role", () => {
+  const [item] = buildProjectChoices([P("TASK", "My Project", "owner")]);
+  // Labels are ANSI-wrapped, but the raw text is still present as substrings.
+  assertEquals(item.label.includes("TASK"), true);
+  assertEquals(item.label.includes("My Project"), true);
+  assertEquals(item.label.includes("owner"), true);
+});

--- a/tests/domain/cloud_project_key_test.ts
+++ b/tests/domain/cloud_project_key_test.ts
@@ -1,0 +1,60 @@
+import { assertEquals, assertMatch } from "@std/assert";
+import {
+  generateProjectKey,
+  MAX_KEY_LEN,
+  slugifyKeyBase,
+} from "../../src/domain/cloud/project_key.ts";
+
+// The server's constraint the generator must always satisfy.
+const SERVER_KEY_RE = /^[A-Z][A-Z0-9]{1,9}$/;
+
+Deno.test("slugifyKeyBase uppercases and strips non-alphanumerics", () => {
+  assertEquals(slugifyKeyBase("Photoshop-AI"), "PHOTOSHOPA"); // 11 chars → clamped to 10
+  assertEquals(slugifyKeyBase("my app"), "MYAPP");
+  assertEquals(slugifyKeyBase("Cloud"), "CLOUD");
+});
+
+Deno.test("slugifyKeyBase drops leading digits so the key starts with a letter", () => {
+  assertEquals(slugifyKeyBase("3D Studio"), "DSTUDIO");
+  assertMatch(slugifyKeyBase("42 things"), SERVER_KEY_RE);
+});
+
+Deno.test("slugifyKeyBase pads a too-short slug to the 2-char minimum", () => {
+  assertEquals(slugifyKeyBase("A"), "APROJECT");
+  assertEquals(slugifyKeyBase("!!!"), "PROJECT"); // no usable chars → fallback
+  assertEquals(slugifyKeyBase(""), "PROJECT");
+});
+
+Deno.test("slugifyKeyBase never exceeds MAX_KEY_LEN", () => {
+  const long = slugifyKeyBase("Supercalifragilistic Expialidocious");
+  assertEquals(long.length, MAX_KEY_LEN);
+  assertMatch(long, SERVER_KEY_RE);
+});
+
+Deno.test("generateProjectKey returns the plain slug when it's free", () => {
+  assertEquals(generateProjectKey("Cloud", []), "CLOUD");
+  assertEquals(generateProjectKey("Cloud", ["TASK", "OTHER"]), "CLOUD");
+});
+
+Deno.test("generateProjectKey appends the smallest free numeric suffix on collision", () => {
+  assertEquals(generateProjectKey("Cloud", ["CLOUD"]), "CLOUD2");
+  assertEquals(generateProjectKey("Cloud", ["CLOUD", "CLOUD2"]), "CLOUD3");
+});
+
+Deno.test("generateProjectKey dedupes case-insensitively", () => {
+  assertEquals(generateProjectKey("Cloud", ["cloud"]), "CLOUD2");
+});
+
+Deno.test("generateProjectKey truncates the base so base+suffix stays within the cap", () => {
+  // "PHOTOSHOPA" (10) is taken → suffix "2" needs one char back: "PHOTOSHOP2".
+  const key = generateProjectKey("Photoshop-AI", ["PHOTOSHOPA"]);
+  assertEquals(key, "PHOTOSHOP2");
+  assertEquals(key.length <= MAX_KEY_LEN, true);
+  assertMatch(key, SERVER_KEY_RE);
+});
+
+Deno.test("generateProjectKey output always satisfies the server regex", () => {
+  for (const name of ["Photoshop-AI", "3D", "!!!", "a", "My Big Long Project Name Here"]) {
+    assertMatch(generateProjectKey(name, []), SERVER_KEY_RE);
+  }
+});


### PR DESCRIPTION
## What

Two rough edges in the post-`cloud login` project step are gone:

**Before**
- A numbered `Select [1-N] or 'n':` prompt to pick/create.
- A `New project key (2–10 uppercase, e.g. CLOUD):` prompt that rejected anything not pre-formatted to the server's task-prefix rule — a real user typing `Photoshop-AI` got a bare `error: invalid request`.

**After**
- **One unified arrow-key list** (↑/↓ + enter) of the account's projects plus a `+ Create a new project` row, reusing the existing `selectInteractive` picker.
- **Create asks only for a project name.** The key — the `CLOUD-12` task-number prefix — is derived from the name automatically: uppercase alphanumerics, ≤10 chars, first char a letter, deduped with a numeric suffix on collision (`Photoshop-AI` → `PHOTOSHOPA`, or `PHOTOSHOP2` if taken). The generated key is shown for transparency; a server `already exists` race bumps the suffix and retries.

## Why client-side

The key must stay a short uppercase task prefix (`schema: "short uppercase key used for task numbers"`), so we generate rather than relax the constraint. The CLI already holds the project list (to dedupe against) and the server contract is untouched — this stays a CLI-only change with no API-version bump.

## Tests

- `cloud_project_key_test.ts` — slug/dedupe/suffix/truncation, and an invariant that every output matches the server regex `^[A-Z][A-Z0-9]{1,9}$`.
- `cloud_project_choices_test.ts` — picker list shape (projects then create row).
- Full suite: 1047 passed.

## Agent adoption

Cloud onboarding is now name-only — when an agent sets up the Cloud backend for a user, it no longer has to invent a valid uppercase key; it just supplies a project name and the CLI derives the key.

```prompt
Connect this repo to Specnaut Cloud: run `specnaut cloud login`, and when it asks, create a new project called "My App" — let the CLI generate the project key.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)