### PR TITLE
fix: picker scroll-drift on cloud login + rebrand keychain service to specnaut-cloud

### DIFF
--- a/src/cli/handlers/cloud_handler.ts
+++ b/src/cli/handlers/cloud_handler.ts
@@ -358,10 +358,13 @@ async function chooseProject(
   token: string,
 ): Promise<string | null> {
   const projects = await client.listProjects(token);
+  // Header is single-line (no embedded "\n") so the picker's redraw height
+  // stays exact; the blank spacer line above stays put across redraws.
   const header = projects.length > 0
-    ? "\nSelect a Cloud project or create one (↑/↓ to move, enter to select):"
-    : "\nNo Cloud projects yet — press enter to create your first:";
+    ? "Select a Cloud project or create one (↑/↓ to move, enter to select):"
+    : "No Cloud projects yet — press enter to create your first:";
 
+  console.log("");
   const picked = await selectInteractive(
     buildProjectChoices(projects),
     0,

--- a/src/cli/select.ts
+++ b/src/cli/select.ts
@@ -78,7 +78,12 @@ export async function selectInteractive<T>(
   if (items.length === 0) return null;
   let current = Math.max(0, Math.min(defaultIndex, items.length - 1));
   const labels = items.map((i) => i.label);
-  const totalLines = labels.length + 1;
+  // Rewind by the frame's ACTUAL physical height, not an assumed
+  // `labels.length + 1`. A header that itself spans multiple lines (embedded
+  // "\n") would otherwise leave the cursor-up count short, so each redraw
+  // drifts downward and the menu "scrolls" instead of updating in place. The
+  // height is constant across redraws (only the ❯ position moves).
+  const totalLines = formatMenu(labels, current, header).split("\n").length;
 
   try {
     io.write(formatMenu(labels, current, header) + "\n");

--- a/src/infrastructure/keychain/keychain_backend.ts
+++ b/src/infrastructure/keychain/keychain_backend.ts
@@ -13,10 +13,16 @@ import { type CloudCredentials, type CredentialStore, keyFor } from "../credenti
 
 /** All keychain items are filed under this service name; the account is the
  *  normalised Cloud API URL, so one machine holds tokens for several deployments.
- *  Intentionally kept as `specflow-cloud` through the specnaut rebrand: it is an
- *  internal at-rest identifier never shown to users, and renaming it would orphan
- *  every existing login's stored secret for no user-visible benefit. */
-export const KEYCHAIN_SERVICE = "specflow-cloud";
+ *  The service name IS user-visible — the macOS Keychain access dialog shows it
+ *  ("… gardées dans « specnaut-cloud »"), so it must carry the current brand.
+ *  Pre-rebrand logins stored under `LEGACY_KEYCHAIN_SERVICE` are migrated
+ *  forward on the next `load()` (see `KeychainCredentialStore`). */
+export const KEYCHAIN_SERVICE = "specnaut-cloud";
+
+/** The pre-rebrand service name. Read-through only: `load()` copies a hit here
+ *  into `KEYCHAIN_SERVICE` and removes it, so a user who logged in before the
+ *  rename keeps their session without re-authenticating. */
+export const LEGACY_KEYCHAIN_SERVICE = "specflow-cloud";
 
 /** Result of a single native keychain operation. `unavailable` is a value, not
  *  an exception — the normal "no reachable keyring" case must never throw. */
@@ -78,10 +84,22 @@ export class KeychainCredentialStore implements CredentialStore {
   // throw), honouring the `CredentialStore` contract — the sync FFI result is
   // wrapped in Promise.resolve/reject.
   load(apiUrl: string): Promise<CloudCredentials | null> {
-    const out = this.backend.get(KEYCHAIN_SERVICE, keyFor(apiUrl));
+    const account = keyFor(apiUrl);
+    const out = this.backend.get(KEYCHAIN_SERVICE, account);
     if (out.kind === "unavailable") return Promise.reject(new KeychainUnavailableError("load"));
-    if (out.kind === "miss") return Promise.resolve(null);
-    return Promise.resolve(parseCredentials(out.value));
+    if (out.kind === "ok") return Promise.resolve(parseCredentials(out.value));
+
+    // miss under the current brand → one-time migration from the pre-rebrand
+    // `specflow-cloud` item, if one exists: copy it forward, best-effort drop
+    // the old one, and return it. `unavailable`/`miss` here → just null.
+    const legacy = this.backend.get(LEGACY_KEYCHAIN_SERVICE, account);
+    if (legacy.kind !== "ok") return Promise.resolve(null);
+    const creds = parseCredentials(legacy.value);
+    if (creds) {
+      this.backend.set(KEYCHAIN_SERVICE, account, legacy.value);
+      this.backend.remove(LEGACY_KEYCHAIN_SERVICE, account);
+    }
+    return Promise.resolve(creds);
   }
 
   save(apiUrl: string, creds: CloudCredentials): Promise<void> {
@@ -91,7 +109,11 @@ export class KeychainCredentialStore implements CredentialStore {
   }
 
   delete(apiUrl: string): Promise<void> {
-    const out = this.backend.remove(KEYCHAIN_SERVICE, keyFor(apiUrl));
+    const account = keyFor(apiUrl);
+    const out = this.backend.remove(KEYCHAIN_SERVICE, account);
+    // Clear any lingering pre-rebrand item too, so logout leaves nothing behind
+    // (best-effort — a legacy miss/unavailable must not fail the logout).
+    this.backend.remove(LEGACY_KEYCHAIN_SERVICE, account);
     if (out.kind === "unavailable") return Promise.reject(new KeychainUnavailableError("delete"));
     return Promise.resolve();
   }

--- a/tests/cli/select_test.ts
+++ b/tests/cli/select_test.ts
@@ -188,6 +188,38 @@ Deno.test("selectInteractive writes a redraw frame on every input event", async 
   assertEquals(frames.length >= 2, true);
 });
 
+Deno.test("selectInteractive rewinds by a single-line header's true height", async () => {
+  const { io, written } = fakeIO([
+    new Uint8Array([0x6a]), // j → down (triggers one redraw)
+    new Uint8Array([0x0d]), // enter
+  ]);
+  await selectInteractive(
+    [{ key: "a", label: "Alpha" }, { key: "b", label: "Beta" }],
+    0,
+    io,
+    "Pick:", // 1-line header + 2 items = 3 physical lines
+  );
+  const rewind = written.find((s) => s.includes("A\x1b[J"));
+  assertEquals(rewind, "\x1b[3A\x1b[J");
+});
+
+Deno.test("selectInteractive rewinds by a multi-line header's true height (scroll-drift regression)", async () => {
+  // A header spanning two physical lines must count as two — else the cursor-up
+  // is short by one and the menu drifts downward on every keypress.
+  const { io, written } = fakeIO([
+    new Uint8Array([0x6a]), // j → down
+    new Uint8Array([0x0d]), // enter
+  ]);
+  await selectInteractive(
+    [{ key: "a", label: "Alpha" }, { key: "b", label: "Beta" }],
+    0,
+    io,
+    "line1\nline2", // 2-line header + 2 items = 4 physical lines
+  );
+  const rewind = written.find((s) => s.includes("A\x1b[J"));
+  assertEquals(rewind, "\x1b[4A\x1b[J");
+});
+
 Deno.test("selectInteractive calls teardown exactly once on normal selection", async () => {
   const fake = fakeIO([new Uint8Array([0x0d])]);
   await selectInteractive(

--- a/tests/infrastructure/keychain_migration_test.ts
+++ b/tests/infrastructure/keychain_migration_test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "@std/assert";
+import {
+  KEYCHAIN_SERVICE,
+  type KeychainBackend,
+  KeychainCredentialStore,
+  type KeychainOutcome,
+  LEGACY_KEYCHAIN_SERVICE,
+} from "../../src/infrastructure/keychain/keychain_backend.ts";
+import { keyFor } from "../../src/infrastructure/credential_store.ts";
+
+const CREDS = { accessToken: "a", refreshToken: "r", accessExpiresAt: 123 };
+const CREDS_JSON = JSON.stringify(CREDS);
+const API = "https://api.specnaut.com";
+
+/** In-memory keychain keyed by `service\x00account`, recording removes. */
+function memBackend(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const removed: string[] = [];
+  const k = (s: string, a: string) => `${s}\x00${a}`;
+  const backend: KeychainBackend = {
+    platform: "macos",
+    get(service, account): KeychainOutcome<string> {
+      const v = store.get(k(service, account));
+      return v === undefined ? { kind: "miss" } : { kind: "ok", value: v };
+    },
+    set(service, account, secret): KeychainOutcome<void> {
+      store.set(k(service, account), secret);
+      return { kind: "ok", value: undefined };
+    },
+    remove(service, account): KeychainOutcome<void> {
+      removed.push(k(service, account));
+      store.delete(k(service, account));
+      return { kind: "ok", value: undefined };
+    },
+    reachable: () => true,
+  };
+  return { backend, store, removed, k };
+}
+
+Deno.test("load migrates a legacy specflow-cloud item forward to specnaut-cloud", async () => {
+  const acct = keyFor(API);
+  const { backend, store, removed, k } = memBackend({
+    [`${LEGACY_KEYCHAIN_SERVICE}\x00${acct}`]: CREDS_JSON,
+  });
+  const store2 = new KeychainCredentialStore(backend);
+
+  const loaded = await store2.load(API);
+  assertEquals(loaded, CREDS);
+  // Copied forward under the new brand …
+  assertEquals(store.get(k(KEYCHAIN_SERVICE, acct)), CREDS_JSON);
+  // … and the legacy item was dropped.
+  assertEquals(removed.includes(k(LEGACY_KEYCHAIN_SERVICE, acct)), true);
+  assertEquals(store.has(k(LEGACY_KEYCHAIN_SERVICE, acct)), false);
+});
+
+Deno.test("load prefers the current-brand item and never touches legacy when present", async () => {
+  const acct = keyFor(API);
+  const { backend, removed, k } = memBackend({
+    [`${KEYCHAIN_SERVICE}\x00${acct}`]: CREDS_JSON,
+  });
+  const loaded = await new KeychainCredentialStore(backend).load(API);
+  assertEquals(loaded, CREDS);
+  // No migration read/remove of the legacy service happened.
+  assertEquals(removed.includes(k(LEGACY_KEYCHAIN_SERVICE, acct)), false);
+});
+
+Deno.test("load returns null when neither brand has an item", async () => {
+  const { backend } = memBackend();
+  assertEquals(await new KeychainCredentialStore(backend).load(API), null);
+});
+
+Deno.test("delete removes both the current and the legacy item", async () => {
+  const acct = keyFor(API);
+  const { backend, removed, k } = memBackend({
+    [`${KEYCHAIN_SERVICE}\x00${acct}`]: CREDS_JSON,
+    [`${LEGACY_KEYCHAIN_SERVICE}\x00${acct}`]: CREDS_JSON,
+  });
+  await new KeychainCredentialStore(backend).delete(API);
+  assertEquals(removed.includes(k(KEYCHAIN_SERVICE, acct)), true);
+  assertEquals(removed.includes(k(LEGACY_KEYCHAIN_SERVICE, acct)), true);
+});


### PR DESCRIPTION
Two issues reported on the new `specnaut cloud login` project step.

## 1. Picker was unusable (regression from #421)

Arrow keys scrolled the whole block down instead of moving the highlight — the flow was stuck.

**Cause:** `selectInteractive` rewound the cursor by an assumed `labels.length + 1` lines, but the cloud headers began with a `\n`, so the rendered frame was one physical line taller than the count. Each keypress under-rewound by one → downward drift.

**Fix:** rewind by the frame's **actual** height — `formatMenu(labels, current, header).split("\n").length` — which is correct for any header, including multi-line ones. Cloud headers are single-line now too. Verified over a real PTY (arrow-down rewinds exactly `\x1b[3A`, highlight moves, no drift). Regression test added for a 2-line header.

## 2. Keychain dialog showed the old brand

macOS prompted: *"… vos informations confidentielles gardées dans « specflow-cloud »"*. The service name **is** user-visible (the OS dialog shows it), contrary to the old code comment claiming otherwise.

**Fix:** renamed the service to `specnaut-cloud`. A read-through migration copies any pre-rebrand `specflow-cloud` item forward on the next `load()` (and `delete()` clears both), so anyone already logged in keeps their session — no forced re-auth.

> Note: the macOS prompt *appearing* is unrelated — an unsigned `deno compile` binary gets a new hash each self-update, so the keychain re-asks. The real cure is code-signing/notarization (separate devops work). This PR only fixes the brand shown.

## Tests
- `select_test.ts` — rewind matches true frame height (1-line and 2-line headers).
- `keychain_migration_test.ts` — legacy→current migration, current-brand preference, null when absent, logout clears both.
- Full suite: 1053 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)