### PR TITLE
fix: don't read the keychain at login (kills the double keychain prompt)

### DIFF
--- a/src/cli/handlers/cloud_handler.ts
+++ b/src/cli/handlers/cloud_handler.ts
@@ -255,7 +255,13 @@ async function runLogin(intent: CloudIntent): Promise<number> {
   // First-ever auth against a URL a project config chose is the phishing window
   // — require an explicit confirmation there (and only there). An --api-url
   // flag, a typed URL, or re-login to a known deployment proceed unprompted.
-  const existing = await store.load(apiUrl);
+  //
+  // Only a `config` source can EVER require the gate, so read credentials only
+  // then. For the default endpoint / an explicit flag the answer is always "no
+  // confirm" — reading here would just pop a keychain prompt (and, mid-rebrand,
+  // a legacy-item migration read) to compute a value we'd discard. Login writes
+  // fresh credentials regardless, so it never needs the existing ones.
+  const existing = resolved.source === "config" ? await store.load(apiUrl) : null;
   if (loginNeedsTrustConfirm(resolved.source, existing !== null)) {
     console.log(
       yellow(


### PR DESCRIPTION
## Symptom

`specnaut cloud login` on the default host pops the macOS keychain password dialog **twice in a row** before authentication even starts.

## Cause

`runLogin` called `store.load(apiUrl)` before the device flow, only to compute `hasExistingCreds` for the anti-phishing trust gate. Two problems:

1. That gate (`loginNeedsTrustConfirm`) can only return true for `source === "config"`. For the `default` endpoint or an explicit `--api-url`, the answer is always false — so the read was pure waste.
2. Mid-rebrand it's worse: `store.load()` runs the `specflow-cloud → specnaut-cloud` migration, which **reads** the legacy item (prompt #1) then **removes** it (prompt #2). Two keychain dialogs, to compute a value we throw away.

## Fix

Read credentials only when `source === "config"` (the one case the gate needs them). Login writes fresh credentials regardless, so it never needs the existing ones. Default-host login is now keychain-prompt-free — the CLI only *writes* the new token (creating an item doesn't prompt).

One line, plus a comment explaining why. Full suite: 1053 passed.