### PR TITLE
feat(spec): pluggable spec backend + init choice (local | cloud) (Lot 2, #424)

### DIFF
--- a/.specnaut/feature.json
+++ b/.specnaut/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specnaut/specs/018-scope-script-hardening",
-  "linked_issue": 389,
+  "feature_directory": ".specnaut/specs/020-cli-spec-backend",
+  "linked_issue": 424,
   "workflow_shape": "full"
 }

--- a/.specnaut/specs/020-cli-spec-backend/checklists/requirements.md
+++ b/.specnaut/specs/020-cli-spec-backend/checklists/requirements.md
@@ -1,27 +1,32 @@
 # Specification Quality Checklist: CLI pluggable spec backend + init choice
 
-**Purpose**: Validate specification completeness before planning
-**Created**: 2026-07-14
+**Purpose**: Validate specification completeness before planning **Created**: 2026-07-14
 **Feature**: [spec.md](../spec.md)
 
 ## Content Quality
-- [x] No implementation details (languages, frameworks, APIs) — described at capability level; `/api/v1/specs*` is the stable external contract from Lot 1, not an implementation choice
+
+- [x] No implementation details (languages, frameworks, APIs) — described at capability level;
+      `/api/v1/specs*` is the stable external contract from Lot 1, not an implementation choice
 - [x] Focused on user value and business needs
 - [x] All mandatory sections completed
 
 ## Requirement Completeness
-- [x] No [NEEDS CLARIFICATION] markers remain — FR-011 resolved (auto-create + link a task, then attach)
+
+- [x] No [NEEDS CLARIFICATION] markers remain — FR-011 resolved (auto-create + link a task, then
+      attach)
 - [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable and technology-agnostic
 - [x] All acceptance scenarios defined; edge cases identified
 - [x] Scope clearly bounded; dependencies and assumptions identified
 
 ## Feature Readiness
+
 - [x] All functional requirements have acceptance criteria
 - [x] User scenarios cover primary flows (init choice, cloud author, pull, push)
 - [x] No implementation details in specification
 
 ## Notes
-All checklist items pass. FR-011 (cloud-mode `specify` with no linked task) was resolved
-during `specify`: **auto-create + link a backlog task, then attach the spec** (an explicit
-`--issue N` overrides). Spec is ready for `/specnaut plan`.
+
+All checklist items pass. FR-011 (cloud-mode `specify` with no linked task) was resolved during
+`specify`: **auto-create + link a backlog task, then attach the spec** (an explicit `--issue N`
+overrides). Spec is ready for `/specnaut plan`.

--- a/.specnaut/specs/020-cli-spec-backend/checklists/requirements.md
+++ b/.specnaut/specs/020-cli-spec-backend/checklists/requirements.md
@@ -1,0 +1,27 @@
+# Specification Quality Checklist: CLI pluggable spec backend + init choice
+
+**Purpose**: Validate specification completeness before planning
+**Created**: 2026-07-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs) — described at capability level; `/api/v1/specs*` is the stable external contract from Lot 1, not an implementation choice
+- [x] Focused on user value and business needs
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain — FR-011 resolved (auto-create + link a task, then attach)
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable and technology-agnostic
+- [x] All acceptance scenarios defined; edge cases identified
+- [x] Scope clearly bounded; dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover primary flows (init choice, cloud author, pull, push)
+- [x] No implementation details in specification
+
+## Notes
+All checklist items pass. FR-011 (cloud-mode `specify` with no linked task) was resolved
+during `specify`: **auto-create + link a backlog task, then attach the spec** (an explicit
+`--issue N` overrides). Spec is ready for `/specnaut plan`.

--- a/.specnaut/specs/020-cli-spec-backend/contracts/spec-client.md
+++ b/.specnaut/specs/020-cli-spec-backend/contracts/spec-client.md
@@ -1,0 +1,42 @@
+# Contract — CLI spec surfaces
+
+Two surfaces: (A) the cloud HTTP calls the CLI makes (consuming Lot 1's shipped
+`/api/v1/specs*`), and (B) the `spec push`/`spec pull` command UX.
+
+## A. Cloud HTTP calls (`spec_client.ts`, mirrors `gate_client.ts`)
+
+Bearer-authed via the CLI credential store; `{apiUrl}/api/v1` prefix. Errors are **status-only**
+(`SpecApiError` + `reasonForStatus`) — the backend's `error` string is never surfaced (§ I).
+
+| Purpose | Call | Notes |
+|---|---|---|
+| Ensure/attach spec | `POST /api/v1/specs` `{projectKey, taskNumber, title?}` | idempotent |
+| Pull a spec | `GET /api/v1/specs?projectKey=&taskNumber=` → `{spec｜null}` | `null` → no spec yet |
+| Push steps (upsert-only) | `PUT /api/v1/specs/steps` `{projectKey, taskNumber, steps:[{key,name,order,body}]}` | never deletes an omitted step |
+| Auto-create task (unlinked specify) | `POST /api/v1/tasks` `{projectKey, title}` → `{task:{number}}` | shipped endpoint; typed `cloud_client.createTask` |
+
+Only `SpecStep{key,name,order,body}` and the public `projectKey`/`taskNumber` cross the wire.
+
+## B. Commands
+
+```
+specnaut spec pull <task>   # materialise the task's cloud spec into .specnaut/specs/.cache/<task>/
+specnaut spec push <task>   # upsert local spec content for <task> to the cloud
+```
+
+- **Backend gate**: both require `specBackend: cloud` + a linked Cloud project. Under
+  `local`, they exit with a clear "spec push/pull are cloud-backend commands" message.
+- **`spec pull <task>`**: fetches the spec, clears + rewrites `.specnaut/specs/.cache/<task>/`,
+  prints the written files. No spec on Cloud → clear "no spec for task <n>" (not an error crash).
+- **`spec push <task>`**: reads the task's cache (or a specified source), upserts to Cloud,
+  prints the pushed step count.
+- **Exit codes** (mirror `gate_handler.ts`): `0` ok · `1` usage/local-backend · `5` cloud/auth
+  failure (actionable message: retry / `specnaut cloud login`).
+- **Offline/auth failure** (FR-008): `pull` reuses an existing cache if present; otherwise a
+  non-zero exit with an actionable message — never a partial/empty spec.
+
+## Template-rendered behaviour (not compiled)
+
+- `specify.md` cloud block: generate steps → `spec push` (auto-create+link task if unlinked) →
+  no branch, no `.specnaut/specs/` files. Local block: unchanged (files + existing branch hook).
+- `implement.md` cloud block: `create-new-feature.sh --branch-only` (the branch-creation point).

--- a/.specnaut/specs/020-cli-spec-backend/contracts/spec-client.md
+++ b/.specnaut/specs/020-cli-spec-backend/contracts/spec-client.md
@@ -1,19 +1,19 @@
 # Contract — CLI spec surfaces
 
-Two surfaces: (A) the cloud HTTP calls the CLI makes (consuming Lot 1's shipped
-`/api/v1/specs*`), and (B) the `spec push`/`spec pull` command UX.
+Two surfaces: (A) the cloud HTTP calls the CLI makes (consuming Lot 1's shipped `/api/v1/specs*`),
+and (B) the `spec push`/`spec pull` command UX.
 
 ## A. Cloud HTTP calls (`spec_client.ts`, mirrors `gate_client.ts`)
 
 Bearer-authed via the CLI credential store; `{apiUrl}/api/v1` prefix. Errors are **status-only**
 (`SpecApiError` + `reasonForStatus`) — the backend's `error` string is never surfaced (§ I).
 
-| Purpose | Call | Notes |
-|---|---|---|
-| Ensure/attach spec | `POST /api/v1/specs` `{projectKey, taskNumber, title?}` | idempotent |
-| Pull a spec | `GET /api/v1/specs?projectKey=&taskNumber=` → `{spec｜null}` | `null` → no spec yet |
-| Push steps (upsert-only) | `PUT /api/v1/specs/steps` `{projectKey, taskNumber, steps:[{key,name,order,body}]}` | never deletes an omitted step |
-| Auto-create task (unlinked specify) | `POST /api/v1/tasks` `{projectKey, title}` → `{task:{number}}` | shipped endpoint; typed `cloud_client.createTask` |
+| Purpose                             | Call                                                                                | Notes                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Ensure/attach spec                  | `POST /api/v1/specs` `{projectKey, taskNumber, title?}`                             | idempotent                                        |
+| Pull a spec                         | `GET /api/v1/specs?projectKey=&taskNumber=` → `{spec｜null}`                        | `null` → no spec yet                              |
+| Push steps (upsert-only)            | `PUT /api/v1/specs/steps` `{projectKey, taskNumber, steps:[{key,name,order,body}]}` | never deletes an omitted step                     |
+| Auto-create task (unlinked specify) | `POST /api/v1/tasks` `{projectKey, title}` → `{task:{number}}`                      | shipped endpoint; typed `cloud_client.createTask` |
 
 Only `SpecStep{key,name,order,body}` and the public `projectKey`/`taskNumber` cross the wire.
 
@@ -24,12 +24,12 @@ specnaut spec pull <task>   # materialise the task's cloud spec into .specnaut/s
 specnaut spec push <task>   # upsert local spec content for <task> to the cloud
 ```
 
-- **Backend gate**: both require `specBackend: cloud` + a linked Cloud project. Under
-  `local`, they exit with a clear "spec push/pull are cloud-backend commands" message.
+- **Backend gate**: both require `specBackend: cloud` + a linked Cloud project. Under `local`, they
+  exit with a clear "spec push/pull are cloud-backend commands" message.
 - **`spec pull <task>`**: fetches the spec, clears + rewrites `.specnaut/specs/.cache/<task>/`,
   prints the written files. No spec on Cloud → clear "no spec for task <n>" (not an error crash).
-- **`spec push <task>`**: reads the task's cache (or a specified source), upserts to Cloud,
-  prints the pushed step count.
+- **`spec push <task>`**: reads the task's cache (or a specified source), upserts to Cloud, prints
+  the pushed step count.
 - **Exit codes** (mirror `gate_handler.ts`): `0` ok · `1` usage/local-backend · `5` cloud/auth
   failure (actionable message: retry / `specnaut cloud login`).
 - **Offline/auth failure** (FR-008): `pull` reuses an existing cache if present; otherwise a
@@ -37,6 +37,6 @@ specnaut spec push <task>   # upsert local spec content for <task> to the cloud
 
 ## Template-rendered behaviour (not compiled)
 
-- `specify.md` cloud block: generate steps → `spec push` (auto-create+link task if unlinked) →
-  no branch, no `.specnaut/specs/` files. Local block: unchanged (files + existing branch hook).
+- `specify.md` cloud block: generate steps → `spec push` (auto-create+link task if unlinked) → no
+  branch, no `.specnaut/specs/` files. Local block: unchanged (files + existing branch hook).
 - `implement.md` cloud block: `create-new-feature.sh --branch-only` (the branch-creation point).

--- a/.specnaut/specs/020-cli-spec-backend/data-model.md
+++ b/.specnaut/specs/020-cli-spec-backend/data-model.md
@@ -2,25 +2,27 @@
 
 ## Value objects
 
-- **SpecBackend** = `"local" | "cloud"` — the persisted backend choice. Default `"cloud"` at
-  init (recommended); absent in an existing lock → `"local"` (FR-010). Lives in
+- **SpecBackend** = `"local" | "cloud"` — the persisted backend choice. Default `"cloud"` at init
+  (recommended); absent in an existing lock → `"local"` (FR-010). Lives in
   `src/domain/installed_lock.ts` alongside `BacklogBackend`.
-- **SpecStep** = `{ readonly key: string; name: string; order: number; body: string }` — the
-  opaque unit exchanged with the cloud contract. `src/domain/spec/spec_step.ts`. This is the
-  **only** shape that crosses the § I boundary.
+- **SpecStep** = `{ readonly key: string; name: string; order: number; body: string }` — the opaque
+  unit exchanged with the cloud contract. `src/domain/spec/spec_step.ts`. This is the **only** shape
+  that crosses the § I boundary.
 
 ## Persisted state — `InstalledLock`
 
-`installed.lock` gains a `spec_backend` YAML key ↔ `specBackend: SpecBackend` field.
-`parseLock` defaults it to `"local"` when absent (mirrors `versionScheme` default). No other
-lock field changes.
+`installed.lock` gains a `spec_backend` YAML key ↔ `specBackend: SpecBackend` field. `parseLock`
+defaults it to `"local"` when absent (mirrors `versionScheme` default). No other lock field changes.
 
 ## Ports (`src/application/ports.ts`)
 
-- **SpecStore** — `{ readonly key: SpecBackend; pull(taskNumber): Promise<readonly SpecStep[] | null>; push(taskNumber, steps): Promise<void> }`.
+- **SpecStore** —
+  `{ readonly key: SpecBackend; pull(taskNumber): Promise<readonly SpecStep[] | null>; push(taskNumber, steps): Promise<void> }`.
   - `LocalSpecStore` (`key:"local"`): both verbs reject with one clear "cloud-only" message.
   - `CloudSpecStore` (`key:"cloud"`): delegates to a `SpecSession`.
-- **SpecCacheStore** — `{ write(projectDir, taskNumber, steps): Promise<string[]>; clear(projectDir, taskNumber): Promise<void> }`. Adapter: `spec_cache_writer.ts`.
+- **SpecCacheStore** —
+  `{ write(projectDir, taskNumber, steps): Promise<string[]>; clear(projectDir, taskNumber): Promise<void> }`.
+  Adapter: `spec_cache_writer.ts`.
 - **BundleOptions** gains `readonly specBackend: SpecBackend`, threaded through
   `harness.mapBundle(core, { backlogBackend, versionScheme, specBackend })`.
 
@@ -39,27 +41,28 @@ Pure types + parse guards mirroring `gate_contract.ts` (ignore unknown fields, n
 ```
 .specnaut/specs/.cache/<taskNumber>/<order>-<slug(key)>.md   # one file per step, gitignored
 ```
+
 - `write` clears the task's cache dir first, then writes current steps (US3 AC2 reconciliation).
 - `.specnaut/specs/.cache/` is added to `templates/core/root/.gitignore` (mergeBlock-reconciled).
 
 ## State transitions (the operations)
 
 - **init**: resolve `specBackend` (flag → interactive picker → `cloud` default) → persist to lock.
-- **cloud `specify`** (template-rendered): generate steps → `spec push` (auto-create+link a
-  task if none linked, via `cloud_client.createTask`) → **no** branch, **no** local files.
+- **cloud `specify`** (template-rendered): generate steps → `spec push` (auto-create+link a task if
+  none linked, via `cloud_client.createTask`) → **no** branch, **no** local files.
 - **`spec pull <task>`**: `CloudSpecStore.pull` → `SpecCacheStore.write` → gitignored files.
   Network/auth failure → reuse existing cache or actionable error (FR-008).
-- **`spec push <task>`**: read local content → `CloudSpecStore.push` (upsert-only; never
-  deletes an omitted step — Lot 1 FR-011).
-- **cloud `implement`** (template-rendered): `create-new-feature.sh --branch-only` → the branch
-  is created here, not at specify (decoupling).
+- **`spec push <task>`**: read local content → `CloudSpecStore.push` (upsert-only; never deletes an
+  omitted step — Lot 1 FR-011).
+- **cloud `implement`** (template-rendered): `create-new-feature.sh --branch-only` → the branch is
+  created here, not at specify (decoupling).
 - **local (any op)**: bypasses `SpecStore` entirely — identical to today (FR-003).
 
 ## Invariants
 
-- **Local parity** — with `specBackend:"local"`, no code path changes; guarded by a
-  golden-file test asserting the rendered `specify.md` is byte-identical to pre-feature output.
+- **Local parity** — with `specBackend:"local"`, no code path changes; guarded by a golden-file test
+  asserting the rendered `specify.md` is byte-identical to pre-feature output.
 - **Cache disposable** — gitignored; cloud is the source of truth.
-- **API-only boundary** — cloud adapter uses only `/api/v1/specs*` (+ the shipped
-  `/api/v1/tasks` for auto-create); no private-half identifier crosses (§ I).
+- **API-only boundary** — cloud adapter uses only `/api/v1/specs*` (+ the shipped `/api/v1/tasks`
+  for auto-create); no private-half identifier crosses (§ I).
 - **No branch in cloud `specify`** — the branch is created only at `implement`.

--- a/.specnaut/specs/020-cli-spec-backend/data-model.md
+++ b/.specnaut/specs/020-cli-spec-backend/data-model.md
@@ -1,0 +1,65 @@
+# Phase 1 Data Model — CLI pluggable spec backend
+
+## Value objects
+
+- **SpecBackend** = `"local" | "cloud"` — the persisted backend choice. Default `"cloud"` at
+  init (recommended); absent in an existing lock → `"local"` (FR-010). Lives in
+  `src/domain/installed_lock.ts` alongside `BacklogBackend`.
+- **SpecStep** = `{ readonly key: string; name: string; order: number; body: string }` — the
+  opaque unit exchanged with the cloud contract. `src/domain/spec/spec_step.ts`. This is the
+  **only** shape that crosses the § I boundary.
+
+## Persisted state — `InstalledLock`
+
+`installed.lock` gains a `spec_backend` YAML key ↔ `specBackend: SpecBackend` field.
+`parseLock` defaults it to `"local"` when absent (mirrors `versionScheme` default). No other
+lock field changes.
+
+## Ports (`src/application/ports.ts`)
+
+- **SpecStore** — `{ readonly key: SpecBackend; pull(taskNumber): Promise<readonly SpecStep[] | null>; push(taskNumber, steps): Promise<void> }`.
+  - `LocalSpecStore` (`key:"local"`): both verbs reject with one clear "cloud-only" message.
+  - `CloudSpecStore` (`key:"cloud"`): delegates to a `SpecSession`.
+- **SpecCacheStore** — `{ write(projectDir, taskNumber, steps): Promise<string[]>; clear(projectDir, taskNumber): Promise<void> }`. Adapter: `spec_cache_writer.ts`.
+- **BundleOptions** gains `readonly specBackend: SpecBackend`, threaded through
+  `harness.mapBundle(core, { backlogBackend, versionScheme, specBackend })`.
+
+## Cloud wire types (`src/domain/cloud/spec_contract.ts`)
+
+Pure types + parse guards mirroring `gate_contract.ts` (ignore unknown fields, no `_id`):
+
+- `SpecWire = { taskNumber: number; title: string; steps: SpecStepWire[] }`
+- `SpecStepWire = { key: string; name: string; order: number; body: string }`
+- `SpecVersionWire = { versionKey: string; source: string; author: string; createdAt: string }`
+- `SpecApiError` — carries only an HTTP status + a `reasonForStatus(status)` string; never the
+  backend's `error` body (§ I).
+
+## Materialisation cache layout
+
+```
+.specnaut/specs/.cache/<taskNumber>/<order>-<slug(key)>.md   # one file per step, gitignored
+```
+- `write` clears the task's cache dir first, then writes current steps (US3 AC2 reconciliation).
+- `.specnaut/specs/.cache/` is added to `templates/core/root/.gitignore` (mergeBlock-reconciled).
+
+## State transitions (the operations)
+
+- **init**: resolve `specBackend` (flag → interactive picker → `cloud` default) → persist to lock.
+- **cloud `specify`** (template-rendered): generate steps → `spec push` (auto-create+link a
+  task if none linked, via `cloud_client.createTask`) → **no** branch, **no** local files.
+- **`spec pull <task>`**: `CloudSpecStore.pull` → `SpecCacheStore.write` → gitignored files.
+  Network/auth failure → reuse existing cache or actionable error (FR-008).
+- **`spec push <task>`**: read local content → `CloudSpecStore.push` (upsert-only; never
+  deletes an omitted step — Lot 1 FR-011).
+- **cloud `implement`** (template-rendered): `create-new-feature.sh --branch-only` → the branch
+  is created here, not at specify (decoupling).
+- **local (any op)**: bypasses `SpecStore` entirely — identical to today (FR-003).
+
+## Invariants
+
+- **Local parity** — with `specBackend:"local"`, no code path changes; guarded by a
+  golden-file test asserting the rendered `specify.md` is byte-identical to pre-feature output.
+- **Cache disposable** — gitignored; cloud is the source of truth.
+- **API-only boundary** — cloud adapter uses only `/api/v1/specs*` (+ the shipped
+  `/api/v1/tasks` for auto-create); no private-half identifier crosses (§ I).
+- **No branch in cloud `specify`** — the branch is created only at `implement`.

--- a/.specnaut/specs/020-cli-spec-backend/plan.md
+++ b/.specnaut/specs/020-cli-spec-backend/plan.md
@@ -1,0 +1,125 @@
+# Implementation Plan: CLI pluggable spec backend + init choice (local | cloud)
+
+**Branch**: `020-cli-spec-backend` | **Date**: 2026-07-14 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `.specnaut/specs/020-cli-spec-backend/spec.md`
+**Issue**: specnaut-cli#424 (Lot 2 of epic specnaut-monorepo#15) · depends on Lot 1 (cloud#154, shipped)
+
+## Summary
+
+Add a second spec-storage backend to the Specnaut CLI, chosen at `specnaut init` exactly
+like the backlog backend: `local` (current `.specnaut/specs/` markdown, first-class default)
+or `cloud` (recommended). A `SpecStore` port with `local` + `cloud` adapters; a `spec_client`
++ `SpecSession` mirroring the existing `gate_client`/`gate_session` against the shipped
+`/api/v1/specs*` contract; `spec push` / `spec pull` commands mirroring `gate`; a gitignored
+materialisation cache under `.specnaut/specs/.cache/<task>/`; and cloud-mode `specify` that
+pushes steps + creates no branch (branch decoupled to `implement`, auto-creating+linking a
+task when none is linked). The local path bypasses the port entirely, preserving byte-for-byte
+parity (FR-003). Grounded in the architect's design pass (see research.md).
+
+## Technical Context
+
+**Language/Version**: TypeScript (strict) on Deno
+**Primary Dependencies**: existing `gate_client`/`gate_session`/`cloud_client`, credential
+store, `backlog_strategies` registry + picker, `conditional_render` + per-harness filters
+**Storage**: filesystem (local specs + gitignored cache) + SpecNaut Cloud via `/api/v1/specs*`
+**Testing**: `deno task test` — unit (fake fetch/fs) + integration + golden-file (local parity)
+**Target Platform**: compiled Deno binary (5 targets via release.yml)
+**Project Type**: CLI (hexagonal: domain / application ports / infrastructure adapters / cli)
+**Performance Goals**: N/A — spec push/pull are low-frequency authoring ops
+**Constraints**: local behaviour byte-identical (FR-003); § I — cloud adapter speaks only the
+versioned HTTP API, no private-half identifier in the public CLI; cache is gitignored + disposable
+**Scale/Scope**: ~1 port + 2 adapters, 1 client + session, 1 command pair, 1 cache writer,
+installed.lock + picker + 7-harness filter fan-out, template marker edits, ~10 test files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The CLI half has no local `constitution.md` (no `.specnaut/memory/`). The governing invariant
+is monorepo **constitution § I** (OSS/proprietary boundary): no private-half code, name,
+identifier, type, or error string may enter the public CLI — the only bridge is the versioned
+HTTP API. This design satisfies it by construction: `spec_client`/`spec_contract` mirror
+`gate_contract.ts` (pure types, status-only errors, opaque `SpecStep{key,name,order,body}`).
+**PASS** (re-checked post-Phase 1: still PASS).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specnaut/specs/020-cli-spec-backend/
+├── spec.md · plan.md · research.md · data-model.md · quickstart.md
+├── contracts/spec-client.md
+└── tasks.md
+```
+
+### Source Code (repository root = `apps/specnaut-cli/`)
+
+```text
+src/domain/
+├── installed_lock.ts                 # MODIFIED — SpecBackend type, spec_backend key, default-on-absent
+├── spec/spec_step.ts                 # NEW — SpecStep value object
+├── spec_strategies/{local,cloud}.ts + registry.ts   # NEW — SpecBackendStrategy (displayName/init copy)
+├── conditional_render.ts             # MODIFIED — renderSpecBackend (sibling of renderBackend)
+└── cloud/
+    ├── spec_contract.ts              # NEW — pure wire types + parse guards (mirror gate_contract.ts)
+    ├── spec_client.ts                # NEW — /api/v1/specs* client (mirror gate_client.ts)
+    ├── spec_session.ts               # NEW — SpecSession + makeSpecSession (mirror gate_session.ts)
+    └── cloud_client.ts               # MODIFIED — createTask() for auto-create-when-unlinked
+
+src/application/
+├── ports.ts                          # MODIFIED — SpecStore + SpecCacheStore ports; BundleOptions.specBackend
+└── init_project.ts                   # MODIFIED — thread specBackend into mapBundle
+
+src/infrastructure/
+├── spec/local_spec_store.ts          # NEW — LocalSpecStore (cloud verbs fail with one clear message)
+├── spec/cloud_spec_store.ts          # NEW — CloudSpecStore (over SpecSession)
+├── spec/spec_cache_writer.ts         # NEW — gitignored .specnaut/specs/.cache/<task>/ materialisation
+└── harness/spec_backend_filter.ts    # NEW — applySpecBackend, wired into all 7 harness mapBundles
+
+src/cli/
+├── spec_picker.ts                    # NEW — pickSpecBackend[Interactive] (mirror backlog_picker.ts)
+├── parser.ts                         # MODIFIED — `spec push|pull` branch (mirror `gate`)
+├── handlers/spec_handler.ts          # NEW — runSpec (mirror gate_handler.ts)
+├── handlers/init_handler.ts          # MODIFIED — resolve + thread specBackend
+└── help.ts                           # MODIFIED — spec push/pull entries
+main.ts                               # MODIFIED — case "spec"
+
+templates/core/
+├── root/.gitignore                   # MODIFIED — add `.specnaut/specs/.cache/`
+├── skills/specnaut/phases/specify.md # MODIFIED — spec-backend marker blocks (cloud: push, no branch)
+├── skills/specnaut/phases/implement.md # MODIFIED — cloud block runs create-new-feature.sh --branch-only
+└── specnaut/scripts/bash/create-new-feature.sh # MODIFIED — --branch-only flag
+```
+
+**Structure Decision**: no new layer — every piece mirrors an existing sibling
+(`gate_*`, `backlog_*`, per-harness filters). The one cross-cutting cost is the 7-harness
+`applySpecBackend` fan-out, identical in shape to the existing backlog/scheme filters.
+
+## Phase 0 — Research (done → research.md)
+
+Architect design pass (47 tool reads over the live code). Decisions D1–D8 in
+[research.md](./research.md). Headlines: SpecStore port scoped to cloud push/pull (local
+bypasses it, D1); init choice mirrors BacklogBackend end-to-end (D2); `spec_client`/`session`
+mirror `gate_*` (D3); branch decoupling via template marker blocks + `create-new-feature.sh
+--branch-only` at implement (D5); auto-create-task via a new typed `cloud_client.createTask`
+(not the backend-gated bash `add.sh`) (D6); § I preserved by mirroring `gate_contract` (D7);
+upgrade path defaults `specBackend` to `local` (D8).
+
+## Phase 1 — Design & Contracts (done)
+
+- [data-model.md](./data-model.md) — SpecBackend, SpecStep, SpecStore/SpecCacheStore ports,
+  the installed.lock field, the cache layout, state transitions.
+- [contracts/spec-client.md](./contracts/spec-client.md) — the `/api/v1/specs*` calls the CLI
+  makes + the `spec push`/`spec pull` command contract (exit codes mirroring `gate`).
+- [quickstart.md](./quickstart.md) — end-to-end local exercise (init both backends, cloud
+  specify, pull, push) with assertions.
+- Agent context file: none marked in this repo → step skipped.
+
+**Constitution re-check post-design**: still PASS — the cloud surface is opaque-keyed and
+status-only; local parity is guarded by a golden-file test.
+
+## Complexity Tracking
+
+No constitution violations — table not needed. The 7-harness fan-out is existing-pattern
+maintenance cost, not a new architectural violation.

--- a/.specnaut/specs/020-cli-spec-backend/plan.md
+++ b/.specnaut/specs/020-cli-spec-backend/plan.md
@@ -1,46 +1,46 @@
 # Implementation Plan: CLI pluggable spec backend + init choice (local | cloud)
 
 **Branch**: `020-cli-spec-backend` | **Date**: 2026-07-14 | **Spec**: [spec.md](./spec.md)
-**Input**: Feature specification from `.specnaut/specs/020-cli-spec-backend/spec.md`
-**Issue**: specnaut-cli#424 (Lot 2 of epic specnaut-monorepo#15) · depends on Lot 1 (cloud#154, shipped)
+**Input**: Feature specification from `.specnaut/specs/020-cli-spec-backend/spec.md` **Issue**:
+specnaut-cli#424 (Lot 2 of epic specnaut-monorepo#15) · depends on Lot 1 (cloud#154, shipped)
 
 ## Summary
 
-Add a second spec-storage backend to the Specnaut CLI, chosen at `specnaut init` exactly
-like the backlog backend: `local` (current `.specnaut/specs/` markdown, first-class default)
-or `cloud` (recommended). A `SpecStore` port with `local` + `cloud` adapters; a `spec_client`
-+ `SpecSession` mirroring the existing `gate_client`/`gate_session` against the shipped
-`/api/v1/specs*` contract; `spec push` / `spec pull` commands mirroring `gate`; a gitignored
-materialisation cache under `.specnaut/specs/.cache/<task>/`; and cloud-mode `specify` that
-pushes steps + creates no branch (branch decoupled to `implement`, auto-creating+linking a
-task when none is linked). The local path bypasses the port entirely, preserving byte-for-byte
-parity (FR-003). Grounded in the architect's design pass (see research.md).
+Add a second spec-storage backend to the Specnaut CLI, chosen at `specnaut init` exactly like the
+backlog backend: `local` (current `.specnaut/specs/` markdown, first-class default) or `cloud`
+(recommended). A `SpecStore` port with `local` + `cloud` adapters; a `spec_client`
+
+- `SpecSession` mirroring the existing `gate_client`/`gate_session` against the shipped
+  `/api/v1/specs*` contract; `spec push` / `spec pull` commands mirroring `gate`; a gitignored
+  materialisation cache under `.specnaut/specs/.cache/<task>/`; and cloud-mode `specify` that pushes
+  steps + creates no branch (branch decoupled to `implement`, auto-creating+linking a task when none
+  is linked). The local path bypasses the port entirely, preserving byte-for-byte parity (FR-003).
+  Grounded in the architect's design pass (see research.md).
 
 ## Technical Context
 
-**Language/Version**: TypeScript (strict) on Deno
-**Primary Dependencies**: existing `gate_client`/`gate_session`/`cloud_client`, credential
-store, `backlog_strategies` registry + picker, `conditional_render` + per-harness filters
-**Storage**: filesystem (local specs + gitignored cache) + SpecNaut Cloud via `/api/v1/specs*`
-**Testing**: `deno task test` — unit (fake fetch/fs) + integration + golden-file (local parity)
-**Target Platform**: compiled Deno binary (5 targets via release.yml)
-**Project Type**: CLI (hexagonal: domain / application ports / infrastructure adapters / cli)
-**Performance Goals**: N/A — spec push/pull are low-frequency authoring ops
-**Constraints**: local behaviour byte-identical (FR-003); § I — cloud adapter speaks only the
-versioned HTTP API, no private-half identifier in the public CLI; cache is gitignored + disposable
-**Scale/Scope**: ~1 port + 2 adapters, 1 client + session, 1 command pair, 1 cache writer,
-installed.lock + picker + 7-harness filter fan-out, template marker edits, ~10 test files
+**Language/Version**: TypeScript (strict) on Deno **Primary Dependencies**: existing
+`gate_client`/`gate_session`/`cloud_client`, credential store, `backlog_strategies` registry +
+picker, `conditional_render` + per-harness filters **Storage**: filesystem (local specs + gitignored
+cache) + SpecNaut Cloud via `/api/v1/specs*` **Testing**: `deno task test` — unit (fake fetch/fs) +
+integration + golden-file (local parity) **Target Platform**: compiled Deno binary (5 targets via
+release.yml) **Project Type**: CLI (hexagonal: domain / application ports / infrastructure adapters
+/ cli) **Performance Goals**: N/A — spec push/pull are low-frequency authoring ops **Constraints**:
+local behaviour byte-identical (FR-003); § I — cloud adapter speaks only the versioned HTTP API, no
+private-half identifier in the public CLI; cache is gitignored + disposable **Scale/Scope**: ~1
+port + 2 adapters, 1 client + session, 1 command pair, 1 cache writer, installed.lock + picker +
+7-harness filter fan-out, template marker edits, ~10 test files
 
 ## Constitution Check
 
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
-The CLI half has no local `constitution.md` (no `.specnaut/memory/`). The governing invariant
-is monorepo **constitution § I** (OSS/proprietary boundary): no private-half code, name,
-identifier, type, or error string may enter the public CLI — the only bridge is the versioned
-HTTP API. This design satisfies it by construction: `spec_client`/`spec_contract` mirror
-`gate_contract.ts` (pure types, status-only errors, opaque `SpecStep{key,name,order,body}`).
-**PASS** (re-checked post-Phase 1: still PASS).
+The CLI half has no local `constitution.md` (no `.specnaut/memory/`). The governing invariant is
+monorepo **constitution § I** (OSS/proprietary boundary): no private-half code, name, identifier,
+type, or error string may enter the public CLI — the only bridge is the versioned HTTP API. This
+design satisfies it by construction: `spec_client`/`spec_contract` mirror `gate_contract.ts` (pure
+types, status-only errors, opaque `SpecStep{key,name,order,body}`). **PASS** (re-checked post-Phase
+1: still PASS).
 
 ## Project Structure
 
@@ -92,28 +92,29 @@ templates/core/
 └── specnaut/scripts/bash/create-new-feature.sh # MODIFIED — --branch-only flag
 ```
 
-**Structure Decision**: no new layer — every piece mirrors an existing sibling
-(`gate_*`, `backlog_*`, per-harness filters). The one cross-cutting cost is the 7-harness
-`applySpecBackend` fan-out, identical in shape to the existing backlog/scheme filters.
+**Structure Decision**: no new layer — every piece mirrors an existing sibling (`gate_*`,
+`backlog_*`, per-harness filters). The one cross-cutting cost is the 7-harness `applySpecBackend`
+fan-out, identical in shape to the existing backlog/scheme filters.
 
 ## Phase 0 — Research (done → research.md)
 
 Architect design pass (47 tool reads over the live code). Decisions D1–D8 in
-[research.md](./research.md). Headlines: SpecStore port scoped to cloud push/pull (local
-bypasses it, D1); init choice mirrors BacklogBackend end-to-end (D2); `spec_client`/`session`
-mirror `gate_*` (D3); branch decoupling via template marker blocks + `create-new-feature.sh
---branch-only` at implement (D5); auto-create-task via a new typed `cloud_client.createTask`
-(not the backend-gated bash `add.sh`) (D6); § I preserved by mirroring `gate_contract` (D7);
-upgrade path defaults `specBackend` to `local` (D8).
+[research.md](./research.md). Headlines: SpecStore port scoped to cloud push/pull (local bypasses
+it, D1); init choice mirrors BacklogBackend end-to-end (D2); `spec_client`/`session` mirror `gate_*`
+(D3); branch decoupling via template marker blocks + `create-new-feature.sh
+--branch-only` at
+implement (D5); auto-create-task via a new typed `cloud_client.createTask` (not the backend-gated
+bash `add.sh`) (D6); § I preserved by mirroring `gate_contract` (D7); upgrade path defaults
+`specBackend` to `local` (D8).
 
 ## Phase 1 — Design & Contracts (done)
 
-- [data-model.md](./data-model.md) — SpecBackend, SpecStep, SpecStore/SpecCacheStore ports,
-  the installed.lock field, the cache layout, state transitions.
+- [data-model.md](./data-model.md) — SpecBackend, SpecStep, SpecStore/SpecCacheStore ports, the
+  installed.lock field, the cache layout, state transitions.
 - [contracts/spec-client.md](./contracts/spec-client.md) — the `/api/v1/specs*` calls the CLI
   makes + the `spec push`/`spec pull` command contract (exit codes mirroring `gate`).
-- [quickstart.md](./quickstart.md) — end-to-end local exercise (init both backends, cloud
-  specify, pull, push) with assertions.
+- [quickstart.md](./quickstart.md) — end-to-end local exercise (init both backends, cloud specify,
+  pull, push) with assertions.
 - Agent context file: none marked in this repo → step skipped.
 
 **Constitution re-check post-design**: still PASS — the cloud surface is opaque-keyed and
@@ -121,5 +122,5 @@ status-only; local parity is guarded by a golden-file test.
 
 ## Complexity Tracking
 
-No constitution violations — table not needed. The 7-harness fan-out is existing-pattern
-maintenance cost, not a new architectural violation.
+No constitution violations — table not needed. The 7-harness fan-out is existing-pattern maintenance
+cost, not a new architectural violation.

--- a/.specnaut/specs/020-cli-spec-backend/quickstart.md
+++ b/.specnaut/specs/020-cli-spec-backend/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart — CLI spec backend, exercised locally
+
+Runs against the working-tree CLI (`deno run --allow-all src/main.ts …`) using the
+test-sandbox skill, no compiled binary needed.
+
+## 1. Local backend — zero behaviour change
+
+```bash
+# init picking local (or --spec-backend local)
+deno run --allow-all src/main.ts init --here --ai claude --spec-backend local
+# installed.lock records spec_backend: local
+# `specify` writes .specnaut/specs/<n>/ files + creates a branch — exactly as today. [SC-002]
+```
+
+## 2. Cloud backend — init + authoring
+
+```bash
+deno run --allow-all src/main.ts init --here --ai claude --spec-backend cloud
+# installed.lock records spec_backend: cloud
+deno run --allow-all src/main.ts cloud login            # existing flow — reused, not new
+# Cloud-mode specify (agent-run): generates steps → spec push; NO branch, NO local spec files. [SC-003]
+```
+
+## 3. Pull a cloud spec into the gitignored cache
+
+```bash
+deno run --allow-all src/main.ts spec pull 154
+# writes .specnaut/specs/.cache/154/<order>-<slug>.md per step
+git check-ignore .specnaut/specs/.cache/154   # → path is ignored [SC-004]
+git status --porcelain | grep -c '.cache/'     # → 0 (never tracked) [SC-004]
+```
+
+## 4. Edit + push back
+
+```bash
+$EDITOR .specnaut/specs/.cache/154/1-specify.md
+deno run --allow-all src/main.ts spec push 154   # upsert; untouched tabs preserved (Lot 1 FR-011)
+```
+
+## 5. Offline / auth-failure behaviour
+
+```bash
+# with no network / expired token:
+deno run --allow-all src/main.ts spec pull 154
+# → reuses an existing cache if present, else exits non-zero with an actionable message.
+#   Never a partial or silently-empty spec. [SC-005]
+```
+
+## 6. Boundary check
+
+```bash
+# grep the cloud adapter surface for any private-half identifier → none; only /api/v1/specs*
+# and SpecStep{key,name,order,body} cross the wire. [SC-006, § I]
+```
+
+## 7. Upgrade path
+
+```bash
+# a pre-feature project (lock without spec_backend):
+deno run --allow-all src/main.ts upgrade --here
+# → spec_backend defaults to local; rendered specify.md is byte-identical to before. [FR-010]
+```
+
+## Automated coverage
+
+`deno task test` — `spec_store_test.ts`, `spec_client_test.ts` (fake fetch),
+`spec_cache_writer_test.ts`, `installed_lock` round-trip, a golden-file local-parity test on
+rendered `specify.md`, and integration tests for cloud specify (no files/branches, task
+auto-created) + the upgrade path.

--- a/.specnaut/specs/020-cli-spec-backend/quickstart.md
+++ b/.specnaut/specs/020-cli-spec-backend/quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart — CLI spec backend, exercised locally
 
-Runs against the working-tree CLI (`deno run --allow-all src/main.ts …`) using the
-test-sandbox skill, no compiled binary needed.
+Runs against the working-tree CLI (`deno run --allow-all src/main.ts …`) using the test-sandbox
+skill, no compiled binary needed.
 
 ## 1. Local backend — zero behaviour change
 

--- a/.specnaut/specs/020-cli-spec-backend/research.md
+++ b/.specnaut/specs/020-cli-spec-backend/research.md
@@ -1,74 +1,73 @@
 # Phase 0 Research — CLI pluggable spec backend
 
-From the architect design pass (47 reads over the live CLI). Every decision cites the
-existing sibling it mirrors, so the implementation follows established patterns, not priors.
+From the architect design pass (47 reads over the live CLI). Every decision cites the existing
+sibling it mirrors, so the implementation follows established patterns, not priors.
 
 ## D1 — SpecStore port scoped to cloud push/pull; local bypasses it
 
 **Decision**: The `SpecStore` port has just `pull(taskNumber)` / `push(taskNumber, steps)`.
-`CloudSpecStore` is the real implementation; `LocalSpecStore` returns a clear "local backend
-has no cloud spec to sync" error for both. The local `specify` authoring flow does **not**
-route through the port.
+`CloudSpecStore` is the real implementation; `LocalSpecStore` returns a clear "local backend has no
+cloud spec to sync" error for both. The local `specify` authoring flow does **not** route through
+the port.
 
 **Rationale**: Routing local authoring through the port would risk regressing FR-003's
-byte-identical guarantee for a feature local users get zero benefit from. `spec push/pull`
-are cloud-only verbs (per the spec's edge cases). Keeping the port narrow and symmetric.
+byte-identical guarantee for a feature local users get zero benefit from. `spec push/pull` are
+cloud-only verbs (per the spec's edge cases). Keeping the port narrow and symmetric.
 
-**Alternatives rejected**: a fat port that also owns local file writing (regression risk, no
-local upside).
+**Alternatives rejected**: a fat port that also owns local file writing (regression risk, no local
+upside).
 
 ## D2 — Init choice mirrors `BacklogBackend` end-to-end
 
-**Decision**: Add `SpecBackend = "local" | "cloud"` + `KNOWN_SPEC_BACKENDS` + a `specBackend`
-field / `spec_backend` YAML key to `installed_lock.ts` (absent → `"local"`, mirroring
+**Decision**: Add `SpecBackend = "local" | "cloud"` + `KNOWN_SPEC_BACKENDS` + a `specBackend` field
+/ `spec_backend` YAML key to `installed_lock.ts` (absent → `"local"`, mirroring
 `versionScheme`→`"semver"` at lines 87-93). New `spec_picker.ts` mirrors `backlog_picker.ts`
 (`DEFAULT_SPEC_BACKEND = "cloud"`, recommended marker, interactive + numeric). New
-`spec_strategies/{local,cloud}.ts` + `registry.ts`. `init_handler.ts` resolves it
-(flag → interactive → default) and threads it via `BundleOptions.specBackend`.
+`spec_strategies/{local,cloud}.ts` + `registry.ts`. `init_handler.ts` resolves it (flag →
+interactive → default) and threads it via `BundleOptions.specBackend`.
 
-**Rationale**: A proven, tested pattern; keeps the two backend choices symmetric and
-predictable. Backward-compatible default satisfies FR-010.
+**Rationale**: A proven, tested pattern; keeps the two backend choices symmetric and predictable.
+Backward-compatible default satisfies FR-010.
 
 ## D3 — `spec_client` / `SpecSession` mirror `gate_*`
 
-**Decision**: `src/domain/cloud/spec_client.ts` mirrors `gate_client.ts` (same `FetchFn`
-injection, `{base}/api/v1` prefix, status-only `SpecApiError`/`reasonForStatus`).
-`spec_session.ts` mirrors `gate_session.ts` (`SpecSession` wraps client + `TokenProvider` +
-`projectKey`; `makeSpecSession(config, store)` returns null when unlinked). Auth reuses
-`defaultCredentialStore()` — no new credential type (FR-007).
+**Decision**: `src/domain/cloud/spec_client.ts` mirrors `gate_client.ts` (same `FetchFn` injection,
+`{base}/api/v1` prefix, status-only `SpecApiError`/`reasonForStatus`). `spec_session.ts` mirrors
+`gate_session.ts` (`SpecSession` wraps client + `TokenProvider` + `projectKey`;
+`makeSpecSession(config, store)` returns null when unlinked). Auth reuses `defaultCredentialStore()`
+— no new credential type (FR-007).
 
 **Rationale**: `gate` is the exact analog (a versioned bearer-authed `/api/v1` surface). The
-existing Cloud-link file (`backlog-config.yml`, written unconditionally by `cloud login`) is
-reused regardless of `backlogBackend` — confirmed safe because gates already depend on it.
+existing Cloud-link file (`backlog-config.yml`, written unconditionally by `cloud login`) is reused
+regardless of `backlogBackend` — confirmed safe because gates already depend on it.
 
 ## D4 — `spec push` / `spec pull` commands mirror `gate`
 
 **Decision**: `parser.ts` gains a `spec` branch (`{kind:"spec", sub:"push"|"pull", task}`);
-`handlers/spec_handler.ts::runSpec` mirrors `gate_handler.ts` (deps built from
-`readCloudConfig` + `defaultCredentialStore()`; exit codes 5/1/0 as `gate`); `main.ts`
-`case "spec"`; `help.ts` entries.
+`handlers/spec_handler.ts::runSpec` mirrors `gate_handler.ts` (deps built from `readCloudConfig` +
+`defaultCredentialStore()`; exit codes 5/1/0 as `gate`); `main.ts` `case "spec"`; `help.ts` entries.
 
 **Rationale**: 1:1 with an existing, tested command family.
 
 ## D5 — Materialisation cache + gitignore
 
 **Decision**: A narrow `SpecCacheStore` port + `spec_cache_writer.ts` adapter writing
-`.specnaut/specs/.cache/<task>/<order>-<slug>.md`, clearing stale files first (US3 AC2). Add
-one line `.specnaut/specs/.cache/` to `templates/core/root/.gitignore` — already
+`.specnaut/specs/.cache/<task>/<order>-<slug>.md`, clearing stale files first (US3 AC2). Add one
+line `.specnaut/specs/.cache/` to `templates/core/root/.gitignore` — already
 `mergeBlock:"gitignore"`-reconciled on every init/upgrade, so no new writer logic.
 
-**Rationale**: Reuses the idempotent gitignore-merge; the cache is disposable and never the
-source of truth.
+**Rationale**: Reuses the idempotent gitignore-merge; the cache is disposable and never the source
+of truth.
 
 ## D6 — Branch decoupling + auto-create-task
 
-**Decision**: Cloud-mode authoring is controlled by `<!-- BEGIN: spec-backend=cloud -->`
-marker blocks in `specify.md` (no branch, no file writes → push instead) and `implement.md`
-(runs `create-new-feature.sh --branch-only` — the actual decoupling point), rendered by a new
+**Decision**: Cloud-mode authoring is controlled by `<!-- BEGIN: spec-backend=cloud -->` marker
+blocks in `specify.md` (no branch, no file writes → push instead) and `implement.md` (runs
+`create-new-feature.sh --branch-only` — the actual decoupling point), rendered by a new
 `renderSpecBackend` in `conditional_render.ts` + `spec_backend_filter.ts` wired into all 7
-harnesses. `create-new-feature.sh` gains `--branch-only`. Auto-create-when-unlinked uses a new
-typed `cloud_client.createTask(accessToken, projectKey, title)` (mirrors `createProject`),
-**not** the bash `add.sh` (which is `backlogBackend`-gated and may be absent).
+harnesses. `create-new-feature.sh` gains `--branch-only`. Auto-create-when-unlinked uses a new typed
+`cloud_client.createTask(accessToken, projectKey, title)` (mirrors `createProject`), **not** the
+bash `add.sh` (which is `backlogBackend`-gated and may be absent).
 
 **Rationale**: Keeps auto-creation inside the same compiled, typed client the push path uses,
 independent of the backlog backend; the template markers are the established conditional-render
@@ -77,23 +76,24 @@ mechanism.
 ## D7 — § I boundary
 
 **Decision**: `spec_contract.ts` mirrors `gate_contract.ts` — pure types, `parseSpec`/
-`parseSpecStep` guards that ignore unknown fields, errors keyed off HTTP status only
-(`SpecApiError` never carries a backend `error` string). Only `SpecStep{key,name,order,body}`
-crosses the wire — no CLI framework identifier.
+`parseSpecStep` guards that ignore unknown fields, errors keyed off HTTP status only (`SpecApiError`
+never carries a backend `error` string). Only `SpecStep{key,name,order,body}` crosses the wire — no
+CLI framework identifier.
 
 **Rationale**: The frozen boundary rule, already applied to gates.
 
 ## D8 — Upgrade path
 
-**Decision**: existing installs default `specBackend` to `"local"` on `parseLock`; `specnaut
-upgrade` re-bundles `specify.md`/`implement.md` with the local marker block → zero behavioural
-change. Guarded by an explicit upgrade-path integration test.
+**Decision**: existing installs default `specBackend` to `"local"` on `parseLock`;
+`specnaut
+upgrade` re-bundles `specify.md`/`implement.md` with the local marker block → zero
+behavioural change. Guarded by an explicit upgrade-path integration test.
 
 **Rationale**: Backward compatibility (FR-010) must be mechanically verified, not assumed.
 
 ## Open items carried to Kevin only if they become blocking (non-blocking defaults chosen)
 
-- Reuse the existing Cloud-link file for specs even when `backlogBackend: github` → **yes**
-  (matches how gates already work).
-- `cloud_client.createTask` over `POST /api/v1/tasks` → **yes** (already a shipped public
-  endpoint used by `add.sh`).
+- Reuse the existing Cloud-link file for specs even when `backlogBackend: github` → **yes** (matches
+  how gates already work).
+- `cloud_client.createTask` over `POST /api/v1/tasks` → **yes** (already a shipped public endpoint
+  used by `add.sh`).

--- a/.specnaut/specs/020-cli-spec-backend/research.md
+++ b/.specnaut/specs/020-cli-spec-backend/research.md
@@ -1,0 +1,99 @@
+# Phase 0 Research — CLI pluggable spec backend
+
+From the architect design pass (47 reads over the live CLI). Every decision cites the
+existing sibling it mirrors, so the implementation follows established patterns, not priors.
+
+## D1 — SpecStore port scoped to cloud push/pull; local bypasses it
+
+**Decision**: The `SpecStore` port has just `pull(taskNumber)` / `push(taskNumber, steps)`.
+`CloudSpecStore` is the real implementation; `LocalSpecStore` returns a clear "local backend
+has no cloud spec to sync" error for both. The local `specify` authoring flow does **not**
+route through the port.
+
+**Rationale**: Routing local authoring through the port would risk regressing FR-003's
+byte-identical guarantee for a feature local users get zero benefit from. `spec push/pull`
+are cloud-only verbs (per the spec's edge cases). Keeping the port narrow and symmetric.
+
+**Alternatives rejected**: a fat port that also owns local file writing (regression risk, no
+local upside).
+
+## D2 — Init choice mirrors `BacklogBackend` end-to-end
+
+**Decision**: Add `SpecBackend = "local" | "cloud"` + `KNOWN_SPEC_BACKENDS` + a `specBackend`
+field / `spec_backend` YAML key to `installed_lock.ts` (absent → `"local"`, mirroring
+`versionScheme`→`"semver"` at lines 87-93). New `spec_picker.ts` mirrors `backlog_picker.ts`
+(`DEFAULT_SPEC_BACKEND = "cloud"`, recommended marker, interactive + numeric). New
+`spec_strategies/{local,cloud}.ts` + `registry.ts`. `init_handler.ts` resolves it
+(flag → interactive → default) and threads it via `BundleOptions.specBackend`.
+
+**Rationale**: A proven, tested pattern; keeps the two backend choices symmetric and
+predictable. Backward-compatible default satisfies FR-010.
+
+## D3 — `spec_client` / `SpecSession` mirror `gate_*`
+
+**Decision**: `src/domain/cloud/spec_client.ts` mirrors `gate_client.ts` (same `FetchFn`
+injection, `{base}/api/v1` prefix, status-only `SpecApiError`/`reasonForStatus`).
+`spec_session.ts` mirrors `gate_session.ts` (`SpecSession` wraps client + `TokenProvider` +
+`projectKey`; `makeSpecSession(config, store)` returns null when unlinked). Auth reuses
+`defaultCredentialStore()` — no new credential type (FR-007).
+
+**Rationale**: `gate` is the exact analog (a versioned bearer-authed `/api/v1` surface). The
+existing Cloud-link file (`backlog-config.yml`, written unconditionally by `cloud login`) is
+reused regardless of `backlogBackend` — confirmed safe because gates already depend on it.
+
+## D4 — `spec push` / `spec pull` commands mirror `gate`
+
+**Decision**: `parser.ts` gains a `spec` branch (`{kind:"spec", sub:"push"|"pull", task}`);
+`handlers/spec_handler.ts::runSpec` mirrors `gate_handler.ts` (deps built from
+`readCloudConfig` + `defaultCredentialStore()`; exit codes 5/1/0 as `gate`); `main.ts`
+`case "spec"`; `help.ts` entries.
+
+**Rationale**: 1:1 with an existing, tested command family.
+
+## D5 — Materialisation cache + gitignore
+
+**Decision**: A narrow `SpecCacheStore` port + `spec_cache_writer.ts` adapter writing
+`.specnaut/specs/.cache/<task>/<order>-<slug>.md`, clearing stale files first (US3 AC2). Add
+one line `.specnaut/specs/.cache/` to `templates/core/root/.gitignore` — already
+`mergeBlock:"gitignore"`-reconciled on every init/upgrade, so no new writer logic.
+
+**Rationale**: Reuses the idempotent gitignore-merge; the cache is disposable and never the
+source of truth.
+
+## D6 — Branch decoupling + auto-create-task
+
+**Decision**: Cloud-mode authoring is controlled by `<!-- BEGIN: spec-backend=cloud -->`
+marker blocks in `specify.md` (no branch, no file writes → push instead) and `implement.md`
+(runs `create-new-feature.sh --branch-only` — the actual decoupling point), rendered by a new
+`renderSpecBackend` in `conditional_render.ts` + `spec_backend_filter.ts` wired into all 7
+harnesses. `create-new-feature.sh` gains `--branch-only`. Auto-create-when-unlinked uses a new
+typed `cloud_client.createTask(accessToken, projectKey, title)` (mirrors `createProject`),
+**not** the bash `add.sh` (which is `backlogBackend`-gated and may be absent).
+
+**Rationale**: Keeps auto-creation inside the same compiled, typed client the push path uses,
+independent of the backlog backend; the template markers are the established conditional-render
+mechanism.
+
+## D7 — § I boundary
+
+**Decision**: `spec_contract.ts` mirrors `gate_contract.ts` — pure types, `parseSpec`/
+`parseSpecStep` guards that ignore unknown fields, errors keyed off HTTP status only
+(`SpecApiError` never carries a backend `error` string). Only `SpecStep{key,name,order,body}`
+crosses the wire — no CLI framework identifier.
+
+**Rationale**: The frozen boundary rule, already applied to gates.
+
+## D8 — Upgrade path
+
+**Decision**: existing installs default `specBackend` to `"local"` on `parseLock`; `specnaut
+upgrade` re-bundles `specify.md`/`implement.md` with the local marker block → zero behavioural
+change. Guarded by an explicit upgrade-path integration test.
+
+**Rationale**: Backward compatibility (FR-010) must be mechanically verified, not assumed.
+
+## Open items carried to Kevin only if they become blocking (non-blocking defaults chosen)
+
+- Reuse the existing Cloud-link file for specs even when `backlogBackend: github` → **yes**
+  (matches how gates already work).
+- `cloud_client.createTask` over `POST /api/v1/tasks` → **yes** (already a shipped public
+  endpoint used by `add.sh`).

--- a/.specnaut/specs/020-cli-spec-backend/spec.md
+++ b/.specnaut/specs/020-cli-spec-backend/spec.md
@@ -1,0 +1,239 @@
+# Feature Specification: CLI pluggable spec backend + init choice (local | cloud)
+
+**Feature Branch**: `020-cli-spec-backend`
+**Created**: 2026-07-14
+**Status**: Draft
+**Input**: User description: "Lot 2 (cli#424) — add a second spec-storage backend to the Specnaut CLI, chosen at `specnaut init` like the backlog backend: `local` (current .specnaut/specs/ markdown, unchanged, first-class default) or `cloud` (recommended — specs hosted on SpecNaut Cloud via the versioned /api/v1/specs* contract from Lot 1). A SpecStore port with local + cloud adapters; `spec push` / `spec pull` commands; gitignored materialisation under .specnaut/specs/.cache/<task>/ so agents read plain files; cloud-mode `specify` pushes steps instead of writing local files and creates NO branch (branch decoupled to implement). The local backend must never be degraded. Boundary: the CLI talks to Cloud only through the versioned HTTP API — no private-half identifier enters the public CLI (§ I)."
+
+> **Design of record**: `docs/superpowers/specs/2026-07-14-cloud-hosted-specs-design.md` (monorepo). Backlog: epic `specnaut-monorepo#15`, this lot `specnaut-cli#424`. Depends on **Lot 1 (cloud#154, shipped)** — the `/api/v1/specs*` contract this consumes.
+> **Scope of THIS spec**: the CLI-side backend abstraction, the init choice, the `spec push`/`spec pull` commands, cloud-mode `specify`, and the gitignored materialisation. **Automatic** phase-entry pull, auto-generation at task creation, and parallel orchestration are **Lot 4** (cli#425).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Choose the spec backend at init (Priority: P1)
+
+When a user runs `specnaut init`, they are offered where specifications should be stored:
+**local** (markdown files in `.specnaut/specs/`, the current behaviour — the first-class
+default) or **cloud** (recommended — hosted on SpecNaut Cloud). The choice is recorded so
+every later command knows which backend is active. Mirrors the existing backlog-backend
+picker.
+
+**Why this priority**: Nothing else in this lot can key off a backend that isn't selected
+and persisted; this is the entry point and the MVP.
+
+**Independent Test**: run `init` and pick `local` → the recorded backend is `local` and
+`specify` writes files as today; run `init` and pick `cloud` (or press Enter for the
+recommended default) → the recorded backend is `cloud`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh `init`, **When** the user is prompted for a spec backend and presses
+   Enter, **Then** the recommended default (`cloud`) is selected and persisted.
+2. **Given** a fresh `init`, **When** the user picks `local`, **Then** `local` is persisted
+   and the CLI behaves exactly as it does today for all spec operations.
+3. **Given** a non-interactive `init` (flag/CI), **When** a spec-backend flag is supplied,
+   **Then** it is honoured without a prompt; absent, the default is used.
+
+---
+
+### User Story 2 - Cloud-mode `specify` pushes steps and creates no branch (Priority: P1)
+
+With the cloud backend active, running the spec-authoring flow generates the same step
+content as today but **sends it to SpecNaut Cloud** (attached to the backlog task) instead
+of writing `.specnaut/specs/` files, and **does not create a git branch**. This is what
+makes specs parallelisable — no dedicated branch per spec.
+
+**Why this priority**: This is the authoring half of the cloud path; without it the cloud
+backend can store nothing the CLI produces.
+
+**Independent Test**: with backend `cloud` and a linked task, run the authoring flow → the
+task's spec on Cloud gains the generated steps (verified by a read), no branch is created,
+and no `.specnaut/specs/<n>/` directory is written.
+
+**Acceptance Scenarios**:
+
+1. **Given** backend `cloud` and a linked task, **When** the authoring flow runs, **Then**
+   the generated steps are pushed to that task's cloud spec and no git branch is created.
+2. **Given** backend `local`, **When** the authoring flow runs, **Then** behaviour is
+   byte-identical to today (files written, branch per the existing hook).
+3. **Given** backend `cloud` and **no** linked task, **When** the authoring flow runs,
+   **Then** the CLI auto-creates a backlog task (from the feature name), links it, and
+   attaches the new spec to it — so the task and its spec are created together (no manual
+   pre-step). An explicit `--issue N` still overrides by attaching to that existing task.
+
+---
+
+### User Story 3 - Materialise a cloud spec for reading (`spec pull`) (Priority: P1)
+
+`specnaut spec pull <task>` fetches a task's cloud-hosted spec and writes its tabs as
+**gitignored** local files under `.specnaut/specs/.cache/<task>/`, so any downstream agent
+(developer, reviewer, QA) reads the spec as ordinary files — with **no** knowledge that it
+lives in the cloud. One fetch materialises the whole spec; the cache is disposable and
+never the source of truth.
+
+**Why this priority**: This is the reading half and the core mitigation of the "every agent
+must fetch online" risk — agents keep reading files; only `spec pull` talks to the network.
+
+**Independent Test**: with a task that has a cloud spec, run `spec pull <task>` → the tabs
+appear as ordered markdown files under `.specnaut/specs/.cache/<task>/`, the path is
+git-ignored, and re-running refreshes them without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task with a cloud spec, **When** `spec pull <task>` runs, **Then** each step
+   is written as an ordered markdown file under `.specnaut/specs/.cache/<task>/` and that
+   path is gitignored.
+2. **Given** a previously-pulled task, **When** `spec pull <task>` runs again, **Then** the
+   cache is refreshed to the current cloud state (stale files reconciled).
+3. **Given** no network/expired auth, **When** `spec pull` runs, **Then** it reuses an
+   existing cache if present, otherwise fails with an actionable message — never a partial
+   or silent empty spec.
+
+---
+
+### User Story 4 - Push local spec content to Cloud (`spec push`) (Priority: P2)
+
+`specnaut spec push <task>` sends spec content for a task to Cloud via the upsert-only
+contract (from a materialised cache edit or a locally-authored set), so a user who edited a
+tab locally can re-sync it. Upsert-only: it never deletes a tab it doesn't send (Lot 1
+FR-011).
+
+**Why this priority**: Useful for round-tripping edits, but the author (US2) and read (US3)
+paths already deliver the core loop; explicit re-push is a convenience.
+
+**Independent Test**: edit a materialised tab, run `spec push <task>` → the cloud spec
+reflects the edit as a new version, and tabs not included are left untouched.
+
+**Acceptance Scenarios**:
+
+1. **Given** an edited cache tab, **When** `spec push <task>` runs, **Then** the cloud spec
+   records the change (a new version) and untouched tabs are preserved.
+
+---
+
+### Edge Cases
+
+- **Backend `local`**: every spec operation behaves exactly as today — this lot adds no
+  friction and no new required flags on the local path.
+- **Cloud unreachable / token expired** on `push`/`pull`: actionable error (retry /
+  `login`); on `pull`, fall back to an existing cache; never implement against an empty spec.
+- **Cache vs cloud drift**: the cache is disposable; `spec pull` reconciles it to the cloud
+  state (the source of truth). A user is never asked to merge cache and cloud by hand.
+- **`.gitignore` already ignores `.specnaut/specs/.cache/`**: idempotent — no duplicate
+  entry; if missing, the cache path is added.
+- **Upgrading a project that predates this feature**: an existing install with no recorded
+  spec backend is treated as `local` (backward compatible — no behaviour change).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `specnaut init` MUST offer a spec-backend choice — `local` (first-class
+  default behaviour) or `cloud` (recommended default selection) — and MUST persist it to the
+  install record, mirroring the backlog-backend picker (interactive + non-interactive).
+- **FR-002**: The CLI MUST resolve spec operations through a single backend abstraction with
+  a `local` adapter (filesystem, current behaviour) and a `cloud` adapter (HTTP), selected
+  from the persisted choice.
+- **FR-003**: With backend `local`, all spec behaviour (authoring, file layout, branch
+  creation) MUST be byte-identical to the pre-feature CLI — no regression, no new required
+  flags.
+- **FR-004**: With backend `cloud`, the authoring flow MUST push generated steps to the
+  linked task's cloud spec via the versioned `/api/v1/specs*` contract and MUST NOT write
+  `.specnaut/specs/` files nor create a git branch.
+- **FR-005**: `specnaut spec pull <task>` MUST materialise a cloud spec's tabs as ordered
+  markdown files under `.specnaut/specs/.cache/<task>/`, and MUST ensure that path is
+  gitignored.
+- **FR-006**: `specnaut spec push <task>` MUST send spec content to Cloud using the
+  upsert-only contract (never deletes an omitted tab).
+- **FR-007**: The cloud adapter MUST authenticate using the CLI's existing Cloud credential
+  store (device/refresh tokens) — no new credential type.
+- **FR-008**: On a cloud `push`/`pull` failure (network/auth), the CLI MUST surface an
+  actionable message; `pull` MUST reuse an existing cache when present and MUST NOT leave a
+  partial or silently-empty spec.
+- **FR-009**: The cloud adapter MUST speak **only** the versioned public HTTP API. No
+  private-half identifier, type, or error string may enter the CLI (constitution § I).
+- **FR-010**: An install with no recorded spec backend MUST be treated as `local`
+  (backward-compatible upgrade path).
+- **FR-011**: In cloud mode, when the authoring flow runs with no linked task, the CLI MUST
+  auto-create a backlog task (named from the feature) and link it, then attach the spec — so
+  the task and its spec are created together. An explicit `--issue N` overrides by attaching
+  to that existing task.
+
+### Key Entities *(see Domain Model section below for full structure)*
+
+- **Spec backend selection**: the persisted `local | cloud` choice.
+- **Spec store**: the backend abstraction; two adapters (local fs, cloud HTTP).
+- **Materialisation cache**: gitignored local files mirroring a cloud spec for reading.
+
+## Domain Model *(mandatory)*
+
+**Bounded context:** Spec storage (CLI side) — how the Specnaut CLI stores and retrieves the
+specifications it authors.
+
+**Vocabulary (Ubiquitous language):**
+
+- **Spec backend** — where specs live: `local` (fs) or `cloud` (SpecNaut Cloud).
+- **Spec store** — the CLI abstraction over a backend (push / pull / read).
+- **Step / Tab** — one named markdown section of a spec (the framework phase), opaque to the
+  cloud.
+- **Materialisation cache** — gitignored local files under `.specnaut/specs/.cache/<task>/`
+  mirroring a cloud spec, so agents read files.
+- **Linked task** — the backlog task/epic a cloud spec attaches to (`projectKey` + number).
+
+**Entities (have identity):**
+
+- **Install record** [aggregate root] — the persisted project install (`installed.lock`);
+  now also carries the spec-backend selection.
+- **Materialisation cache** — identified by task; the on-disk mirror of a cloud spec.
+
+**Value objects (no identity, immutable):**
+
+- **SpecBackend("local" | "cloud")** — the backend choice; default `cloud`, `local` fully
+  supported.
+- **SpecStep(key, name, order, body)** — an opaque step exchanged with the cloud contract.
+
+**Invariants (rules the domain must never break):**
+
+- **Local parity** — with backend `local`, behaviour is identical to the pre-feature CLI.
+- **Cache is disposable** — the materialisation cache is gitignored and never the source of
+  truth; the cloud (or local files) is authoritative.
+- **API-only boundary** — the cloud adapter uses only the versioned HTTP API; no private-half
+  identifier crosses into the public CLI (§ I).
+- **No branch in cloud authoring** — cloud-mode `specify` never creates a git branch.
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- **Cloud spec store + API** — Lot 1 (cloud#154, shipped); this lot only consumes it.
+- **Web UI** — Lot 3 (cloud#155).
+- **Automatic phase-entry pull, auto-generation at task creation, parallel orchestration** —
+  Lot 4 (cli#425). This lot ships the manual `spec pull`/`push` commands and cloud `specify`;
+  wiring them automatically into every phase is Lot 4.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can select each backend at `init`; the choice persists and drives every
+  later spec operation.
+- **SC-002**: With backend `local`, the full existing spec test suite passes unchanged (zero
+  regressions).
+- **SC-003**: With backend `cloud`, authoring a spec results in the steps being retrievable
+  from Cloud and produces zero `.specnaut/specs/` files and zero new git branches.
+- **SC-004**: After `spec pull <task>`, an agent with no network access can read the full
+  spec as local files, and the cache path is gitignored (0 cache files ever tracked by git).
+- **SC-005**: A cloud `push`/`pull` under a broken connection yields an actionable error and
+  never a partial/empty spec.
+- **SC-006**: No CLI source file or wire payload references a private-half identifier (verified
+  by boundary review) — the only Cloud coupling is the versioned `/api/v1/specs*` contract.
+
+## Assumptions
+
+- Lot 1's `/api/v1/specs*` contract is available and stable (shipped).
+- The spec-backend choice is stored in the existing install record (`installed.lock`), like
+  the backlog backend; absence means `local` (backward compatible).
+- Cloud auth reuses the CLI's existing credential store (device/refresh tokens).
+- A cloud spec attaches to a backlog task; when cloud-mode `specify` runs with no linked
+  task, the CLI auto-creates and links one (FR-011, resolved) — an explicit `--issue N`
+  overrides.
+- Automatic phase-entry pull and parallel orchestration are Lot 4; this lot delivers the
+  backend, the init choice, the manual commands, and cloud `specify`.

--- a/.specnaut/specs/020-cli-spec-backend/spec.md
+++ b/.specnaut/specs/020-cli-spec-backend/spec.md
@@ -1,171 +1,176 @@
 # Feature Specification: CLI pluggable spec backend + init choice (local | cloud)
 
-**Feature Branch**: `020-cli-spec-backend`
-**Created**: 2026-07-14
-**Status**: Draft
-**Input**: User description: "Lot 2 (cli#424) — add a second spec-storage backend to the Specnaut CLI, chosen at `specnaut init` like the backlog backend: `local` (current .specnaut/specs/ markdown, unchanged, first-class default) or `cloud` (recommended — specs hosted on SpecNaut Cloud via the versioned /api/v1/specs* contract from Lot 1). A SpecStore port with local + cloud adapters; `spec push` / `spec pull` commands; gitignored materialisation under .specnaut/specs/.cache/<task>/ so agents read plain files; cloud-mode `specify` pushes steps instead of writing local files and creates NO branch (branch decoupled to implement). The local backend must never be degraded. Boundary: the CLI talks to Cloud only through the versioned HTTP API — no private-half identifier enters the public CLI (§ I)."
+**Feature Branch**: `020-cli-spec-backend` **Created**: 2026-07-14 **Status**: Draft **Input**: User
+description: "Lot 2 (cli#424) — add a second spec-storage backend to the Specnaut CLI, chosen at
+`specnaut init` like the backlog backend: `local` (current .specnaut/specs/ markdown, unchanged,
+first-class default) or `cloud` (recommended — specs hosted on SpecNaut Cloud via the versioned
+/api/v1/specs* contract from Lot 1). A SpecStore port with local + cloud adapters; `spec push` /
+`spec pull` commands; gitignored materialisation under .specnaut/specs/.cache/<task>/ so agents read
+plain files; cloud-mode `specify` pushes steps instead of writing local files and creates NO branch
+(branch decoupled to implement). The local backend must never be degraded. Boundary: the CLI talks
+to Cloud only through the versioned HTTP API — no private-half identifier enters the public CLI (§
+I)."
 
-> **Design of record**: `docs/superpowers/specs/2026-07-14-cloud-hosted-specs-design.md` (monorepo). Backlog: epic `specnaut-monorepo#15`, this lot `specnaut-cli#424`. Depends on **Lot 1 (cloud#154, shipped)** — the `/api/v1/specs*` contract this consumes.
-> **Scope of THIS spec**: the CLI-side backend abstraction, the init choice, the `spec push`/`spec pull` commands, cloud-mode `specify`, and the gitignored materialisation. **Automatic** phase-entry pull, auto-generation at task creation, and parallel orchestration are **Lot 4** (cli#425).
+> **Design of record**: `docs/superpowers/specs/2026-07-14-cloud-hosted-specs-design.md` (monorepo).
+> Backlog: epic `specnaut-monorepo#15`, this lot `specnaut-cli#424`. Depends on **Lot 1 (cloud#154,
+> shipped)** — the `/api/v1/specs*` contract this consumes. **Scope of THIS spec**: the CLI-side
+> backend abstraction, the init choice, the `spec push`/`spec pull` commands, cloud-mode `specify`,
+> and the gitignored materialisation. **Automatic** phase-entry pull, auto-generation at task
+> creation, and parallel orchestration are **Lot 4** (cli#425).
 
-## User Scenarios & Testing *(mandatory)*
+## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Choose the spec backend at init (Priority: P1)
 
-When a user runs `specnaut init`, they are offered where specifications should be stored:
-**local** (markdown files in `.specnaut/specs/`, the current behaviour — the first-class
-default) or **cloud** (recommended — hosted on SpecNaut Cloud). The choice is recorded so
-every later command knows which backend is active. Mirrors the existing backlog-backend
-picker.
+When a user runs `specnaut init`, they are offered where specifications should be stored: **local**
+(markdown files in `.specnaut/specs/`, the current behaviour — the first-class default) or **cloud**
+(recommended — hosted on SpecNaut Cloud). The choice is recorded so every later command knows which
+backend is active. Mirrors the existing backlog-backend picker.
 
-**Why this priority**: Nothing else in this lot can key off a backend that isn't selected
-and persisted; this is the entry point and the MVP.
+**Why this priority**: Nothing else in this lot can key off a backend that isn't selected and
+persisted; this is the entry point and the MVP.
 
-**Independent Test**: run `init` and pick `local` → the recorded backend is `local` and
-`specify` writes files as today; run `init` and pick `cloud` (or press Enter for the
-recommended default) → the recorded backend is `cloud`.
+**Independent Test**: run `init` and pick `local` → the recorded backend is `local` and `specify`
+writes files as today; run `init` and pick `cloud` (or press Enter for the recommended default) →
+the recorded backend is `cloud`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a fresh `init`, **When** the user is prompted for a spec backend and presses
-   Enter, **Then** the recommended default (`cloud`) is selected and persisted.
-2. **Given** a fresh `init`, **When** the user picks `local`, **Then** `local` is persisted
-   and the CLI behaves exactly as it does today for all spec operations.
-3. **Given** a non-interactive `init` (flag/CI), **When** a spec-backend flag is supplied,
-   **Then** it is honoured without a prompt; absent, the default is used.
+1. **Given** a fresh `init`, **When** the user is prompted for a spec backend and presses Enter,
+   **Then** the recommended default (`cloud`) is selected and persisted.
+2. **Given** a fresh `init`, **When** the user picks `local`, **Then** `local` is persisted and the
+   CLI behaves exactly as it does today for all spec operations.
+3. **Given** a non-interactive `init` (flag/CI), **When** a spec-backend flag is supplied, **Then**
+   it is honoured without a prompt; absent, the default is used.
 
 ---
 
 ### User Story 2 - Cloud-mode `specify` pushes steps and creates no branch (Priority: P1)
 
-With the cloud backend active, running the spec-authoring flow generates the same step
-content as today but **sends it to SpecNaut Cloud** (attached to the backlog task) instead
-of writing `.specnaut/specs/` files, and **does not create a git branch**. This is what
-makes specs parallelisable — no dedicated branch per spec.
+With the cloud backend active, running the spec-authoring flow generates the same step content as
+today but **sends it to SpecNaut Cloud** (attached to the backlog task) instead of writing
+`.specnaut/specs/` files, and **does not create a git branch**. This is what makes specs
+parallelisable — no dedicated branch per spec.
 
-**Why this priority**: This is the authoring half of the cloud path; without it the cloud
-backend can store nothing the CLI produces.
+**Why this priority**: This is the authoring half of the cloud path; without it the cloud backend
+can store nothing the CLI produces.
 
-**Independent Test**: with backend `cloud` and a linked task, run the authoring flow → the
-task's spec on Cloud gains the generated steps (verified by a read), no branch is created,
-and no `.specnaut/specs/<n>/` directory is written.
+**Independent Test**: with backend `cloud` and a linked task, run the authoring flow → the task's
+spec on Cloud gains the generated steps (verified by a read), no branch is created, and no
+`.specnaut/specs/<n>/` directory is written.
 
 **Acceptance Scenarios**:
 
-1. **Given** backend `cloud` and a linked task, **When** the authoring flow runs, **Then**
-   the generated steps are pushed to that task's cloud spec and no git branch is created.
-2. **Given** backend `local`, **When** the authoring flow runs, **Then** behaviour is
-   byte-identical to today (files written, branch per the existing hook).
-3. **Given** backend `cloud` and **no** linked task, **When** the authoring flow runs,
-   **Then** the CLI auto-creates a backlog task (from the feature name), links it, and
-   attaches the new spec to it — so the task and its spec are created together (no manual
-   pre-step). An explicit `--issue N` still overrides by attaching to that existing task.
+1. **Given** backend `cloud` and a linked task, **When** the authoring flow runs, **Then** the
+   generated steps are pushed to that task's cloud spec and no git branch is created.
+2. **Given** backend `local`, **When** the authoring flow runs, **Then** behaviour is byte-identical
+   to today (files written, branch per the existing hook).
+3. **Given** backend `cloud` and **no** linked task, **When** the authoring flow runs, **Then** the
+   CLI auto-creates a backlog task (from the feature name), links it, and attaches the new spec to
+   it — so the task and its spec are created together (no manual pre-step). An explicit `--issue N`
+   still overrides by attaching to that existing task.
 
 ---
 
 ### User Story 3 - Materialise a cloud spec for reading (`spec pull`) (Priority: P1)
 
-`specnaut spec pull <task>` fetches a task's cloud-hosted spec and writes its tabs as
-**gitignored** local files under `.specnaut/specs/.cache/<task>/`, so any downstream agent
-(developer, reviewer, QA) reads the spec as ordinary files — with **no** knowledge that it
-lives in the cloud. One fetch materialises the whole spec; the cache is disposable and
-never the source of truth.
+`specnaut spec pull <task>` fetches a task's cloud-hosted spec and writes its tabs as **gitignored**
+local files under `.specnaut/specs/.cache/<task>/`, so any downstream agent (developer, reviewer,
+QA) reads the spec as ordinary files — with **no** knowledge that it lives in the cloud. One fetch
+materialises the whole spec; the cache is disposable and never the source of truth.
 
-**Why this priority**: This is the reading half and the core mitigation of the "every agent
-must fetch online" risk — agents keep reading files; only `spec pull` talks to the network.
+**Why this priority**: This is the reading half and the core mitigation of the "every agent must
+fetch online" risk — agents keep reading files; only `spec pull` talks to the network.
 
-**Independent Test**: with a task that has a cloud spec, run `spec pull <task>` → the tabs
-appear as ordered markdown files under `.specnaut/specs/.cache/<task>/`, the path is
-git-ignored, and re-running refreshes them without error.
+**Independent Test**: with a task that has a cloud spec, run `spec pull <task>` → the tabs appear as
+ordered markdown files under `.specnaut/specs/.cache/<task>/`, the path is git-ignored, and
+re-running refreshes them without error.
 
 **Acceptance Scenarios**:
 
-1. **Given** a task with a cloud spec, **When** `spec pull <task>` runs, **Then** each step
-   is written as an ordered markdown file under `.specnaut/specs/.cache/<task>/` and that
-   path is gitignored.
-2. **Given** a previously-pulled task, **When** `spec pull <task>` runs again, **Then** the
-   cache is refreshed to the current cloud state (stale files reconciled).
-3. **Given** no network/expired auth, **When** `spec pull` runs, **Then** it reuses an
-   existing cache if present, otherwise fails with an actionable message — never a partial
-   or silent empty spec.
+1. **Given** a task with a cloud spec, **When** `spec pull <task>` runs, **Then** each step is
+   written as an ordered markdown file under `.specnaut/specs/.cache/<task>/` and that path is
+   gitignored.
+2. **Given** a previously-pulled task, **When** `spec pull <task>` runs again, **Then** the cache is
+   refreshed to the current cloud state (stale files reconciled).
+3. **Given** no network/expired auth, **When** `spec pull` runs, **Then** it reuses an existing
+   cache if present, otherwise fails with an actionable message — never a partial or silent empty
+   spec.
 
 ---
 
 ### User Story 4 - Push local spec content to Cloud (`spec push`) (Priority: P2)
 
-`specnaut spec push <task>` sends spec content for a task to Cloud via the upsert-only
-contract (from a materialised cache edit or a locally-authored set), so a user who edited a
-tab locally can re-sync it. Upsert-only: it never deletes a tab it doesn't send (Lot 1
-FR-011).
+`specnaut spec push <task>` sends spec content for a task to Cloud via the upsert-only contract
+(from a materialised cache edit or a locally-authored set), so a user who edited a tab locally can
+re-sync it. Upsert-only: it never deletes a tab it doesn't send (Lot 1 FR-011).
 
-**Why this priority**: Useful for round-tripping edits, but the author (US2) and read (US3)
-paths already deliver the core loop; explicit re-push is a convenience.
+**Why this priority**: Useful for round-tripping edits, but the author (US2) and read (US3) paths
+already deliver the core loop; explicit re-push is a convenience.
 
-**Independent Test**: edit a materialised tab, run `spec push <task>` → the cloud spec
-reflects the edit as a new version, and tabs not included are left untouched.
+**Independent Test**: edit a materialised tab, run `spec push <task>` → the cloud spec reflects the
+edit as a new version, and tabs not included are left untouched.
 
 **Acceptance Scenarios**:
 
-1. **Given** an edited cache tab, **When** `spec push <task>` runs, **Then** the cloud spec
-   records the change (a new version) and untouched tabs are preserved.
+1. **Given** an edited cache tab, **When** `spec push <task>` runs, **Then** the cloud spec records
+   the change (a new version) and untouched tabs are preserved.
 
 ---
 
 ### Edge Cases
 
-- **Backend `local`**: every spec operation behaves exactly as today — this lot adds no
-  friction and no new required flags on the local path.
-- **Cloud unreachable / token expired** on `push`/`pull`: actionable error (retry /
-  `login`); on `pull`, fall back to an existing cache; never implement against an empty spec.
-- **Cache vs cloud drift**: the cache is disposable; `spec pull` reconciles it to the cloud
-  state (the source of truth). A user is never asked to merge cache and cloud by hand.
-- **`.gitignore` already ignores `.specnaut/specs/.cache/`**: idempotent — no duplicate
-  entry; if missing, the cache path is added.
-- **Upgrading a project that predates this feature**: an existing install with no recorded
-  spec backend is treated as `local` (backward compatible — no behaviour change).
+- **Backend `local`**: every spec operation behaves exactly as today — this lot adds no friction and
+  no new required flags on the local path.
+- **Cloud unreachable / token expired** on `push`/`pull`: actionable error (retry / `login`); on
+  `pull`, fall back to an existing cache; never implement against an empty spec.
+- **Cache vs cloud drift**: the cache is disposable; `spec pull` reconciles it to the cloud state
+  (the source of truth). A user is never asked to merge cache and cloud by hand.
+- **`.gitignore` already ignores `.specnaut/specs/.cache/`**: idempotent — no duplicate entry; if
+  missing, the cache path is added.
+- **Upgrading a project that predates this feature**: an existing install with no recorded spec
+  backend is treated as `local` (backward compatible — no behaviour change).
 
-## Requirements *(mandatory)*
+## Requirements _(mandatory)_
 
 ### Functional Requirements
 
-- **FR-001**: `specnaut init` MUST offer a spec-backend choice — `local` (first-class
-  default behaviour) or `cloud` (recommended default selection) — and MUST persist it to the
-  install record, mirroring the backlog-backend picker (interactive + non-interactive).
-- **FR-002**: The CLI MUST resolve spec operations through a single backend abstraction with
-  a `local` adapter (filesystem, current behaviour) and a `cloud` adapter (HTTP), selected
-  from the persisted choice.
-- **FR-003**: With backend `local`, all spec behaviour (authoring, file layout, branch
-  creation) MUST be byte-identical to the pre-feature CLI — no regression, no new required
-  flags.
-- **FR-004**: With backend `cloud`, the authoring flow MUST push generated steps to the
-  linked task's cloud spec via the versioned `/api/v1/specs*` contract and MUST NOT write
+- **FR-001**: `specnaut init` MUST offer a spec-backend choice — `local` (first-class default
+  behaviour) or `cloud` (recommended default selection) — and MUST persist it to the install record,
+  mirroring the backlog-backend picker (interactive + non-interactive).
+- **FR-002**: The CLI MUST resolve spec operations through a single backend abstraction with a
+  `local` adapter (filesystem, current behaviour) and a `cloud` adapter (HTTP), selected from the
+  persisted choice.
+- **FR-003**: With backend `local`, all spec behaviour (authoring, file layout, branch creation)
+  MUST be byte-identical to the pre-feature CLI — no regression, no new required flags.
+- **FR-004**: With backend `cloud`, the authoring flow MUST push generated steps to the linked
+  task's cloud spec via the versioned `/api/v1/specs*` contract and MUST NOT write
   `.specnaut/specs/` files nor create a git branch.
-- **FR-005**: `specnaut spec pull <task>` MUST materialise a cloud spec's tabs as ordered
-  markdown files under `.specnaut/specs/.cache/<task>/`, and MUST ensure that path is
-  gitignored.
-- **FR-006**: `specnaut spec push <task>` MUST send spec content to Cloud using the
-  upsert-only contract (never deletes an omitted tab).
-- **FR-007**: The cloud adapter MUST authenticate using the CLI's existing Cloud credential
-  store (device/refresh tokens) — no new credential type.
-- **FR-008**: On a cloud `push`/`pull` failure (network/auth), the CLI MUST surface an
-  actionable message; `pull` MUST reuse an existing cache when present and MUST NOT leave a
-  partial or silently-empty spec.
-- **FR-009**: The cloud adapter MUST speak **only** the versioned public HTTP API. No
-  private-half identifier, type, or error string may enter the CLI (constitution § I).
+- **FR-005**: `specnaut spec pull <task>` MUST materialise a cloud spec's tabs as ordered markdown
+  files under `.specnaut/specs/.cache/<task>/`, and MUST ensure that path is gitignored.
+- **FR-006**: `specnaut spec push <task>` MUST send spec content to Cloud using the upsert-only
+  contract (never deletes an omitted tab).
+- **FR-007**: The cloud adapter MUST authenticate using the CLI's existing Cloud credential store
+  (device/refresh tokens) — no new credential type.
+- **FR-008**: On a cloud `push`/`pull` failure (network/auth), the CLI MUST surface an actionable
+  message; `pull` MUST reuse an existing cache when present and MUST NOT leave a partial or
+  silently-empty spec.
+- **FR-009**: The cloud adapter MUST speak **only** the versioned public HTTP API. No private-half
+  identifier, type, or error string may enter the CLI (constitution § I).
 - **FR-010**: An install with no recorded spec backend MUST be treated as `local`
   (backward-compatible upgrade path).
 - **FR-011**: In cloud mode, when the authoring flow runs with no linked task, the CLI MUST
-  auto-create a backlog task (named from the feature) and link it, then attach the spec — so
-  the task and its spec are created together. An explicit `--issue N` overrides by attaching
-  to that existing task.
+  auto-create a backlog task (named from the feature) and link it, then attach the spec — so the
+  task and its spec are created together. An explicit `--issue N` overrides by attaching to that
+  existing task.
 
-### Key Entities *(see Domain Model section below for full structure)*
+### Key Entities _(see Domain Model section below for full structure)_
 
 - **Spec backend selection**: the persisted `local | cloud` choice.
 - **Spec store**: the backend abstraction; two adapters (local fs, cloud HTTP).
 - **Materialisation cache**: gitignored local files mirroring a cloud spec for reading.
 
-## Domain Model *(mandatory)*
+## Domain Model _(mandatory)_
 
 **Bounded context:** Spec storage (CLI side) — how the Specnaut CLI stores and retrieves the
 specifications it authors.
@@ -174,29 +179,27 @@ specifications it authors.
 
 - **Spec backend** — where specs live: `local` (fs) or `cloud` (SpecNaut Cloud).
 - **Spec store** — the CLI abstraction over a backend (push / pull / read).
-- **Step / Tab** — one named markdown section of a spec (the framework phase), opaque to the
-  cloud.
+- **Step / Tab** — one named markdown section of a spec (the framework phase), opaque to the cloud.
 - **Materialisation cache** — gitignored local files under `.specnaut/specs/.cache/<task>/`
   mirroring a cloud spec, so agents read files.
 - **Linked task** — the backlog task/epic a cloud spec attaches to (`projectKey` + number).
 
 **Entities (have identity):**
 
-- **Install record** [aggregate root] — the persisted project install (`installed.lock`);
-  now also carries the spec-backend selection.
+- **Install record** [aggregate root] — the persisted project install (`installed.lock`); now also
+  carries the spec-backend selection.
 - **Materialisation cache** — identified by task; the on-disk mirror of a cloud spec.
 
 **Value objects (no identity, immutable):**
 
-- **SpecBackend("local" | "cloud")** — the backend choice; default `cloud`, `local` fully
-  supported.
+- **SpecBackend("local" | "cloud")** — the backend choice; default `cloud`, `local` fully supported.
 - **SpecStep(key, name, order, body)** — an opaque step exchanged with the cloud contract.
 
 **Invariants (rules the domain must never break):**
 
 - **Local parity** — with backend `local`, behaviour is identical to the pre-feature CLI.
-- **Cache is disposable** — the materialisation cache is gitignored and never the source of
-  truth; the cloud (or local files) is authoritative.
+- **Cache is disposable** — the materialisation cache is gitignored and never the source of truth;
+  the cloud (or local files) is authoritative.
 - **API-only boundary** — the cloud adapter uses only the versioned HTTP API; no private-half
   identifier crosses into the public CLI (§ I).
 - **No branch in cloud authoring** — cloud-mode `specify` never creates a git branch.
@@ -205,35 +208,34 @@ specifications it authors.
 
 - **Cloud spec store + API** — Lot 1 (cloud#154, shipped); this lot only consumes it.
 - **Web UI** — Lot 3 (cloud#155).
-- **Automatic phase-entry pull, auto-generation at task creation, parallel orchestration** —
-  Lot 4 (cli#425). This lot ships the manual `spec pull`/`push` commands and cloud `specify`;
-  wiring them automatically into every phase is Lot 4.
+- **Automatic phase-entry pull, auto-generation at task creation, parallel orchestration** — Lot 4
+  (cli#425). This lot ships the manual `spec pull`/`push` commands and cloud `specify`; wiring them
+  automatically into every phase is Lot 4.
 
-## Success Criteria *(mandatory)*
+## Success Criteria _(mandatory)_
 
 ### Measurable Outcomes
 
-- **SC-001**: A user can select each backend at `init`; the choice persists and drives every
-  later spec operation.
+- **SC-001**: A user can select each backend at `init`; the choice persists and drives every later
+  spec operation.
 - **SC-002**: With backend `local`, the full existing spec test suite passes unchanged (zero
   regressions).
-- **SC-003**: With backend `cloud`, authoring a spec results in the steps being retrievable
-  from Cloud and produces zero `.specnaut/specs/` files and zero new git branches.
-- **SC-004**: After `spec pull <task>`, an agent with no network access can read the full
-  spec as local files, and the cache path is gitignored (0 cache files ever tracked by git).
-- **SC-005**: A cloud `push`/`pull` under a broken connection yields an actionable error and
-  never a partial/empty spec.
-- **SC-006**: No CLI source file or wire payload references a private-half identifier (verified
-  by boundary review) — the only Cloud coupling is the versioned `/api/v1/specs*` contract.
+- **SC-003**: With backend `cloud`, authoring a spec results in the steps being retrievable from
+  Cloud and produces zero `.specnaut/specs/` files and zero new git branches.
+- **SC-004**: After `spec pull <task>`, an agent with no network access can read the full spec as
+  local files, and the cache path is gitignored (0 cache files ever tracked by git).
+- **SC-005**: A cloud `push`/`pull` under a broken connection yields an actionable error and never a
+  partial/empty spec.
+- **SC-006**: No CLI source file or wire payload references a private-half identifier (verified by
+  boundary review) — the only Cloud coupling is the versioned `/api/v1/specs*` contract.
 
 ## Assumptions
 
 - Lot 1's `/api/v1/specs*` contract is available and stable (shipped).
-- The spec-backend choice is stored in the existing install record (`installed.lock`), like
-  the backlog backend; absence means `local` (backward compatible).
+- The spec-backend choice is stored in the existing install record (`installed.lock`), like the
+  backlog backend; absence means `local` (backward compatible).
 - Cloud auth reuses the CLI's existing credential store (device/refresh tokens).
-- A cloud spec attaches to a backlog task; when cloud-mode `specify` runs with no linked
-  task, the CLI auto-creates and links one (FR-011, resolved) — an explicit `--issue N`
-  overrides.
-- Automatic phase-entry pull and parallel orchestration are Lot 4; this lot delivers the
-  backend, the init choice, the manual commands, and cloud `specify`.
+- A cloud spec attaches to a backlog task; when cloud-mode `specify` runs with no linked task, the
+  CLI auto-creates and links one (FR-011, resolved) — an explicit `--issue N` overrides.
+- Automatic phase-entry pull and parallel orchestration are Lot 4; this lot delivers the backend,
+  the init choice, the manual commands, and cloud `specify`.

--- a/.specnaut/specs/020-cli-spec-backend/tasks.md
+++ b/.specnaut/specs/020-cli-spec-backend/tasks.md
@@ -14,20 +14,20 @@ are P1; US4 (push) is P2. Paths relative to `apps/specnaut-cli/`.
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm `deno task test` harness + fake-fetch/fake-fs patterns (see
+- [X] T001 Confirm `deno task test` harness + fake-fetch/fake-fs patterns (see
       `tests/unit/*gate*`, `tests/**`); no new deps.
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-- [ ] T002 Add `SpecBackend = "local"|"cloud"`, `KNOWN_SPEC_BACKENDS`, the `specBackend`
+- [X] T002 Add `SpecBackend = "local"|"cloud"`, `KNOWN_SPEC_BACKENDS`, the `specBackend`
       field + `spec_backend` YAML key to `src/domain/installed_lock.ts`; `parseLock` defaults
       to `"local"` when absent (mirror `versionScheme`). [FR-001/010]
-- [ ] T003 [P] Create `src/domain/spec/spec_step.ts` — `SpecStep{key,name,order,body}`.
-- [ ] T004 [P] Add `SpecStore` + `SpecCacheStore` ports and `BundleOptions.specBackend` to
+- [X] T003 [P] Create `src/domain/spec/spec_step.ts` — `SpecStep{key,name,order,body}`.
+- [X] T004 [P] Add `SpecStore` + `SpecCacheStore` ports and `BundleOptions.specBackend` to
       `src/application/ports.ts` (per data-model.md).
-- [ ] T005 [US-foundation] Test: `tests/unit/installed_lock_spec_backend_test.ts` — round-trip
+- [X] T005 [US-foundation] Test: `tests/unit/installed_lock_spec_backend_test.ts` — round-trip
       write/parse of `spec_backend`; absent → `"local"`. [FR-010]
 
 **Checkpoint**: types + ports + lock field ready.
@@ -41,21 +41,21 @@ selection), persists it, and local stays byte-identical (FR-001/003, SC-001/002)
 
 ### Tests for US1
 
-- [ ] T006 [P] [US1] `tests/unit/spec_picker_test.ts` — default (Enter) → `cloud`; numeric
+- [X] T006 [P] [US1] `tests/unit/spec_picker_test.ts` — default (Enter) → `cloud`; numeric
       pick → chosen; invalid re-prompts. Mirror `backlog_picker` tests. [SC-001]
-- [ ] T007 [P] [US1] `tests/unit/spec_backend_filter_golden_test.ts` — the `local`-rendered
+- [X] T007 [P] [US1] `tests/unit/spec_backend_filter_golden_test.ts` — the `local`-rendered
       `specify.md` is **byte-identical** to the pre-feature bundle output. [SC-002]
 
 ### Implementation for US1
 
-- [ ] T008 [US1] Create `src/cli/spec_picker.ts` (`DEFAULT_SPEC_BACKEND="cloud"`, recommended
+- [X] T008 [US1] Create `src/cli/spec_picker.ts` (`DEFAULT_SPEC_BACKEND="cloud"`, recommended
       marker, `pickSpecBackend` + `pickSpecBackendInteractive`) — mirror `backlog_picker.ts`.
-- [ ] T009 [US1] Create `src/domain/spec_strategies/{local,cloud}.ts` + `registry.ts`
+- [X] T009 [US1] Create `src/domain/spec_strategies/{local,cloud}.ts` + `registry.ts`
       (`SpecBackendStrategy`: displayName + init copy).
-- [ ] T010 [US1] Add `renderSpecBackend` to `src/domain/conditional_render.ts` and create
+- [X] T010 [US1] Add `renderSpecBackend` to `src/domain/conditional_render.ts` and create
       `src/infrastructure/harness/spec_backend_filter.ts` (`applySpecBackend`); wire it into all
       7 harness `mapBundle`s (claude/cursor/codex/copilot/windsurf/opencode/antigravity).
-- [ ] T011 [US1] Resolve + thread `specBackend` (flag → interactive → default) in
+- [X] T011 [US1] Resolve + thread `specBackend` (flag → interactive → default) in
       `src/cli/handlers/init_handler.ts`, `src/cli/parser.ts` (`--spec-backend`), and
       `src/application/init_project.ts` (`mapBundle` options). Update `src/cli/help.ts`.
 
@@ -70,22 +70,22 @@ a task when none is linked (FR-004/011, SC-003).
 
 ### Tests for US2
 
-- [ ] T012 [P] [US2] `tests/unit/spec_client_test.ts` — POST/GET/PUT calls, status-only errors,
+- [X] T012 [P] [US2] `tests/unit/spec_client_test.ts` — POST/GET/PUT calls, status-only errors,
       no `_id`/backend-error leakage. Fake fetch. [SC-006]
-- [ ] T013 [P] [US2] `tests/integration/cloud_specify_test.ts` — cloud-mode authoring pushes
+- [X] T013 [P] [US2] `tests/integration/cloud_specify_test.ts` — cloud-mode authoring pushes
       steps, writes **zero** `.specnaut/specs/` files, creates **zero** branches, and
       auto-creates+links a task when none linked. [SC-003, FR-011]
 
 ### Implementation for US2
 
-- [ ] T014 [P] [US2] Create `src/domain/cloud/spec_contract.ts` (pure types + parse guards,
+- [X] T014 [P] [US2] Create `src/domain/cloud/spec_contract.ts` (pure types + parse guards,
       mirror `gate_contract.ts`). [§ I]
-- [ ] T015 [US2] Create `src/domain/cloud/spec_client.ts` (`/api/v1/specs*`, mirror
+- [X] T015 [US2] Create `src/domain/cloud/spec_client.ts` (`/api/v1/specs*`, mirror
       `gate_client.ts`) and `src/domain/cloud/spec_session.ts` (`SpecSession`/`makeSpecSession`,
       mirror `gate_session.ts`; reuse credential store + Cloud-link file).
-- [ ] T016 [US2] Add `createTask(accessToken, projectKey, title)` to
+- [X] T016 [US2] Add `createTask(accessToken, projectKey, title)` to
       `src/domain/cloud/cloud_client.ts` (mirror `createProject`; `POST /api/v1/tasks`).
-- [ ] T017 [US2] Edit `templates/core/skills/specnaut/phases/specify.md` +
+- [X] T017 [US2] Edit `templates/core/skills/specnaut/phases/specify.md` +
       `implement.md` with `spec-backend=local|cloud` marker blocks (cloud specify: push, no
       branch, no files; cloud implement: `create-new-feature.sh --branch-only`); add
       `--branch-only` to `templates/core/specnaut/scripts/bash/create-new-feature.sh`.
@@ -101,18 +101,18 @@ a task when none is linked (FR-004/011, SC-003).
 
 ### Tests for US3
 
-- [ ] T018 [P] [US3] `tests/unit/spec_cache_writer_test.ts` — writes ordered files, clears
+- [X] T018 [P] [US3] `tests/unit/spec_cache_writer_test.ts` — writes ordered files, clears
       stale on re-pull, path layout `.cache/<task>/<order>-<slug>.md`. [SC-004]
-- [ ] T019 [P] [US3] `tests/unit/spec_store_test.ts` — `CloudSpecStore.pull` (fake session),
+- [X] T019 [P] [US3] `tests/unit/spec_store_test.ts` — `CloudSpecStore.pull` (fake session),
       `LocalSpecStore` verbs fail with a clear cloud-only message. [FR-002]
 
 ### Implementation for US3
 
-- [ ] T020 [US3] Create `src/infrastructure/spec/{local_spec_store,cloud_spec_store}.ts`
+- [X] T020 [US3] Create `src/infrastructure/spec/{local_spec_store,cloud_spec_store}.ts`
       (implement `SpecStore`).
-- [ ] T021 [US3] Create `src/infrastructure/spec/spec_cache_writer.ts` (`SpecCacheStore`);
+- [X] T021 [US3] Create `src/infrastructure/spec/spec_cache_writer.ts` (`SpecCacheStore`);
       add `.specnaut/specs/.cache/` to `templates/core/root/.gitignore`.
-- [ ] T022 [US3] Wire `spec pull <task>`: `parser.ts` (`spec` branch),
+- [X] T022 [US3] Wire `spec pull <task>`: `parser.ts` (`spec` branch),
       `src/cli/handlers/spec_handler.ts::runSpec` (mirror `gate_handler.ts`; offline → reuse
       cache or actionable error, FR-008), `main.ts` `case "spec"`, `help.ts`. [SC-005]
 
@@ -122,18 +122,18 @@ a task when none is linked (FR-004/011, SC-003).
 
 ## Phase 6: User Story 4 — Push local spec content (`spec push`) (Priority: P2)
 
-- [ ] T023 [US4] Implement `spec push <task>` in the same `spec_handler.ts` (`CloudSpecStore.push`,
+- [X] T023 [US4] Implement `spec push <task>` in the same `spec_handler.ts` (`CloudSpecStore.push`,
       upsert-only); print pushed step count. [FR-006]
-- [ ] T024 [P] [US4] `tests/integration/spec_push_pull_test.ts` — edit a cached tab → push →
+- [X] T024 [P] [US4] `tests/integration/spec_push_pull_test.ts` — edit a cached tab → push →
       cloud reflects it; untouched tabs preserved.
 
 ---
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T025 [P] `tests/integration/upgrade_spec_backend_test.ts` — pre-feature lock → `upgrade`
+- [X] T025 [P] `tests/integration/upgrade_spec_backend_test.ts` — pre-feature lock → `upgrade`
       → `spec_backend: local`, rendered `specify.md` unchanged. [FR-010]
-- [ ] T026 Run `deno task lint` + `deno task test` (+ `deno task bundle` if templates changed) —
+- [X] T026 Run `deno task lint` + `deno task test` (+ `deno task bundle` if templates changed) —
       all green. Fix drift.
 
 ---

--- a/.specnaut/specs/020-cli-spec-backend/tasks.md
+++ b/.specnaut/specs/020-cli-spec-backend/tasks.md
@@ -1,0 +1,154 @@
+# Tasks: CLI pluggable spec backend + init choice (local | cloud)
+
+**Input**: Design documents from `.specnaut/specs/020-cli-spec-backend/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/spec-client.md, quickstart.md
+**Tests**: INCLUDED — SC-002 (local parity) needs a golden-file test; SC-003/004/005/006 are
+testable capabilities. Test tasks accompany each story.
+
+**Organization**: grouped by user story. US1 (init choice) + US2 (cloud specify) + US3 (pull)
+are P1; US4 (push) is P2. Paths relative to `apps/specnaut-cli/`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm `deno task test` harness + fake-fetch/fake-fs patterns (see
+      `tests/unit/*gate*`, `tests/**`); no new deps.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+- [ ] T002 Add `SpecBackend = "local"|"cloud"`, `KNOWN_SPEC_BACKENDS`, the `specBackend`
+      field + `spec_backend` YAML key to `src/domain/installed_lock.ts`; `parseLock` defaults
+      to `"local"` when absent (mirror `versionScheme`). [FR-001/010]
+- [ ] T003 [P] Create `src/domain/spec/spec_step.ts` — `SpecStep{key,name,order,body}`.
+- [ ] T004 [P] Add `SpecStore` + `SpecCacheStore` ports and `BundleOptions.specBackend` to
+      `src/application/ports.ts` (per data-model.md).
+- [ ] T005 [US-foundation] Test: `tests/unit/installed_lock_spec_backend_test.ts` — round-trip
+      write/parse of `spec_backend`; absent → `"local"`. [FR-010]
+
+**Checkpoint**: types + ports + lock field ready.
+
+---
+
+## Phase 3: User Story 1 — Choose the spec backend at init (Priority: P1) 🎯 MVP
+
+**Goal**: `init` offers local (first-class default behaviour) | cloud (recommended default
+selection), persists it, and local stays byte-identical (FR-001/003, SC-001/002).
+
+### Tests for US1
+
+- [ ] T006 [P] [US1] `tests/unit/spec_picker_test.ts` — default (Enter) → `cloud`; numeric
+      pick → chosen; invalid re-prompts. Mirror `backlog_picker` tests. [SC-001]
+- [ ] T007 [P] [US1] `tests/unit/spec_backend_filter_golden_test.ts` — the `local`-rendered
+      `specify.md` is **byte-identical** to the pre-feature bundle output. [SC-002]
+
+### Implementation for US1
+
+- [ ] T008 [US1] Create `src/cli/spec_picker.ts` (`DEFAULT_SPEC_BACKEND="cloud"`, recommended
+      marker, `pickSpecBackend` + `pickSpecBackendInteractive`) — mirror `backlog_picker.ts`.
+- [ ] T009 [US1] Create `src/domain/spec_strategies/{local,cloud}.ts` + `registry.ts`
+      (`SpecBackendStrategy`: displayName + init copy).
+- [ ] T010 [US1] Add `renderSpecBackend` to `src/domain/conditional_render.ts` and create
+      `src/infrastructure/harness/spec_backend_filter.ts` (`applySpecBackend`); wire it into all
+      7 harness `mapBundle`s (claude/cursor/codex/copilot/windsurf/opencode/antigravity).
+- [ ] T011 [US1] Resolve + thread `specBackend` (flag → interactive → default) in
+      `src/cli/handlers/init_handler.ts`, `src/cli/parser.ts` (`--spec-backend`), and
+      `src/application/init_project.ts` (`mapBundle` options). Update `src/cli/help.ts`.
+
+**Checkpoint**: `init` records the backend; local path unchanged.
+
+---
+
+## Phase 4: User Story 2 — Cloud-mode `specify` pushes + no branch (Priority: P1)
+
+**Goal**: cloud authoring pushes steps to the linked task, creates no branch, auto-creates+links
+a task when none is linked (FR-004/011, SC-003).
+
+### Tests for US2
+
+- [ ] T012 [P] [US2] `tests/unit/spec_client_test.ts` — POST/GET/PUT calls, status-only errors,
+      no `_id`/backend-error leakage. Fake fetch. [SC-006]
+- [ ] T013 [P] [US2] `tests/integration/cloud_specify_test.ts` — cloud-mode authoring pushes
+      steps, writes **zero** `.specnaut/specs/` files, creates **zero** branches, and
+      auto-creates+links a task when none linked. [SC-003, FR-011]
+
+### Implementation for US2
+
+- [ ] T014 [P] [US2] Create `src/domain/cloud/spec_contract.ts` (pure types + parse guards,
+      mirror `gate_contract.ts`). [§ I]
+- [ ] T015 [US2] Create `src/domain/cloud/spec_client.ts` (`/api/v1/specs*`, mirror
+      `gate_client.ts`) and `src/domain/cloud/spec_session.ts` (`SpecSession`/`makeSpecSession`,
+      mirror `gate_session.ts`; reuse credential store + Cloud-link file).
+- [ ] T016 [US2] Add `createTask(accessToken, projectKey, title)` to
+      `src/domain/cloud/cloud_client.ts` (mirror `createProject`; `POST /api/v1/tasks`).
+- [ ] T017 [US2] Edit `templates/core/skills/specnaut/phases/specify.md` +
+      `implement.md` with `spec-backend=local|cloud` marker blocks (cloud specify: push, no
+      branch, no files; cloud implement: `create-new-feature.sh --branch-only`); add
+      `--branch-only` to `templates/core/specnaut/scripts/bash/create-new-feature.sh`.
+
+**Checkpoint**: cloud specify authors to the cloud with no branch/files.
+
+---
+
+## Phase 5: User Story 3 — Materialise a cloud spec for reading (`spec pull`) (Priority: P1)
+
+**Goal**: `spec pull <task>` writes gitignored cache files so agents read plain files
+(FR-005/008, SC-004/005).
+
+### Tests for US3
+
+- [ ] T018 [P] [US3] `tests/unit/spec_cache_writer_test.ts` — writes ordered files, clears
+      stale on re-pull, path layout `.cache/<task>/<order>-<slug>.md`. [SC-004]
+- [ ] T019 [P] [US3] `tests/unit/spec_store_test.ts` — `CloudSpecStore.pull` (fake session),
+      `LocalSpecStore` verbs fail with a clear cloud-only message. [FR-002]
+
+### Implementation for US3
+
+- [ ] T020 [US3] Create `src/infrastructure/spec/{local_spec_store,cloud_spec_store}.ts`
+      (implement `SpecStore`).
+- [ ] T021 [US3] Create `src/infrastructure/spec/spec_cache_writer.ts` (`SpecCacheStore`);
+      add `.specnaut/specs/.cache/` to `templates/core/root/.gitignore`.
+- [ ] T022 [US3] Wire `spec pull <task>`: `parser.ts` (`spec` branch),
+      `src/cli/handlers/spec_handler.ts::runSpec` (mirror `gate_handler.ts`; offline → reuse
+      cache or actionable error, FR-008), `main.ts` `case "spec"`, `help.ts`. [SC-005]
+
+**Checkpoint**: full author → pull → read loop works.
+
+---
+
+## Phase 6: User Story 4 — Push local spec content (`spec push`) (Priority: P2)
+
+- [ ] T023 [US4] Implement `spec push <task>` in the same `spec_handler.ts` (`CloudSpecStore.push`,
+      upsert-only); print pushed step count. [FR-006]
+- [ ] T024 [P] [US4] `tests/integration/spec_push_pull_test.ts` — edit a cached tab → push →
+      cloud reflects it; untouched tabs preserved.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T025 [P] `tests/integration/upgrade_spec_backend_test.ts` — pre-feature lock → `upgrade`
+      → `spec_backend: local`, rendered `specify.md` unchanged. [FR-010]
+- [ ] T026 Run `deno task lint` + `deno task test` (+ `deno task bundle` if templates changed) —
+      all green. Fix drift.
+
+---
+
+## Dependencies & order
+
+- **Phase 2** blocks all. **US1** is the MVP (backend selectable + local parity). **US2/US3**
+  depend on the foundation + the cloud client (T014-T016). **US4** depends on US3's store +
+  handler. **Polish** last.
+
+## Parallel opportunities
+
+- T003/T004 after T002; T012/T014 (client/contract) parallel; all `[P]` test tasks parallel.
+
+## Suggested MVP
+
+**Phase 2 + US1** — the backend is selectable at init and local is provably unchanged. US2/US3
+deliver the cloud value; US4 is a convenience.

--- a/.specnaut/specs/020-cli-spec-backend/tasks.md
+++ b/.specnaut/specs/020-cli-spec-backend/tasks.md
@@ -1,12 +1,12 @@
 # Tasks: CLI pluggable spec backend + init choice (local | cloud)
 
-**Input**: Design documents from `.specnaut/specs/020-cli-spec-backend/`
-**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/spec-client.md, quickstart.md
-**Tests**: INCLUDED — SC-002 (local parity) needs a golden-file test; SC-003/004/005/006 are
-testable capabilities. Test tasks accompany each story.
+**Input**: Design documents from `.specnaut/specs/020-cli-spec-backend/` **Prerequisites**: plan.md,
+spec.md, research.md, data-model.md, contracts/spec-client.md, quickstart.md **Tests**: INCLUDED —
+SC-002 (local parity) needs a golden-file test; SC-003/004/005/006 are testable capabilities. Test
+tasks accompany each story.
 
-**Organization**: grouped by user story. US1 (init choice) + US2 (cloud specify) + US3 (pull)
-are P1; US4 (push) is P2. Paths relative to `apps/specnaut-cli/`.
+**Organization**: grouped by user story. US1 (init choice) + US2 (cloud specify) + US3 (pull) are
+P1; US4 (push) is P2. Paths relative to `apps/specnaut-cli/`.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -14,20 +14,20 @@ are P1; US4 (push) is P2. Paths relative to `apps/specnaut-cli/`.
 
 ## Phase 1: Setup
 
-- [X] T001 Confirm `deno task test` harness + fake-fetch/fake-fs patterns (see
-      `tests/unit/*gate*`, `tests/**`); no new deps.
+- [x] T001 Confirm `deno task test` harness + fake-fetch/fake-fs patterns (see `tests/unit/*gate*`,
+      `tests/**`); no new deps.
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-- [X] T002 Add `SpecBackend = "local"|"cloud"`, `KNOWN_SPEC_BACKENDS`, the `specBackend`
-      field + `spec_backend` YAML key to `src/domain/installed_lock.ts`; `parseLock` defaults
-      to `"local"` when absent (mirror `versionScheme`). [FR-001/010]
-- [X] T003 [P] Create `src/domain/spec/spec_step.ts` — `SpecStep{key,name,order,body}`.
-- [X] T004 [P] Add `SpecStore` + `SpecCacheStore` ports and `BundleOptions.specBackend` to
+- [x] T002 Add `SpecBackend = "local"|"cloud"`, `KNOWN_SPEC_BACKENDS`, the `specBackend` field +
+      `spec_backend` YAML key to `src/domain/installed_lock.ts`; `parseLock` defaults to `"local"`
+      when absent (mirror `versionScheme`). [FR-001/010]
+- [x] T003 [P] Create `src/domain/spec/spec_step.ts` — `SpecStep{key,name,order,body}`.
+- [x] T004 [P] Add `SpecStore` + `SpecCacheStore` ports and `BundleOptions.specBackend` to
       `src/application/ports.ts` (per data-model.md).
-- [X] T005 [US-foundation] Test: `tests/unit/installed_lock_spec_backend_test.ts` — round-trip
+- [x] T005 [US-foundation] Test: `tests/unit/installed_lock_spec_backend_test.ts` — round-trip
       write/parse of `spec_backend`; absent → `"local"`. [FR-010]
 
 **Checkpoint**: types + ports + lock field ready.
@@ -41,21 +41,21 @@ selection), persists it, and local stays byte-identical (FR-001/003, SC-001/002)
 
 ### Tests for US1
 
-- [X] T006 [P] [US1] `tests/unit/spec_picker_test.ts` — default (Enter) → `cloud`; numeric
-      pick → chosen; invalid re-prompts. Mirror `backlog_picker` tests. [SC-001]
-- [X] T007 [P] [US1] `tests/unit/spec_backend_filter_golden_test.ts` — the `local`-rendered
+- [x] T006 [P] [US1] `tests/unit/spec_picker_test.ts` — default (Enter) → `cloud`; numeric pick →
+      chosen; invalid re-prompts. Mirror `backlog_picker` tests. [SC-001]
+- [x] T007 [P] [US1] `tests/unit/spec_backend_filter_golden_test.ts` — the `local`-rendered
       `specify.md` is **byte-identical** to the pre-feature bundle output. [SC-002]
 
 ### Implementation for US1
 
-- [X] T008 [US1] Create `src/cli/spec_picker.ts` (`DEFAULT_SPEC_BACKEND="cloud"`, recommended
+- [x] T008 [US1] Create `src/cli/spec_picker.ts` (`DEFAULT_SPEC_BACKEND="cloud"`, recommended
       marker, `pickSpecBackend` + `pickSpecBackendInteractive`) — mirror `backlog_picker.ts`.
-- [X] T009 [US1] Create `src/domain/spec_strategies/{local,cloud}.ts` + `registry.ts`
+- [x] T009 [US1] Create `src/domain/spec_strategies/{local,cloud}.ts` + `registry.ts`
       (`SpecBackendStrategy`: displayName + init copy).
-- [X] T010 [US1] Add `renderSpecBackend` to `src/domain/conditional_render.ts` and create
-      `src/infrastructure/harness/spec_backend_filter.ts` (`applySpecBackend`); wire it into all
-      7 harness `mapBundle`s (claude/cursor/codex/copilot/windsurf/opencode/antigravity).
-- [X] T011 [US1] Resolve + thread `specBackend` (flag → interactive → default) in
+- [x] T010 [US1] Add `renderSpecBackend` to `src/domain/conditional_render.ts` and create
+      `src/infrastructure/harness/spec_backend_filter.ts` (`applySpecBackend`); wire it into all 7
+      harness `mapBundle`s (claude/cursor/codex/copilot/windsurf/opencode/antigravity).
+- [x] T011 [US1] Resolve + thread `specBackend` (flag → interactive → default) in
       `src/cli/handlers/init_handler.ts`, `src/cli/parser.ts` (`--spec-backend`), and
       `src/application/init_project.ts` (`mapBundle` options). Update `src/cli/help.ts`.
 
@@ -65,30 +65,30 @@ selection), persists it, and local stays byte-identical (FR-001/003, SC-001/002)
 
 ## Phase 4: User Story 2 — Cloud-mode `specify` pushes + no branch (Priority: P1)
 
-**Goal**: cloud authoring pushes steps to the linked task, creates no branch, auto-creates+links
-a task when none is linked (FR-004/011, SC-003).
+**Goal**: cloud authoring pushes steps to the linked task, creates no branch, auto-creates+links a
+task when none is linked (FR-004/011, SC-003).
 
 ### Tests for US2
 
-- [X] T012 [P] [US2] `tests/unit/spec_client_test.ts` — POST/GET/PUT calls, status-only errors,
-      no `_id`/backend-error leakage. Fake fetch. [SC-006]
-- [X] T013 [P] [US2] `tests/integration/cloud_specify_test.ts` — cloud-mode authoring pushes
-      steps, writes **zero** `.specnaut/specs/` files, creates **zero** branches, and
-      auto-creates+links a task when none linked. [SC-003, FR-011]
+- [x] T012 [P] [US2] `tests/unit/spec_client_test.ts` — POST/GET/PUT calls, status-only errors, no
+      `_id`/backend-error leakage. Fake fetch. [SC-006]
+- [x] T013 [P] [US2] `tests/integration/cloud_specify_test.ts` — cloud-mode authoring pushes steps,
+      writes **zero** `.specnaut/specs/` files, creates **zero** branches, and auto-creates+links a
+      task when none linked. [SC-003, FR-011]
 
 ### Implementation for US2
 
-- [X] T014 [P] [US2] Create `src/domain/cloud/spec_contract.ts` (pure types + parse guards,
-      mirror `gate_contract.ts`). [§ I]
-- [X] T015 [US2] Create `src/domain/cloud/spec_client.ts` (`/api/v1/specs*`, mirror
+- [x] T014 [P] [US2] Create `src/domain/cloud/spec_contract.ts` (pure types + parse guards, mirror
+      `gate_contract.ts`). [§ I]
+- [x] T015 [US2] Create `src/domain/cloud/spec_client.ts` (`/api/v1/specs*`, mirror
       `gate_client.ts`) and `src/domain/cloud/spec_session.ts` (`SpecSession`/`makeSpecSession`,
       mirror `gate_session.ts`; reuse credential store + Cloud-link file).
-- [X] T016 [US2] Add `createTask(accessToken, projectKey, title)` to
+- [x] T016 [US2] Add `createTask(accessToken, projectKey, title)` to
       `src/domain/cloud/cloud_client.ts` (mirror `createProject`; `POST /api/v1/tasks`).
-- [X] T017 [US2] Edit `templates/core/skills/specnaut/phases/specify.md` +
-      `implement.md` with `spec-backend=local|cloud` marker blocks (cloud specify: push, no
-      branch, no files; cloud implement: `create-new-feature.sh --branch-only`); add
-      `--branch-only` to `templates/core/specnaut/scripts/bash/create-new-feature.sh`.
+- [x] T017 [US2] Edit `templates/core/skills/specnaut/phases/specify.md` + `implement.md` with
+      `spec-backend=local|cloud` marker blocks (cloud specify: push, no branch, no files; cloud
+      implement: `create-new-feature.sh --branch-only`); add `--branch-only` to
+      `templates/core/specnaut/scripts/bash/create-new-feature.sh`.
 
 **Checkpoint**: cloud specify authors to the cloud with no branch/files.
 
@@ -96,25 +96,25 @@ a task when none is linked (FR-004/011, SC-003).
 
 ## Phase 5: User Story 3 — Materialise a cloud spec for reading (`spec pull`) (Priority: P1)
 
-**Goal**: `spec pull <task>` writes gitignored cache files so agents read plain files
-(FR-005/008, SC-004/005).
+**Goal**: `spec pull <task>` writes gitignored cache files so agents read plain files (FR-005/008,
+SC-004/005).
 
 ### Tests for US3
 
-- [X] T018 [P] [US3] `tests/unit/spec_cache_writer_test.ts` — writes ordered files, clears
-      stale on re-pull, path layout `.cache/<task>/<order>-<slug>.md`. [SC-004]
-- [X] T019 [P] [US3] `tests/unit/spec_store_test.ts` — `CloudSpecStore.pull` (fake session),
+- [x] T018 [P] [US3] `tests/unit/spec_cache_writer_test.ts` — writes ordered files, clears stale on
+      re-pull, path layout `.cache/<task>/<order>-<slug>.md`. [SC-004]
+- [x] T019 [P] [US3] `tests/unit/spec_store_test.ts` — `CloudSpecStore.pull` (fake session),
       `LocalSpecStore` verbs fail with a clear cloud-only message. [FR-002]
 
 ### Implementation for US3
 
-- [X] T020 [US3] Create `src/infrastructure/spec/{local_spec_store,cloud_spec_store}.ts`
-      (implement `SpecStore`).
-- [X] T021 [US3] Create `src/infrastructure/spec/spec_cache_writer.ts` (`SpecCacheStore`);
-      add `.specnaut/specs/.cache/` to `templates/core/root/.gitignore`.
-- [X] T022 [US3] Wire `spec pull <task>`: `parser.ts` (`spec` branch),
-      `src/cli/handlers/spec_handler.ts::runSpec` (mirror `gate_handler.ts`; offline → reuse
-      cache or actionable error, FR-008), `main.ts` `case "spec"`, `help.ts`. [SC-005]
+- [x] T020 [US3] Create `src/infrastructure/spec/{local_spec_store,cloud_spec_store}.ts` (implement
+      `SpecStore`).
+- [x] T021 [US3] Create `src/infrastructure/spec/spec_cache_writer.ts` (`SpecCacheStore`); add
+      `.specnaut/specs/.cache/` to `templates/core/root/.gitignore`.
+- [x] T022 [US3] Wire `spec pull <task>`: `parser.ts` (`spec` branch),
+      `src/cli/handlers/spec_handler.ts::runSpec` (mirror `gate_handler.ts`; offline → reuse cache
+      or actionable error, FR-008), `main.ts` `case "spec"`, `help.ts`. [SC-005]
 
 **Checkpoint**: full author → pull → read loop works.
 
@@ -122,27 +122,27 @@ a task when none is linked (FR-004/011, SC-003).
 
 ## Phase 6: User Story 4 — Push local spec content (`spec push`) (Priority: P2)
 
-- [X] T023 [US4] Implement `spec push <task>` in the same `spec_handler.ts` (`CloudSpecStore.push`,
+- [x] T023 [US4] Implement `spec push <task>` in the same `spec_handler.ts` (`CloudSpecStore.push`,
       upsert-only); print pushed step count. [FR-006]
-- [X] T024 [P] [US4] `tests/integration/spec_push_pull_test.ts` — edit a cached tab → push →
-      cloud reflects it; untouched tabs preserved.
+- [x] T024 [P] [US4] `tests/integration/spec_push_pull_test.ts` — edit a cached tab → push → cloud
+      reflects it; untouched tabs preserved.
 
 ---
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [X] T025 [P] `tests/integration/upgrade_spec_backend_test.ts` — pre-feature lock → `upgrade`
-      → `spec_backend: local`, rendered `specify.md` unchanged. [FR-010]
-- [X] T026 Run `deno task lint` + `deno task test` (+ `deno task bundle` if templates changed) —
-      all green. Fix drift.
+- [x] T025 [P] `tests/integration/upgrade_spec_backend_test.ts` — pre-feature lock → `upgrade` →
+      `spec_backend: local`, rendered `specify.md` unchanged. [FR-010]
+- [x] T026 Run `deno task lint` + `deno task test` (+ `deno task bundle` if templates changed) — all
+      green. Fix drift.
 
 ---
 
 ## Dependencies & order
 
-- **Phase 2** blocks all. **US1** is the MVP (backend selectable + local parity). **US2/US3**
-  depend on the foundation + the cloud client (T014-T016). **US4** depends on US3's store +
-  handler. **Polish** last.
+- **Phase 2** blocks all. **US1** is the MVP (backend selectable + local parity). **US2/US3** depend
+  on the foundation + the cloud client (T014-T016). **US4** depends on US3's store + handler.
+  **Polish** last.
 
 ## Parallel opportunities
 

--- a/deno.json
+++ b/deno.json
@@ -37,6 +37,7 @@
     "spec-kit/",
     "examples/",
     "templates/",
+    "tests/fixtures/",
     ".claude/",
     "packaging/",
     "plugin/skills/",

--- a/plugin/skills/specnaut/phases/implement.md
+++ b/plugin/skills/specnaut/phases/implement.md
@@ -43,6 +43,18 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+0. **Cloud spec setup** (spec backend = cloud): the spec lives on SpecNaut Cloud
+   and `/specnaut specify` created NO git branch. Before anything else:
+   - **Create the feature branch now** — this is the decoupling point. Run
+     `.specnaut/scripts/bash/create-new-feature.sh --branch-only "<feature description>"`
+     (the `--branch-only` flag creates only the branch — no `.specnaut/specs/` dir).
+   - **Materialise the spec** so the steps below read plain files:
+     `specnaut spec pull <task>` writes `.specnaut/specs/.cache/<task>/`.
+   - Read the spec, plan, tasks, and the mandatory Domain Model block from that
+     cache directory instead of `.specnaut/specs/<n>/`.
+
+<!-- END: spec-backend=cloud -->
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):

--- a/plugin/skills/specnaut/phases/specify.md
+++ b/plugin/skills/specnaut/phases/specify.md
@@ -67,6 +67,7 @@ Given that feature description, do this:
    - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
    - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
 
+<!-- BEGIN: spec-backend=local -->
 2. **Branch creation** (optional, via hook):
 
    If a `before_specify` hook ran, it will have created/switched to a git branch and output JSON with `BRANCH_NAME` and `FEATURE_NUM`. Note these for reference; the branch name does **not** dictate the spec directory name.
@@ -112,6 +113,33 @@ Given that feature description, do this:
    - Create only one feature per `/specnaut specify` invocation.
    - The spec directory name and git branch name are independent.
    - The spec directory and file are always created by this command, never by the hook.
+<!-- END: spec-backend=local -->
+<!-- BEGIN: spec-backend=cloud -->
+2. **Cloud spec authoring** (spec backend = cloud — NO git branch, NO local files):
+
+   This project stores specifications on SpecNaut Cloud, not in `.specnaut/specs/`.
+   Do **NOT** create a git branch and do **NOT** write any `.specnaut/specs/<n>/`
+   files. The branch is created later, at `/specnaut implement`. The spec is
+   authored directly to the linked backlog task and read back on demand with
+   `specnaut spec pull <task>`.
+
+3. **Resolve the linked task and author the spec to Cloud**:
+
+   1. Determine the task number:
+      - If the user passed `--issue <N>`, use it.
+      - Otherwise `specnaut spec push` auto-creates a backlog task named from the
+        feature and links it — the task and its spec are created together (no
+        manual pre-step).
+   2. Generate the spec body using `templates/spec-template.md` for structure,
+      exactly as you would locally (same sections, same mandatory Domain Model
+      block).
+   3. Write the generated spec to the gitignored cache as the `specify` step:
+      `.specnaut/specs/.cache/<task>/1-specify.md`, then push it:
+      `specnaut spec push <task>` (upsert-only; it never deletes other tabs).
+   4. Persist the resolved task number to `.specnaut/feature.json`
+      (`{ "linked_issue": <N>, "workflow_shape": "<lite|full>" }`) so downstream
+      phases locate the spec. No `feature_directory` is written in cloud mode.
+<!-- END: spec-backend=cloud -->
 
 4. Load `templates/spec-template.md` to understand required sections.
 
@@ -191,7 +219,12 @@ Given that feature description, do this:
    - `optional: true` → `## Extension Hooks` block with `**Optional Hook**: {extension}`, command, description, prompt.
    - `optional: false` → `## Extension Hooks` block with `**Automatic Hook**: {extension}`, `EXECUTE_COMMAND: {command}`.
 
+<!-- BEGIN: spec-backend=local -->
 **NOTE:** Branch creation is handled by the `before_specify` hook. Spec directory and file creation are always handled by this core command.
+<!-- END: spec-backend=local -->
+<!-- BEGIN: spec-backend=cloud -->
+**NOTE:** In cloud spec mode no git branch and no `.specnaut/specs/` files are created here — the spec is pushed to SpecNaut Cloud and the branch is created later at `/specnaut implement`.
+<!-- END: spec-backend=cloud -->
 
 ## Quick Guidelines
 

--- a/src/application/diff_project.ts
+++ b/src/application/diff_project.ts
@@ -77,6 +77,7 @@ export class DiffProjectUseCase {
     const bundle = harness.mapBundle(core, {
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
+      specBackend: lock.specBackend,
     });
 
     const results: DivergenceResult[] = [];

--- a/src/application/init_project.ts
+++ b/src/application/init_project.ts
@@ -5,6 +5,7 @@ import type {
   InstalledLock,
   KnownHarness,
   LockEntry,
+  SpecBackend,
   VersionScheme,
 } from "../domain/installed_lock.ts";
 import type { CoreBundle } from "../domain/core_bundle.ts";
@@ -49,6 +50,8 @@ export type InitProjectDeps = {
   harness: Harness;
   backlogBackend: BacklogBackend;
   versionScheme: VersionScheme;
+  /** Which spec backend to persist + render the phase docs against (spec 020). */
+  specBackend: SpecBackend;
   core: CoreBundle;
   /** Creates the target directory if it does not exist (idempotent). */
   ensureDir(path: string): Promise<void>;
@@ -97,6 +100,7 @@ export class InitProjectUseCase {
       harness,
       backlogBackend,
       versionScheme,
+      specBackend,
       core,
       ensureDir,
     } = this.deps;
@@ -109,7 +113,7 @@ export class InitProjectUseCase {
       await ensureDir(input.targetDir);
     }
 
-    const mappedBundle = harness.mapBundle(core, { backlogBackend, versionScheme });
+    const mappedBundle = harness.mapBundle(core, { backlogBackend, versionScheme, specBackend });
     // Parent-managed targets inherit agentic files from the providing
     // workspace: filter them out of the bundle here — after harness mapping,
     // before BOTH writeBundle and lock-entry construction — so suppressed
@@ -211,6 +215,7 @@ export class InitProjectUseCase {
       harness: harness.key as KnownHarness,
       backlogBackend,
       versionScheme,
+      specBackend,
       templatesVersion: TEMPLATES_VERSION,
       entries: lockEntries,
       // Cache the decision so a later upgrade suppresses agentic files

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -144,7 +144,8 @@ export interface PluginDetector {
 }
 
 import type { CoreBundle } from "../domain/core_bundle.ts";
-import type { BacklogBackend, VersionScheme } from "../domain/installed_lock.ts";
+import type { BacklogBackend, SpecBackend, VersionScheme } from "../domain/installed_lock.ts";
+import type { SpecStep } from "../domain/spec/spec_step.ts";
 
 export type BundleOptions = {
   /**
@@ -159,7 +160,53 @@ export type BundleOptions = {
    * against this value at bundle time.
    */
   readonly versionScheme: VersionScheme;
+  /**
+   * Which spec backend's conditional sections the phase docs should keep
+   * (spec 020). `specify.md` / `implement.md` carry `spec-backend=local|cloud`
+   * marker blocks rendered against this value at bundle time. `local` yields
+   * output byte-identical to the pre-feature CLI (FR-003).
+   */
+  readonly specBackend: SpecBackend;
 };
+
+/**
+ * Backend abstraction over a project's spec storage (spec 020, data-model.md).
+ * Scoped to the cloud-only verbs: the `local` adapter rejects both with a clear
+ * "cloud-only" message, and the local authoring flow bypasses this port entirely
+ * so its behaviour stays byte-identical to the pre-feature CLI (FR-003, D1).
+ */
+export interface SpecStore {
+  readonly key: SpecBackend;
+  /**
+   * Fetch a task's spec steps. `null` when the task has no spec yet (not an
+   * error). Cloud adapter delegates to a `SpecSession`; local adapter rejects.
+   */
+  pull(taskNumber: number): Promise<readonly SpecStep[] | null>;
+  /**
+   * Upsert-only push of a task's steps — never deletes an omitted step
+   * (Lot 1 FR-011). Cloud adapter delegates to a `SpecSession`; local rejects.
+   */
+  push(taskNumber: number, steps: readonly SpecStep[]): Promise<void>;
+}
+
+/**
+ * Gitignored materialisation cache for a cloud spec (spec 020) — the on-disk
+ * mirror agents read as ordinary files, under `.specnaut/specs/.cache/<task>/`.
+ * Disposable and never the source of truth; the cloud (or local files) is
+ * authoritative. Adapter: `infrastructure/spec/spec_cache_writer.ts`.
+ */
+export interface SpecCacheStore {
+  /**
+   * Clear the task's cache dir, then write one ordered markdown file per step.
+   * Returns the project-relative paths written (US3 AC2 — stale files are
+   * reconciled by the clear-first write).
+   */
+  write(projectDir: string, taskNumber: number, steps: readonly SpecStep[]): Promise<string[]>;
+  /** Read the task's cached steps back (for `spec push`), or `null` if absent. */
+  read(projectDir: string, taskNumber: number): Promise<readonly SpecStep[] | null>;
+  /** Remove the task's cache dir. Idempotent. */
+  clear(projectDir: string, taskNumber: number): Promise<void>;
+}
 
 export interface Harness {
   readonly key: string;

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -103,6 +103,7 @@ export class UpgradeProjectUseCase {
     const mappedBundle = harness.mapBundle(core, {
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
+      specBackend: lock.specBackend,
     });
 
     // Parent-managed targets inherit agentic files from the providing
@@ -203,6 +204,7 @@ export class UpgradeProjectUseCase {
           harness: lock.harness,
           backlogBackend: lock.backlogBackend,
           versionScheme: lock.versionScheme,
+          specBackend: lock.specBackend,
           templatesVersion: lock.templatesVersion,
           entries: lock.entries,
           ...(parentManaged ? { parentManaged: true as const } : {}),
@@ -338,6 +340,7 @@ export class UpgradeProjectUseCase {
       harness: lock.harness,
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
+      specBackend: lock.specBackend,
       templatesVersion,
       entries: updatedEntries,
       // Persist the (possibly re-derived) decision so future upgrades read it

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -13,10 +13,7 @@ import {
   pickVersionScheme,
   pickVersionSchemeInteractive,
 } from "../scheme_picker.ts";
-import {
-  pickSpecBackend,
-  pickSpecBackendInteractive,
-} from "../spec_picker.ts";
+import { pickSpecBackend, pickSpecBackendInteractive } from "../spec_picker.ts";
 import { makeStdinSelectIO } from "../select.ts";
 import type { BacklogBackend, SpecBackend, VersionScheme } from "../../domain/installed_lock.ts";
 import { SPEC_STRATEGIES } from "../../domain/spec_strategies/registry.ts";

--- a/src/cli/handlers/init_handler.ts
+++ b/src/cli/handlers/init_handler.ts
@@ -13,8 +13,13 @@ import {
   pickVersionScheme,
   pickVersionSchemeInteractive,
 } from "../scheme_picker.ts";
+import {
+  pickSpecBackend,
+  pickSpecBackendInteractive,
+} from "../spec_picker.ts";
 import { makeStdinSelectIO } from "../select.ts";
-import type { BacklogBackend, VersionScheme } from "../../domain/installed_lock.ts";
+import type { BacklogBackend, SpecBackend, VersionScheme } from "../../domain/installed_lock.ts";
+import { SPEC_STRATEGIES } from "../../domain/spec_strategies/registry.ts";
 import { detectVersionScheme } from "../../domain/project_detection.ts";
 import {
   BACKLOG_STRATEGIES,
@@ -49,6 +54,11 @@ export type InitIntent = {
   backlogRepo: string | null;
   /** Explicit `--scheme` value (`semver` | `date`). Null = ask/detect. */
   scheme: VersionScheme | null;
+  /**
+   * Explicit `--spec-backend` value (`local` | `cloud`). Null triggers the
+   * interactive picker (TTY) or the recommended default (non-TTY). Spec 020.
+   */
+  specBackend: SpecBackend | null;
   force: boolean;
   /**
    * `--dry-run`. Compute the plan and print it without writing anywhere
@@ -95,6 +105,30 @@ async function resolveBacklogBackend(
     });
   }
   const picked = await pickBacklogBackendInteractive(makeStdinSelectIO());
+  if (picked === null) {
+    console.error(red("aborted."));
+    Deno.exit(130);
+  }
+  return picked;
+}
+
+/**
+ * Resolves the spec backend: explicit `--spec-backend` flag wins; otherwise the
+ * interactive picker (TTY) or the non-TTY numeric prompt fall back to the
+ * recommended default (spec 020, FR-001). Mirrors {@link resolveBacklogBackend}.
+ */
+async function resolveSpecBackend(
+  explicit: SpecBackend | null,
+): Promise<SpecBackend> {
+  if (explicit !== null) return explicit;
+  if (!Deno.stdin.isTerminal()) {
+    return pickSpecBackend({
+      readLine: () => prompt(`Choose [1-${SPEC_STRATEGIES.length}]:`),
+      log: (s) => console.log(s),
+      errLog: (s) => console.error(red(s)),
+    });
+  }
+  const picked = await pickSpecBackendInteractive(makeStdinSelectIO());
   if (picked === null) {
     console.error(red("aborted."));
     Deno.exit(130);
@@ -390,6 +424,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
     const probeBundle = harness.mapBundle(CORE_BUNDLE, {
       backlogBackend: "local",
       versionScheme: DEFAULT_VERSION_SCHEME,
+      specBackend: "local",
     });
     const conflicts = await writer.detectConflicts(probeBundle, targetDir);
     if (conflicts.length > 0) {
@@ -406,6 +441,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
     intent.scheme,
     schemeSuggestion,
   );
+  const specBackend = await resolveSpecBackend(intent.specBackend);
 
   // Capture the Kanban URL up front (interactive prompt or --backlog-url
   // flag) so the populated config lands at init time and the PO never
@@ -455,7 +491,11 @@ export async function runInit(intent: InitIntent): Promise<number> {
   // (FR-004/FR-005). The bundle is mapped exactly as the use case maps it,
   // including the parent-managed agentic filter so a declared agentic path in
   // a parent-managed sub-repo is a clean no-op (D8 — it is simply not a dest).
-  const mappedForPreserve = harness.mapBundle(CORE_BUNDLE, { backlogBackend, versionScheme });
+  const mappedForPreserve = harness.mapBundle(CORE_BUNDLE, {
+    backlogBackend,
+    versionScheme,
+    specBackend,
+  });
   const bundleDests = parentManaged
     ? Object.keys(mappedForPreserve).filter((d) => !isAgenticPath(d))
     : Object.keys(mappedForPreserve);
@@ -480,6 +520,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
     harness,
     backlogBackend,
     versionScheme,
+    specBackend,
     core: CORE_BUNDLE,
     ensureDir: (path) => Deno.mkdir(path, { recursive: true }),
   });
@@ -516,6 +557,7 @@ export async function runInit(intent: InitIntent): Promise<number> {
     const probeBundle = harness.mapBundle(CORE_BUNDLE, {
       backlogBackend,
       versionScheme,
+      specBackend,
     });
     const totalManaged = countManagedFiles(probeBundle);
     printConflictsError(result.conflicts, result.lockExists, totalManaged);

--- a/src/cli/handlers/spec_handler.ts
+++ b/src/cli/handlers/spec_handler.ts
@@ -1,0 +1,176 @@
+// `specnaut spec <push|pull> <task>` (spec 020) — sync a task's spec with
+// SpecNaut Cloud. `pull` materialises a cloud spec into the gitignored cache so
+// downstream agents read plain files; `push` upserts local cache content back to
+// the cloud. Both are cloud-backend-only: under the `local` backend they exit
+// with a clear message (there is no remote spec to sync). Mirrors gate_handler.ts
+// — deps built from readCloudConfig + defaultCredentialStore(), exit codes 0/1/5.
+//
+//   pull  exit 0 (materialised / no-spec) · 1 (usage / local backend) · 5 (cloud/auth)
+//   push  exit 0 (upserted) · 1 (usage / local backend / nothing to push) · 5 (cloud/auth)
+//
+// Constitution § I: stdout/stderr carry only CLI-owned messages + public
+// task/step data; a cloud failure is a status-derived reason, never a backend
+// string or Cloud-internal identifier.
+
+import { dim, green, red, yellow } from "@std/fmt/colors";
+import { readCloudConfig } from "../../domain/cloud/cloud_config.ts";
+import { defaultCredentialStore } from "../../infrastructure/credential_store.ts";
+import { makeSpecSession, type SpecSession } from "../../domain/cloud/spec_session.ts";
+import { SpecApiError } from "../../domain/cloud/spec_client.ts";
+import { CloudSpecStore } from "../../infrastructure/spec/cloud_spec_store.ts";
+import { SpecCacheWriter } from "../../infrastructure/spec/spec_cache_writer.ts";
+import type { SpecCacheStore } from "../../application/ports.ts";
+import { FsLockStore } from "../../infrastructure/fs_lock_store.ts";
+import type { SpecBackend } from "../../domain/installed_lock.ts";
+import type { SpecStep } from "../../domain/spec/spec_step.ts";
+
+export type SpecIntent = {
+  kind: "spec";
+  sub: "push" | "pull";
+  task: number | null;
+  apiUrl: string | null;
+};
+
+/** Injectable IO/deps seam — defaults to real stdio/cwd/lock/cache; tests override. */
+export type SpecDeps = {
+  out: (s: string) => void;
+  err: (s: string) => void;
+  projectDir: string;
+  /** The project's persisted spec backend (absent lock → "local"). */
+  readSpecBackend: () => Promise<SpecBackend>;
+  /** Build a cloud spec session, or null when not Cloud-linked. */
+  buildSession: () => Promise<SpecSession | null>;
+  cache: SpecCacheStore;
+};
+
+function defaultDeps(intent: SpecIntent): SpecDeps {
+  const projectDir = Deno.cwd();
+  return {
+    out: (s) => console.log(s),
+    err: (s) => console.error(s),
+    projectDir,
+    readSpecBackend: async () => {
+      const lock = await new FsLockStore().read(projectDir);
+      return lock?.specBackend ?? "local";
+    },
+    buildSession: async () => {
+      const config = await readCloudConfig(projectDir);
+      if (!config) return null;
+      const apiUrl = intent.apiUrl ?? config.apiUrl;
+      if (!apiUrl) return null;
+      return makeSpecSession({
+        config: { ...config, apiUrl },
+        store: defaultCredentialStore(),
+      });
+    },
+    cache: new SpecCacheWriter(),
+  };
+}
+
+export async function runSpec(
+  intent: SpecIntent,
+  deps: SpecDeps = defaultDeps(intent),
+): Promise<number> {
+  if (intent.task === null) {
+    deps.err(red(`error: \`specnaut spec ${intent.sub}\` requires a task number.`));
+    return 1;
+  }
+
+  // Backend gate: spec push/pull are cloud-only verbs (contract § B). Under the
+  // local backend there is no remote spec to sync — exit with a clear message.
+  const backend = await deps.readSpecBackend();
+  if (backend !== "cloud") {
+    deps.err(
+      red(
+        "error: `spec push`/`spec pull` are cloud-backend commands — this project uses the " +
+          "local spec backend (.specnaut/specs/). Nothing to sync.",
+      ),
+    );
+    return 1;
+  }
+
+  return intent.sub === "pull"
+    ? await runPull(intent.task, deps)
+    : await runPush(intent.task, deps);
+}
+
+async function runPull(task: number, deps: SpecDeps): Promise<number> {
+  const session = await deps.buildSession();
+  if (!session) {
+    deps.err(red("error: project is not Cloud-linked (run `specnaut cloud login`)."));
+    return 5;
+  }
+
+  let steps: readonly SpecStep[] | null;
+  try {
+    steps = await new CloudSpecStore(session).pull(task);
+  } catch (e) {
+    // Offline / auth failure (FR-008): fall back to an existing cache if present,
+    // otherwise a non-zero exit with an actionable message — never a partial or
+    // silently-empty spec.
+    const cached = await deps.cache.read(deps.projectDir, task);
+    if (cached && cached.length > 0) {
+      deps.err(
+        yellow(
+          `warning: could not reach Cloud (${reasonOf(e)}); reusing the existing cache for task ${task}.`,
+        ),
+      );
+      deps.out(dim(`↳ ${cached.length} cached step(s) under .specnaut/specs/.cache/${task}/`));
+      return 0;
+    }
+    deps.err(actionable(e, `pull spec for task ${task}`));
+    return 5;
+  }
+
+  if (steps === null || steps.length === 0) {
+    deps.out(yellow(`no spec for task ${task} on Cloud yet — nothing to materialise.`));
+    return 0;
+  }
+
+  const written = await deps.cache.write(deps.projectDir, task, steps);
+  deps.out(green(`✓ materialised ${written.length} step(s) for task ${task}:`));
+  for (const p of written) deps.out(dim(`  ↳ ${p}`));
+  return 0;
+}
+
+async function runPush(task: number, deps: SpecDeps): Promise<number> {
+  const steps = await deps.cache.read(deps.projectDir, task);
+  if (steps === null || steps.length === 0) {
+    deps.err(
+      red(
+        `error: no cached spec content for task ${task} to push ` +
+          `(run \`specnaut spec pull ${task}\` first, then edit the cached tabs).`,
+      ),
+    );
+    return 1;
+  }
+
+  const session = await deps.buildSession();
+  if (!session) {
+    deps.err(red("error: project is not Cloud-linked (run `specnaut cloud login`)."));
+    return 5;
+  }
+
+  try {
+    await new CloudSpecStore(session).push(task, steps);
+  } catch (e) {
+    deps.err(actionable(e, `push spec for task ${task}`));
+    return 5;
+  }
+  deps.out(green(`✓ pushed ${steps.length} step(s) for task ${task} to Cloud.`));
+  return 0;
+}
+
+/** The typed status-reason of a cloud failure (never a backend string — § I). */
+function reasonOf(e: unknown): string {
+  return e instanceof SpecApiError ? e.reason : "unknown";
+}
+
+/** An actionable, § I-safe error message for a cloud failure. */
+function actionable(e: unknown, what: string): string {
+  const reason = reasonOf(e);
+  if (reason === "unauthorized") {
+    return red(`error: not authenticated to ${what} — run \`specnaut cloud login\` and retry.`);
+  }
+  return red(`error: could not ${what} (${reason}) — check your connection and retry.`);
+}

--- a/src/cli/handlers/spec_handler.ts
+++ b/src/cli/handlers/spec_handler.ts
@@ -112,7 +112,9 @@ async function runPull(task: number, deps: SpecDeps): Promise<number> {
     if (cached && cached.length > 0) {
       deps.err(
         yellow(
-          `warning: could not reach Cloud (${reasonOf(e)}); reusing the existing cache for task ${task}.`,
+          `warning: could not reach Cloud (${
+            reasonOf(e)
+          }); reusing the existing cache for task ${task}.`,
         ),
       );
       deps.out(dim(`↳ ${cached.length} cached step(s) under .specnaut/specs/.cache/${task}/`));

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -69,10 +69,12 @@ export async function switchBacklogBackend(
   const newBundle = dropAgentic(harness.mapBundle(CORE_BUNDLE, {
     backlogBackend: newBackend,
     versionScheme: lock.versionScheme,
+    specBackend: lock.specBackend,
   }));
   const oldBundle = dropAgentic(harness.mapBundle(CORE_BUNDLE, {
     backlogBackend: from,
     versionScheme: lock.versionScheme,
+    specBackend: lock.specBackend,
   }));
 
   const writer = new DenoFsWriter();
@@ -137,6 +139,7 @@ export async function switchBacklogBackend(
     harness: lock.harness,
     backlogBackend: newBackend,
     versionScheme: lock.versionScheme,
+    specBackend: lock.specBackend,
     templatesVersion: lock.templatesVersion,
     entries: updatedEntries,
     // Preserve the parent-managed decision across a backend switch — dropping
@@ -287,6 +290,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
       const mapped = harnessForPreserve.mapBundle(CORE_BUNDLE, {
         backlogBackend: lockForDetection.backlogBackend,
         versionScheme: lockForDetection.versionScheme,
+        specBackend: lockForDetection.specBackend,
       });
       const parentManaged = (parentManagedOverride ?? lockForDetection.parentManaged) ?? false;
       const bundleDests = parentManaged
@@ -371,6 +375,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
       ? harness.mapBundle(CORE_BUNDLE, {
         backlogBackend: lock.backlogBackend,
         versionScheme: lock.versionScheme,
+        specBackend: lock.specBackend,
       })
       : {};
     for (const action of preserves) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -15,6 +15,8 @@ ${bold("Usage:")}
   specnaut reconcile --status         List files pending post-upgrade reconciliation
   specnaut reconcile <path> --accept-upstream | --accept-current
                                       Resolve a preserved file after upgrade
+  specnaut spec pull <task>           Materialise a task's cloud-hosted spec into .specnaut/specs/.cache/<task>/
+  specnaut spec push <task>           Upsert local spec content for <task> to Specnaut Cloud (cloud backend)
   specnaut login [--api-url <url>]    Authenticate with Specnaut Cloud (alias for "cloud login")
   specnaut cloud login [--api-url <url>]
                                       Authenticate with Specnaut Cloud (browser device flow) and link a project
@@ -41,6 +43,9 @@ ${bold("Flags (for init):")}
                       Cargo.toml [lib], composer.json type=library), semver-shaped git tags
                       (v1.2.3), or a CHANGELOG.md with Keep-a-Changelog headers. Falls back to
                       "date" when no signal is found.
+  --spec-backend <n>  Where specs are stored: cloud (default, recommended) | local
+                      (cloud: hosted specs via Specnaut Cloud — run "specnaut cloud login" after init;
+                       local: markdown files in .specnaut/specs/, unchanged from before)
   --force             Overwrite locally-customized files (existing content backed up to *.specnaut.bak)
   --reset-preserved   Ignore .specnaut/preserve.yml for this run so declared files are refreshed too
                       (never the default; reported per overridden file)

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -2,7 +2,9 @@ import { parseArgs as stdParseArgs } from "@std/cli/parse-args";
 import {
   type BacklogBackend,
   KNOWN_BACKLOG_BACKENDS,
+  KNOWN_SPEC_BACKENDS,
   KNOWN_VERSION_SCHEMES,
+  type SpecBackend,
   type VersionScheme,
 } from "../domain/installed_lock.ts";
 
@@ -26,6 +28,18 @@ function validateSchemeArg(
   if (raw === null) return { ok: true, value: null };
   if ((KNOWN_VERSION_SCHEMES as ReadonlyArray<string>).includes(raw)) {
     return { ok: true, value: raw as VersionScheme };
+  }
+  return { ok: false };
+}
+
+function validateSpecBackendArg(
+  raw: string | null,
+):
+  | { ok: true; value: SpecBackend | null }
+  | { ok: false } {
+  if (raw === null) return { ok: true, value: null };
+  if ((KNOWN_SPEC_BACKENDS as ReadonlyArray<string>).includes(raw)) {
+    return { ok: true, value: raw as SpecBackend };
   }
   return { ok: false };
 }
@@ -77,6 +91,11 @@ export type Intent =
      * (TTY) or the auto-detection default (non-TTY).
      */
     scheme: "semver" | "date" | null;
+    /**
+     * Explicit `--spec-backend` value (`local` | `cloud`). `null` triggers the
+     * interactive picker (TTY) or the recommended default (non-TTY). Spec 020.
+     */
+    specBackend: SpecBackend | null;
     force: boolean;
     /**
      * `--dry-run`. Compute the plan (conflicts + would-write counts) and
@@ -153,6 +172,14 @@ export type Intent =
     payload: string | null;
     task: number | null;
     id: string | null;
+  }
+  | {
+    /** `specnaut spec <push|pull> <task>` (spec 020) — sync a task's spec with
+     *  SpecNaut Cloud. Cloud-backend only; see spec_handler.ts. */
+    kind: "spec";
+    sub: "push" | "pull";
+    task: number | null;
+    apiUrl: string | null;
   };
 
 export function parseArgs(argv: string[]): Intent {
@@ -181,6 +208,7 @@ export function parseArgs(argv: string[]): Intent {
       "backlog-url",
       "backlog-repo",
       "scheme",
+      "spec-backend",
       "api-url",
       "type",
       "title",
@@ -227,6 +255,13 @@ export function parseArgs(argv: string[]): Intent {
     if (!schemeResult.ok) {
       return { kind: "unknown", received: `init --scheme ${schemeRaw}` };
     }
+    const specBackendRaw = typeof parsed["spec-backend"] === "string"
+      ? (parsed["spec-backend"] as string)
+      : null;
+    const specBackendResult = validateSpecBackendArg(specBackendRaw);
+    if (!specBackendResult.ok) {
+      return { kind: "unknown", received: `init --spec-backend ${specBackendRaw}` };
+    }
     return {
       kind: "init",
       projectName: rest[0] ?? null,
@@ -237,6 +272,7 @@ export function parseArgs(argv: string[]): Intent {
       backlogUrl: backlogUrlRaw,
       backlogRepo: backlogRepoRaw,
       scheme: schemeResult.value,
+      specBackend: specBackendResult.value,
       force: Boolean(parsed.force),
       dryRun: Boolean(parsed["dry-run"]),
       resetPreserved: Boolean(parsed["reset-preserved"]),
@@ -354,6 +390,18 @@ export function parseArgs(argv: string[]): Intent {
       task: taskNum,
       id: rest[1] ?? null, // `gate cancel <id>`
     };
+  }
+
+  if (command === "spec") {
+    const sub = rest[0];
+    if (sub !== "push" && sub !== "pull") {
+      return { kind: "unknown", received: `spec ${sub ?? ""}`.trim() };
+    }
+    // `spec <push|pull> <task>` — the task number is a positional after the sub.
+    const taskRaw = rest[1] ?? null;
+    const task = taskRaw !== null && /^\d+$/.test(taskRaw) ? Number(taskRaw) : null;
+    const apiUrl = typeof parsed["api-url"] === "string" ? parsed["api-url"] : null;
+    return { kind: "spec", sub, task, apiUrl };
   }
 
   return { kind: "unknown", received: command ?? "" };

--- a/src/cli/spec_picker.ts
+++ b/src/cli/spec_picker.ts
@@ -65,9 +65,7 @@ export async function pickSpecBackendInteractive(
   );
   const items = SPEC_STRATEGIES.map((s) => ({
     key: s.key,
-    label: s.key === DEFAULT_SPEC_BACKEND
-      ? `${s.displayName}${RECOMMENDED_MARKER}`
-      : s.displayName,
+    label: s.key === DEFAULT_SPEC_BACKEND ? `${s.displayName}${RECOMMENDED_MARKER}` : s.displayName,
   }));
   // Printed once above the menu; the picker's redraw only rewinds over the
   // menu frame, so this benefit line stays put.

--- a/src/cli/spec_picker.ts
+++ b/src/cli/spec_picker.ts
@@ -1,0 +1,82 @@
+import { type SpecBackend } from "../domain/installed_lock.ts";
+import { SPEC_STRATEGIES } from "../domain/spec_strategies/registry.ts";
+import { selectInteractive, type SelectIO } from "./select.ts";
+
+export const DEFAULT_SPEC_BACKEND: SpecBackend = "cloud";
+
+/** Suffix on the default backend's line — signals it's the recommended pick. */
+const RECOMMENDED_MARKER = " — recommended (default)";
+
+/**
+ * One-line "why this is the recommended default" note, shown once above the
+ * choices for whichever backend is the default. Keyed by backend so it stays
+ * correct if the default ever moves.
+ */
+const DEFAULT_BACKEND_NOTE: Partial<Record<SpecBackend, string>> = {
+  cloud: "SpecNaut Cloud: hosted specs — parallelisable (no branch per spec), shareable.",
+};
+
+export type SpecPickerIO = {
+  readLine: () => string | null;
+  log: (s: string) => void;
+  errLog: (s: string) => void;
+};
+
+/**
+ * Non-interactive picker (numeric prompt / CI). Enter → the recommended default
+ * (`cloud`); a valid number → that backend; anything else re-prompts.
+ * Mirrors {@link pickBacklogBackend}.
+ */
+export function pickSpecBackend(io: SpecPickerIO): SpecBackend {
+  io.log("Choose where your specifications are stored (press Enter for default):");
+  for (let i = 0; i < SPEC_STRATEGIES.length; i++) {
+    const s = SPEC_STRATEGIES[i];
+    const marker = s.key === DEFAULT_SPEC_BACKEND ? RECOMMENDED_MARKER : "";
+    io.log(`  ${i + 1}) ${s.displayName}${marker}`);
+  }
+  const note = DEFAULT_BACKEND_NOTE[DEFAULT_SPEC_BACKEND];
+  if (note) io.log(`  ↳ ${note}`);
+  while (true) {
+    const raw = (io.readLine() ?? "").trim();
+    if (raw === "") return DEFAULT_SPEC_BACKEND;
+    const idx = parseInt(raw, 10) - 1;
+    if (
+      Number.isInteger(idx) &&
+      idx >= 0 &&
+      idx < SPEC_STRATEGIES.length
+    ) {
+      return SPEC_STRATEGIES[idx].key;
+    }
+    io.errLog(
+      `invalid choice "${raw}" — expected 1-${SPEC_STRATEGIES.length} or empty for default`,
+    );
+  }
+}
+
+/**
+ * Interactive arrow-key picker (TTY). Returns the chosen backend, or `null`
+ * when the user cancels (Ctrl-C). Mirrors {@link pickBacklogBackendInteractive}.
+ */
+export async function pickSpecBackendInteractive(
+  io: SelectIO,
+): Promise<SpecBackend | null> {
+  const defaultIdx = SPEC_STRATEGIES.findIndex(
+    (s) => s.key === DEFAULT_SPEC_BACKEND,
+  );
+  const items = SPEC_STRATEGIES.map((s) => ({
+    key: s.key,
+    label: s.key === DEFAULT_SPEC_BACKEND
+      ? `${s.displayName}${RECOMMENDED_MARKER}`
+      : s.displayName,
+  }));
+  // Printed once above the menu; the picker's redraw only rewinds over the
+  // menu frame, so this benefit line stays put.
+  const note = DEFAULT_BACKEND_NOTE[DEFAULT_SPEC_BACKEND];
+  if (note) io.write(`  ↳ ${note}\n`);
+  return await selectInteractive(
+    items,
+    defaultIdx >= 0 ? defaultIdx : 0,
+    io,
+    "Choose where your specs are stored (↑/↓ to move, space/enter to select, Ctrl-C to cancel):",
+  );
+}

--- a/src/domain/cloud/cloud_client.ts
+++ b/src/domain/cloud/cloud_client.ts
@@ -222,6 +222,33 @@ export class CloudClient {
     const p = (json.project ?? {}) as Record<string, unknown>;
     return { key: String(p.key ?? key), name: String(p.name ?? name), role: "owner" };
   }
+
+  /**
+   * Create a backlog task on a project's board (`POST /api/v1/tasks`, the
+   * shipped endpoint the `add.sh` script also uses). Returns the new task's
+   * public number — used by cloud-mode `specify` to auto-create + link a task
+   * when the authoring flow runs with none linked (spec 020, FR-011). Kept as a
+   * typed compiled call (not the backend-gated bash `add.sh`) so auto-creation
+   * is independent of which backlog backend is configured.
+   */
+  async createTask(
+    accessToken: string,
+    projectKey: string,
+    title: string,
+  ): Promise<CloudTask> {
+    const { status, json } = await this.postJson("/tasks", { projectKey, title }, accessToken);
+    if (status !== 201 && status !== 200) {
+      throw new CloudApiError(status, strField(json, "error") ?? "create task failed");
+    }
+    const t = (json.task ?? {}) as Record<string, unknown>;
+    return {
+      number: Number(t.number ?? 0),
+      title: cleanText(t.title ?? title),
+      columnId: String(t.columnId ?? ""),
+      priority: typeof t.priority === "string" ? t.priority : null,
+      size: typeof t.size === "string" ? t.size : null,
+    };
+  }
 }
 
 async function readJson(res: Response): Promise<Record<string, unknown>> {

--- a/src/domain/cloud/spec_client.ts
+++ b/src/domain/cloud/spec_client.ts
@@ -1,0 +1,125 @@
+// HTTP client for the public spec endpoints (spec 020, consuming Lot 1's shipped
+// `/api/v1/specs*`). A sibling of GateClient / CloudClient: same `{base}/api/v1`
+// surface, same injectable `FetchFn`, same `Authorization: Bearer` scheme.
+//
+// Constitution § I: this speaks ONLY the versioned public wire format. Errors are
+// surfaced as a status-carrying SpecApiError keyed off the HTTP status — the
+// backend's `error` string is NEVER propagated into CLI logs or state, only the
+// public status code is, so no Cloud-internal message can leak.
+
+import type { FetchFn } from "./cloud_client.ts";
+import { parseSpec, type SpecWire } from "./spec_contract.ts";
+import type { SpecStep } from "../spec/spec_step.ts";
+
+/** Typed error reasons the caller branches on. Derived from HTTP status only. */
+export type SpecErrorReason =
+  | "unauthorized" // 401
+  | "not_found" // 404
+  | "conflict" // 409
+  | "invalid" // 422 — bad payload
+  | "transient"; // network / 5xx — retryable
+
+export class SpecApiError extends Error {
+  constructor(public readonly status: number, public readonly reason: SpecErrorReason) {
+    // CLI-owned message; deliberately NOT the backend's error string (§ I).
+    super(`spec request failed (${reason}, status ${status})`);
+    this.name = "SpecApiError";
+  }
+}
+
+/** Map an HTTP status to a typed reason. 5xx and 0 (network) → transient. */
+export function reasonForStatus(status: number): SpecErrorReason {
+  if (status === 401) return "unauthorized";
+  if (status === 404) return "not_found";
+  if (status === 409) return "conflict";
+  if (status === 422) return "invalid";
+  return "transient"; // 5xx, 0, and anything else
+}
+
+export class SpecClient {
+  private readonly base: string;
+  private readonly fetchFn: FetchFn;
+
+  constructor(apiUrl: string, fetchFn: FetchFn = fetch) {
+    this.base = `${apiUrl.replace(/\/+$/, "")}/api/v1`;
+    this.fetchFn = fetchFn;
+  }
+
+  private async send(
+    method: string,
+    path: string,
+    token: string,
+    body?: unknown,
+  ): Promise<{ status: number; json: Record<string, unknown> }> {
+    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    let res: Response;
+    try {
+      res = await this.fetchFn(`${this.base}${path}`, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch {
+      // Network failure — surface as transient (status 0) so callers can retry.
+      throw new SpecApiError(0, "transient");
+    }
+    return { status: res.status, json: await readJson(res) };
+  }
+
+  /**
+   * POST /api/v1/specs — ensure a spec exists for a task and attach it,
+   * idempotently. Returns the (possibly newly-created) spec.
+   */
+  async ensure(token: string, projectKey: string, taskNumber: number, title?: string): Promise<SpecWire> {
+    const { status, json } = await this.send("POST", "/specs", token, {
+      projectKey,
+      taskNumber,
+      ...(title !== undefined ? { title } : {}),
+    });
+    if (status !== 201 && status !== 200) throw new SpecApiError(status, reasonForStatus(status));
+    const spec = parseSpec(json.spec);
+    if (!spec) throw new SpecApiError(status, "transient");
+    return spec;
+  }
+
+  /**
+   * GET /api/v1/specs?projectKey=&taskNumber= — pull a task's spec. Returns
+   * null when the task has no spec yet (a `null` body or a 404), which the
+   * caller treats as "nothing to materialise", not an error.
+   */
+  async get(token: string, projectKey: string, taskNumber: number): Promise<SpecWire | null> {
+    const qs = new URLSearchParams({ projectKey, taskNumber: String(taskNumber) });
+    const { status, json } = await this.send("GET", `/specs?${qs.toString()}`, token);
+    if (status === 404) return null;
+    if (status !== 200) throw new SpecApiError(status, reasonForStatus(status));
+    if (json.spec === null || json.spec === undefined) return null;
+    return parseSpec(json.spec);
+  }
+
+  /**
+   * PUT /api/v1/specs/steps — upsert-only push of a task's steps. Never deletes
+   * an omitted step (Lot 1 FR-011); only the sent steps are created/updated.
+   */
+  async putSteps(
+    token: string,
+    projectKey: string,
+    taskNumber: number,
+    steps: readonly SpecStep[],
+  ): Promise<void> {
+    const { status } = await this.send("PUT", "/specs/steps", token, {
+      projectKey,
+      taskNumber,
+      steps: steps.map((s) => ({ key: s.key, name: s.name, order: s.order, body: s.body })),
+    });
+    if (status !== 200 && status !== 201) throw new SpecApiError(status, reasonForStatus(status));
+  }
+}
+
+async function readJson(res: Response): Promise<Record<string, unknown>> {
+  try {
+    return (await res.json()) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}

--- a/src/domain/cloud/spec_client.ts
+++ b/src/domain/cloud/spec_client.ts
@@ -71,7 +71,12 @@ export class SpecClient {
    * POST /api/v1/specs — ensure a spec exists for a task and attach it,
    * idempotently. Returns the (possibly newly-created) spec.
    */
-  async ensure(token: string, projectKey: string, taskNumber: number, title?: string): Promise<SpecWire> {
+  async ensure(
+    token: string,
+    projectKey: string,
+    taskNumber: number,
+    title?: string,
+  ): Promise<SpecWire> {
     const { status, json } = await this.send("POST", "/specs", token, {
       projectKey,
       taskNumber,

--- a/src/domain/cloud/spec_contract.ts
+++ b/src/domain/cloud/spec_contract.ts
@@ -1,0 +1,74 @@
+// Agent-side types + guards for the public spec wire contract (spec 020,
+// consuming Lot 1's `/api/v1/specs*`). This module is PURE — no IO. It mirrors
+// the versioned `/api/v1` spec object exactly; nothing Cloud-internal is
+// modelled here (constitution § I).
+//
+// Per the contract, consumers MUST ignore unknown fields rather than erroring,
+// so the guards below defensively project the wire body and drop anything they
+// don't recognise. The only shape that crosses the boundary is
+// SpecStep{key,name,order,body} plus the public projectKey / taskNumber.
+
+import type { SpecStep } from "../spec/spec_step.ts";
+
+/** One step as it travels on the wire — structurally the domain {@link SpecStep}. */
+export type SpecStepWire = SpecStep;
+
+/** A task's spec as returned by `GET /api/v1/specs`. */
+export type SpecWire = {
+  taskNumber: number;
+  title: string;
+  steps: SpecStep[];
+};
+
+/**
+ * A spec version descriptor (`versionKey` is opaque). Modelled for
+ * completeness of the read surface; the CLI only ever displays it, never
+ * reasons about the Cloud-internal id behind it (§ I).
+ */
+export type SpecVersionWire = {
+  versionKey: string;
+  source: string;
+  author: string;
+  createdAt: string;
+};
+
+/**
+ * Defensive projection of a single wire step. Returns null when the step is
+ * structurally unusable (missing/empty `key`) so callers can skip it rather
+ * than surface a half-formed spec. Unknown extra fields are ignored.
+ */
+export function parseSpecStep(json: unknown): SpecStep | null {
+  if (typeof json !== "object" || json === null) return null;
+  const o = json as Record<string, unknown>;
+  if (typeof o.key !== "string" || o.key === "") return null;
+  return {
+    key: o.key,
+    name: typeof o.name === "string" ? o.name : o.key,
+    order: typeof o.order === "number" && Number.isFinite(o.order) ? o.order : 0,
+    body: typeof o.body === "string" ? o.body : "",
+  };
+}
+
+/**
+ * Defensive projection of a wire spec object. Returns null on a structurally
+ * invalid body (no `taskNumber`) so a `pull` can treat it as "no spec yet"
+ * rather than throwing. Steps that fail {@link parseSpecStep} are dropped, and
+ * the survivors are sorted by `order` so materialisation is deterministic.
+ */
+export function parseSpec(json: unknown): SpecWire | null {
+  if (typeof json !== "object" || json === null) return null;
+  const o = json as Record<string, unknown>;
+  if (typeof o.taskNumber !== "number" || !Number.isFinite(o.taskNumber)) return null;
+  const rawSteps = Array.isArray(o.steps) ? o.steps : [];
+  const steps: SpecStep[] = [];
+  for (const r of rawSteps) {
+    const step = parseSpecStep(r);
+    if (step) steps.push(step);
+  }
+  steps.sort((a, b) => a.order - b.order);
+  return {
+    taskNumber: o.taskNumber,
+    title: typeof o.title === "string" ? o.title : "",
+    steps,
+  };
+}

--- a/src/domain/cloud/spec_session.ts
+++ b/src/domain/cloud/spec_session.ts
@@ -1,0 +1,141 @@
+// Spec session orchestration (spec 020): the compiled surface the spec push /
+// pull commands and cloud-mode `specify` drive. Mirrors gate_session.ts — all IO
+// is injected (the SpecClient, a CloudClient for task auto-creation, and a token
+// provider with transparent refresh) so the whole thing is unit-testable with a
+// fake fetch and no network / keychain.
+//
+// Constitution § I: only the opaque SpecStep{key,name,order,body} and the public
+// projectKey / taskNumber cross the wire. Errors are CLI-owned SpecApiErrors
+// keyed off HTTP status — never a Cloud-internal identifier or backend string.
+
+import { SpecApiError, SpecClient } from "./spec_client.ts";
+import { CloudClient, type FetchFn } from "./cloud_client.ts";
+import { freshAccessToken } from "./auth_flow.ts";
+import type { CloudConfig } from "./cloud_config.ts";
+import type { CredentialStore } from "../../infrastructure/credential_store.ts";
+import type { SpecStep } from "../spec/spec_step.ts";
+
+/** A valid bearer token, or null when the user must re-authenticate. */
+export type TokenProvider = () => Promise<string | null>;
+
+export type SpecSessionDeps = {
+  projectKey: string;
+  client: SpecClient;
+  cloudClient: CloudClient;
+  token: TokenProvider;
+};
+
+/** Outcome of authoring a spec to the cloud (cloud-mode `specify`). */
+export type AuthorResult = {
+  /** The task the spec is attached to — created here when none was linked. */
+  taskNumber: number;
+  /** Number of steps pushed. */
+  pushed: number;
+  /** True when the task was auto-created because none was linked (FR-011). */
+  created: boolean;
+};
+
+export class SpecSession {
+  constructor(private readonly deps: SpecSessionDeps) {}
+
+  get projectKey(): string {
+    return this.deps.projectKey;
+  }
+
+  /** Obtain a bearer token or fail with a typed unauthorized error (→ re-login). */
+  private async requireToken(): Promise<string> {
+    const tok = await this.deps.token();
+    if (!tok) throw new SpecApiError(401, "unauthorized");
+    return tok;
+  }
+
+  /** Pull a task's spec steps, or `null` when the task has no spec yet. */
+  async pull(taskNumber: number): Promise<readonly SpecStep[] | null> {
+    const tok = await this.requireToken();
+    const spec = await this.deps.client.get(tok, this.deps.projectKey, taskNumber);
+    return spec ? spec.steps : null;
+  }
+
+  /** Upsert-only push of a task's steps (never deletes an omitted step). */
+  async push(taskNumber: number, steps: readonly SpecStep[]): Promise<void> {
+    const tok = await this.requireToken();
+    await this.deps.client.putSteps(tok, this.deps.projectKey, taskNumber, steps);
+  }
+
+  /** Ensure a spec exists for a task and attach it (idempotent). */
+  async ensure(taskNumber: number, title?: string): Promise<void> {
+    const tok = await this.requireToken();
+    await this.deps.client.ensure(tok, this.deps.projectKey, taskNumber, title);
+  }
+
+  /** Auto-create a backlog task from a title and return its number (FR-011). */
+  async createTask(title: string): Promise<number> {
+    const tok = await this.requireToken();
+    const task = await this.deps.cloudClient.createTask(tok, this.deps.projectKey, title);
+    return task.number;
+  }
+
+  /**
+   * Cloud-mode `specify` authoring: resolve the target task (auto-creating +
+   * linking one from `title` when `taskNumber` is null — FR-011), ensure its
+   * spec exists, then upsert the generated steps. Creates NO branch and touches
+   * NO `.specnaut/specs/` files — those side effects live only on the local path
+   * (the caller persists the returned `taskNumber` to link it).
+   */
+  async author(
+    taskNumber: number | null,
+    title: string,
+    steps: readonly SpecStep[],
+  ): Promise<AuthorResult> {
+    let created = false;
+    let resolved = taskNumber;
+    if (resolved === null) {
+      resolved = await this.createTask(title);
+      created = true;
+    }
+    await this.ensure(resolved, title);
+    await this.push(resolved, steps);
+    return { taskNumber: resolved, pushed: steps.length, created };
+  }
+}
+
+/**
+ * One-call factory to obtain a ready SpecSession from the project's Cloud config
+ * + credentials. Reuses the same Cloud-link file (`backlog-config.yml`) and
+ * credential store the gate/backlog paths use — no new credential type (FR-007).
+ * Returns `null` when the project isn't Cloud-linked (no api_url / project_key),
+ * which the caller treats as "not a cloud-backed spec project". `fetchFn` / `now`
+ * are injectable for tests. Mirrors {@link makeGateSession}.
+ */
+export function makeSpecSession(deps: {
+  config: CloudConfig;
+  store: CredentialStore;
+  env?: (key: string) => string | undefined;
+  fetchFn?: FetchFn;
+  now?: () => number;
+}): SpecSession | null {
+  const { config, store } = deps;
+  if (!config.apiUrl || !config.projectKey) return null;
+
+  const env = deps.env ?? ((k) => Deno.env.get(k));
+  const now = deps.now ?? (() => Date.now());
+  const fetchFn = deps.fetchFn ?? fetch;
+
+  const cloudClient = new CloudClient(config.apiUrl, fetchFn);
+  const specClient = new SpecClient(config.apiUrl, fetchFn);
+
+  // Headless escape hatch: an explicit SPECNAUT_CLOUD_TOKEN short-circuits the
+  // stored-credential refresh path (mirroring gate_session). The legacy
+  // SPECFLOW_CLOUD_TOKEN name is still honored as a fallback.
+  const headlessToken = env("SPECNAUT_CLOUD_TOKEN") ?? env("SPECFLOW_CLOUD_TOKEN");
+  const token: TokenProvider = headlessToken && headlessToken.trim() !== ""
+    ? () => Promise.resolve(headlessToken)
+    : () => freshAccessToken({ apiUrl: config.apiUrl, client: cloudClient, store, now });
+
+  return new SpecSession({
+    projectKey: config.projectKey,
+    client: specClient,
+    cloudClient,
+    token,
+  });
+}

--- a/src/domain/conditional_render.ts
+++ b/src/domain/conditional_render.ts
@@ -1,5 +1,9 @@
-import type { BacklogBackend, VersionScheme } from "./installed_lock.ts";
-import { KNOWN_BACKLOG_BACKENDS, KNOWN_VERSION_SCHEMES } from "./installed_lock.ts";
+import type { BacklogBackend, SpecBackend, VersionScheme } from "./installed_lock.ts";
+import {
+  KNOWN_BACKLOG_BACKENDS,
+  KNOWN_SPEC_BACKENDS,
+  KNOWN_VERSION_SCHEMES,
+} from "./installed_lock.ts";
 
 const BEGIN_RE = /^\s*<!--\s*BEGIN:\s*backend=([a-zA-Z0-9_-]+)\s*-->\s*$/;
 const END_RE = /^\s*<!--\s*END:\s*backend=([a-zA-Z0-9_-]+)\s*-->\s*$/;
@@ -90,6 +94,98 @@ export function assertKnownBackend(s: string): asserts s is BacklogBackend {
   if (!KNOWN_BACKLOG_BACKENDS.includes(s as BacklogBackend)) {
     throw new Error(
       `unknown backlog backend '${s}' — known: ${KNOWN_BACKLOG_BACKENDS.join(", ")}`,
+    );
+  }
+}
+
+const SPEC_BEGIN_RE = /^\s*<!--\s*BEGIN:\s*spec-backend=([a-zA-Z0-9_-]+)\s*-->\s*$/;
+const SPEC_END_RE = /^\s*<!--\s*END:\s*spec-backend=([a-zA-Z0-9_-]+)\s*-->\s*$/;
+
+/**
+ * Strip spec-backend-conditional sections from a Markdown source (spec 020).
+ *
+ * Markers are HTML comments on their own line, deliberately distinct from the
+ * backlog `backend=` markers so the two never collide:
+ *   <!-- BEGIN: spec-backend=local -->
+ *   ...content kept when the spec backend === "local"...
+ *   <!-- END: spec-backend=local -->
+ *
+ * For the `active` backend the content is preserved and only the surrounding
+ * marker lines are removed; for any other backend the markers AND the content
+ * between them are removed. Markers inside fenced code blocks are plain content.
+ * A source with no `spec-backend=` markers passes through byte-for-byte — this is
+ * what preserves FR-003 local parity for phase docs that were never marked up.
+ *
+ * Throws on unmatched (BEGIN without END, END without BEGIN) or nested markers.
+ */
+export function renderSpecBackend(source: string, active: SpecBackend): string {
+  const lines = source.split("\n");
+  const out: string[] = [];
+  let insideFence = false;
+  let openBackend: string | null = null;
+  let openLine = -1;
+  let keepBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (FENCE_RE.test(line)) {
+      insideFence = !insideFence;
+      if (openBackend === null || keepBlock) out.push(line);
+      continue;
+    }
+
+    if (!insideFence) {
+      const beginMatch = line.match(SPEC_BEGIN_RE);
+      if (beginMatch) {
+        if (openBackend !== null) {
+          throw new Error(
+            `nested spec-backend marker at line ${i + 1}: BEGIN ${beginMatch[1]} ` +
+              `inside open block ${openBackend} (started at line ${openLine + 1})`,
+          );
+        }
+        openBackend = beginMatch[1];
+        openLine = i;
+        keepBlock = openBackend === active;
+        continue;
+      }
+
+      const endMatch = line.match(SPEC_END_RE);
+      if (endMatch) {
+        if (openBackend === null) {
+          throw new Error(
+            `unmatched END marker at line ${i + 1}: spec-backend=${endMatch[1]}`,
+          );
+        }
+        if (endMatch[1] !== openBackend) {
+          throw new Error(
+            `mismatched END marker at line ${i + 1}: expected spec-backend=${openBackend} ` +
+              `(opened at line ${openLine + 1}), got spec-backend=${endMatch[1]}`,
+          );
+        }
+        openBackend = null;
+        keepBlock = false;
+        continue;
+      }
+    }
+
+    if (openBackend === null || keepBlock) out.push(line);
+  }
+
+  if (openBackend !== null) {
+    throw new Error(
+      `unmatched BEGIN marker at line ${openLine + 1}: spec-backend=${openBackend}`,
+    );
+  }
+
+  return out.join("\n");
+}
+
+/** Throws if `s` is not a known spec backend. */
+export function assertKnownSpecBackend(s: string): asserts s is SpecBackend {
+  if (!KNOWN_SPEC_BACKENDS.includes(s as SpecBackend)) {
+    throw new Error(
+      `unknown spec backend '${s}' — known: ${KNOWN_SPEC_BACKENDS.join(", ")}`,
     );
   }
 }

--- a/src/domain/installed_lock.ts
+++ b/src/domain/installed_lock.ts
@@ -30,6 +30,18 @@ export const KNOWN_VERSION_SCHEMES: ReadonlyArray<VersionScheme> = [
   "date",
 ];
 
+/**
+ * Where a project's specifications are stored (spec 020 / cli#424).
+ * `local` = `.specnaut/specs/` markdown files (the pre-feature behaviour, first-
+ * class default); `cloud` = hosted on SpecNaut Cloud via the versioned
+ * `/api/v1/specs*` contract. Sibling of {@link BacklogBackend}.
+ */
+export type SpecBackend = "local" | "cloud";
+export const KNOWN_SPEC_BACKENDS: ReadonlyArray<SpecBackend> = [
+  "local",
+  "cloud",
+];
+
 export type LockEntry = {
   readonly sha256: string;
   readonly installedAt: string;
@@ -41,6 +53,11 @@ export type InstalledLock = {
   readonly harness: KnownHarness;
   readonly backlogBackend: BacklogBackend;
   readonly versionScheme: VersionScheme;
+  /**
+   * Where this project's specs live (spec 020). Absent in a pre-feature lock →
+   * `"local"` (FR-010, backward compatible). Sibling of `backlogBackend`.
+   */
+  readonly specBackend: SpecBackend;
   readonly templatesVersion: string;
   readonly entries: ReadonlyMap<string, LockEntry>;
   /**
@@ -102,6 +119,15 @@ export function parseLock(yaml: string): InstalledLock {
     ? (rawScheme as VersionScheme)
     : "semver";
 
+  // Default to "local" when absent: existing locks pre-date the spec-backend
+  // selection feature, and the local-md flow is what was implicitly active
+  // (FR-010 — backward-compatible upgrade path). Mirrors `backlog_backend`.
+  const rawSpecBackend = root.spec_backend;
+  const specBackend: SpecBackend = typeof rawSpecBackend === "string" &&
+      KNOWN_SPEC_BACKENDS.includes(rawSpecBackend as SpecBackend)
+    ? (rawSpecBackend as SpecBackend)
+    : "local";
+
   const templatesVersion = root.templates_version;
   if (typeof templatesVersion !== "string") {
     throw new Error("missing top-level templates_version");
@@ -131,6 +157,7 @@ export function parseLock(yaml: string): InstalledLock {
     harness,
     backlogBackend,
     versionScheme,
+    specBackend,
     templatesVersion,
     entries,
     ...(parentManaged ? { parentManaged } : {}),
@@ -153,6 +180,7 @@ export function serializeLock(lock: InstalledLock): string {
     harness: lock.harness,
     backlog_backend: lock.backlogBackend,
     version_scheme: lock.versionScheme,
+    spec_backend: lock.specBackend,
     // Emit `parent_managed` only when set so legacy/standalone locks stay
     // byte-for-byte identical to before this feature.
     ...(lock.parentManaged ? { parent_managed: true } : {}),

--- a/src/domain/spec/spec_step.ts
+++ b/src/domain/spec/spec_step.ts
@@ -1,0 +1,22 @@
+// The opaque unit of a specification exchanged with SpecNaut Cloud (spec 020).
+//
+// A step is one named markdown section of a spec — the framework phase
+// (`specify`, `plan`, `tasks`, …). It is deliberately opaque to the cloud: only
+// `key`, `name`, `order`, and `body` cross the wire. This is the SOLE shape that
+// crosses the OSS↔Cloud boundary for specs (constitution § I) — no CLI framework
+// identifier, no private-half type, ever travels with it.
+
+/**
+ * One ordered, named markdown section of a specification.
+ *
+ * - `key`   — stable slug the cloud upserts on (e.g. `"specify"`, `"plan"`).
+ * - `name`  — human-readable tab label (e.g. `"Specify"`).
+ * - `order` — 1-based display / materialisation order.
+ * - `body`  — the raw markdown content.
+ */
+export type SpecStep = {
+  readonly key: string;
+  readonly name: string;
+  readonly order: number;
+  readonly body: string;
+};

--- a/src/domain/spec_backend_strategy.ts
+++ b/src/domain/spec_backend_strategy.ts
@@ -1,0 +1,26 @@
+import type { SpecBackend } from "./installed_lock.ts";
+
+/**
+ * Strategy for a spec-storage backend (spec 020). Each backend exposes its
+ * display label and post-init copy without call sites switching on the backend
+ * string. A thinner sibling of {@link BacklogBackendStrategy}: the cloud spec
+ * backend reuses the Cloud-link file (`backlog-config.yml`) that
+ * `specnaut cloud login` writes, so no per-backend config stub is needed here.
+ *
+ * To add a new backend:
+ *   1. Add the string to `SpecBackend` in `installed_lock.ts`.
+ *   2. Implement `SpecBackendStrategy` in `spec_strategies/<new>.ts`.
+ *   3. Register it in `spec_strategies/registry.ts`.
+ */
+export interface SpecBackendStrategy {
+  readonly key: SpecBackend;
+
+  /** Human-readable label shown in the interactive picker. */
+  readonly displayName: string;
+
+  /**
+   * Lines to print via `console.log(dim(...))` after a successful init.
+   * Empty array = silent. Always emitted in order.
+   */
+  initMessages(): readonly string[];
+}

--- a/src/domain/spec_strategies/cloud.ts
+++ b/src/domain/spec_strategies/cloud.ts
@@ -1,0 +1,19 @@
+import type { SpecBackendStrategy } from "../spec_backend_strategy.ts";
+
+/**
+ * Specs hosted on SpecNaut Cloud via the versioned `/api/v1/specs*` contract.
+ * The recommended default: parallelisable specs (no branch per spec), shareable,
+ * no local file upkeep. Reuses the Cloud-link file + credentials that
+ * `specnaut cloud login` provisions, so init only points the user at that step.
+ */
+export class CloudSpecStrategy implements SpecBackendStrategy {
+  readonly key = "cloud" as const;
+  readonly displayName = "SpecNaut Cloud (hosted specs — browser login)";
+
+  initMessages(): readonly string[] {
+    return [
+      "↳ specs will be hosted on SpecNaut Cloud (spec_backend: cloud)",
+      "  next: run `specnaut cloud login` to authenticate and link a Cloud project",
+    ];
+  }
+}

--- a/src/domain/spec_strategies/local.ts
+++ b/src/domain/spec_strategies/local.ts
@@ -1,0 +1,15 @@
+import type { SpecBackendStrategy } from "../spec_backend_strategy.ts";
+
+/**
+ * The pre-feature behaviour: specs are markdown files under `.specnaut/specs/`.
+ * A first-class, fully-supported default — zero-config and silent at init
+ * (FR-003 local parity).
+ */
+export class LocalSpecStrategy implements SpecBackendStrategy {
+  readonly key = "local" as const;
+  readonly displayName = "Local Markdown files (.specnaut/specs/)";
+
+  initMessages(): readonly string[] {
+    return [];
+  }
+}

--- a/src/domain/spec_strategies/registry.ts
+++ b/src/domain/spec_strategies/registry.ts
@@ -1,0 +1,26 @@
+import type { SpecBackend } from "../installed_lock.ts";
+import type { SpecBackendStrategy } from "../spec_backend_strategy.ts";
+import { LocalSpecStrategy } from "./local.ts";
+import { CloudSpecStrategy } from "./cloud.ts";
+
+// Order drives the picker: SpecNaut Cloud is listed first and is the
+// recommended default (see DEFAULT_SPEC_BACKEND in cli/spec_picker.ts).
+export const SPEC_STRATEGIES: ReadonlyArray<SpecBackendStrategy> = [
+  new CloudSpecStrategy(),
+  new LocalSpecStrategy(),
+];
+
+/**
+ * Returns the strategy for the given backend key.
+ *
+ * Throws when `key` is not a known backend — this should never happen with a
+ * well-formed lock, but defends against typos / corrupt locks without silently
+ * picking the wrong strategy.
+ */
+export function findSpecStrategy(key: SpecBackend): SpecBackendStrategy {
+  const s = SPEC_STRATEGIES.find((s) => s.key === key);
+  if (!s) {
+    throw new Error(`unknown spec backend: ${String(key)}`);
+  }
+  return s;
+}

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -5,6 +5,7 @@ import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 
 function toAntigravityWorkflowMarkdown(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -72,7 +73,7 @@ export class AntigravityHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -4,6 +4,7 @@ import type { Bundle } from "../../domain/template.ts";
 import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 import { ensureSkillFrontmatter } from "./skill_folder.ts";
 
 function destinationFor(entry: CoreEntry): string {
@@ -56,7 +57,7 @@ export class ClaudeHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
 
       // Skill-folder categories ship as `.claude/skills/<name>/SKILL.md`.
       // Claude Code derives the skill name from the folder, but we inject

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -7,6 +7,7 @@ import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 
 function parseAgentFrontmatter(
   content: string,
@@ -61,7 +62,7 @@ export class CodexHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -5,6 +5,7 @@ import { skillFolderName } from "./skill_folder.ts";
 import { splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 
 function toCopilotInstructionMarkdown(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -50,7 +51,7 @@ export class CopilotHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -5,6 +5,7 @@ import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 
 function destinationFor(entry: CoreEntry): string {
   switch (entry.category) {
@@ -43,7 +44,7 @@ export class CursorHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -5,6 +5,7 @@ import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 
 type PermissionValue = "allow" | "ask" | "deny" | { "*": "ask" | "allow" | "deny" };
 type PermissionMap = Record<string, PermissionValue>;
@@ -135,7 +136,7 @@ export class OpenCodeHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/spec_backend_filter.ts
+++ b/src/infrastructure/harness/spec_backend_filter.ts
@@ -1,0 +1,20 @@
+import type { CoreEntry } from "../../domain/core_bundle.ts";
+import type { BundleOptions } from "../../application/ports.ts";
+import { renderSpecBackend } from "../../domain/conditional_render.ts";
+
+/**
+ * Renders `<!-- BEGIN: spec-backend=X -->` blocks in a `phase` entry against the
+ * active spec backend (spec 020). Only `specify.md` / `implement.md` carry these
+ * markers today; every other phase (and non-phase category) passes through
+ * unchanged, so `local` output stays byte-identical to the pre-feature CLI
+ * (FR-003). Sibling of {@link applyScheme}.
+ *
+ * Idempotent and pure — no IO, no Deno globals.
+ */
+export function applySpecBackend(entry: CoreEntry, opts: BundleOptions): CoreEntry {
+  if (entry.category !== "phase") return entry;
+  return {
+    ...entry,
+    content: renderSpecBackend(entry.content, opts.specBackend),
+  };
+}

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -5,6 +5,7 @@ import { skillFolderName } from "./skill_folder.ts";
 import { splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
+import { applySpecBackend } from "./spec_backend_filter.ts";
 
 // Cascade ignores Claude-only frontmatter fields (e.g. `color:`). Strip them
 // before emission so they don't eat into the 12k-char workflow cap.
@@ -66,7 +67,7 @@ export class WindsurfHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applyScheme(backendApplied, opts);
+      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/spec/cloud_spec_store.ts
+++ b/src/infrastructure/spec/cloud_spec_store.ts
@@ -1,0 +1,24 @@
+import type { SpecStore } from "../../application/ports.ts";
+import type { SpecStep } from "../../domain/spec/spec_step.ts";
+import type { SpecSession } from "../../domain/cloud/spec_session.ts";
+
+/**
+ * The `cloud` spec backend adapter (spec 020, D1). A thin bridge from the
+ * {@link SpecStore} port onto a {@link SpecSession} — all HTTP, auth, and the
+ * § I boundary live in the session/client. `pull` returns `null` when the task
+ * has no cloud spec yet (a clean "nothing to materialise", not an error);
+ * `push` is upsert-only.
+ */
+export class CloudSpecStore implements SpecStore {
+  readonly key = "cloud" as const;
+
+  constructor(private readonly session: SpecSession) {}
+
+  pull(taskNumber: number): Promise<readonly SpecStep[] | null> {
+    return this.session.pull(taskNumber);
+  }
+
+  push(taskNumber: number, steps: readonly SpecStep[]): Promise<void> {
+    return this.session.push(taskNumber, steps);
+  }
+}

--- a/src/infrastructure/spec/local_spec_store.ts
+++ b/src/infrastructure/spec/local_spec_store.ts
@@ -1,0 +1,32 @@
+import type { SpecStore } from "../../application/ports.ts";
+import type { SpecStep } from "../../domain/spec/spec_step.ts";
+
+/**
+ * The `local` spec backend adapter (spec 020, D1). `spec push` / `spec pull` are
+ * cloud-only verbs — there is no remote spec to sync when specs are plain
+ * `.specnaut/specs/` markdown files. Both verbs reject with one clear, actionable
+ * message so a misdirected call never silently succeeds or produces an empty
+ * spec. The local authoring flow never routes through this store (it bypasses
+ * the port entirely, preserving byte-identical behaviour — FR-003).
+ */
+export class LocalSpecStore implements SpecStore {
+  readonly key = "local" as const;
+
+  private cloudOnly(): never {
+    throw new Error(
+      "spec push/pull are cloud-backend commands — this project uses the local spec " +
+        "backend (.specnaut/specs/ markdown). Re-run `specnaut init --spec-backend cloud` " +
+        "to host specs on SpecNaut Cloud.",
+    );
+  }
+
+  // `async` so the guard surfaces as a rejected promise (the SpecStore contract),
+  // not a synchronous throw — callers uniformly `await` it.
+  pull(_taskNumber: number): Promise<readonly SpecStep[] | null> {
+    return Promise.resolve().then(() => this.cloudOnly());
+  }
+
+  push(_taskNumber: number, _steps: readonly SpecStep[]): Promise<void> {
+    return Promise.resolve().then(() => this.cloudOnly());
+  }
+}

--- a/src/infrastructure/spec/spec_cache_writer.ts
+++ b/src/infrastructure/spec/spec_cache_writer.ts
@@ -1,0 +1,136 @@
+import type { SpecCacheStore } from "../../application/ports.ts";
+import type { SpecStep } from "../../domain/spec/spec_step.ts";
+
+/**
+ * Filesystem adapter for the gitignored spec materialisation cache (spec 020,
+ * D5). Writes one ordered markdown file per step under
+ * `.specnaut/specs/.cache/<task>/<order>-<slug(key)>.md`, so any downstream agent
+ * reads a cloud spec as ordinary files with no knowledge it lives in the cloud.
+ *
+ * A small `steps.json` manifest sits beside the markdown files, recording each
+ * step's `key` / `name` / `order` / filename. The markdown holds the (editable)
+ * body; the manifest lets `read` reconstruct full {@link SpecStep}s for
+ * `spec push` after a user edits a tab — the filename alone can't recover `name`.
+ *
+ * The cache is disposable and never the source of truth: `write` clears the
+ * task's dir first so a re-pull reconciles stale files to the current cloud
+ * state (US3 AC2).
+ */
+export class SpecCacheWriter implements SpecCacheStore {
+  private cacheDir(projectDir: string, taskNumber: number): string {
+    return `${projectDir}/.specnaut/specs/.cache/${taskNumber}`;
+  }
+
+  private relDir(taskNumber: number): string {
+    return `.specnaut/specs/.cache/${taskNumber}`;
+  }
+
+  private manifestPath(projectDir: string, taskNumber: number): string {
+    return `${this.cacheDir(projectDir, taskNumber)}/steps.json`;
+  }
+
+  async write(
+    projectDir: string,
+    taskNumber: number,
+    steps: readonly SpecStep[],
+  ): Promise<string[]> {
+    await this.clear(projectDir, taskNumber);
+    const dir = this.cacheDir(projectDir, taskNumber);
+    await Deno.mkdir(dir, { recursive: true });
+
+    const written: string[] = [];
+    const manifest: ManifestEntry[] = [];
+    for (const step of steps) {
+      const file = `${step.order}-${slug(step.key)}.md`;
+      await Deno.writeTextFile(`${dir}/${file}`, step.body);
+      written.push(`${this.relDir(taskNumber)}/${file}`);
+      manifest.push({ key: step.key, name: step.name, order: step.order, file });
+    }
+    await Deno.writeTextFile(
+      this.manifestPath(projectDir, taskNumber),
+      JSON.stringify(manifest, null, 2),
+    );
+    return written;
+  }
+
+  async read(
+    projectDir: string,
+    taskNumber: number,
+  ): Promise<readonly SpecStep[] | null> {
+    const dir = this.cacheDir(projectDir, taskNumber);
+    let raw: string | null;
+    try {
+      raw = await Deno.readTextFile(this.manifestPath(projectDir, taskNumber));
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) throw e;
+      // No manifest → fall back to reconstructing steps from `<order>-<slug>.md`
+      // filenames, so a spec authored by writing cache files directly (cloud
+      // `specify`, before any `pull`) is still pushable.
+      raw = null;
+    }
+
+    const manifest = raw !== null
+      ? (JSON.parse(raw) as ManifestEntry[])
+      : await this.scanFilenames(dir);
+    if (manifest === null) return null;
+
+    const steps: SpecStep[] = [];
+    for (const m of manifest) {
+      // Re-read the body each time so a user's edit to the cached tab is what
+      // gets pushed (the manifest only pins identity/order, never the content).
+      const body = await Deno.readTextFile(`${dir}/${m.file}`);
+      steps.push({ key: m.key, name: m.name, order: m.order, body });
+    }
+    steps.sort((a, b) => a.order - b.order);
+    return steps;
+  }
+
+  /** Reconstruct manifest entries from `<order>-<slug>.md` filenames in a cache
+   *  dir with no `steps.json`. Returns null when the dir is absent/empty. */
+  private async scanFilenames(dir: string): Promise<ManifestEntry[] | null> {
+    const entries: ManifestEntry[] = [];
+    try {
+      for await (const e of Deno.readDir(dir)) {
+        if (!e.isFile || !e.name.endsWith(".md")) continue;
+        const m = e.name.match(/^(\d+)-(.+)\.md$/);
+        if (!m) continue;
+        const order = Number(m[1]);
+        const key = m[2];
+        entries.push({ key, name: titleCase(key), order, file: e.name });
+      }
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) return null;
+      throw e;
+    }
+    return entries.length > 0 ? entries : null;
+  }
+
+  async clear(projectDir: string, taskNumber: number): Promise<void> {
+    try {
+      await Deno.remove(this.cacheDir(projectDir, taskNumber), { recursive: true });
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) return; // already absent — idempotent
+      throw e;
+    }
+  }
+}
+
+type ManifestEntry = { key: string; name: string; order: number; file: string };
+
+/** Slugify a step key for a filesystem-safe filename segment. */
+function slug(key: string): string {
+  return key
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "step";
+}
+
+/** Derive a human-readable name from a slug (`user-auth` → `User Auth`) when no
+ *  manifest preserved the original — a best-effort label for filename fallback. */
+function titleCase(s: string): string {
+  return s
+    .split("-")
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,10 @@ export async function run(argv: string[]): Promise<number> {
       const { runGate } = await import("./cli/handlers/gate_handler.ts");
       return await runGate(intent);
     }
+    case "spec": {
+      const { runSpec } = await import("./cli/handlers/spec_handler.ts");
+      return await runSpec(intent);
+    }
     case "unknown":
       console.error(red(`Unknown command: "${intent.received}"`));
       console.error(HELP);

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -400,6 +400,7 @@ Given that feature description, do this:
    - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
    - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
 
+<!-- BEGIN: spec-backend=local -->
 2. **Branch creation** (optional, via hook):
 
    If a \`before_specify\` hook ran, it will have created/switched to a git branch and output JSON with \`BRANCH_NAME\` and \`FEATURE_NUM\`. Note these for reference; the branch name does **not** dictate the spec directory name.
@@ -445,6 +446,33 @@ Given that feature description, do this:
    - Create only one feature per \`/specnaut specify\` invocation.
    - The spec directory name and git branch name are independent.
    - The spec directory and file are always created by this command, never by the hook.
+<!-- END: spec-backend=local -->
+<!-- BEGIN: spec-backend=cloud -->
+2. **Cloud spec authoring** (spec backend = cloud — NO git branch, NO local files):
+
+   This project stores specifications on SpecNaut Cloud, not in \`.specnaut/specs/\`.
+   Do **NOT** create a git branch and do **NOT** write any \`.specnaut/specs/<n>/\`
+   files. The branch is created later, at \`/specnaut implement\`. The spec is
+   authored directly to the linked backlog task and read back on demand with
+   \`specnaut spec pull <task>\`.
+
+3. **Resolve the linked task and author the spec to Cloud**:
+
+   1. Determine the task number:
+      - If the user passed \`--issue <N>\`, use it.
+      - Otherwise \`specnaut spec push\` auto-creates a backlog task named from the
+        feature and links it — the task and its spec are created together (no
+        manual pre-step).
+   2. Generate the spec body using \`templates/spec-template.md\` for structure,
+      exactly as you would locally (same sections, same mandatory Domain Model
+      block).
+   3. Write the generated spec to the gitignored cache as the \`specify\` step:
+      \`.specnaut/specs/.cache/<task>/1-specify.md\`, then push it:
+      \`specnaut spec push <task>\` (upsert-only; it never deletes other tabs).
+   4. Persist the resolved task number to \`.specnaut/feature.json\`
+      (\`{ "linked_issue": <N>, "workflow_shape": "<lite|full>" }\`) so downstream
+      phases locate the spec. No \`feature_directory\` is written in cloud mode.
+<!-- END: spec-backend=cloud -->
 
 4. Load \`templates/spec-template.md\` to understand required sections.
 
@@ -524,7 +552,12 @@ Given that feature description, do this:
    - \`optional: true\` → \`## Extension Hooks\` block with \`**Optional Hook**: {extension}\`, command, description, prompt.
    - \`optional: false\` → \`## Extension Hooks\` block with \`**Automatic Hook**: {extension}\`, \`EXECUTE_COMMAND: {command}\`.
 
+<!-- BEGIN: spec-backend=local -->
 **NOTE:** Branch creation is handled by the \`before_specify\` hook. Spec directory and file creation are always handled by this core command.
+<!-- END: spec-backend=local -->
+<!-- BEGIN: spec-backend=cloud -->
+**NOTE:** In cloud spec mode no git branch and no \`.specnaut/specs/\` files are created here — the spec is pushed to SpecNaut Cloud and the branch is created later at \`/specnaut implement\`.
+<!-- END: spec-backend=cloud -->
 
 ## Quick Guidelines
 
@@ -1384,6 +1417,18 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+0. **Cloud spec setup** (spec backend = cloud): the spec lives on SpecNaut Cloud
+   and \`/specnaut specify\` created NO git branch. Before anything else:
+   - **Create the feature branch now** — this is the decoupling point. Run
+     \`.specnaut/scripts/bash/create-new-feature.sh --branch-only "<feature description>"\`
+     (the \`--branch-only\` flag creates only the branch — no \`.specnaut/specs/\` dir).
+   - **Materialise the spec** so the steps below read plain files:
+     \`specnaut spec pull <task>\` writes \`.specnaut/specs/.cache/<task>/\`.
+   - Read the spec, plan, tasks, and the mandatory Domain Model block from that
+     cache directory instead of \`.specnaut/specs/<n>/\`.
+
+<!-- END: spec-backend=cloud -->
 1. Run \`{SCRIPT}\` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
@@ -14304,6 +14349,7 @@ set -e
 JSON_MODE=false
 DRY_RUN=false
 ALLOW_EXISTING=false
+BRANCH_ONLY=false
 SHORT_NAME=""
 BRANCH_NUMBER=""
 USE_TIMESTAMP=false
@@ -14318,6 +14364,9 @@ while [ \$i -le \$# ]; do
             ;;
         --dry-run)
             DRY_RUN=true
+            ;;
+        --branch-only)
+            BRANCH_ONLY=true
             ;;
         --allow-existing-branch)
             ALLOW_EXISTING=true
@@ -14370,11 +14419,14 @@ while [ \$i -le \$# ]; do
             LINKED_ISSUE="\$next_arg"
             ;;
         --help|-h)
-            echo "Usage: \$0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] [--issue <id>] <feature_description>"
+            echo "Usage: \$0 [--json] [--dry-run] [--branch-only] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] [--issue <id>] <feature_description>"
             echo ""
             echo "Options:"
             echo "  --json              Output in JSON format"
             echo "  --dry-run           Compute branch name and paths without creating branches, directories, or files"
+            echo "  --branch-only       Create ONLY the git branch — skip the spec directory + spec file."
+            echo "                      Used by cloud-mode /specnaut implement, where the spec lives on"
+            echo "                      SpecNaut Cloud and the branch is created at implement (not specify)."
             echo "  --allow-existing-branch  Switch to branch if it already exists instead of failing"
             echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
             echo "  --number N          Specify branch number manually (overrides auto-detection)"
@@ -14686,15 +14738,20 @@ if [ "\$DRY_RUN" != true ]; then
         >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for \$BRANCH_NAME"
     fi
 
-    mkdir -p "\$FEATURE_DIR"
+    # --branch-only: create the branch above but skip the spec directory + file.
+    # In cloud spec mode the spec lives on SpecNaut Cloud, so /specnaut implement
+    # only needs the branch (the decoupling point — no local .specnaut/specs/ dir).
+    if [ "\$BRANCH_ONLY" != true ]; then
+        mkdir -p "\$FEATURE_DIR"
 
-    if [ ! -f "\$SPEC_FILE" ]; then
-        TEMPLATE=\$(resolve_template "spec-template" "\$REPO_ROOT") || true
-        if [ -n "\$TEMPLATE" ] && [ -f "\$TEMPLATE" ]; then
-            cp "\$TEMPLATE" "\$SPEC_FILE"
-        else
-            echo "Warning: Spec template not found; created empty spec file" >&2
-            touch "\$SPEC_FILE"
+        if [ ! -f "\$SPEC_FILE" ]; then
+            TEMPLATE=\$(resolve_template "spec-template" "\$REPO_ROOT") || true
+            if [ -n "\$TEMPLATE" ] && [ -f "\$TEMPLATE" ]; then
+                cp "\$TEMPLATE" "\$SPEC_FILE"
+            else
+                echo "Warning: Spec template not found; created empty spec file" >&2
+                touch "\$SPEC_FILE"
+            fi
         fi
     fi
 
@@ -16097,6 +16154,7 @@ Generated by Specnaut. Edit freely.
 .specnaut/logs/
 .specnaut/upgrade-pending.json
 .specnaut/upgrade-staging/
+.specnaut/specs/.cache/
 `,
     executable: false,
     backend: null,

--- a/templates/core/root/.gitignore
+++ b/templates/core/root/.gitignore
@@ -2,3 +2,4 @@
 .specnaut/logs/
 .specnaut/upgrade-pending.json
 .specnaut/upgrade-staging/
+.specnaut/specs/.cache/

--- a/templates/core/skills/specnaut/phases/implement.md
+++ b/templates/core/skills/specnaut/phases/implement.md
@@ -43,6 +43,18 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+0. **Cloud spec setup** (spec backend = cloud): the spec lives on SpecNaut Cloud
+   and `/specnaut specify` created NO git branch. Before anything else:
+   - **Create the feature branch now** — this is the decoupling point. Run
+     `.specnaut/scripts/bash/create-new-feature.sh --branch-only "<feature description>"`
+     (the `--branch-only` flag creates only the branch — no `.specnaut/specs/` dir).
+   - **Materialise the spec** so the steps below read plain files:
+     `specnaut spec pull <task>` writes `.specnaut/specs/.cache/<task>/`.
+   - Read the spec, plan, tasks, and the mandatory Domain Model block from that
+     cache directory instead of `.specnaut/specs/<n>/`.
+
+<!-- END: spec-backend=cloud -->
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):

--- a/templates/core/skills/specnaut/phases/specify.md
+++ b/templates/core/skills/specnaut/phases/specify.md
@@ -67,6 +67,7 @@ Given that feature description, do this:
    - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
    - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
 
+<!-- BEGIN: spec-backend=local -->
 2. **Branch creation** (optional, via hook):
 
    If a `before_specify` hook ran, it will have created/switched to a git branch and output JSON with `BRANCH_NAME` and `FEATURE_NUM`. Note these for reference; the branch name does **not** dictate the spec directory name.
@@ -112,6 +113,33 @@ Given that feature description, do this:
    - Create only one feature per `/specnaut specify` invocation.
    - The spec directory name and git branch name are independent.
    - The spec directory and file are always created by this command, never by the hook.
+<!-- END: spec-backend=local -->
+<!-- BEGIN: spec-backend=cloud -->
+2. **Cloud spec authoring** (spec backend = cloud — NO git branch, NO local files):
+
+   This project stores specifications on SpecNaut Cloud, not in `.specnaut/specs/`.
+   Do **NOT** create a git branch and do **NOT** write any `.specnaut/specs/<n>/`
+   files. The branch is created later, at `/specnaut implement`. The spec is
+   authored directly to the linked backlog task and read back on demand with
+   `specnaut spec pull <task>`.
+
+3. **Resolve the linked task and author the spec to Cloud**:
+
+   1. Determine the task number:
+      - If the user passed `--issue <N>`, use it.
+      - Otherwise `specnaut spec push` auto-creates a backlog task named from the
+        feature and links it — the task and its spec are created together (no
+        manual pre-step).
+   2. Generate the spec body using `templates/spec-template.md` for structure,
+      exactly as you would locally (same sections, same mandatory Domain Model
+      block).
+   3. Write the generated spec to the gitignored cache as the `specify` step:
+      `.specnaut/specs/.cache/<task>/1-specify.md`, then push it:
+      `specnaut spec push <task>` (upsert-only; it never deletes other tabs).
+   4. Persist the resolved task number to `.specnaut/feature.json`
+      (`{ "linked_issue": <N>, "workflow_shape": "<lite|full>" }`) so downstream
+      phases locate the spec. No `feature_directory` is written in cloud mode.
+<!-- END: spec-backend=cloud -->
 
 4. Load `templates/spec-template.md` to understand required sections.
 
@@ -191,7 +219,12 @@ Given that feature description, do this:
    - `optional: true` → `## Extension Hooks` block with `**Optional Hook**: {extension}`, command, description, prompt.
    - `optional: false` → `## Extension Hooks` block with `**Automatic Hook**: {extension}`, `EXECUTE_COMMAND: {command}`.
 
+<!-- BEGIN: spec-backend=local -->
 **NOTE:** Branch creation is handled by the `before_specify` hook. Spec directory and file creation are always handled by this core command.
+<!-- END: spec-backend=local -->
+<!-- BEGIN: spec-backend=cloud -->
+**NOTE:** In cloud spec mode no git branch and no `.specnaut/specs/` files are created here — the spec is pushed to SpecNaut Cloud and the branch is created later at `/specnaut implement`.
+<!-- END: spec-backend=cloud -->
 
 ## Quick Guidelines
 

--- a/templates/core/specnaut/scripts/bash/create-new-feature.sh
+++ b/templates/core/specnaut/scripts/bash/create-new-feature.sh
@@ -5,6 +5,7 @@ set -e
 JSON_MODE=false
 DRY_RUN=false
 ALLOW_EXISTING=false
+BRANCH_ONLY=false
 SHORT_NAME=""
 BRANCH_NUMBER=""
 USE_TIMESTAMP=false
@@ -19,6 +20,9 @@ while [ $i -le $# ]; do
             ;;
         --dry-run)
             DRY_RUN=true
+            ;;
+        --branch-only)
+            BRANCH_ONLY=true
             ;;
         --allow-existing-branch)
             ALLOW_EXISTING=true
@@ -71,11 +75,14 @@ while [ $i -le $# ]; do
             LINKED_ISSUE="$next_arg"
             ;;
         --help|-h)
-            echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] [--issue <id>] <feature_description>"
+            echo "Usage: $0 [--json] [--dry-run] [--branch-only] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] [--issue <id>] <feature_description>"
             echo ""
             echo "Options:"
             echo "  --json              Output in JSON format"
             echo "  --dry-run           Compute branch name and paths without creating branches, directories, or files"
+            echo "  --branch-only       Create ONLY the git branch — skip the spec directory + spec file."
+            echo "                      Used by cloud-mode /specnaut implement, where the spec lives on"
+            echo "                      SpecNaut Cloud and the branch is created at implement (not specify)."
             echo "  --allow-existing-branch  Switch to branch if it already exists instead of failing"
             echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
             echo "  --number N          Specify branch number manually (overrides auto-detection)"
@@ -387,15 +394,20 @@ if [ "$DRY_RUN" != true ]; then
         >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
     fi
 
-    mkdir -p "$FEATURE_DIR"
+    # --branch-only: create the branch above but skip the spec directory + file.
+    # In cloud spec mode the spec lives on SpecNaut Cloud, so /specnaut implement
+    # only needs the branch (the decoupling point — no local .specnaut/specs/ dir).
+    if [ "$BRANCH_ONLY" != true ]; then
+        mkdir -p "$FEATURE_DIR"
 
-    if [ ! -f "$SPEC_FILE" ]; then
-        TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT") || true
-        if [ -n "$TEMPLATE" ] && [ -f "$TEMPLATE" ]; then
-            cp "$TEMPLATE" "$SPEC_FILE"
-        else
-            echo "Warning: Spec template not found; created empty spec file" >&2
-            touch "$SPEC_FILE"
+        if [ ! -f "$SPEC_FILE" ]; then
+            TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT") || true
+            if [ -n "$TEMPLATE" ] && [ -f "$TEMPLATE" ]; then
+                cp "$TEMPLATE" "$SPEC_FILE"
+            else
+                echo "Warning: Spec template not found; created empty spec file" >&2
+                touch "$SPEC_FILE"
+            fi
         fi
     fi
 

--- a/tests/application/diff_project_test.ts
+++ b/tests/application/diff_project_test.ts
@@ -67,6 +67,7 @@ async function lockWith(
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "1.2.3",
     entries: map,
   };

--- a/tests/application/init_project_test.ts
+++ b/tests/application/init_project_test.ts
@@ -100,6 +100,7 @@ Deno.test("InitProjectUseCase writes the bundle to the target dir (happy path)",
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -125,6 +126,7 @@ Deno.test("InitProjectUseCase fails with 'conflicts' when target already has spe
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -148,6 +150,7 @@ Deno.test("InitProjectUseCase reports lockExists=true when conflicts hit a previ
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.0.0",
     entries: new Map(),
   };
@@ -158,6 +161,7 @@ Deno.test("InitProjectUseCase reports lockExists=true when conflicts hit a previ
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -182,6 +186,7 @@ Deno.test("InitProjectUseCase calls git.init when repo not initialized and initG
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -198,6 +203,7 @@ Deno.test("InitProjectUseCase skips git.init when initGit=false", async () => {
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -214,6 +220,7 @@ Deno.test("InitProjectUseCase skips git.init when git not available", async () =
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -240,6 +247,7 @@ Deno.test("InitProjectUseCase skips git.init when repo already initialized", asy
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -266,6 +274,7 @@ Deno.test("InitProjectUseCase with force=true skips conflict detection and reque
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -298,6 +307,7 @@ Deno.test("InitProjectUseCase returns backups array from writer report", async (
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -321,6 +331,7 @@ Deno.test("InitProjectUseCase persists an installed.lock with SHA256 of every fi
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: [
       {
         category: "project-root",
@@ -364,6 +375,7 @@ Deno.test("InitProjectUseCase records harness.key in the installed lock", async 
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -381,6 +393,7 @@ Deno.test("InitProjectUseCase suppresses agentic dests from writes AND lock when
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: MIXED_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -422,6 +435,7 @@ Deno.test("InitProjectUseCase writes all dests and sets no parentManaged when no
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: MIXED_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -452,6 +466,7 @@ Deno.test("InitProjectUseCase uses harness.mapBundle output as the file tree", a
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: SAMPLE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -485,6 +500,7 @@ Deno.test("InitProjectUseCase: preservedPaths are absent from the write set and 
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: PRESERVE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -517,6 +533,7 @@ Deno.test("InitProjectUseCase: filesWritten excludes preserved paths", async () 
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: PRESERVE_CORE, // 3 non-mergeable files
     ensureDir: () => Promise.resolve(),
   });
@@ -545,6 +562,7 @@ Deno.test("InitProjectUseCase: dry-run filesWritten excludes preserved paths", a
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: PRESERVE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -573,6 +591,7 @@ Deno.test("InitProjectUseCase: preserved file remains in the installed.lock (FR-
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: PRESERVE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -599,6 +618,7 @@ Deno.test("InitProjectUseCase: new bundle path still written when preserves are 
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: PRESERVE_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -628,6 +648,7 @@ Deno.test("InitProjectUseCase: declared agentic path in a parent-managed sub-rep
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: MIXED_CORE,
     ensureDir: () => Promise.resolve(),
   });
@@ -665,6 +686,7 @@ Deno.test("InitProjectUseCase: absent preservedPaths writes the full bundle (FR-
     harness: fakeClaudeHarness(),
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     core: PRESERVE_CORE,
     ensureDir: () => Promise.resolve(),
   });

--- a/tests/application/reconcile_path_test.ts
+++ b/tests/application/reconcile_path_test.ts
@@ -23,6 +23,7 @@ function mockLock(): InstalledLock {
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "1.6.0",
     entries,
   };

--- a/tests/application/upgrade_project_test.ts
+++ b/tests/application/upgrade_project_test.ts
@@ -130,6 +130,7 @@ Deno.test("UpgradeProjectUseCase returns up-to-date when disk + lock + bundle al
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.3.0",
     entries: new Map([["a.md", {
       sha256: sha,
@@ -158,6 +159,7 @@ Deno.test("UpgradeProjectUseCase returns planned (no writes) in dry-run", async 
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.2.0",
     entries: new Map([["a.md", {
       sha256: oldSha,
@@ -189,6 +191,7 @@ Deno.test("UpgradeProjectUseCase applies auto-update and skips preserve", async 
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.2.0",
     entries: new Map([
       ["clean.md", {
@@ -230,6 +233,7 @@ Deno.test("UpgradeProjectUseCase with --force overwrites preserve actions with b
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.2.0",
     entries: new Map([["a.md", {
       sha256: await sha256Hex("ORIGINAL"),
@@ -260,6 +264,7 @@ Deno.test("UpgradeProjectUseCase deletes clean orphans (lock entry + on disk + m
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["a.md", {
@@ -295,6 +300,7 @@ Deno.test("UpgradeProjectUseCase preserves customized orphan without --force, dr
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["a.md", {
@@ -334,6 +340,7 @@ Deno.test("UpgradeProjectUseCase with --force deletes customized orphan with bac
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["orphan.md", {
@@ -373,6 +380,7 @@ Deno.test("UpgradeProjectUseCase: vanilla on-disk + plugin installed → backed 
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -409,6 +417,7 @@ Deno.test("UpgradeProjectUseCase: customized on-disk + plugin installed → pres
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -454,6 +463,7 @@ Deno.test("UpgradeProjectUseCase: missing on-disk + plugin installed → deferre
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -492,6 +502,7 @@ Deno.test("UpgradeProjectUseCase: vanilla on-disk + plugin NOT installed → exi
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.7.0",
     entries: new Map([[
       PLUGIN_DEST,
@@ -530,6 +541,7 @@ Deno.test("UpgradeProjectUseCase: writes upstream content to .specnaut/upgrade-s
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "1.4.0",
     entries: lockEntries,
   };
@@ -581,6 +593,7 @@ Deno.test("UpgradeProjectUseCase: does NOT write staging for auto-update files",
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "1.4.0",
     entries: lockEntries,
   };
@@ -615,6 +628,7 @@ Deno.test("UpgradeProjectUseCase: lock.parentManaged=true filters agentic dests 
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.7.0",
     entries: new Map(), // parent-managed lock never had agentic entries (FR-012)
     parentManaged: true,
@@ -665,6 +679,7 @@ Deno.test("UpgradeProjectUseCase: parentManagedOverride re-derives + persists on
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.7.0",
     entries: new Map(),
   };
@@ -707,6 +722,7 @@ Deno.test("UpgradeProjectUseCase: legacy lock + parentManagedOverride persists p
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.8.0",
     // Only a non-agentic toolkit entry; agentic dests are suppressed by the
     // override so they never enter the plan.

--- a/tests/cli/parser_test.ts
+++ b/tests/cli/parser_test.ts
@@ -23,6 +23,7 @@ Deno.test("parseArgs returns init intent with a project name", () => {
     backlogUrl: null,
     backlogRepo: null,
     scheme: null,
+    specBackend: null,
     force: false,
     dryRun: false,
     resetPreserved: false,
@@ -40,6 +41,7 @@ Deno.test("parseArgs returns init intent with --here", () => {
     backlogUrl: null,
     backlogRepo: null,
     scheme: null,
+    specBackend: null,
     force: false,
     dryRun: false,
     resetPreserved: false,
@@ -57,6 +59,7 @@ Deno.test("parseArgs returns init intent with --no-git", () => {
     backlogUrl: null,
     backlogRepo: null,
     scheme: null,
+    specBackend: null,
     force: false,
     dryRun: false,
     resetPreserved: false,
@@ -100,6 +103,7 @@ Deno.test("parseArgs init with --force", () => {
     backlogUrl: null,
     backlogRepo: null,
     scheme: null,
+    specBackend: null,
     force: true,
     dryRun: false,
     resetPreserved: false,
@@ -117,6 +121,7 @@ Deno.test("parseArgs init with --dry-run", () => {
     backlogUrl: null,
     backlogRepo: null,
     scheme: null,
+    specBackend: null,
     force: false,
     dryRun: true,
     resetPreserved: false,
@@ -134,6 +139,46 @@ Deno.test("parseArgs init with --force --dry-run captures both flags", () => {
 Deno.test("parseArgs init without --force defaults to false", () => {
   const result = parseArgs(["init", "demo"]);
   if (result.kind === "init") assertEquals(result.force, false);
+});
+
+Deno.test("parseArgs init --spec-backend cloud|local is captured; absent → null", () => {
+  const cloud = parseArgs(["init", "demo", "--spec-backend", "cloud"]);
+  if (cloud.kind === "init") assertEquals(cloud.specBackend, "cloud");
+  const local = parseArgs(["init", "demo", "--spec-backend", "local"]);
+  if (local.kind === "init") assertEquals(local.specBackend, "local");
+  const none = parseArgs(["init", "demo"]);
+  if (none.kind === "init") assertEquals(none.specBackend, null);
+});
+
+Deno.test("parseArgs init rejects an invalid --spec-backend value", () => {
+  assertEquals(parseArgs(["init", "demo", "--spec-backend", "nope"]), {
+    kind: "unknown",
+    received: "init --spec-backend nope",
+  });
+});
+
+Deno.test("parseArgs returns spec pull/push intents with a task number", () => {
+  assertEquals(parseArgs(["spec", "pull", "154"]), {
+    kind: "spec",
+    sub: "pull",
+    task: 154,
+    apiUrl: null,
+  });
+  assertEquals(parseArgs(["spec", "push", "7"]), {
+    kind: "spec",
+    sub: "push",
+    task: 7,
+    apiUrl: null,
+  });
+});
+
+Deno.test("parseArgs spec with a non-numeric task yields task null", () => {
+  const r = parseArgs(["spec", "pull", "abc"]);
+  if (r.kind === "spec") assertEquals(r.task, null);
+});
+
+Deno.test("parseArgs rejects an unknown spec subcommand", () => {
+  assertEquals(parseArgs(["spec", "bogus"]), { kind: "unknown", received: "spec bogus" });
 });
 
 Deno.test("parseArgs returns upgrade intent", () => {

--- a/tests/cli/spec_picker_test.ts
+++ b/tests/cli/spec_picker_test.ts
@@ -1,0 +1,83 @@
+import { assertEquals } from "@std/assert";
+import {
+  DEFAULT_SPEC_BACKEND,
+  pickSpecBackend,
+  pickSpecBackendInteractive,
+} from "../../src/cli/spec_picker.ts";
+import type { SelectIO } from "../../src/cli/select.ts";
+
+// Spec 020 / SC-001 — the init spec-backend picker. Mirrors backlog_picker_test:
+// Enter → recommended default (cloud); numeric pick → chosen; invalid re-prompts.
+
+function scriptedIO(reads: ReadonlyArray<Uint8Array | null>): SelectIO {
+  const queue = [...reads];
+  return {
+    write: () => {},
+    readBytes: () => {
+      const next = queue.shift();
+      return Promise.resolve(next === undefined ? null : next);
+    },
+    teardown: () => {},
+  };
+}
+
+function fakeIO(answers: ReadonlyArray<string | null>) {
+  const queue = [...answers];
+  const log: string[] = [];
+  const errLog: string[] = [];
+  return {
+    io: {
+      readLine: () => queue.shift() ?? null,
+      log: (s: string) => log.push(s),
+      errLog: (s: string) => errLog.push(s),
+    },
+    log,
+    errLog,
+  };
+}
+
+Deno.test("pickSpecBackend defaults to cloud on empty input", () => {
+  const { io, log } = fakeIO([""]);
+  assertEquals(pickSpecBackend(io), "cloud");
+  assertEquals(DEFAULT_SPEC_BACKEND, "cloud");
+  const all = log.join("\n");
+  // Cloud is listed first, marked recommended (default), with a benefit note;
+  // local remains a first-class listed choice.
+  assertEquals(all.includes("SpecNaut Cloud"), true);
+  assertEquals(all.includes("recommended (default)"), true);
+  assertEquals(all.includes("Local Markdown"), true);
+});
+
+Deno.test("pickSpecBackend picks 1 for cloud (listed first)", () => {
+  const { io } = fakeIO(["1"]);
+  assertEquals(pickSpecBackend(io), "cloud");
+});
+
+Deno.test("pickSpecBackend picks 2 for local", () => {
+  const { io } = fakeIO(["2"]);
+  assertEquals(pickSpecBackend(io), "local");
+});
+
+Deno.test("pickSpecBackend re-prompts on invalid input", () => {
+  const { io, errLog } = fakeIO(["999", "bad", "2"]);
+  assertEquals(pickSpecBackend(io), "local");
+  assertEquals(errLog.length, 2);
+});
+
+Deno.test("pickSpecBackendInteractive returns 'cloud' on Enter (default)", async () => {
+  const io = scriptedIO([new Uint8Array([0x0d])]);
+  assertEquals(await pickSpecBackendInteractive(io), "cloud");
+});
+
+Deno.test("pickSpecBackendInteractive returns 'local' after arrow-down + space", async () => {
+  const io = scriptedIO([
+    new Uint8Array([0x1b, 0x5b, 0x42]),
+    new Uint8Array([0x20]),
+  ]);
+  assertEquals(await pickSpecBackendInteractive(io), "local");
+});
+
+Deno.test("pickSpecBackendInteractive returns null on Ctrl-C cancel", async () => {
+  const io = scriptedIO([new Uint8Array([0x03])]);
+  assertEquals(await pickSpecBackendInteractive(io), null);
+});

--- a/tests/domain/conditional_render_spec_backend_test.ts
+++ b/tests/domain/conditional_render_spec_backend_test.ts
@@ -1,0 +1,82 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { renderSpecBackend } from "../../src/domain/conditional_render.ts";
+
+// Spec 020 — renderSpecBackend keeps the active spec backend's block and drops
+// the other, mirroring renderBackend/renderScheme. Its markers are distinct
+// (`spec-backend=`) so they never collide with backlog `backend=` markers.
+
+Deno.test("renderSpecBackend keeps only the active backend's block", () => {
+  const src = [
+    "shared before",
+    "<!-- BEGIN: spec-backend=local -->",
+    "LOCAL steps",
+    "<!-- END: spec-backend=local -->",
+    "<!-- BEGIN: spec-backend=cloud -->",
+    "CLOUD push",
+    "<!-- END: spec-backend=cloud -->",
+    "shared after",
+  ].join("\n");
+
+  assertEquals(
+    renderSpecBackend(src, "local"),
+    ["shared before", "LOCAL steps", "shared after"].join("\n"),
+  );
+  assertEquals(
+    renderSpecBackend(src, "cloud"),
+    ["shared before", "CLOUD push", "shared after"].join("\n"),
+  );
+});
+
+Deno.test("renderSpecBackend is a no-op when no spec-backend markers are present", () => {
+  const src = "plain line\nsecond line\n";
+  assertEquals(renderSpecBackend(src, "local"), src);
+  assertEquals(renderSpecBackend(src, "cloud"), src);
+});
+
+Deno.test("renderSpecBackend ignores backlog `backend=` markers (no collision)", () => {
+  const src = [
+    "<!-- BEGIN: backend=github -->",
+    "github only",
+    "<!-- END: backend=github -->",
+  ].join("\n");
+  // A backlog marker is plain content to the spec renderer — passed through.
+  assertEquals(renderSpecBackend(src, "local"), src);
+});
+
+Deno.test("renderSpecBackend treats markers inside fenced code blocks as content", () => {
+  const src = [
+    "```",
+    "<!-- BEGIN: spec-backend=cloud -->",
+    "not a marker",
+    "<!-- END: spec-backend=cloud -->",
+    "```",
+  ].join("\n");
+  assertEquals(renderSpecBackend(src, "local"), src);
+});
+
+Deno.test("renderSpecBackend rejects unmatched / mismatched / nested markers", () => {
+  assertThrows(
+    () => renderSpecBackend("<!-- BEGIN: spec-backend=local -->\noops\n", "local"),
+    Error,
+    "unmatched BEGIN",
+  );
+  assertThrows(
+    () => renderSpecBackend("x\n<!-- END: spec-backend=local -->\n", "local"),
+    Error,
+    "unmatched END",
+  );
+  assertThrows(
+    () =>
+      renderSpecBackend(
+        [
+          "<!-- BEGIN: spec-backend=local -->",
+          "<!-- BEGIN: spec-backend=cloud -->",
+          "<!-- END: spec-backend=cloud -->",
+          "<!-- END: spec-backend=local -->",
+        ].join("\n"),
+        "local",
+      ),
+    Error,
+    "nested spec-backend marker",
+  );
+});

--- a/tests/domain/installed_lock_spec_backend_test.ts
+++ b/tests/domain/installed_lock_spec_backend_test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "@std/assert";
+import {
+  type InstalledLock,
+  type LockEntry,
+  parseLock,
+  serializeLock,
+} from "../../src/domain/installed_lock.ts";
+
+// Spec 020 / FR-010 — the `spec_backend` lock field: round-trips through
+// serialize/parse and defaults to "local" when absent (backward-compatible
+// upgrade path). Mirrors the backlog_backend default-on-absent coverage.
+
+function lockWith(specBackend: InstalledLock["specBackend"]): InstalledLock {
+  return {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend,
+    templatesVersion: "1.0.0",
+    entries: new Map<string, LockEntry>([
+      ["CLAUDE.md", {
+        sha256: "aaa",
+        installedAt: "2026-07-14T00:00:00Z",
+        templatesVersion: "1.0.0",
+      }],
+    ]),
+  };
+}
+
+Deno.test("serializeLock emits spec_backend and parseLock round-trips it (cloud)", () => {
+  const yaml = serializeLock(lockWith("cloud"));
+  assertEquals(yaml.includes("spec_backend: cloud"), true);
+  assertEquals(parseLock(yaml).specBackend, "cloud");
+});
+
+Deno.test("serializeLock round-trips spec_backend: local", () => {
+  const yaml = serializeLock(lockWith("local"));
+  assertEquals(yaml.includes("spec_backend: local"), true);
+  assertEquals(parseLock(yaml).specBackend, "local");
+});
+
+Deno.test("parseLock defaults spec_backend to local when absent (FR-010)", () => {
+  const v2 = `version: 2
+harness: claude
+templates_version: 0.7.0
+entries: {}
+`;
+  assertEquals(parseLock(v2).specBackend, "local");
+});
+
+Deno.test("parseLock accepts spec_backend: cloud", () => {
+  const v2 = `version: 2
+harness: claude
+spec_backend: cloud
+templates_version: 0.7.0
+entries: {}
+`;
+  assertEquals(parseLock(v2).specBackend, "cloud");
+});
+
+Deno.test("parseLock falls back to local on an unknown spec_backend value", () => {
+  const v2 = `version: 2
+harness: claude
+spec_backend: not-a-backend
+templates_version: 0.7.0
+entries: {}
+`;
+  assertEquals(parseLock(v2).specBackend, "local");
+});

--- a/tests/domain/installed_lock_test.ts
+++ b/tests/domain/installed_lock_test.ts
@@ -45,6 +45,7 @@ Deno.test("serializeLock round-trips", () => {
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.3.0",
     entries: new Map<string, LockEntry>([
       ["CLAUDE.md", {
@@ -107,6 +108,7 @@ Deno.test("serializeLock writes version 2 with harness field", () => {
     harness: "cursor",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.3.0",
     entries: new Map(),
   };
@@ -212,6 +214,7 @@ Deno.test("serializeLock emits parent_managed: true when set, round-trips throug
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "1.0.0",
     entries: new Map(),
     parentManaged: true,
@@ -228,6 +231,7 @@ Deno.test("serializeLock omits parent_managed when not set", () => {
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "1.0.0",
     entries: new Map(),
   };

--- a/tests/domain/spec_client_test.ts
+++ b/tests/domain/spec_client_test.ts
@@ -1,0 +1,148 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { reasonForStatus, SpecApiError, SpecClient } from "../../src/domain/cloud/spec_client.ts";
+import type { FetchFn } from "../../src/domain/cloud/cloud_client.ts";
+
+// Spec 020 / SC-006 — the spec HTTP client. Mirrors gate_client_test: a scripted
+// fake fetch, status-only errors, and the § I boundary check that no backend
+// `error` string / `_id` ever surfaces in a CLI-owned message or the parsed spec.
+
+const API = "https://dep.convex.site";
+
+function specJson(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    // A private-half id the CLI must NEVER surface — proves parseSpec drops it.
+    _id: "cloud_internal_deadbeef",
+    taskNumber: 154,
+    title: "Cloud-hosted specs",
+    steps: [
+      { key: "specify", name: "Specify", order: 1, body: "# spec body" },
+      { key: "plan", name: "Plan", order: 2, body: "# plan body" },
+    ],
+    ...over,
+  };
+}
+
+type Route = { method: string; test: (url: string) => boolean; status: number; body: unknown };
+
+/** A scripted fetch: each request consumes the first matching route in order. */
+function scripted(
+  routes: Route[],
+): { fetchFn: FetchFn; calls: { method: string; url: string; body: string | null }[] } {
+  const calls: { method: string; url: string; body: string | null }[] = [];
+  const remaining = [...routes];
+  const fetchFn = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ method, url, body: (init?.body as string) ?? null });
+    const idx = remaining.findIndex((r) => r.method === method && r.test(url));
+    if (idx === -1) throw new Error(`no scripted route for ${method} ${url}`);
+    const [r] = remaining.splice(idx, 1);
+    return Promise.resolve(
+      new Response(JSON.stringify(r.body), {
+        status: r.status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as FetchFn;
+  return { fetchFn, calls };
+}
+
+Deno.test("reasonForStatus maps statuses; everything else is transient", () => {
+  assertEquals(reasonForStatus(401), "unauthorized");
+  assertEquals(reasonForStatus(404), "not_found");
+  assertEquals(reasonForStatus(409), "conflict");
+  assertEquals(reasonForStatus(422), "invalid");
+  assertEquals(reasonForStatus(500), "transient");
+  assertEquals(reasonForStatus(0), "transient");
+});
+
+Deno.test("ensure() posts projectKey/taskNumber and returns the parsed spec", async () => {
+  const { fetchFn, calls } = scripted([
+    { method: "POST", test: (u) => u.endsWith("/api/v1/specs"), status: 201, body: { spec: specJson() } },
+  ]);
+  const spec = await new SpecClient(API, fetchFn).ensure("tok", "CLOUD", 154, "Cloud-hosted specs");
+  assertEquals(spec.taskNumber, 154);
+  assertEquals(spec.steps.length, 2);
+  const sent = JSON.parse(calls[0].body!);
+  assertEquals(sent.projectKey, "CLOUD");
+  assertEquals(sent.taskNumber, 154);
+  assertEquals(sent.title, "Cloud-hosted specs");
+});
+
+Deno.test("get() returns the spec with steps sorted by order", async () => {
+  const { fetchFn, calls } = scripted([
+    {
+      method: "GET",
+      test: (u) => u.includes("/specs?") && u.includes("taskNumber=154"),
+      status: 200,
+      body: {
+        spec: specJson({
+          steps: [
+            { key: "plan", name: "Plan", order: 2, body: "b2" },
+            { key: "specify", name: "Specify", order: 1, body: "b1" },
+          ],
+        }),
+      },
+    },
+  ]);
+  const spec = await new SpecClient(API, fetchFn).get("tok", "CLOUD", 154);
+  assertEquals(spec?.steps.map((s) => s.key), ["specify", "plan"]);
+  assertEquals(calls[0].url.includes("projectKey=CLOUD"), true);
+});
+
+Deno.test("get() returns null when the task has no spec (null body or 404)", async () => {
+  const nullBody = scripted([
+    { method: "GET", test: (u) => u.includes("/specs?"), status: 200, body: { spec: null } },
+  ]);
+  assertEquals(await new SpecClient(API, nullBody.fetchFn).get("tok", "CLOUD", 9), null);
+
+  const notFound = scripted([
+    { method: "GET", test: (u) => u.includes("/specs?"), status: 404, body: { error: "nope" } },
+  ]);
+  assertEquals(await new SpecClient(API, notFound.fetchFn).get("tok", "CLOUD", 9), null);
+});
+
+Deno.test("putSteps() sends only key/name/order/body per step (§ I opaque shape)", async () => {
+  const { fetchFn, calls } = scripted([
+    { method: "PUT", test: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
+  ]);
+  await new SpecClient(API, fetchFn).putSteps("tok", "CLOUD", 154, [
+    { key: "specify", name: "Specify", order: 1, body: "b" },
+  ]);
+  const sent = JSON.parse(calls[0].body!);
+  assertEquals(sent.projectKey, "CLOUD");
+  assertEquals(sent.taskNumber, 154);
+  assertEquals(Object.keys(sent.steps[0]).sort(), ["body", "key", "name", "order"]);
+});
+
+Deno.test("a 422 maps to an invalid SpecApiError and never leaks the backend error string (§ I)", async () => {
+  const { fetchFn } = scripted([
+    { method: "PUT", test: (u) => u.includes("/specs/steps"), status: 422, body: { error: "internal-only-string" } },
+  ]);
+  const err = await assertRejects(
+    () => new SpecClient(API, fetchFn).putSteps("tok", "CLOUD", 1, []),
+    SpecApiError,
+  );
+  assertEquals(err.reason, "invalid");
+  assertEquals(err.status, 422);
+  assertEquals(err.message.includes("internal-only-string"), false);
+});
+
+Deno.test("a network failure surfaces as a transient SpecApiError (status 0)", async () => {
+  const fetchFn = (() => Promise.reject(new TypeError("network down"))) as FetchFn;
+  const err = await assertRejects(
+    () => new SpecClient(API, fetchFn).get("tok", "CLOUD", 1),
+    SpecApiError,
+  );
+  assertEquals(err.reason, "transient");
+  assertEquals(err.status, 0);
+});
+
+Deno.test("parsed spec never carries the backend's _id (§ I)", async () => {
+  const { fetchFn } = scripted([
+    { method: "GET", test: (u) => u.includes("/specs?"), status: 200, body: { spec: specJson() } },
+  ]);
+  const spec = await new SpecClient(API, fetchFn).get("tok", "CLOUD", 154);
+  assertEquals(JSON.stringify(spec).includes("cloud_internal_deadbeef"), false);
+  assertEquals(JSON.stringify(spec).includes("_id"), false);
+});

--- a/tests/domain/spec_client_test.ts
+++ b/tests/domain/spec_client_test.ts
@@ -58,7 +58,12 @@ Deno.test("reasonForStatus maps statuses; everything else is transient", () => {
 
 Deno.test("ensure() posts projectKey/taskNumber and returns the parsed spec", async () => {
   const { fetchFn, calls } = scripted([
-    { method: "POST", test: (u) => u.endsWith("/api/v1/specs"), status: 201, body: { spec: specJson() } },
+    {
+      method: "POST",
+      test: (u) => u.endsWith("/api/v1/specs"),
+      status: 201,
+      body: { spec: specJson() },
+    },
   ]);
   const spec = await new SpecClient(API, fetchFn).ensure("tok", "CLOUD", 154, "Cloud-hosted specs");
   assertEquals(spec.taskNumber, 154);
@@ -117,7 +122,12 @@ Deno.test("putSteps() sends only key/name/order/body per step (§ I opaque shape
 
 Deno.test("a 422 maps to an invalid SpecApiError and never leaks the backend error string (§ I)", async () => {
   const { fetchFn } = scripted([
-    { method: "PUT", test: (u) => u.includes("/specs/steps"), status: 422, body: { error: "internal-only-string" } },
+    {
+      method: "PUT",
+      test: (u) => u.includes("/specs/steps"),
+      status: 422,
+      body: { error: "internal-only-string" },
+    },
   ]);
   const err = await assertRejects(
     () => new SpecClient(API, fetchFn).putSteps("tok", "CLOUD", 1, []),

--- a/tests/domain/upgrade_plan_test.ts
+++ b/tests/domain/upgrade_plan_test.ts
@@ -8,6 +8,7 @@ const emptyLock: InstalledLock = {
   harness: "claude",
   backlogBackend: "local",
   versionScheme: "semver",
+  specBackend: "local",
   templatesVersion: "0.1.0",
   entries: new Map(),
 };
@@ -18,6 +19,7 @@ function lockWith(path: string, sha: string): InstalledLock {
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.1.0",
     entries: new Map([[
       path,
@@ -121,6 +123,7 @@ Deno.test("computeUpgradePlan emits remove for clean orphan (lock + on disk + ma
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["a.md", {
@@ -155,6 +158,7 @@ Deno.test("computeUpgradePlan emits remove with wasCustomized=true when disk div
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["orphan.md", {
@@ -182,6 +186,7 @@ Deno.test("computeUpgradePlan emits no action for orphan-not-on-disk (user alrea
     harness: "claude",
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
     templatesVersion: "0.6.1",
     entries: new Map([
       ["orphan.md", {

--- a/tests/fixtures/implement_local_golden.md
+++ b/tests/fixtures/implement_local_golden.md
@@ -1,0 +1,196 @@
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specnaut/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specnaut/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **REQUIRED**: Read the `## Domain Model` section in spec.md. If the section is absent, empty, or still contains `[NEEDS CLARIFICATION]` markers / template placeholders → halt and report BLOCKED with reason `awaiting:product-owner-domain-brief`. The developer agent refuses to write code without this brief — its "First action" checklist (step 4) reads the block and returns the same BLOCKED reason. Recommend running `/specnaut clarify` to fill the section before re-attempting `/specnaut implement`.
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/specnaut tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specnaut/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specnaut/extensions.yml` does not exist, skip silently

--- a/tests/fixtures/specify_local_golden.md
+++ b/tests/fixtures/specify_local_golden.md
@@ -1,0 +1,223 @@
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check extension hooks (`hooks.before_specify` in `.specnaut/extensions.yml`)**:
+Skip silently if the file is absent or unparseable. For each enabled entry
+(treat missing `enabled` as `true`) without a non-empty `condition`, emit:
+
+- `optional: true` → `## Extension Hooks` block with `**Optional Pre-Hook**: {extension}`,
+  command, description, and prompt.
+- `optional: false` → `## Extension Hooks` block with `**Automatic Pre-Hook**: {extension}`,
+  `EXECUTE_COMMAND: {command}`, and wait for the result before proceeding.
+
+Hooks with non-empty `condition` are deferred to the HookExecutor.
+
+## Chain shape selection
+
+Before running the outline below, determine the **chain shape** that
+will apply to this `/specnaut specify` invocation (and the rest of
+the chain after it):
+
+1. **Read `CHAIN_SHAPE` from the router context** (set by `SKILL.md`
+   step 1 chain-shape parsing).
+   - `CHAIN_SHAPE == lite` → use lite, no prompt. Skip step 2.
+   - `CHAIN_SHAPE == full` → use full, no prompt. Skip step 2.
+   - `CHAIN_SHAPE == auto` → proceed to step 2.
+
+2. **Apply the lite heuristic.** Read `phases/lite-heuristic.md`,
+   score the feature brief (the original user input from
+   `/specnaut specify`, before flag stripping is irrelevant — use the
+   substantive brief), and:
+   - If `score < 2`: silently set `CHAIN_SHAPE = full`. No prompt.
+   - If `score ≥ 2`: emit the prompt from `phases/lite-heuristic.md`
+     ("This brief looks small — run the lite chain? [Y/n]") **exactly
+     once**, wait for the user's answer:
+     - `Y` / `yes` / empty (default-Y if you treated the prompt as a
+       Y/n with capital Y) → `CHAIN_SHAPE = lite`.
+     - `n` / `no` / anything else interpreted as no → `CHAIN_SHAPE =
+       full`.
+
+3. **Persist the chosen shape** to `.specnaut/feature.json` (when
+   step 3 of the Outline below writes that file, include
+   `"workflow_shape": "lite"` or `"workflow_shape": "full"` alongside
+   `feature_directory` and `linked_issue`).
+
+4. **Log line on phase transition** (used by the chain when invoking
+   the next phase): emit `✓ specify (lite) complete — proceeding to
+   plan` when `CHAIN_SHAPE == lite`, or the unchanged `✓ specify
+   complete — proceeding to clarify` when `CHAIN_SHAPE == full`.
+   `phases/auto-chain.md` reads `workflow_shape` from `feature.json`
+   to decide which phase to chain to next.
+
+## Outline
+
+The text the user typed after `/specnaut specify` is the feature description. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran, it will have created/switched to a git branch and output JSON with `BRANCH_NAME` and `FEATURE_NUM`. Note these for reference; the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it to the hook so it uses that exact value.
+
+3. **Create the spec feature directory**:
+
+   Specs live under `.specnaut/specs/` unless the user provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided it, use as-is.
+   2. Otherwise auto-generate under `.specnaut/specs/`:
+      - Check `.specnaut/init-options.json` for `branch_numbering`
+      - `"timestamp"`: prefix is `YYYYMMDD-HHMMSS`
+      - `"sequential"` or absent: prefix is `NNN` (next available 3-digit number)
+      - Construct: `<prefix>-<short-name>` (e.g., `003-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `.specnaut/specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist to `.specnaut/feature.json`:
+     ```json
+     { "feature_directory": "<resolved feature dir>", "linked_issue": <N or null>, "workflow_shape": "<lite|full>" }
+     ```
+     Write the actual resolved path (e.g., `.specnaut/specs/003-user-auth`), not the literal string.
+     This lets downstream commands (`/specnaut plan`, `/specnaut tasks`, etc.) locate the feature directory.
+
+     **`linked_issue`**: when the user invokes `/specnaut specify` with `--issue <id>` (or the
+     hook's JSON output includes a non-null `LINKED_ISSUE`), persist it as a JSON integer here.
+     Otherwise persist `null`. The merge phase reads this field to auto-close the linked
+     backlog item on the project board after a successful fast-forward + push. Backward-compat
+     with existing `feature.json` files: absent or null is a no-op everywhere downstream.
+
+     **`workflow_shape`**: the chain shape chosen during "Chain shape selection" above —
+     `"lite"` or `"full"`. `phases/auto-chain.md` reads this field at every chain transition
+     to decide which phase comes next (lite skips `clarify` and `tasks`). Backward-compat
+     with existing `feature.json` files: absent → treat as `"full"` everywhere downstream.
+
+   **IMPORTANT**:
+   - Create only one feature per `/specnaut specify` invocation.
+   - The spec directory name and git branch name are independent.
+   - The spec directory and file are always created by this command, never by the hook.
+
+4. Load `templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description; if empty: ERROR "No feature description provided"
+    2. Extract key concepts: actors, actions, data, constraints
+    3. For unclear aspects, make informed guesses. Mark with `[NEEDS CLARIFICATION: question]` only when the choice significantly impacts scope/UX and no reasonable default exists. **Maximum 3 markers total.**
+    4. Fill User Scenarios & Testing; if no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements — each must be testable
+    6. Define Success Criteria — measurable, technology-agnostic, verifiable
+    7. **Populate the `## Domain Model` block (mandatory)** — Bounded context, Vocabulary (Ubiquitous language), Entities (have identity), Value objects, Invariants, Out of scope. Use `[NEEDS CLARIFICATION: <question>]` markers for fields the input does not let you fill — `/specnaut clarify` resolves them. The developer refuses to proceed if this block is absent or contains unresolved placeholders.
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to `SPEC_FILE` using the template structure, replacing placeholders with concrete details while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the spec, validate it:
+
+   a. **Create Spec Quality Checklist** at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md`:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+
+      **Purpose**: Validate specification completeness before planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+
+      ## Content Quality
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] All mandatory sections completed
+
+      ## Requirement Completeness
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable and technology-agnostic
+      - [ ] All acceptance scenarios defined; edge cases identified
+      - [ ] Scope clearly bounded; dependencies and assumptions identified
+
+      ## Feature Readiness
+      - [ ] All functional requirements have acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] No implementation details in specification
+
+      ## Notes
+      Items marked incomplete require spec updates before `/specnaut clarify` or `/specnaut plan`
+      ```
+
+   b. **Run Validation**: Review spec against each checklist item; document specific failures.
+
+   c. **Handle Results**:
+
+      - **All pass**: Mark checklist complete and proceed to step 8.
+
+      - **Items fail** (excluding [NEEDS CLARIFICATION]):
+        1. List failing items and issues; update spec; re-run (max 3 iterations).
+        2. After 3 iterations, document remaining issues and warn user.
+
+      - **[NEEDS CLARIFICATION] markers remain**: keep ≤3 most critical,
+        document informed-guess defaults in Assumptions, leave the
+        surviving markers verbatim for `/specnaut clarify` to resolve.
+        **Do NOT prompt inline.** In `lite` shape, markers become
+        Assumptions and the chain continues.
+
+   d. **Update Checklist** after each validation iteration.
+
+8. **Report completion and proceed (no permission ask)**:
+   - Report `SPECIFY_FEATURE_DIRECTORY`, `SPEC_FILE`, and checklist
+     summary in one short block.
+   - Chain unconditionally to the next phase: `full` → `/specnaut clarify`,
+     `lite` → `/specnaut plan`. Pause only on `--manual` or `--once`.
+     Transition wording is a statement (`✓ specify complete — proceeding
+     to <next>`), never a question.
+
+9. **Check extension hooks (`hooks.after_specify` in `.specnaut/extensions.yml`)**:
+   Same rules as Pre-Execution Checks. For each executable hook emit:
+
+   - `optional: true` → `## Extension Hooks` block with `**Optional Hook**: {extension}`, command, description, prompt.
+   - `optional: false` → `## Extension Hooks` block with `**Automatic Hook**: {extension}`, `EXECUTE_COMMAND: {command}`.
+
+**NOTE:** Branch creation is handled by the `before_specify` hook. Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**. Avoid HOW (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- Do NOT embed checklists in the spec itself — that is a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: complete for every feature.
+- **Optional sections**: include only when relevant; remove inapplicable sections entirely (don't leave "N/A").
+
+### For AI Generation
+
+1. **Make informed guesses** using context, industry standards, and common patterns.
+2. **Document assumptions** in the Assumptions section.
+3. **Limit clarifications**: max 3 `[NEEDS CLARIFICATION]` markers — only for critical decisions with no reasonable default.
+4. **Prioritize**: scope > security/privacy > user experience > technical details.
+5. **Think like a tester**: vague requirements should fail the "testable and unambiguous" check.
+
+**Reasonable defaults** (don't ask about these): data retention, performance targets, error handling, authentication method, integration patterns.
+
+### Success Criteria Guidelines
+
+Success criteria must be **measurable** (specific metrics), **technology-agnostic** (no frameworks/databases), **user-focused** (outcomes from user/business perspective), and **verifiable** without implementation knowledge.
+
+**Good**: "Users can complete checkout in under 3 minutes" · "System supports 10,000 concurrent users" · "95% of searches return results in under 1 second"
+
+**Bad**: "API response time under 200ms" (too technical) · "Database handles 1000 TPS" (implementation detail) · "React components render efficiently" (framework-specific)

--- a/tests/infrastructure/fs_lock_store_test.ts
+++ b/tests/infrastructure/fs_lock_store_test.ts
@@ -17,6 +17,7 @@ const SAMPLE: InstalledLock = {
   harness: "claude",
   backlogBackend: "local",
   versionScheme: "semver",
+  specBackend: "local",
   templatesVersion: "0.3.0",
   entries: new Map([
     ["CLAUDE.md", {

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -10,7 +10,7 @@ Deno.test("ClaudeHarness.key and displayName", () => {
 
 Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   // Router skill + 11 phase docs + specnaut-review alias +
   // backlog skill + 1 backlog cmd + 9 agents + 5 agent-memory stubs +
   // 16 spec-root entries + AGENTS.md + .gitignore + 5 backlog scripts +
@@ -46,7 +46,7 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
 
 Deno.test("ClaudeHarness includes HARNESS_STATIC claude files (.claude/CLAUDE.md)", () => {
   const h = new ClaudeHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const claudeMd = mapped[".claude/CLAUDE.md"];
   const staticClaude = HARNESS_STATIC.claude[".claude/CLAUDE.md"];
   assertEquals(claudeMd?.content, staticClaude?.content);

--- a/tests/infrastructure/harness/claude_harness_test.ts
+++ b/tests/infrastructure/harness/claude_harness_test.ts
@@ -10,7 +10,11 @@ Deno.test("ClaudeHarness.key and displayName", () => {
 
 Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
   const h = new ClaudeHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(CORE_BUNDLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   // Router skill + 11 phase docs + specnaut-review alias +
   // backlog skill + 1 backlog cmd + 9 agents + 5 agent-memory stubs +
   // 16 spec-root entries + AGENTS.md + .gitignore + 5 backlog scripts +
@@ -46,7 +50,11 @@ Deno.test("ClaudeHarness.mapBundle emits the Claude tree", () => {
 
 Deno.test("ClaudeHarness includes HARNESS_STATIC claude files (.claude/CLAUDE.md)", () => {
   const h = new ClaudeHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(CORE_BUNDLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const claudeMd = mapped[".claude/CLAUDE.md"];
   const staticClaude = HARNESS_STATIC.claude[".claude/CLAUDE.md"];
   assertEquals(claudeMd?.content, staticClaude?.content);

--- a/tests/infrastructure/harness/codex_harness_test.ts
+++ b/tests/infrastructure/harness/codex_harness_test.ts
@@ -64,31 +64,51 @@ Deno.test("CodexHarness.key and displayName", () => {
 
 Deno.test("CodexHarness maps router skill to .agents/skills/specnaut/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".agents/skills/specnaut/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps phase docs under .agents/skills/specnaut/phases/", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".agents/skills/specnaut/phases/specify.md" in mapped);
 });
 
 Deno.test("CodexHarness maps backlog-cmd to .agents/skills/specnaut-backlog/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".agents/skills/specnaut-backlog/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps skill to .agents/skills/specnaut-<name>/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".agents/skills/specnaut-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps agent to .codex/agents/<name>.toml with valid TOML", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const agentToml = mapped[".codex/agents/product-owner.toml"];
   assert(agentToml, "agent TOML not emitted");
   const parsed = parseToml(agentToml.content);
@@ -125,7 +145,11 @@ Deno.test("CodexHarness maps agent model tiers to model_reasoning_effort", () =>
     agent("weird", "gpt-9-ultra"), // → omitted (unrecognised, no guess)
   ];
   const h = new CodexHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(core, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
 
   const effortOf = (name: string) => {
     const file = mapped[`.codex/agents/${name}.toml`];
@@ -149,14 +173,22 @@ Deno.test("CodexHarness maps agent model tiers to model_reasoning_effort", () =>
 
 Deno.test("CodexHarness maps spec-root to .specnaut/<suffix> and project-root to <suffix>", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CodexHarness emits no Claude/Cursor artefacts", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/ keys allowed");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/ keys allowed");
@@ -172,7 +204,11 @@ Deno.test("CodexHarness injects name+description into SKILL.md when absent", () 
     executable: false,
   }];
   const h = new CodexHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(core, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const skill = mapped[".agents/skills/specnaut-auto/SKILL.md"];
   assert(skill?.content.startsWith("---\n"));
   assert(skill?.content.includes("name: specnaut-auto"));

--- a/tests/infrastructure/harness/codex_harness_test.ts
+++ b/tests/infrastructure/harness/codex_harness_test.ts
@@ -64,31 +64,31 @@ Deno.test("CodexHarness.key and displayName", () => {
 
 Deno.test("CodexHarness maps router skill to .agents/skills/specnaut/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".agents/skills/specnaut/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps phase docs under .agents/skills/specnaut/phases/", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".agents/skills/specnaut/phases/specify.md" in mapped);
 });
 
 Deno.test("CodexHarness maps backlog-cmd to .agents/skills/specnaut-backlog/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".agents/skills/specnaut-backlog/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps skill to .agents/skills/specnaut-<name>/SKILL.md", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".agents/skills/specnaut-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CodexHarness maps agent to .codex/agents/<name>.toml with valid TOML", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const agentToml = mapped[".codex/agents/product-owner.toml"];
   assert(agentToml, "agent TOML not emitted");
   const parsed = parseToml(agentToml.content);
@@ -125,7 +125,7 @@ Deno.test("CodexHarness maps agent model tiers to model_reasoning_effort", () =>
     agent("weird", "gpt-9-ultra"), // → omitted (unrecognised, no guess)
   ];
   const h = new CodexHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
 
   const effortOf = (name: string) => {
     const file = mapped[`.codex/agents/${name}.toml`];
@@ -149,14 +149,14 @@ Deno.test("CodexHarness maps agent model tiers to model_reasoning_effort", () =>
 
 Deno.test("CodexHarness maps spec-root to .specnaut/<suffix> and project-root to <suffix>", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CodexHarness emits no Claude/Cursor artefacts", () => {
   const h = new CodexHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/ keys allowed");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/ keys allowed");
@@ -172,7 +172,7 @@ Deno.test("CodexHarness injects name+description into SKILL.md when absent", () 
     executable: false,
   }];
   const h = new CodexHarness();
-  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(core, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const skill = mapped[".agents/skills/specnaut-auto/SKILL.md"];
   assert(skill?.content.startsWith("---\n"));
   assert(skill?.content.includes("name: specnaut-auto"));

--- a/tests/infrastructure/harness/copilot_harness_test.ts
+++ b/tests/infrastructure/harness/copilot_harness_test.ts
@@ -64,37 +64,61 @@ Deno.test("CopilotHarness.key and displayName", () => {
 
 Deno.test("CopilotHarness maps router skill to .github/instructions/specnaut.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".github/instructions/specnaut.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps phase docs to .github/instructions/specnaut-<phase>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".github/instructions/specnaut-specify.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps backlog-cmd to .github/instructions/specnaut-backlog.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".github/instructions/specnaut-backlog.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps skill to .github/instructions/specnaut-<name>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".github/instructions/specnaut-auto.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps agents to .github/instructions/specnaut-agent-<name>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".github/instructions/specnaut-agent-product-owner.instructions.md" in mapped);
 });
 
 Deno.test('CopilotHarness rewrites instruction frontmatter to applyTo: "**" and strips Claude fields', () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const cmd = mapped[".github/instructions/specnaut.instructions.md"];
   assert(cmd, "instruction file not emitted");
   assert(cmd.content.startsWith("---\n"));
@@ -107,14 +131,22 @@ Deno.test('CopilotHarness rewrites instruction frontmatter to applyTo: "**" and 
 
 Deno.test("CopilotHarness maps spec-root to .specnaut/<suffix> and project-root to <suffix>", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CopilotHarness emits no Claude/Cursor/Codex/Windsurf artefacts", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");

--- a/tests/infrastructure/harness/copilot_harness_test.ts
+++ b/tests/infrastructure/harness/copilot_harness_test.ts
@@ -64,37 +64,37 @@ Deno.test("CopilotHarness.key and displayName", () => {
 
 Deno.test("CopilotHarness maps router skill to .github/instructions/specnaut.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".github/instructions/specnaut.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps phase docs to .github/instructions/specnaut-<phase>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".github/instructions/specnaut-specify.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps backlog-cmd to .github/instructions/specnaut-backlog.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".github/instructions/specnaut-backlog.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps skill to .github/instructions/specnaut-<name>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".github/instructions/specnaut-auto.instructions.md" in mapped);
 });
 
 Deno.test("CopilotHarness maps agents to .github/instructions/specnaut-agent-<name>.instructions.md", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".github/instructions/specnaut-agent-product-owner.instructions.md" in mapped);
 });
 
 Deno.test('CopilotHarness rewrites instruction frontmatter to applyTo: "**" and strips Claude fields', () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const cmd = mapped[".github/instructions/specnaut.instructions.md"];
   assert(cmd, "instruction file not emitted");
   assert(cmd.content.startsWith("---\n"));
@@ -107,14 +107,14 @@ Deno.test('CopilotHarness rewrites instruction frontmatter to applyTo: "**" and 
 
 Deno.test("CopilotHarness maps spec-root to .specnaut/<suffix> and project-root to <suffix>", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CopilotHarness emits no Claude/Cursor/Codex/Windsurf artefacts", () => {
   const h = new CopilotHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");

--- a/tests/infrastructure/harness/cursor_harness_test.ts
+++ b/tests/infrastructure/harness/cursor_harness_test.ts
@@ -62,43 +62,71 @@ Deno.test("CursorHarness.key and displayName", () => {
 
 Deno.test("CursorHarness maps router skill to .cursor/skills/specnaut/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".cursor/skills/specnaut/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps phase docs under .cursor/skills/specnaut/phases/", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".cursor/skills/specnaut/phases/specify.md" in mapped);
 });
 
 Deno.test("CursorHarness maps the backlog command to .cursor/skills/specnaut-backlog/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".cursor/skills/specnaut-backlog/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps agents to .cursor/skills/specnaut-agent-<name>/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".cursor/skills/specnaut-agent-product-owner/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps skills to .cursor/skills/specnaut-<name>/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".cursor/skills/specnaut-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps spec-root to .specnaut/ and project-root unchanged", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CursorHarness includes .cursor/rules/specify-rules.mdc from HARNESS_STATIC", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".cursor/rules/specify-rules.mdc" in mapped);
 });

--- a/tests/infrastructure/harness/cursor_harness_test.ts
+++ b/tests/infrastructure/harness/cursor_harness_test.ts
@@ -62,43 +62,43 @@ Deno.test("CursorHarness.key and displayName", () => {
 
 Deno.test("CursorHarness maps router skill to .cursor/skills/specnaut/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".cursor/skills/specnaut/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps phase docs under .cursor/skills/specnaut/phases/", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".cursor/skills/specnaut/phases/specify.md" in mapped);
 });
 
 Deno.test("CursorHarness maps the backlog command to .cursor/skills/specnaut-backlog/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".cursor/skills/specnaut-backlog/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps agents to .cursor/skills/specnaut-agent-<name>/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".cursor/skills/specnaut-agent-product-owner/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps skills to .cursor/skills/specnaut-<name>/SKILL.md", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".cursor/skills/specnaut-auto/SKILL.md" in mapped);
 });
 
 Deno.test("CursorHarness maps spec-root to .specnaut/ and project-root unchanged", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("CursorHarness includes .cursor/rules/specify-rules.mdc from HARNESS_STATIC", () => {
   const h = new CursorHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".cursor/rules/specify-rules.mdc" in mapped);
 });

--- a/tests/infrastructure/harness/opencode_harness_test.ts
+++ b/tests/infrastructure/harness/opencode_harness_test.ts
@@ -77,7 +77,11 @@ Deno.test("backlog-cmd emits to .opencode/commands/backlog.md", () => {
     content: `---\ndescription: Backlog\n---\nBody`,
     executable: false,
   };
-  const bundle = harness.mapBundle([entry], { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const bundle = harness.mapBundle([entry], {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assertEquals(Object.keys(bundle), [".opencode/commands/backlog.md"]);
 });
 

--- a/tests/infrastructure/harness/opencode_harness_test.ts
+++ b/tests/infrastructure/harness/opencode_harness_test.ts
@@ -51,6 +51,7 @@ Deno.test("router skill emits to .opencode/skills/specnaut/SKILL.md", () => {
   const bundle = harness.mapBundle([routerSkillEntry()], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const dest = ".opencode/skills/specnaut/SKILL.md";
   assertEquals(Object.keys(bundle), [dest]);
@@ -61,6 +62,7 @@ Deno.test("phase emits to .opencode/skills/specnaut/phases/<name>.md", () => {
   const bundle = harness.mapBundle([phaseEntry("specify")], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const dest = ".opencode/skills/specnaut/phases/specify.md";
   assertEquals(Object.keys(bundle), [dest]);
@@ -75,14 +77,14 @@ Deno.test("backlog-cmd emits to .opencode/commands/backlog.md", () => {
     content: `---\ndescription: Backlog\n---\nBody`,
     executable: false,
   };
-  const bundle = harness.mapBundle([entry], { backlogBackend: "local", versionScheme: "semver" });
+  const bundle = harness.mapBundle([entry], { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assertEquals(Object.keys(bundle), [".opencode/commands/backlog.md"]);
 });
 
 Deno.test("agent emits to .opencode/agents/specnaut-<name>.md with mode: subagent", () => {
   const bundle = harness.mapBundle([
     agentEntry("developer", "Read, Write, Edit, Grep, Glob, Bash"),
-  ], { backlogBackend: "local", versionScheme: "semver" });
+  ], { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const dest = ".opencode/agents/specnaut-developer.md";
   assertEquals(Object.keys(bundle), [dest]);
   assertStringIncludes(bundle[dest].content, "description: developer agent");
@@ -95,6 +97,7 @@ Deno.test("agent translates Read+Write+Edit+Bash to permission block", () => {
   const bundle = harness.mapBundle([agentEntry("dev", "Read, Write, Edit, Bash")], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const content = bundle[".opencode/agents/specnaut-dev.md"].content;
   assertStringIncludes(content, "read: allow");
@@ -108,6 +111,7 @@ Deno.test("agent de-dups Edit+MultiEdit into single edit permission", () => {
   const bundle = harness.mapBundle([agentEntry("dev", "Edit, MultiEdit")], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const content = bundle[".opencode/agents/specnaut-dev.md"].content;
   assertEquals(content.match(/edit: allow/g)?.length, 1);
@@ -116,7 +120,7 @@ Deno.test("agent de-dups Edit+MultiEdit into single edit permission", () => {
 Deno.test("agent omits Grep/Glob/Task/TodoWrite/NotebookEdit and unknowns", () => {
   const bundle = harness.mapBundle([
     agentEntry("dev", "Grep, Glob, Task, TodoWrite, NotebookEdit, Mystery"),
-  ], { backlogBackend: "local", versionScheme: "semver" });
+  ], { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const content = bundle[".opencode/agents/specnaut-dev.md"].content;
   assertEquals(content.includes("permission:"), false);
 });
@@ -125,6 +129,7 @@ Deno.test("agent strips Bash(git log *) parenthesized variants to Bash", () => {
   const bundle = harness.mapBundle([agentEntry("po", "Read, Bash(git log *), Bash(git diff *)")], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const content = bundle[".opencode/agents/specnaut-po.md"].content;
   assertStringIncludes(content, "read: allow");
@@ -136,7 +141,7 @@ Deno.test("agent strips Bash(git log *) parenthesized variants to Bash", () => {
 Deno.test("agent strips Agent(...) entries (subagent dispatch is native)", () => {
   const bundle = harness.mapBundle([
     agentEntry("wf", "Read, Bash, Agent(code-reviewer, security-auditor)"),
-  ], { backlogBackend: "local", versionScheme: "semver" });
+  ], { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const content = bundle[".opencode/agents/specnaut-wf.md"].content;
   assertEquals(content.includes("agent:"), false);
 });
@@ -145,6 +150,7 @@ Deno.test("agent with no tools field emits no permission block", () => {
   const bundle = harness.mapBundle([agentEntry("dev", null)], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const content = bundle[".opencode/agents/specnaut-dev.md"].content;
   assertEquals(content.includes("permission:"), false);
@@ -154,6 +160,7 @@ Deno.test("skill emits to .opencode/skills/specnaut-<name>/SKILL.md with name+de
   const bundle = harness.mapBundle([skillEntry("specnaut-auto")], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   const dest = ".opencode/skills/specnaut-auto/SKILL.md";
   assertEquals(Object.keys(bundle), [dest]);
@@ -165,6 +172,7 @@ Deno.test("router skill named 'specnaut' is not double-prefixed", () => {
   const bundle = harness.mapBundle([routerSkillEntry()], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   assertEquals(Object.keys(bundle), [".opencode/skills/specnaut/SKILL.md"]);
 });
@@ -187,6 +195,7 @@ Deno.test("spec-root and project-root pass through unchanged", () => {
   const bundle = harness.mapBundle([specRoot, projectRoot], {
     backlogBackend: "local",
     versionScheme: "semver",
+    specBackend: "local",
   });
   assertEquals(bundle[".specnaut/memory/constitution.md"].content, "raw constitution");
   assertEquals(bundle["AGENTS.md"].content, "raw AGENTS");

--- a/tests/infrastructure/harness/spec_backend_filter_golden_test.ts
+++ b/tests/infrastructure/harness/spec_backend_filter_golden_test.ts
@@ -25,8 +25,13 @@ function phaseEntry(name: string): CoreEntry {
 
 for (const name of ["specify", "implement"]) {
   Deno.test(`${name}.md rendered for spec-backend=local is byte-identical to the pre-feature bundle`, async () => {
-    const golden = await Deno.readTextFile(abs(`fixtures/${name}_local_golden.md`));
-    const rendered = renderSpecBackend(phaseEntry(name).content, "local");
+    // EOL-agnostic: a released binary always embeds LF (the bundle is compiled
+    // from committed LF source), but Windows CI regenerates the bundle from a
+    // CRLF checkout. Content parity — not the OS line-ending — is the FR-003
+    // guarantee, so compare line-ending-agnostically.
+    const lf = (s: string) => s.replaceAll("\r\n", "\n");
+    const golden = lf(await Deno.readTextFile(abs(`fixtures/${name}_local_golden.md`)));
+    const rendered = lf(renderSpecBackend(phaseEntry(name).content, "local"));
     assertEquals(
       rendered,
       golden,

--- a/tests/infrastructure/harness/spec_backend_filter_golden_test.ts
+++ b/tests/infrastructure/harness/spec_backend_filter_golden_test.ts
@@ -1,0 +1,83 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { CORE_BUNDLE } from "../../../src/templates_bundle.ts";
+import { renderSpecBackend } from "../../../src/domain/conditional_render.ts";
+import { applySpecBackend } from "../../../src/infrastructure/harness/spec_backend_filter.ts";
+import type { CoreEntry } from "../../../src/domain/core_bundle.ts";
+
+// Spec 020 / SC-002 / FR-003 — LOCAL PARITY. The golden fixtures under
+// tests/fixtures/*_local_golden.md are byte-for-byte copies of specify.md /
+// implement.md as they shipped BEFORE this feature added `spec-backend=` marker
+// blocks. This test proves the `local`-rendered phase docs are byte-identical to
+// that pre-feature output — the mechanical guarantee that a `local` project sees
+// zero behaviour change. If a future edit legitimately changes the local content,
+// re-capture the fixture in the same commit; an accidental drift fails here.
+
+function abs(rel: string): string {
+  return fromFileUrl(new URL(`../../${rel}`, import.meta.url));
+}
+
+function phaseEntry(name: string): CoreEntry {
+  const e = CORE_BUNDLE.find((x) => x.category === "phase" && x.name === name);
+  if (!e) throw new Error(`missing phase entry: ${name}`);
+  return e;
+}
+
+for (const name of ["specify", "implement"]) {
+  Deno.test(`${name}.md rendered for spec-backend=local is byte-identical to the pre-feature bundle`, async () => {
+    const golden = await Deno.readTextFile(abs(`fixtures/${name}_local_golden.md`));
+    const rendered = renderSpecBackend(phaseEntry(name).content, "local");
+    assertEquals(
+      rendered,
+      golden,
+      `local-rendered ${name}.md drifted from the pre-feature golden — FR-003 local parity broken.`,
+    );
+  });
+
+  Deno.test(`${name}.md leaves no stray spec-backend markers in either render`, () => {
+    const entry = phaseEntry(name);
+    for (const backend of ["local", "cloud"] as const) {
+      const out = renderSpecBackend(entry.content, backend);
+      assertEquals(out.includes("spec-backend="), false);
+      assertEquals(out.includes("BEGIN:"), false);
+    }
+  });
+}
+
+Deno.test("cloud render diverges from local for both phase docs (markers are consumed)", () => {
+  for (const name of ["specify", "implement"]) {
+    const entry = phaseEntry(name);
+    assertNotEquals(
+      renderSpecBackend(entry.content, "cloud"),
+      renderSpecBackend(entry.content, "local"),
+    );
+  }
+  // The cloud specify block instructs pushing steps instead of writing files.
+  assertEquals(
+    renderSpecBackend(phaseEntry("specify").content, "cloud").includes("spec push"),
+    true,
+  );
+  // The cloud implement block runs the branch-only decoupling point.
+  assertEquals(
+    renderSpecBackend(phaseEntry("implement").content, "cloud").includes("--branch-only"),
+    true,
+  );
+});
+
+Deno.test("applySpecBackend only transforms `phase` entries; other categories pass through", () => {
+  const opts = {
+    backlogBackend: "local" as const,
+    versionScheme: "semver" as const,
+    specBackend: "cloud" as const,
+  };
+  // A non-phase entry is returned unchanged (same object identity is not
+  // required, but content must be untouched).
+  const skill: CoreEntry = {
+    category: "skill",
+    name: "specnaut",
+    suffix: null,
+    content: "<!-- BEGIN: spec-backend=local -->kept<!-- END: spec-backend=local -->",
+    executable: false,
+  };
+  assertEquals(applySpecBackend(skill, opts).content, skill.content);
+});

--- a/tests/infrastructure/harness/windsurf_harness_test.ts
+++ b/tests/infrastructure/harness/windsurf_harness_test.ts
@@ -64,44 +64,72 @@ Deno.test("WindsurfHarness.key and displayName", () => {
 
 Deno.test("WindsurfHarness maps router skill to .windsurf/workflows/specnaut.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".windsurf/workflows/specnaut.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps phase docs to sibling specnaut-<phase>.md files", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".windsurf/workflows/specnaut-specify.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps backlog-cmd to .windsurf/workflows/specnaut-backlog.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".windsurf/workflows/specnaut-backlog.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps skill to .windsurf/workflows/specnaut-<name>.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".windsurf/workflows/specnaut-auto.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps agents to .windsurf/workflows/specnaut-agent-<name>.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".windsurf/workflows/specnaut-agent-product-owner.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps spec-root to .specnaut/<suffix> and project-root to <suffix>", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("WindsurfHarness emits content byte-identical to entry.content (no frontmatter rewrite)", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const router = mapped[".windsurf/workflows/specnaut.md"];
   assertEquals(router.content, SAMPLE[0].content);
   const phase = mapped[".windsurf/workflows/specnaut-specify.md"];
@@ -110,7 +138,11 @@ Deno.test("WindsurfHarness emits content byte-identical to entry.content (no fro
 
 Deno.test("WindsurfHarness emits no Claude/Cursor/Codex artefacts", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(SAMPLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");
@@ -121,7 +153,11 @@ Deno.test("WindsurfHarness emits no Claude/Cursor/Codex artefacts", () => {
 
 Deno.test("WindsurfHarness emits no workflow exceeding the Cascade cap", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  const mapped = h.mapBundle(CORE_BUNDLE, {
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+  });
   for (const [path, file] of Object.entries(mapped)) {
     if (!path.startsWith(".windsurf/workflows/")) continue;
     assert(

--- a/tests/infrastructure/harness/windsurf_harness_test.ts
+++ b/tests/infrastructure/harness/windsurf_harness_test.ts
@@ -64,44 +64,44 @@ Deno.test("WindsurfHarness.key and displayName", () => {
 
 Deno.test("WindsurfHarness maps router skill to .windsurf/workflows/specnaut.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".windsurf/workflows/specnaut.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps phase docs to sibling specnaut-<phase>.md files", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".windsurf/workflows/specnaut-specify.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps backlog-cmd to .windsurf/workflows/specnaut-backlog.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".windsurf/workflows/specnaut-backlog.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps skill to .windsurf/workflows/specnaut-<name>.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".windsurf/workflows/specnaut-auto.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps agents to .windsurf/workflows/specnaut-agent-<name>.md", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".windsurf/workflows/specnaut-agent-product-owner.md" in mapped);
 });
 
 Deno.test("WindsurfHarness maps spec-root to .specnaut/<suffix> and project-root to <suffix>", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   assert(".specnaut/memory/constitution.md" in mapped);
   assert("AGENTS.md" in mapped);
 });
 
 Deno.test("WindsurfHarness emits content byte-identical to entry.content (no frontmatter rewrite)", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const router = mapped[".windsurf/workflows/specnaut.md"];
   assertEquals(router.content, SAMPLE[0].content);
   const phase = mapped[".windsurf/workflows/specnaut-specify.md"];
@@ -110,7 +110,7 @@ Deno.test("WindsurfHarness emits content byte-identical to entry.content (no fro
 
 Deno.test("WindsurfHarness emits no Claude/Cursor/Codex artefacts", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(SAMPLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const keys = Object.keys(mapped);
   assert(!keys.some((k) => k.startsWith(".claude/")), "no .claude/");
   assert(!keys.some((k) => k.startsWith(".cursor/")), "no .cursor/");
@@ -121,7 +121,7 @@ Deno.test("WindsurfHarness emits no Claude/Cursor/Codex artefacts", () => {
 
 Deno.test("WindsurfHarness emits no workflow exceeding the Cascade cap", () => {
   const h = new WindsurfHarness();
-  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver" });
+  const mapped = h.mapBundle(CORE_BUNDLE, { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   for (const [path, file] of Object.entries(mapped)) {
     if (!path.startsWith(".windsurf/workflows/")) continue;
     assert(

--- a/tests/infrastructure/spec_cache_writer_test.ts
+++ b/tests/infrastructure/spec_cache_writer_test.ts
@@ -24,26 +24,37 @@ async function withTmp(fn: (dir: string) => Promise<void>) {
 
 Deno.test("write lays out one ordered file per step and returns their paths", async () => {
   await withTmp(async (dir) => {
-    const written = await writer.write(dir, 154, steps(
-      ["specify", "Specify", 1, "# spec"],
-      ["plan", "Plan", 2, "# plan"],
-    ));
+    const written = await writer.write(
+      dir,
+      154,
+      steps(
+        ["specify", "Specify", 1, "# spec"],
+        ["plan", "Plan", 2, "# plan"],
+      ),
+    );
     assertEquals(written, [
       ".specnaut/specs/.cache/154/1-specify.md",
       ".specnaut/specs/.cache/154/2-plan.md",
     ]);
-    assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`), "# spec");
+    assertEquals(
+      await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`),
+      "# spec",
+    );
     assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/2-plan.md`), "# plan");
   });
 });
 
 Deno.test("write clears stale files on re-pull (US3 AC2 reconciliation)", async () => {
   await withTmp(async (dir) => {
-    await writer.write(dir, 154, steps(
-      ["specify", "Specify", 1, "a"],
-      ["plan", "Plan", 2, "b"],
-      ["tasks", "Tasks", 3, "c"],
-    ));
+    await writer.write(
+      dir,
+      154,
+      steps(
+        ["specify", "Specify", 1, "a"],
+        ["plan", "Plan", 2, "b"],
+        ["tasks", "Tasks", 3, "c"],
+      ),
+    );
     // A shorter re-pull must not leave the removed step's file behind.
     await writer.write(dir, 154, steps(["specify", "Specify", 1, "a2"]));
     const names: string[] = [];
@@ -56,10 +67,14 @@ Deno.test("write clears stale files on re-pull (US3 AC2 reconciliation)", async 
 
 Deno.test("read round-trips written steps and reflects an edit to a cached tab", async () => {
   await withTmp(async (dir) => {
-    await writer.write(dir, 154, steps(
-      ["specify", "Specify", 1, "orig"],
-      ["plan", "Plan", 2, "planbody"],
-    ));
+    await writer.write(
+      dir,
+      154,
+      steps(
+        ["specify", "Specify", 1, "orig"],
+        ["plan", "Plan", 2, "planbody"],
+      ),
+    );
     // Simulate a user editing a materialised tab, then reading it back to push.
     await Deno.writeTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`, "edited");
     const read = await writer.read(dir, 154);

--- a/tests/infrastructure/spec_cache_writer_test.ts
+++ b/tests/infrastructure/spec_cache_writer_test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from "@std/assert";
+import { SpecCacheWriter } from "../../src/infrastructure/spec/spec_cache_writer.ts";
+import type { SpecStep } from "../../src/domain/spec/spec_step.ts";
+
+// Spec 020 / SC-004 — the gitignored materialisation cache. Writes ordered files
+// under `.specnaut/specs/.cache/<task>/<order>-<slug>.md`, clears stale files on
+// re-pull (US3 AC2), and reads content back (with a filename fallback when no
+// manifest exists, so a hand-authored cloud spec is still pushable).
+
+const writer = new SpecCacheWriter();
+
+function steps(...s: Array<[string, string, number, string]>): SpecStep[] {
+  return s.map(([key, name, order, body]) => ({ key, name, order, body }));
+}
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "spec_cache_" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("write lays out one ordered file per step and returns their paths", async () => {
+  await withTmp(async (dir) => {
+    const written = await writer.write(dir, 154, steps(
+      ["specify", "Specify", 1, "# spec"],
+      ["plan", "Plan", 2, "# plan"],
+    ));
+    assertEquals(written, [
+      ".specnaut/specs/.cache/154/1-specify.md",
+      ".specnaut/specs/.cache/154/2-plan.md",
+    ]);
+    assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`), "# spec");
+    assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/2-plan.md`), "# plan");
+  });
+});
+
+Deno.test("write clears stale files on re-pull (US3 AC2 reconciliation)", async () => {
+  await withTmp(async (dir) => {
+    await writer.write(dir, 154, steps(
+      ["specify", "Specify", 1, "a"],
+      ["plan", "Plan", 2, "b"],
+      ["tasks", "Tasks", 3, "c"],
+    ));
+    // A shorter re-pull must not leave the removed step's file behind.
+    await writer.write(dir, 154, steps(["specify", "Specify", 1, "a2"]));
+    const names: string[] = [];
+    for await (const e of Deno.readDir(`${dir}/.specnaut/specs/.cache/154`)) names.push(e.name);
+    assertEquals(names.includes("2-plan.md"), false);
+    assertEquals(names.includes("3-tasks.md"), false);
+    assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`), "a2");
+  });
+});
+
+Deno.test("read round-trips written steps and reflects an edit to a cached tab", async () => {
+  await withTmp(async (dir) => {
+    await writer.write(dir, 154, steps(
+      ["specify", "Specify", 1, "orig"],
+      ["plan", "Plan", 2, "planbody"],
+    ));
+    // Simulate a user editing a materialised tab, then reading it back to push.
+    await Deno.writeTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`, "edited");
+    const read = await writer.read(dir, 154);
+    assertEquals(read?.map((s) => [s.key, s.name, s.order, s.body]), [
+      ["specify", "Specify", 1, "edited"],
+      ["plan", "Plan", 2, "planbody"],
+    ]);
+  });
+});
+
+Deno.test("read reconstructs steps from filenames when no manifest exists (cloud specify)", async () => {
+  await withTmp(async (dir) => {
+    const cache = `${dir}/.specnaut/specs/.cache/9`;
+    await Deno.mkdir(cache, { recursive: true });
+    await Deno.writeTextFile(`${cache}/1-specify.md`, "hand-authored");
+    const read = await writer.read(dir, 9);
+    assertEquals(read?.length, 1);
+    assertEquals(read?.[0].key, "specify");
+    assertEquals(read?.[0].body, "hand-authored");
+  });
+});
+
+Deno.test("read returns null when the task has no cache", async () => {
+  await withTmp(async (dir) => {
+    assertEquals(await writer.read(dir, 404), null);
+  });
+});
+
+Deno.test("clear removes the task's cache dir and is idempotent", async () => {
+  await withTmp(async (dir) => {
+    await writer.write(dir, 154, steps(["specify", "Specify", 1, "x"]));
+    await writer.clear(dir, 154);
+    assertEquals(await writer.read(dir, 154), null);
+    await writer.clear(dir, 154); // second clear is a no-op, not an error
+  });
+});

--- a/tests/infrastructure/spec_store_test.ts
+++ b/tests/infrastructure/spec_store_test.ts
@@ -1,0 +1,82 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { CloudSpecStore } from "../../src/infrastructure/spec/cloud_spec_store.ts";
+import { LocalSpecStore } from "../../src/infrastructure/spec/local_spec_store.ts";
+import { makeSpecSession } from "../../src/domain/cloud/spec_session.ts";
+import type { FetchFn } from "../../src/domain/cloud/cloud_client.ts";
+import type { CredentialStore } from "../../src/infrastructure/credential_store.ts";
+
+// Spec 020 / FR-002 — the SpecStore adapters. CloudSpecStore.pull delegates to a
+// (fake-fetch) session; LocalSpecStore's cloud-only verbs reject with one clear
+// message so a misdirected call never silently succeeds.
+
+const API = "https://dep.convex.site";
+
+const stubStore: CredentialStore = {
+  kind: "file",
+  load: () => Promise.resolve(null),
+  save: () => Promise.resolve(),
+  delete: () => Promise.resolve(),
+};
+
+function cloudStore(fetchFn: FetchFn) {
+  const session = makeSpecSession({
+    config: { apiUrl: API, projectKey: "CLOUD" },
+    store: stubStore,
+    fetchFn,
+    env: (k) => (k === "SPECNAUT_CLOUD_TOKEN" ? "headless-token" : undefined),
+  })!;
+  return new CloudSpecStore(session);
+}
+
+function jsonFetch(status: number, body: unknown): FetchFn {
+  return (() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )) as FetchFn;
+}
+
+Deno.test("CloudSpecStore.pull returns the task's steps (sorted)", async () => {
+  const store = cloudStore(jsonFetch(200, {
+    spec: {
+      taskNumber: 154,
+      title: "t",
+      steps: [
+        { key: "plan", name: "Plan", order: 2, body: "b2" },
+        { key: "specify", name: "Specify", order: 1, body: "b1" },
+      ],
+    },
+  }));
+  const steps = await store.pull(154);
+  assertEquals(steps?.map((s) => s.key), ["specify", "plan"]);
+});
+
+Deno.test("CloudSpecStore.pull returns null when the task has no cloud spec", async () => {
+  const store = cloudStore(jsonFetch(200, { spec: null }));
+  assertEquals(await store.pull(154), null);
+});
+
+Deno.test("CloudSpecStore.push upserts without throwing on 200", async () => {
+  const store = cloudStore(jsonFetch(200, {}));
+  await store.push(154, [{ key: "specify", name: "Specify", order: 1, body: "b" }]);
+});
+
+Deno.test("LocalSpecStore.pull rejects with a clear cloud-only message", async () => {
+  const err = await assertRejects(() => new LocalSpecStore().pull(1), Error);
+  assertEquals(err.message.includes("cloud-backend commands"), true);
+  assertEquals(err.message.includes("local spec backend"), true);
+});
+
+Deno.test("LocalSpecStore.push rejects with a clear cloud-only message", async () => {
+  const err = await assertRejects(
+    () => new LocalSpecStore().push(1, [{ key: "specify", name: "Specify", order: 1, body: "b" }]),
+    Error,
+  );
+  assertEquals(err.message.includes("cloud-backend commands"), true);
+});
+
+Deno.test("LocalSpecStore advertises the local key", () => {
+  assertEquals(new LocalSpecStore().key, "local");
+});

--- a/tests/integration/cloud_specify_test.ts
+++ b/tests/integration/cloud_specify_test.ts
@@ -59,8 +59,18 @@ const STEPS: SpecStep[] = [
 
 Deno.test("cloud specify with NO linked task auto-creates + links one, then pushes (FR-011)", async () => {
   const { fetchFn, calls } = scripted([
-    { method: "POST", match: (u) => u.endsWith("/tasks"), status: 201, body: { task: { number: 207 } } },
-    { method: "POST", match: (u) => u.endsWith("/specs"), status: 201, body: { spec: { taskNumber: 207, title: "Feature X", steps: [] } } },
+    {
+      method: "POST",
+      match: (u) => u.endsWith("/tasks"),
+      status: 201,
+      body: { task: { number: 207 } },
+    },
+    {
+      method: "POST",
+      match: (u) => u.endsWith("/specs"),
+      status: 201,
+      body: { spec: { taskNumber: 207, title: "Feature X", steps: [] } },
+    },
     { method: "PUT", match: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
   ]);
   const result = await sessionWith(fetchFn).author(null, "Feature X", STEPS);
@@ -81,7 +91,12 @@ Deno.test("cloud specify with NO linked task auto-creates + links one, then push
 
 Deno.test("cloud specify with an explicit task attaches to it (no auto-create)", async () => {
   const { fetchFn, calls } = scripted([
-    { method: "POST", match: (u) => u.endsWith("/specs"), status: 200, body: { spec: { taskNumber: 154, title: "t", steps: [] } } },
+    {
+      method: "POST",
+      match: (u) => u.endsWith("/specs"),
+      status: 200,
+      body: { spec: { taskNumber: 154, title: "t", steps: [] } },
+    },
     { method: "PUT", match: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
   ]);
   const result = await sessionWith(fetchFn).author(154, "t", STEPS);
@@ -95,8 +110,18 @@ Deno.test("cloud specify writes ZERO .specnaut/specs files and creates ZERO bran
   try {
     await Deno.mkdir(`${tmp}/.specnaut`, { recursive: true });
     const { fetchFn } = scripted([
-      { method: "POST", match: (u) => u.endsWith("/tasks"), status: 201, body: { task: { number: 5 } } },
-      { method: "POST", match: (u) => u.endsWith("/specs"), status: 201, body: { spec: { taskNumber: 5, title: "t", steps: [] } } },
+      {
+        method: "POST",
+        match: (u) => u.endsWith("/tasks"),
+        status: 201,
+        body: { task: { number: 5 } },
+      },
+      {
+        method: "POST",
+        match: (u) => u.endsWith("/specs"),
+        status: 201,
+        body: { spec: { taskNumber: 5, title: "t", steps: [] } },
+      },
       { method: "PUT", match: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
     ]);
     await sessionWith(fetchFn).author(null, "t", STEPS);

--- a/tests/integration/cloud_specify_test.ts
+++ b/tests/integration/cloud_specify_test.ts
@@ -1,0 +1,123 @@
+import { assertEquals } from "@std/assert";
+import { makeSpecSession } from "../../src/domain/cloud/spec_session.ts";
+import type { FetchFn } from "../../src/domain/cloud/cloud_client.ts";
+import type { CredentialStore } from "../../src/infrastructure/credential_store.ts";
+import type { SpecStep } from "../../src/domain/spec/spec_step.ts";
+
+// Spec 020 / SC-003 / FR-011 — cloud-mode `specify` authoring. Driving
+// SpecSession.author with a fake fetch in a throwaway project dir proves the
+// compiled path: it pushes steps to Cloud, auto-creates + links a task when none
+// is linked, and touches NO `.specnaut/specs/` files and NO git branch (the
+// session has no filesystem/git dependency — those side effects live only on the
+// local path).
+
+const API = "https://dep.convex.site";
+
+type Route = { method: string; match: (u: string) => boolean; status: number; body: unknown };
+
+function scripted(routes: Route[]) {
+  const calls: { method: string; url: string; body: string | null }[] = [];
+  const fetchFn = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ method, url, body: (init?.body as string) ?? null });
+    const r = routes.find((x) => x.method === method && x.match(url));
+    if (!r) throw new Error(`no route for ${method} ${url}`);
+    return Promise.resolve(
+      new Response(JSON.stringify(r.body), {
+        status: r.status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as FetchFn;
+  return { fetchFn, calls };
+}
+
+// A stub credential store — never consulted, because the headless-token env seam
+// short-circuits the refresh path in makeSpecSession.
+const stubStore: CredentialStore = {
+  kind: "file",
+  load: () => Promise.resolve(null),
+  save: () => Promise.resolve(),
+  delete: () => Promise.resolve(),
+};
+
+function sessionWith(fetchFn: FetchFn) {
+  const session = makeSpecSession({
+    config: { apiUrl: API, projectKey: "CLOUD" },
+    store: stubStore,
+    fetchFn,
+    env: (k) => (k === "SPECNAUT_CLOUD_TOKEN" ? "headless-token" : undefined),
+  });
+  if (!session) throw new Error("expected a cloud-linked session");
+  return session;
+}
+
+const STEPS: SpecStep[] = [
+  { key: "specify", name: "Specify", order: 1, body: "# spec" },
+];
+
+Deno.test("cloud specify with NO linked task auto-creates + links one, then pushes (FR-011)", async () => {
+  const { fetchFn, calls } = scripted([
+    { method: "POST", match: (u) => u.endsWith("/tasks"), status: 201, body: { task: { number: 207 } } },
+    { method: "POST", match: (u) => u.endsWith("/specs"), status: 201, body: { spec: { taskNumber: 207, title: "Feature X", steps: [] } } },
+    { method: "PUT", match: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
+  ]);
+  const result = await sessionWith(fetchFn).author(null, "Feature X", STEPS);
+
+  assertEquals(result.created, true);
+  assertEquals(result.taskNumber, 207);
+  assertEquals(result.pushed, 1);
+  // The task was created from the title, then the spec was attached + pushed.
+  assertEquals(calls.map((c) => `${c.method} ${new URL(c.url).pathname}`), [
+    "POST /api/v1/tasks",
+    "POST /api/v1/specs",
+    "PUT /api/v1/specs/steps",
+  ]);
+  const created = JSON.parse(calls[0].body!);
+  assertEquals(created.projectKey, "CLOUD");
+  assertEquals(created.title, "Feature X");
+});
+
+Deno.test("cloud specify with an explicit task attaches to it (no auto-create)", async () => {
+  const { fetchFn, calls } = scripted([
+    { method: "POST", match: (u) => u.endsWith("/specs"), status: 200, body: { spec: { taskNumber: 154, title: "t", steps: [] } } },
+    { method: "PUT", match: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
+  ]);
+  const result = await sessionWith(fetchFn).author(154, "t", STEPS);
+  assertEquals(result.created, false);
+  assertEquals(result.taskNumber, 154);
+  assertEquals(calls.some((c) => c.url.endsWith("/tasks")), false);
+});
+
+Deno.test("cloud specify writes ZERO .specnaut/specs files and creates ZERO branches (SC-003)", async () => {
+  const tmp = await Deno.makeTempDir({ prefix: "cloud_specify_" });
+  try {
+    await Deno.mkdir(`${tmp}/.specnaut`, { recursive: true });
+    const { fetchFn } = scripted([
+      { method: "POST", match: (u) => u.endsWith("/tasks"), status: 201, body: { task: { number: 5 } } },
+      { method: "POST", match: (u) => u.endsWith("/specs"), status: 201, body: { spec: { taskNumber: 5, title: "t", steps: [] } } },
+      { method: "PUT", match: (u) => u.endsWith("/specs/steps"), status: 200, body: {} },
+    ]);
+    await sessionWith(fetchFn).author(null, "t", STEPS);
+
+    // The authoring path never materialises a spec directory…
+    let specsExists = true;
+    try {
+      await Deno.stat(`${tmp}/.specnaut/specs`);
+    } catch {
+      specsExists = false;
+    }
+    assertEquals(specsExists, false);
+    // …and never creates a git repo / branch.
+    let gitExists = true;
+    try {
+      await Deno.stat(`${tmp}/.git`);
+    } catch {
+      gitExists = false;
+    }
+    assertEquals(gitExists, false);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});

--- a/tests/integration/spec_push_pull_test.ts
+++ b/tests/integration/spec_push_pull_test.ts
@@ -86,18 +86,29 @@ Deno.test("edit a materialised tab → push → cloud reflects it; untouched tab
 
     // 1. pull → materialise both tabs into the gitignored cache.
     const pull = deps({ projectDir: dir, cache, buildSession: () => Promise.resolve(session) });
-    assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, pull.deps), 0);
-    assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`), "orig-specify");
+    assertEquals(
+      await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, pull.deps),
+      0,
+    );
+    assertEquals(
+      await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`),
+      "orig-specify",
+    );
 
     // 2. edit one tab locally.
     await Deno.writeTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`, "EDITED-specify");
 
     // 3. push → the edited tab AND the untouched tab both travel upsert.
     const push = deps({ projectDir: dir, cache, buildSession: () => Promise.resolve(session) });
-    assertEquals(await runSpec({ kind: "spec", sub: "push", task: 154, apiUrl: null }, push.deps), 0);
+    assertEquals(
+      await runSpec({ kind: "spec", sub: "push", task: 154, apiUrl: null }, push.deps),
+      0,
+    );
 
     const sent = JSON.parse(pushBodies[0]);
-    const bodies = Object.fromEntries(sent.steps.map((s: { key: string; body: string }) => [s.key, s.body]));
+    const bodies = Object.fromEntries(
+      sent.steps.map((s: { key: string; body: string }) => [s.key, s.body]),
+    );
     assertEquals(bodies.specify, "EDITED-specify"); // the edit is reflected
     assertEquals(bodies.plan, "orig-plan"); // the untouched tab is preserved
   });
@@ -106,9 +117,13 @@ Deno.test("edit a materialised tab → push → cloud reflects it; untouched tab
 Deno.test("spec pull with no spec on Cloud reports cleanly (exit 0, not a crash)", async () => {
   await withTmp(async (dir) => {
     const session = sessionWith(
-      (() => Promise.resolve(new Response(JSON.stringify({ spec: null }), { status: 200 }))) as FetchFn,
+      (() =>
+        Promise.resolve(new Response(JSON.stringify({ spec: null }), { status: 200 }))) as FetchFn,
     );
-    const { deps: d, out } = deps({ projectDir: dir, buildSession: () => Promise.resolve(session) });
+    const { deps: d, out } = deps({
+      projectDir: dir,
+      buildSession: () => Promise.resolve(session),
+    });
     assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 9, apiUrl: null }, d), 0);
     assertEquals(out.join("\n").includes("no spec for task 9"), true);
   });
@@ -126,7 +141,11 @@ Deno.test("spec pull falls back to an existing cache when Cloud is unreachable (
     // Seed a prior cache, then simulate a network failure on the fresh pull.
     await cache.write(dir, 154, [{ key: "specify", name: "Specify", order: 1, body: "cached" }]);
     const session = sessionWith((() => Promise.reject(new TypeError("offline"))) as FetchFn);
-    const { deps: d, err } = deps({ projectDir: dir, cache, buildSession: () => Promise.resolve(session) });
+    const { deps: d, err } = deps({
+      projectDir: dir,
+      cache,
+      buildSession: () => Promise.resolve(session),
+    });
     assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, d), 0);
     assertEquals(err.join("\n").includes("reusing the existing cache"), true);
   });
@@ -135,7 +154,10 @@ Deno.test("spec pull falls back to an existing cache when Cloud is unreachable (
 Deno.test("spec pull with a broken connection and NO cache exits 5 with an actionable message", async () => {
   await withTmp(async (dir) => {
     const session = sessionWith((() => Promise.reject(new TypeError("offline"))) as FetchFn);
-    const { deps: d, err } = deps({ projectDir: dir, buildSession: () => Promise.resolve(session) });
+    const { deps: d, err } = deps({
+      projectDir: dir,
+      buildSession: () => Promise.resolve(session),
+    });
     assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, d), 5);
     assertEquals(err.join("\n").includes("retry"), true);
   });

--- a/tests/integration/spec_push_pull_test.ts
+++ b/tests/integration/spec_push_pull_test.ts
@@ -1,0 +1,142 @@
+import { assertEquals } from "@std/assert";
+import { runSpec, type SpecDeps } from "../../src/cli/handlers/spec_handler.ts";
+import { makeSpecSession, type SpecSession } from "../../src/domain/cloud/spec_session.ts";
+import { SpecCacheWriter } from "../../src/infrastructure/spec/spec_cache_writer.ts";
+import type { FetchFn } from "../../src/domain/cloud/cloud_client.ts";
+import type { CredentialStore } from "../../src/infrastructure/credential_store.ts";
+import type { SpecBackend } from "../../src/domain/installed_lock.ts";
+
+// Spec 020 / US3 + US4 — the full author → pull → edit → push loop through the
+// `spec` handler: `pull` materialises the cloud spec into the gitignored cache,
+// an edit to a cached tab is picked up by `push`, and untouched tabs are carried
+// through unchanged (upsert-only). Also covers the local-backend gate + the
+// offline cache-reuse fallback (FR-008).
+
+const API = "https://dep.convex.site";
+
+const stubStore: CredentialStore = {
+  kind: "file",
+  load: () => Promise.resolve(null),
+  save: () => Promise.resolve(),
+  delete: () => Promise.resolve(),
+};
+
+function sessionWith(fetchFn: FetchFn): SpecSession {
+  return makeSpecSession({
+    config: { apiUrl: API, projectKey: "CLOUD" },
+    store: stubStore,
+    fetchFn,
+    env: (k) => (k === "SPECNAUT_CLOUD_TOKEN" ? "headless-token" : undefined),
+  })!;
+}
+
+function deps(over: Partial<SpecDeps>): { deps: SpecDeps; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const base: SpecDeps = {
+    out: (s) => out.push(s),
+    err: (s) => err.push(s),
+    projectDir: "/nonexistent",
+    readSpecBackend: () => Promise.resolve("cloud" as SpecBackend),
+    buildSession: () => Promise.resolve(null),
+    cache: new SpecCacheWriter(),
+    ...over,
+  };
+  return { deps: base, out, err };
+}
+
+async function withTmp(fn: (dir: string) => Promise<void>) {
+  const dir = await Deno.makeTempDir({ prefix: "spec_pushpull_" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("edit a materialised tab → push → cloud reflects it; untouched tabs preserved", async () => {
+  await withTmp(async (dir) => {
+    const pushBodies: string[] = [];
+    // GET for the pull; PUT captures the pushed payload for the push.
+    const fetchFn = ((_input: string | URL | Request, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              spec: {
+                taskNumber: 154,
+                title: "t",
+                steps: [
+                  { key: "specify", name: "Specify", order: 1, body: "orig-specify" },
+                  { key: "plan", name: "Plan", order: 2, body: "orig-plan" },
+                ],
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      pushBodies.push(init?.body as string);
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as FetchFn;
+
+    const session = sessionWith(fetchFn);
+    const cache = new SpecCacheWriter();
+
+    // 1. pull → materialise both tabs into the gitignored cache.
+    const pull = deps({ projectDir: dir, cache, buildSession: () => Promise.resolve(session) });
+    assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, pull.deps), 0);
+    assertEquals(await Deno.readTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`), "orig-specify");
+
+    // 2. edit one tab locally.
+    await Deno.writeTextFile(`${dir}/.specnaut/specs/.cache/154/1-specify.md`, "EDITED-specify");
+
+    // 3. push → the edited tab AND the untouched tab both travel upsert.
+    const push = deps({ projectDir: dir, cache, buildSession: () => Promise.resolve(session) });
+    assertEquals(await runSpec({ kind: "spec", sub: "push", task: 154, apiUrl: null }, push.deps), 0);
+
+    const sent = JSON.parse(pushBodies[0]);
+    const bodies = Object.fromEntries(sent.steps.map((s: { key: string; body: string }) => [s.key, s.body]));
+    assertEquals(bodies.specify, "EDITED-specify"); // the edit is reflected
+    assertEquals(bodies.plan, "orig-plan"); // the untouched tab is preserved
+  });
+});
+
+Deno.test("spec pull with no spec on Cloud reports cleanly (exit 0, not a crash)", async () => {
+  await withTmp(async (dir) => {
+    const session = sessionWith(
+      (() => Promise.resolve(new Response(JSON.stringify({ spec: null }), { status: 200 }))) as FetchFn,
+    );
+    const { deps: d, out } = deps({ projectDir: dir, buildSession: () => Promise.resolve(session) });
+    assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 9, apiUrl: null }, d), 0);
+    assertEquals(out.join("\n").includes("no spec for task 9"), true);
+  });
+});
+
+Deno.test("spec commands under the local backend exit 1 with a clear message", async () => {
+  const { deps: d, err } = deps({ readSpecBackend: () => Promise.resolve("local" as SpecBackend) });
+  assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 1, apiUrl: null }, d), 1);
+  assertEquals(err.join("\n").includes("cloud-backend commands"), true);
+});
+
+Deno.test("spec pull falls back to an existing cache when Cloud is unreachable (FR-008)", async () => {
+  await withTmp(async (dir) => {
+    const cache = new SpecCacheWriter();
+    // Seed a prior cache, then simulate a network failure on the fresh pull.
+    await cache.write(dir, 154, [{ key: "specify", name: "Specify", order: 1, body: "cached" }]);
+    const session = sessionWith((() => Promise.reject(new TypeError("offline"))) as FetchFn);
+    const { deps: d, err } = deps({ projectDir: dir, cache, buildSession: () => Promise.resolve(session) });
+    assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, d), 0);
+    assertEquals(err.join("\n").includes("reusing the existing cache"), true);
+  });
+});
+
+Deno.test("spec pull with a broken connection and NO cache exits 5 with an actionable message", async () => {
+  await withTmp(async (dir) => {
+    const session = sessionWith((() => Promise.reject(new TypeError("offline"))) as FetchFn);
+    const { deps: d, err } = deps({ projectDir: dir, buildSession: () => Promise.resolve(session) });
+    assertEquals(await runSpec({ kind: "spec", sub: "pull", task: 154, apiUrl: null }, d), 5);
+    assertEquals(err.join("\n").includes("retry"), true);
+  });
+});

--- a/tests/integration/upgrade_spec_backend_test.ts
+++ b/tests/integration/upgrade_spec_backend_test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parseLock } from "../../src/domain/installed_lock.ts";
+
+// Spec 020 / FR-010 — the backward-compatible upgrade path. A project whose lock
+// predates this feature (no `spec_backend` key) must upgrade to `spec_backend:
+// local` with the rendered `specify.md` byte-identical to before — a `local`
+// project sees zero behaviour change. Driven through the real compiled CLI.
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+const GOLDEN = fromFileUrl(new URL("../fixtures/specify_local_golden.md", import.meta.url));
+
+async function runSpecnaut(
+  args: string[],
+  cwd: string,
+): Promise<{ code: number; stderr: string }> {
+  const { code, stderr } = await new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", "--allow-run", "--allow-env", MAIN, ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return { code, stderr: new TextDecoder().decode(stderr) };
+}
+
+Deno.test("pre-feature lock → upgrade → spec_backend: local, specify.md unchanged", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "specnaut-upgrade-spec-" });
+  try {
+    // 1. Init a real claude project on the local backend.
+    const init = await runSpecnaut(
+      ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local", "--spec-backend", "local"],
+      dir,
+    );
+    assertEquals(init.code, 0, `init failed: ${init.stderr}`);
+
+    const lockPath = join(dir, ".specnaut/installed.lock");
+    // 2. Simulate a pre-feature lock by stripping the spec_backend key.
+    const stripped = (await Deno.readTextFile(lockPath))
+      .split("\n")
+      .filter((l) => !l.startsWith("spec_backend:"))
+      .join("\n");
+    await Deno.writeTextFile(lockPath, stripped);
+    assertEquals(parseLock(stripped).specBackend, "local"); // absent → local (FR-010)
+
+    // 3. Upgrade the project.
+    const up = await runSpecnaut(["upgrade", "--force"], dir);
+    assertEquals(up.code, 0, `upgrade failed: ${up.stderr}`);
+
+    // 4. The lock now records spec_backend: local...
+    const after = parseLock(await Deno.readTextFile(lockPath));
+    assertEquals(after.specBackend, "local");
+
+    // 5. ...and the rendered specify.md is byte-identical to the pre-feature output.
+    const onDisk = await Deno.readTextFile(
+      join(dir, ".claude/skills/specnaut/phases/specify.md"),
+    );
+    assertEquals(onDisk, await Deno.readTextFile(GOLDEN));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/upgrade_spec_backend_test.ts
+++ b/tests/integration/upgrade_spec_backend_test.ts
@@ -61,10 +61,13 @@ Deno.test("pre-feature lock → upgrade → spec_backend: local, specify.md unch
     assertEquals(after.specBackend, "local");
 
     // 5. ...and the rendered specify.md is byte-identical to the pre-feature output.
-    const onDisk = await Deno.readTextFile(
-      join(dir, ".claude/skills/specnaut/phases/specify.md"),
+    // EOL-agnostic: content parity is the FR-003 guarantee (Windows writes CRLF
+    // natively; released binaries embed LF from the committed bundle).
+    const lf = (s: string) => s.replaceAll("\r\n", "\n");
+    const onDisk = lf(
+      await Deno.readTextFile(join(dir, ".claude/skills/specnaut/phases/specify.md")),
     );
-    assertEquals(onDisk, await Deno.readTextFile(GOLDEN));
+    assertEquals(onDisk, lf(await Deno.readTextFile(GOLDEN)));
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/tests/integration/upgrade_spec_backend_test.ts
+++ b/tests/integration/upgrade_spec_backend_test.ts
@@ -28,7 +28,17 @@ Deno.test("pre-feature lock → upgrade → spec_backend: local, specify.md unch
   try {
     // 1. Init a real claude project on the local backend.
     const init = await runSpecnaut(
-      ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local", "--spec-backend", "local"],
+      [
+        "init",
+        "--here",
+        "--no-git",
+        "--ai",
+        "claude",
+        "--backlog",
+        "local",
+        "--spec-backend",
+        "local",
+      ],
       dir,
     );
     assertEquals(init.code, 0, `init failed: ${init.stderr}`);


### PR DESCRIPTION
Closes #424 · Lot 2 of the cloud-hosted specifications epic (specnaut-monorepo#15). Depends on **Lot 1 (cloud#154, shipped)**.

## What
A second spec-storage backend chosen at `specnaut init` — `local` (current `.specnaut/specs/` markdown, first-class default) or `cloud` (recommended, hosted on SpecNaut Cloud via the shipped `/api/v1/specs*` contract). Full design under `.specnaut/specs/020-cli-spec-backend/`.

## Changes
- **Backend choice**: `SpecBackend` + `spec_backend` lock key (absent → `local`, FR-010); `spec_picker.ts` + strategies mirroring the backlog picker; `--spec-backend` flag threaded through init.
- **SpecStore port + adapters**: local (cloud verbs fail clearly) + cloud (over a `SpecSession`); `SpecCacheStore` + gitignored materialisation under `.specnaut/specs/.cache/<task>/`.
- **Cloud client family** (mirrors `gate_*`): `spec_contract` / `spec_client` / `spec_session`, plus `cloud_client.createTask` for auto-create+link when `specify` runs unlinked.
- **Commands**: `spec push` / `spec pull` (parser + `spec_handler` + `main` + `help`), exit codes 0/1/5, offline → cache-reuse.
- **Render fan-out**: `renderSpecBackend` + `spec_backend_filter` wired into all 7 harnesses; `spec-backend=local|cloud` marker blocks in `specify.md`/`implement.md`; `--branch-only` in `create-new-feature.sh` (branch decoupled to implement).

## Key invariant results
- **Local parity (FR-003)** — a golden-file test proves the `local`-rendered `specify.md` **and** `implement.md` are **byte-identical** to pre-feature output. The upgrade-path test confirms an existing install defaults to `local` with unchanged behaviour.
- **§ I boundary** — `spec_client` test asserts no backend `_id`/error string ever surfaces; only `SpecStep{key,name,order,body}` + `projectKey`/`taskNumber` cross the wire.
- **Cloud `specify`** — pushes steps, auto-creates+links a task when unlinked, writes **zero** `.specnaut/specs/` files and **zero** branches.

## Validation
`deno task lint` clean (240 files) · `deno task test` **1110 passed / 0 failed** · `deno task bundle` regenerated. No new deps.

## Out of scope (other lots)
Web UI (Lot 3, cloud#155) · automatic phase-entry pull + auto-generation + parallel orchestration (Lot 4, cli#425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Agent adoption

```prompt
Add a second spec-storage backend to the Specnaut CLI, chosen at `specnaut init` like the backlog backend: `local` (current .specnaut/specs/ markdown, first-class default) or `cloud` (recommended — specs hosted on SpecNaut Cloud via the versioned /api/v1/specs* contract). Introduce a SpecStore port with local + cloud adapters, `spec push`/`spec pull` commands, gitignored materialisation under .specnaut/specs/.cache/<task>/, and cloud-mode `specify` that pushes steps + creates no branch (branch decoupled to implement, auto-creating+linking a task when none is linked). Keep the local backend byte-identical. Mirror the existing gate_* / backlog_* patterns; the cloud adapter speaks only the versioned HTTP API (no private-half identifier in the public CLI).
```