### PR TITLE
feat(spec): phase-entry pull, auto-gen & parallel-authoring guidance (Lot 4, #425)

### DIFF
--- a/.specnaut/feature.json
+++ b/.specnaut/feature.json
@@ -1,5 +1,5 @@
 {
-  "feature_directory": ".specnaut/specs/020-cli-spec-backend",
-  "linked_issue": 424,
+  "feature_directory": ".specnaut/specs/021-cli-phase-wiring",
+  "linked_issue": 425,
   "workflow_shape": "full"
 }

--- a/.specnaut/specs/021-cli-phase-wiring/checklists/requirements.md
+++ b/.specnaut/specs/021-cli-phase-wiring/checklists/requirements.md
@@ -1,0 +1,27 @@
+# Specification Quality Checklist: Phase-entry pull, auto-generation & parallel orchestration
+
+**Purpose**: Validate specification completeness before planning
+**Created**: 2026-07-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs) — capability level; builds on Lot 2's shipped commands
+- [x] Focused on user value and business needs
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable and technology-agnostic
+- [x] All acceptance scenarios defined; edge cases identified
+- [x] Scope clearly bounded; dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover primary flows (phase-entry pull, auto-gen, parallel authoring)
+- [x] No implementation details in specification
+
+## Notes
+Clean — no open clarifications. The one nuance (auto-generation automatic vs opt-in) is resolved
+in scope: **opt-in, default off**, to avoid surprising task creation with heavy spec-gen. Ready
+for `/specnaut plan`.

--- a/.specnaut/specs/021-cli-phase-wiring/checklists/requirements.md
+++ b/.specnaut/specs/021-cli-phase-wiring/checklists/requirements.md
@@ -1,15 +1,17 @@
 # Specification Quality Checklist: Phase-entry pull, auto-generation & parallel orchestration
 
-**Purpose**: Validate specification completeness before planning
-**Created**: 2026-07-14
+**Purpose**: Validate specification completeness before planning **Created**: 2026-07-14
 **Feature**: [spec.md](../spec.md)
 
 ## Content Quality
-- [x] No implementation details (languages, frameworks, APIs) — capability level; builds on Lot 2's shipped commands
+
+- [x] No implementation details (languages, frameworks, APIs) — capability level; builds on Lot 2's
+      shipped commands
 - [x] Focused on user value and business needs
 - [x] All mandatory sections completed
 
 ## Requirement Completeness
+
 - [x] No [NEEDS CLARIFICATION] markers remain
 - [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable and technology-agnostic
@@ -17,11 +19,13 @@
 - [x] Scope clearly bounded; dependencies and assumptions identified
 
 ## Feature Readiness
+
 - [x] All functional requirements have acceptance criteria
 - [x] User scenarios cover primary flows (phase-entry pull, auto-gen, parallel authoring)
 - [x] No implementation details in specification
 
 ## Notes
-Clean — no open clarifications. The one nuance (auto-generation automatic vs opt-in) is resolved
-in scope: **opt-in, default off**, to avoid surprising task creation with heavy spec-gen. Ready
-for `/specnaut plan`.
+
+Clean — no open clarifications. The one nuance (auto-generation automatic vs opt-in) is resolved in
+scope: **opt-in, default off**, to avoid surprising task creation with heavy spec-gen. Ready for
+`/specnaut plan`.

--- a/.specnaut/specs/021-cli-phase-wiring/contracts/phase-wiring.md
+++ b/.specnaut/specs/021-cli-phase-wiring/contracts/phase-wiring.md
@@ -1,0 +1,46 @@
+# Contract — phase wiring
+
+## A. Pull-on-entry (consuming phase docs, `spec-backend=cloud` block)
+
+For each of `implement.md`, `review.md`, `analyze.md`, `tasks.md`, the cloud block prepends a
+single materialisation step before any spec-reading:
+
+```
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now. The tabs are
+written to the gitignored `.specnaut/specs/.cache/<task>/`; read the spec from there as files.
+If the pull fails (offline/auth), stop with its message — do not proceed against an empty spec.
+<!-- END: spec-backend=cloud -->
+<!-- BEGIN: spec-backend=local -->
+…unchanged pre-feature content…
+<!-- END: spec-backend=local -->
+```
+
+- `implement.md`: the pull precedes the existing Lot 2 cloud step (`create-new-feature.sh --branch-only`).
+- Local block: byte-identical to the pre-feature doc (golden test guards this).
+
+## B. Auto-generation (task-creation guidance)
+
+Rendered guidance (honoured by the agent that creates tasks) when `spec_autogen && cloud`:
+
+```
+After creating the task, ALSO generate its spec now: run the cloud `specify` flow for the new
+task (branch-free). If generation fails, report it and continue — the task remains created
+(auto-generation is never fatal to task creation).
+```
+
+Default (`spec_autogen` absent/false) or local backend: no auto-generation; task creation unchanged.
+
+## C. Parallel authoring (guidance)
+
+A note in the relevant skill/phase doc: cloud `specify` creates no branch, so several task specs
+can be authored concurrently (by a user or an agent fleet) with no git-branch collision — drive
+one `specify` per task in parallel.
+
+## D. Lock field
+
+`installed.lock` gains `spec_autogen: <bool>` (absent → `false`). Read by the rendered guidance;
+set at init or by editing the lock. No new command required.
+
+## Non-goals
+The `spec pull`/`push` commands + cloud `specify` (Lot 2); the Cloud store/API (Lot 1); Web UI (Lot 3).

--- a/.specnaut/specs/021-cli-phase-wiring/contracts/phase-wiring.md
+++ b/.specnaut/specs/021-cli-phase-wiring/contracts/phase-wiring.md
@@ -2,8 +2,8 @@
 
 ## A. Pull-on-entry (consuming phase docs, `spec-backend=cloud` block)
 
-For each of `implement.md`, `review.md`, `analyze.md`, `tasks.md`, the cloud block prepends a
-single materialisation step before any spec-reading:
+For each of `implement.md`, `review.md`, `analyze.md`, `tasks.md`, the cloud block prepends a single
+materialisation step before any spec-reading:
 
 ```
 <!-- BEGIN: spec-backend=cloud -->
@@ -16,7 +16,8 @@ If the pull fails (offline/auth), stop with its message — do not proceed again
 <!-- END: spec-backend=local -->
 ```
 
-- `implement.md`: the pull precedes the existing Lot 2 cloud step (`create-new-feature.sh --branch-only`).
+- `implement.md`: the pull precedes the existing Lot 2 cloud step
+  (`create-new-feature.sh --branch-only`).
 - Local block: byte-identical to the pre-feature doc (golden test guards this).
 
 ## B. Auto-generation (task-creation guidance)
@@ -33,14 +34,16 @@ Default (`spec_autogen` absent/false) or local backend: no auto-generation; task
 
 ## C. Parallel authoring (guidance)
 
-A note in the relevant skill/phase doc: cloud `specify` creates no branch, so several task specs
-can be authored concurrently (by a user or an agent fleet) with no git-branch collision — drive
-one `specify` per task in parallel.
+A note in the relevant skill/phase doc: cloud `specify` creates no branch, so several task specs can
+be authored concurrently (by a user or an agent fleet) with no git-branch collision — drive one
+`specify` per task in parallel.
 
 ## D. Lock field
 
-`installed.lock` gains `spec_autogen: <bool>` (absent → `false`). Read by the rendered guidance;
-set at init or by editing the lock. No new command required.
+`installed.lock` gains `spec_autogen: <bool>` (absent → `false`). Read by the rendered guidance; set
+at init or by editing the lock. No new command required.
 
 ## Non-goals
-The `spec pull`/`push` commands + cloud `specify` (Lot 2); the Cloud store/API (Lot 1); Web UI (Lot 3).
+
+The `spec pull`/`push` commands + cloud `specify` (Lot 2); the Cloud store/API (Lot 1); Web UI (Lot
+3).

--- a/.specnaut/specs/021-cli-phase-wiring/data-model.md
+++ b/.specnaut/specs/021-cli-phase-wiring/data-model.md
@@ -18,7 +18,8 @@ Add `spec_autogen: boolean` ↔ `specAutogen` field. `parseLock` defaults to `fa
 - **Pull-on-entry** (consuming phases): the `spec-backend=cloud` block prepends
   `EXECUTE: specnaut spec pull <task>` (single pull) before the phase's spec-reading steps; the
   `spec-backend=local` block is the unchanged pre-feature content.
-- **Auto-generation** (task-creation guidance): `if specAutogen && cloud → after creating a
+- **Auto-generation** (task-creation guidance):
+  `if specAutogen && cloud → after creating a
   task, run cloud specify for it (branch-free); a failure is reported, the task stays created.`
 - **Parallel authoring** (guidance): a note that cloud specify is branch-free ⇒ N specs can be
   authored concurrently.

--- a/.specnaut/specs/021-cli-phase-wiring/data-model.md
+++ b/.specnaut/specs/021-cli-phase-wiring/data-model.md
@@ -1,0 +1,31 @@
+# Phase 1 Data Model — Phase wiring
+
+No new compiled command; one lock field + template behaviour.
+
+## Persisted state — `InstalledLock`
+
+Add `spec_autogen: boolean` ↔ `specAutogen` field. `parseLock` defaults to `false` when absent
+(mirrors `spec_backend` → `local`). Serialised alongside `spec_backend`.
+
+## Value objects
+
+- **PhaseMode(local | cloud)** — derived from `installedLock.specBackend`; selects which
+  marker-block branch `renderSpecBackend` keeps in a phase doc.
+- **AutogenSetting(boolean)** — `installedLock.specAutogen`; read by the task-creation guidance.
+
+## Behaviour (template-rendered, not compiled)
+
+- **Pull-on-entry** (consuming phases): the `spec-backend=cloud` block prepends
+  `EXECUTE: specnaut spec pull <task>` (single pull) before the phase's spec-reading steps; the
+  `spec-backend=local` block is the unchanged pre-feature content.
+- **Auto-generation** (task-creation guidance): `if specAutogen && cloud → after creating a
+  task, run cloud specify for it (branch-free); a failure is reported, the task stays created.`
+- **Parallel authoring** (guidance): a note that cloud specify is branch-free ⇒ N specs can be
+  authored concurrently.
+
+## Invariants
+
+- **Local parity** — `spec-backend=local` render of every touched phase doc is byte-identical to
+  pre-feature (golden test, EOL-agnostic).
+- **Auto-gen non-fatal** — never fails task creation.
+- **API-only** — every Cloud touch is a Lot 2 command (`spec pull` / cloud `specify`); § I holds.

--- a/.specnaut/specs/021-cli-phase-wiring/plan.md
+++ b/.specnaut/specs/021-cli-phase-wiring/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Phase-entry spec pull, auto-generation & parallel orchestration
+
+**Branch**: `021-cli-phase-wiring` | **Date**: 2026-07-14 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `.specnaut/specs/021-cli-phase-wiring/spec.md`
+**Issue**: specnaut-cli#425 (Lot 4 of epic specnaut-monorepo#15) · depends on Lot 2 (cli#424, shipped)
+
+## Summary
+
+Make the cloud spec backend **automatic** across the phase flow, building entirely on Lot 2's
+shipped mechanism (`renderSpecBackend`, `spec-backend=local|cloud` marker blocks,
+`spec_backend_filter`, the `spec pull`/`spec push` commands, cloud `specify`, the gitignored
+cache). Three parts: (1) add a `spec-backend=cloud` **pull-on-entry** block to the consuming
+phase docs (`implement`, `review`, `analyze`, `tasks`) so each runs one `spec pull <task>`
+before agents read files; (2) an **opt-in auto-generation** toggle (`spec_autogen` in
+`installed.lock`, default off) that the task-creation guidance honours to run cloud `specify`
+at task creation; (3) **parallel-authoring guidance** (docs) leaning on Lot 2's branch-free
+`specify`. Mostly template/phase-doc edits + a small lock field — no new compiled command.
+
+## Technical Context
+
+**Language/Version**: TypeScript (strict) on Deno
+**Primary Dependencies**: Lot 2's `spec_backend_filter` / `renderSpecBackend` / `spec pull`
+command / `installed_lock`
+**Storage**: filesystem (Lot 2 cache) + Cloud via Lot 2's commands
+**Testing**: `deno task test` — golden local-parity (new phase docs) + integration (pull-on-entry, auto-gen toggle)
+**Target Platform**: compiled Deno binary
+**Project Type**: CLI (hexagonal)
+**Constraints**: local parity byte-identical (FR-003); auto-gen non-fatal (FR-006); § I — Cloud
+only via Lot 2 commands / versioned API
+**Scale/Scope**: ~4 phase-doc edits + 1 lock field + guidance docs + tests
+
+## Constitution Check
+
+No local CLI constitution → monorepo § I governs. This lot adds no new Cloud coupling (it drives
+Lot 2's commands); the phase docs carry only opaque `spec pull <task>` invocations. **PASS**
+(re-checked post-Phase 1: PASS).
+
+## Project Structure
+
+### Documentation (this feature)
+```text
+.specnaut/specs/021-cli-phase-wiring/
+├── spec.md · plan.md · research.md · data-model.md · quickstart.md
+├── contracts/phase-wiring.md
+└── tasks.md
+```
+
+### Source Code (repository root = `apps/specnaut-cli/`)
+```text
+src/domain/
+├── installed_lock.ts        # MODIFIED — add `spec_autogen: boolean` (absent → false); round-trip
+└── conditional_render.ts    # (reuse Lot 2's renderSpecBackend — confirm it processes ALL phase docs,
+                             #  not just specify/implement; extend the filter's entry set if needed)
+
+templates/core/skills/specnaut/phases/
+├── implement.md             # MODIFIED — cloud block: `spec pull <task>` at entry (before the
+│                            #   existing create-new-feature.sh --branch-only step from Lot 2)
+├── review.md · analyze.md · tasks.md   # MODIFIED — cloud block: `spec pull <task>` at entry
+└── (specify.md — Lot 2; task-creation guidance references auto-gen)
+
+templates/core/skills/backlog|specnaut/…   # MODIFIED — auto-gen guidance: when spec_autogen && cloud,
+                             #   task creation also runs cloud `specify`; parallel-authoring note
+src/infrastructure/harness/spec_backend_filter.ts   # (verify all 4 consuming phase docs are filtered)
+```
+
+**Structure Decision**: reuse Lot 2's established `spec-backend` marker + filter mechanism
+verbatim; the only compiled change is one `installed.lock` field. This keeps the lot low-risk —
+it's an extension of a shipped, tested pattern, not new machinery.
+
+## Phase 0 — Research (done → research.md)
+
+Grounded in Lot 2's shipped code. Decisions: reuse `renderSpecBackend` for the 4 consuming
+phase docs (D1); `spec_autogen` lock field, default off (D2); auto-gen is agent-workflow
+guidance honouring the toggle + Lot 2 cloud specify, non-fatal (D3); parallel authoring is
+guidance only, no compiled orchestrator (D4); local parity guarded by golden tests on the new
+phase docs (D5).
+
+## Phase 1 — Design & Contracts (done)
+
+- [data-model.md](./data-model.md) — the `spec_autogen` field, the PhaseMode value object, the
+  pull-on-entry step shape.
+- [contracts/phase-wiring.md](./contracts/phase-wiring.md) — the exact cloud-block content per
+  phase doc + the auto-gen guidance contract.
+- [quickstart.md](./quickstart.md) — exercise pull-on-entry + auto-gen + parallel locally.
+
+**Constitution re-check**: PASS — no new Cloud surface; opaque `spec pull` invocations only.
+
+## Complexity Tracking
+
+No violations — reuses Lot 2's mechanism; one additive lock field.

--- a/.specnaut/specs/021-cli-phase-wiring/plan.md
+++ b/.specnaut/specs/021-cli-phase-wiring/plan.md
@@ -1,43 +1,41 @@
 # Implementation Plan: Phase-entry spec pull, auto-generation & parallel orchestration
 
 **Branch**: `021-cli-phase-wiring` | **Date**: 2026-07-14 | **Spec**: [spec.md](./spec.md)
-**Input**: Feature specification from `.specnaut/specs/021-cli-phase-wiring/spec.md`
-**Issue**: specnaut-cli#425 (Lot 4 of epic specnaut-monorepo#15) · depends on Lot 2 (cli#424, shipped)
+**Input**: Feature specification from `.specnaut/specs/021-cli-phase-wiring/spec.md` **Issue**:
+specnaut-cli#425 (Lot 4 of epic specnaut-monorepo#15) · depends on Lot 2 (cli#424, shipped)
 
 ## Summary
 
 Make the cloud spec backend **automatic** across the phase flow, building entirely on Lot 2's
 shipped mechanism (`renderSpecBackend`, `spec-backend=local|cloud` marker blocks,
-`spec_backend_filter`, the `spec pull`/`spec push` commands, cloud `specify`, the gitignored
-cache). Three parts: (1) add a `spec-backend=cloud` **pull-on-entry** block to the consuming
-phase docs (`implement`, `review`, `analyze`, `tasks`) so each runs one `spec pull <task>`
-before agents read files; (2) an **opt-in auto-generation** toggle (`spec_autogen` in
-`installed.lock`, default off) that the task-creation guidance honours to run cloud `specify`
-at task creation; (3) **parallel-authoring guidance** (docs) leaning on Lot 2's branch-free
-`specify`. Mostly template/phase-doc edits + a small lock field — no new compiled command.
+`spec_backend_filter`, the `spec pull`/`spec push` commands, cloud `specify`, the gitignored cache).
+Three parts: (1) add a `spec-backend=cloud` **pull-on-entry** block to the consuming phase docs
+(`implement`, `review`, `analyze`, `tasks`) so each runs one `spec pull <task>` before agents read
+files; (2) an **opt-in auto-generation** toggle (`spec_autogen` in `installed.lock`, default off)
+that the task-creation guidance honours to run cloud `specify` at task creation; (3)
+**parallel-authoring guidance** (docs) leaning on Lot 2's branch-free `specify`. Mostly
+template/phase-doc edits + a small lock field — no new compiled command.
 
 ## Technical Context
 
-**Language/Version**: TypeScript (strict) on Deno
-**Primary Dependencies**: Lot 2's `spec_backend_filter` / `renderSpecBackend` / `spec pull`
-command / `installed_lock`
-**Storage**: filesystem (Lot 2 cache) + Cloud via Lot 2's commands
-**Testing**: `deno task test` — golden local-parity (new phase docs) + integration (pull-on-entry, auto-gen toggle)
-**Target Platform**: compiled Deno binary
-**Project Type**: CLI (hexagonal)
-**Constraints**: local parity byte-identical (FR-003); auto-gen non-fatal (FR-006); § I — Cloud
-only via Lot 2 commands / versioned API
+**Language/Version**: TypeScript (strict) on Deno **Primary Dependencies**: Lot 2's
+`spec_backend_filter` / `renderSpecBackend` / `spec pull` command / `installed_lock` **Storage**:
+filesystem (Lot 2 cache) + Cloud via Lot 2's commands **Testing**: `deno task test` — golden
+local-parity (new phase docs) + integration (pull-on-entry, auto-gen toggle) **Target Platform**:
+compiled Deno binary **Project Type**: CLI (hexagonal) **Constraints**: local parity byte-identical
+(FR-003); auto-gen non-fatal (FR-006); § I — Cloud only via Lot 2 commands / versioned API
 **Scale/Scope**: ~4 phase-doc edits + 1 lock field + guidance docs + tests
 
 ## Constitution Check
 
-No local CLI constitution → monorepo § I governs. This lot adds no new Cloud coupling (it drives
-Lot 2's commands); the phase docs carry only opaque `spec pull <task>` invocations. **PASS**
-(re-checked post-Phase 1: PASS).
+No local CLI constitution → monorepo § I governs. This lot adds no new Cloud coupling (it drives Lot
+2's commands); the phase docs carry only opaque `spec pull <task>` invocations. **PASS** (re-checked
+post-Phase 1: PASS).
 
 ## Project Structure
 
 ### Documentation (this feature)
+
 ```text
 .specnaut/specs/021-cli-phase-wiring/
 ├── spec.md · plan.md · research.md · data-model.md · quickstart.md
@@ -46,6 +44,7 @@ Lot 2's commands); the phase docs carry only opaque `spec pull <task>` invocatio
 ```
 
 ### Source Code (repository root = `apps/specnaut-cli/`)
+
 ```text
 src/domain/
 ├── installed_lock.ts        # MODIFIED — add `spec_autogen: boolean` (absent → false); round-trip
@@ -63,24 +62,23 @@ templates/core/skills/backlog|specnaut/…   # MODIFIED — auto-gen guidance: w
 src/infrastructure/harness/spec_backend_filter.ts   # (verify all 4 consuming phase docs are filtered)
 ```
 
-**Structure Decision**: reuse Lot 2's established `spec-backend` marker + filter mechanism
-verbatim; the only compiled change is one `installed.lock` field. This keeps the lot low-risk —
-it's an extension of a shipped, tested pattern, not new machinery.
+**Structure Decision**: reuse Lot 2's established `spec-backend` marker + filter mechanism verbatim;
+the only compiled change is one `installed.lock` field. This keeps the lot low-risk — it's an
+extension of a shipped, tested pattern, not new machinery.
 
 ## Phase 0 — Research (done → research.md)
 
-Grounded in Lot 2's shipped code. Decisions: reuse `renderSpecBackend` for the 4 consuming
-phase docs (D1); `spec_autogen` lock field, default off (D2); auto-gen is agent-workflow
-guidance honouring the toggle + Lot 2 cloud specify, non-fatal (D3); parallel authoring is
-guidance only, no compiled orchestrator (D4); local parity guarded by golden tests on the new
-phase docs (D5).
+Grounded in Lot 2's shipped code. Decisions: reuse `renderSpecBackend` for the 4 consuming phase
+docs (D1); `spec_autogen` lock field, default off (D2); auto-gen is agent-workflow guidance
+honouring the toggle + Lot 2 cloud specify, non-fatal (D3); parallel authoring is guidance only, no
+compiled orchestrator (D4); local parity guarded by golden tests on the new phase docs (D5).
 
 ## Phase 1 — Design & Contracts (done)
 
 - [data-model.md](./data-model.md) — the `spec_autogen` field, the PhaseMode value object, the
   pull-on-entry step shape.
-- [contracts/phase-wiring.md](./contracts/phase-wiring.md) — the exact cloud-block content per
-  phase doc + the auto-gen guidance contract.
+- [contracts/phase-wiring.md](./contracts/phase-wiring.md) — the exact cloud-block content per phase
+  doc + the auto-gen guidance contract.
 - [quickstart.md](./quickstart.md) — exercise pull-on-entry + auto-gen + parallel locally.
 
 **Constitution re-check**: PASS — no new Cloud surface; opaque `spec pull` invocations only.

--- a/.specnaut/specs/021-cli-phase-wiring/quickstart.md
+++ b/.specnaut/specs/021-cli-phase-wiring/quickstart.md
@@ -3,6 +3,7 @@
 Against the working-tree CLI (`deno run --allow-all src/main.ts …`).
 
 ## 1. Local mode — nothing changes
+
 ```bash
 deno run --allow-all src/main.ts init --here --ai claude --spec-backend local
 # The rendered implement.md / review.md / analyze.md / tasks.md are byte-identical to
@@ -10,6 +11,7 @@ deno run --allow-all src/main.ts init --here --ai claude --spec-backend local
 ```
 
 ## 2. Cloud mode — pull-on-entry
+
 ```bash
 deno run --allow-all src/main.ts init --here --ai claude --spec-backend cloud
 # The rendered implement.md (and review/analyze/tasks) now open with a single
@@ -17,6 +19,7 @@ deno run --allow-all src/main.ts init --here --ai claude --spec-backend cloud
 ```
 
 ## 3. Auto-generation toggle
+
 ```bash
 # enable in the lock:
 #   spec_autogen: true
@@ -26,18 +29,21 @@ deno run --allow-all src/main.ts init --here --ai claude --spec-backend cloud
 ```
 
 ## 4. Parallel authoring
+
 ```bash
 # In cloud mode, author specs for 3 tasks at once — each cloud specify is branch-free,
 # so no collision; each pushes to its own task. [SC-005]
 ```
 
 ## 5. Boundary
+
 ```bash
 # grep the touched phase docs: the only Cloud touch is `specnaut spec pull` / cloud specify —
 # no private-half identifier. [SC-006, § I]
 ```
 
 ## Automated coverage
+
 `deno task test` — golden local-parity tests on implement/review/analyze/tasks (EOL-agnostic);
-`installed_lock` round-trip of `spec_autogen` (absent→false); integration: cloud-mode rendered
-docs contain the pull step, local docs don't.
+`installed_lock` round-trip of `spec_autogen` (absent→false); integration: cloud-mode rendered docs
+contain the pull step, local docs don't.

--- a/.specnaut/specs/021-cli-phase-wiring/quickstart.md
+++ b/.specnaut/specs/021-cli-phase-wiring/quickstart.md
@@ -1,0 +1,43 @@
+# Quickstart — phase wiring, locally
+
+Against the working-tree CLI (`deno run --allow-all src/main.ts …`).
+
+## 1. Local mode — nothing changes
+```bash
+deno run --allow-all src/main.ts init --here --ai claude --spec-backend local
+# The rendered implement.md / review.md / analyze.md / tasks.md are byte-identical to
+# pre-feature — no `spec pull`, no auto-gen. [SC-002]
+```
+
+## 2. Cloud mode — pull-on-entry
+```bash
+deno run --allow-all src/main.ts init --here --ai claude --spec-backend cloud
+# The rendered implement.md (and review/analyze/tasks) now open with a single
+# `specnaut spec pull <task>` step; agents then read the materialised cache files. [SC-001]
+```
+
+## 3. Auto-generation toggle
+```bash
+# enable in the lock:
+#   spec_autogen: true
+# Now the task-creation guidance instructs: create task → also run cloud specify for it,
+# branch-free; a gen failure is reported but the task stays created. [SC-003, SC-004]
+# Default (absent/false): task creation is unchanged.
+```
+
+## 4. Parallel authoring
+```bash
+# In cloud mode, author specs for 3 tasks at once — each cloud specify is branch-free,
+# so no collision; each pushes to its own task. [SC-005]
+```
+
+## 5. Boundary
+```bash
+# grep the touched phase docs: the only Cloud touch is `specnaut spec pull` / cloud specify —
+# no private-half identifier. [SC-006, § I]
+```
+
+## Automated coverage
+`deno task test` — golden local-parity tests on implement/review/analyze/tasks (EOL-agnostic);
+`installed_lock` round-trip of `spec_autogen` (absent→false); integration: cloud-mode rendered
+docs contain the pull step, local docs don't.

--- a/.specnaut/specs/021-cli-phase-wiring/research.md
+++ b/.specnaut/specs/021-cli-phase-wiring/research.md
@@ -1,0 +1,52 @@
+# Phase 0 Research — Phase wiring
+
+Grounded in Lot 2's shipped code (already merged): `src/domain/conditional_render.ts`
+(`renderSpecBackend`), `src/infrastructure/harness/spec_backend_filter.ts` (`applySpecBackend`),
+`src/domain/installed_lock.ts` (`SpecBackend`), the `spec pull`/`spec push` commands, cloud
+`specify`, and the `spec-backend=local|cloud` marker blocks in `specify.md`/`implement.md`.
+
+## D1 — Reuse `renderSpecBackend` for the 4 consuming phase docs
+
+**Decision**: Add `spec-backend=cloud` pull-on-entry marker blocks to `implement.md`,
+`review.md`, `analyze.md`, `tasks.md`; the block runs one `spec pull <task>` before agents read
+the spec. Confirm `applySpecBackend` processes every phase doc (not just specify/implement); if
+the filter's entry set is narrowed, widen it to all phase docs.
+
+**Rationale**: Lot 2 already ships the marker+filter mechanism and applies it per-harness. Adding
+markers to more phase docs is the same, tested path — no new machinery.
+
+## D2 — `spec_autogen` lock field, default off
+
+**Decision**: Add `spec_autogen: boolean` to `installed_lock.ts` (absent → `false`, mirroring
+the `spec_backend` default). It is the opt-in toggle for auto-generation at task creation.
+
+**Rationale**: Mirrors how backends persist; backward-compatible; off by default so task creation
+is never surprised by heavy spec-gen (FR-005).
+
+## D3 — Auto-generation is agent-workflow guidance, non-fatal
+
+**Decision**: Auto-generation is not a new compiled command — it's guidance in the task-creation
+skill/phase docs: when `spec_autogen && spec_backend == cloud`, after creating a task also run
+cloud `specify` for it (Lot 2's branch-free path). A generation failure is surfaced separately
+and never fails the task creation.
+
+**Rationale**: Task creation already flows through agents (product-owner / the cloud flow);
+coupling spec-gen as guarded guidance keeps it non-fatal (FR-006) and reuses Lot 2's cloud
+`specify` rather than inventing a compiled orchestrator.
+
+## D4 — Parallel authoring is guidance only
+
+**Decision**: Document that, because cloud `specify` creates no branch (Lot 2), N task specs can
+be authored concurrently with no collision. No compiled orchestration engine in v1.
+
+**Rationale**: The branch-free property (shipped in Lot 2) already makes parallel authoring safe;
+this lot only needs to say so and show the pattern.
+
+## D5 — Local parity guarded by golden tests on the new phase docs
+
+**Decision**: Extend the golden local-parity approach (Lot 2's `spec_backend_filter_golden_test`)
+to `review.md`/`analyze.md`/`tasks.md` — the `local`-rendered docs must be byte-identical to
+pre-feature. Reuse the EOL-agnostic comparison Lot 2 established (Windows CRLF).
+
+**Rationale**: FR-003 must be mechanically proven for every phase doc this lot touches; the EOL
+lesson from Lot 2's CI carries over.

--- a/.specnaut/specs/021-cli-phase-wiring/research.md
+++ b/.specnaut/specs/021-cli-phase-wiring/research.md
@@ -7,45 +7,45 @@ Grounded in Lot 2's shipped code (already merged): `src/domain/conditional_rende
 
 ## D1 — Reuse `renderSpecBackend` for the 4 consuming phase docs
 
-**Decision**: Add `spec-backend=cloud` pull-on-entry marker blocks to `implement.md`,
-`review.md`, `analyze.md`, `tasks.md`; the block runs one `spec pull <task>` before agents read
-the spec. Confirm `applySpecBackend` processes every phase doc (not just specify/implement); if
-the filter's entry set is narrowed, widen it to all phase docs.
+**Decision**: Add `spec-backend=cloud` pull-on-entry marker blocks to `implement.md`, `review.md`,
+`analyze.md`, `tasks.md`; the block runs one `spec pull <task>` before agents read the spec. Confirm
+`applySpecBackend` processes every phase doc (not just specify/implement); if the filter's entry set
+is narrowed, widen it to all phase docs.
 
 **Rationale**: Lot 2 already ships the marker+filter mechanism and applies it per-harness. Adding
 markers to more phase docs is the same, tested path — no new machinery.
 
 ## D2 — `spec_autogen` lock field, default off
 
-**Decision**: Add `spec_autogen: boolean` to `installed_lock.ts` (absent → `false`, mirroring
-the `spec_backend` default). It is the opt-in toggle for auto-generation at task creation.
+**Decision**: Add `spec_autogen: boolean` to `installed_lock.ts` (absent → `false`, mirroring the
+`spec_backend` default). It is the opt-in toggle for auto-generation at task creation.
 
-**Rationale**: Mirrors how backends persist; backward-compatible; off by default so task creation
-is never surprised by heavy spec-gen (FR-005).
+**Rationale**: Mirrors how backends persist; backward-compatible; off by default so task creation is
+never surprised by heavy spec-gen (FR-005).
 
 ## D3 — Auto-generation is agent-workflow guidance, non-fatal
 
 **Decision**: Auto-generation is not a new compiled command — it's guidance in the task-creation
-skill/phase docs: when `spec_autogen && spec_backend == cloud`, after creating a task also run
-cloud `specify` for it (Lot 2's branch-free path). A generation failure is surfaced separately
-and never fails the task creation.
+skill/phase docs: when `spec_autogen && spec_backend == cloud`, after creating a task also run cloud
+`specify` for it (Lot 2's branch-free path). A generation failure is surfaced separately and never
+fails the task creation.
 
-**Rationale**: Task creation already flows through agents (product-owner / the cloud flow);
-coupling spec-gen as guarded guidance keeps it non-fatal (FR-006) and reuses Lot 2's cloud
-`specify` rather than inventing a compiled orchestrator.
+**Rationale**: Task creation already flows through agents (product-owner / the cloud flow); coupling
+spec-gen as guarded guidance keeps it non-fatal (FR-006) and reuses Lot 2's cloud `specify` rather
+than inventing a compiled orchestrator.
 
 ## D4 — Parallel authoring is guidance only
 
-**Decision**: Document that, because cloud `specify` creates no branch (Lot 2), N task specs can
-be authored concurrently with no collision. No compiled orchestration engine in v1.
+**Decision**: Document that, because cloud `specify` creates no branch (Lot 2), N task specs can be
+authored concurrently with no collision. No compiled orchestration engine in v1.
 
 **Rationale**: The branch-free property (shipped in Lot 2) already makes parallel authoring safe;
 this lot only needs to say so and show the pattern.
 
 ## D5 — Local parity guarded by golden tests on the new phase docs
 
-**Decision**: Extend the golden local-parity approach (Lot 2's `spec_backend_filter_golden_test`)
-to `review.md`/`analyze.md`/`tasks.md` — the `local`-rendered docs must be byte-identical to
+**Decision**: Extend the golden local-parity approach (Lot 2's `spec_backend_filter_golden_test`) to
+`review.md`/`analyze.md`/`tasks.md` — the `local`-rendered docs must be byte-identical to
 pre-feature. Reuse the EOL-agnostic comparison Lot 2 established (Windows CRLF).
 
 **Rationale**: FR-003 must be mechanically proven for every phase doc this lot touches; the EOL

--- a/.specnaut/specs/021-cli-phase-wiring/spec.md
+++ b/.specnaut/specs/021-cli-phase-wiring/spec.md
@@ -1,34 +1,42 @@
 # Feature Specification: Phase-entry spec pull, auto-generation & parallel orchestration
 
-**Feature Branch**: `021-cli-phase-wiring`
-**Created**: 2026-07-14
-**Status**: Draft
-**Input**: User description: "Lot 4 (cli#425) — wire the cloud spec backend into the phase flow: (1) each phase that consumes the spec (implement/review/analyze/tasks) does a single automatic `spec pull <task>` at entry in cloud mode, so agents read materialised files and no agent is network-aware; (2) auto-generate a task's spec at creation time (cloud mode, opt-in) so it's ready when implementation starts; (3) support authoring multiple specs in parallel — enabled by Lot 2's branch decoupling — without collisions."
+**Feature Branch**: `021-cli-phase-wiring` **Created**: 2026-07-14 **Status**: Draft **Input**: User
+description: "Lot 4 (cli#425) — wire the cloud spec backend into the phase flow: (1) each phase that
+consumes the spec (implement/review/analyze/tasks) does a single automatic `spec pull <task>` at
+entry in cloud mode, so agents read materialised files and no agent is network-aware; (2)
+auto-generate a task's spec at creation time (cloud mode, opt-in) so it's ready when implementation
+starts; (3) support authoring multiple specs in parallel — enabled by Lot 2's branch decoupling —
+without collisions."
 
-> **Design of record**: `docs/superpowers/specs/2026-07-14-cloud-hosted-specs-design.md` (monorepo). Backlog: epic `specnaut-monorepo#15`, this lot `specnaut-cli#425`. Depends on **Lot 2 (cli#424, shipped)** — the `spec push`/`spec pull` commands, cloud-mode `specify`, and the gitignored materialisation cache.
-> **Scope of THIS spec**: the phase-doc / workflow wiring that makes the cloud backend *automatic* (no manual `spec pull`), the opt-in auto-generation at task creation, and the parallel-authoring guidance. It ships mostly template/phase-doc edits + orchestration guidance, building on Lot 2's compiled commands.
+> **Design of record**: `docs/superpowers/specs/2026-07-14-cloud-hosted-specs-design.md` (monorepo).
+> Backlog: epic `specnaut-monorepo#15`, this lot `specnaut-cli#425`. Depends on **Lot 2 (cli#424,
+> shipped)** — the `spec push`/`spec pull` commands, cloud-mode `specify`, and the gitignored
+> materialisation cache. **Scope of THIS spec**: the phase-doc / workflow wiring that makes the
+> cloud backend _automatic_ (no manual `spec pull`), the opt-in auto-generation at task creation,
+> and the parallel-authoring guidance. It ships mostly template/phase-doc edits + orchestration
+> guidance, building on Lot 2's compiled commands.
 
-## User Scenarios & Testing *(mandatory)*
+## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Agents read the spec automatically at phase entry (Priority: P1)
 
-In cloud mode, when a phase that needs the spec runs — `implement`, `review`, `analyze`,
-`tasks` — the flow performs **one** `spec pull <task>` at the start, materialising the spec's
-tabs into the gitignored cache, so every downstream agent reads plain files. No agent has to
-know the spec lives in the cloud; no agent makes a network call.
+In cloud mode, when a phase that needs the spec runs — `implement`, `review`, `analyze`, `tasks` —
+the flow performs **one** `spec pull <task>` at the start, materialising the spec's tabs into the
+gitignored cache, so every downstream agent reads plain files. No agent has to know the spec lives
+in the cloud; no agent makes a network call.
 
-**Why this priority**: This is the payoff of the whole design — it neutralises the "every agent
-must fetch online" risk. Without it, cloud specs aren't usable in the phase flow.
+**Why this priority**: This is the payoff of the whole design — it neutralises the "every agent must
+fetch online" risk. Without it, cloud specs aren't usable in the phase flow.
 
-**Independent Test**: with cloud mode and a task whose spec is on Cloud, run a consuming phase →
-the cache is populated once at entry and the agents read the materialised files; running the
-same phase twice refreshes the cache without error.
+**Independent Test**: with cloud mode and a task whose spec is on Cloud, run a consuming phase → the
+cache is populated once at entry and the agents read the materialised files; running the same phase
+twice refreshes the cache without error.
 
 **Acceptance Scenarios**:
 
-1. **Given** cloud mode and a task with a cloud spec, **When** `implement` (or `review` /
-   `analyze` / `tasks`) starts, **Then** a single `spec pull <task>` runs first and the phase
-   proceeds against the materialised files.
+1. **Given** cloud mode and a task with a cloud spec, **When** `implement` (or `review` / `analyze`
+   / `tasks`) starts, **Then** a single `spec pull <task>` runs first and the phase proceeds against
+   the materialised files.
 2. **Given** local mode, **When** any phase runs, **Then** no pull happens and behaviour is
    byte-identical to today.
 3. **Given** cloud mode but the pull fails (offline/auth), **When** a phase starts, **Then** it
@@ -39,87 +47,87 @@ same phase twice refreshes the cache without error.
 
 ### User Story 2 - Auto-generate a task's spec at creation (Priority: P1)
 
-In cloud mode, creating a task can **also generate its specification immediately** (opt-in), so
-that when the task is later picked for implementation the spec is already written — no waiting.
+In cloud mode, creating a task can **also generate its specification immediately** (opt-in), so that
+when the task is later picked for implementation the spec is already written — no waiting.
 
-**Why this priority**: This is what unlocks "prepare many tasks' specs ahead of time"; it turns
-spec authoring from a blocking pre-step into background preparation.
+**Why this priority**: This is what unlocks "prepare many tasks' specs ahead of time"; it turns spec
+authoring from a blocking pre-step into background preparation.
 
-**Independent Test**: with cloud mode and auto-generation enabled, create a task → its cloud
-spec is generated and attached without a manual `specify` step; with it disabled, task creation
-is unchanged.
+**Independent Test**: with cloud mode and auto-generation enabled, create a task → its cloud spec is
+generated and attached without a manual `specify` step; with it disabled, task creation is
+unchanged.
 
 **Acceptance Scenarios**:
 
-1. **Given** cloud mode with auto-generation enabled, **When** a task is created, **Then** its
-   spec is generated and pushed to that task (via Lot 2's cloud `specify` path) with no branch.
-2. **Given** auto-generation disabled (the default), **When** a task is created, **Then** no
-   spec is generated — task creation is unchanged.
+1. **Given** cloud mode with auto-generation enabled, **When** a task is created, **Then** its spec
+   is generated and pushed to that task (via Lot 2's cloud `specify` path) with no branch.
+2. **Given** auto-generation disabled (the default), **When** a task is created, **Then** no spec is
+   generated — task creation is unchanged.
 3. **Given** local mode, **When** a task is created, **Then** auto-generation never triggers.
 
 ---
 
 ### User Story 3 - Author multiple specs in parallel (Priority: P2)
 
-Because cloud-mode `specify` no longer creates a branch (Lot 2), several specs can be authored
-at once. This lot provides the guidance/orchestration so a user (or an agent fleet) can drive N
-task specs in parallel without git-branch collisions or shared local state.
+Because cloud-mode `specify` no longer creates a branch (Lot 2), several specs can be authored at
+once. This lot provides the guidance/orchestration so a user (or an agent fleet) can drive N task
+specs in parallel without git-branch collisions or shared local state.
 
-**Why this priority**: Valuable throughput gain, but the single-spec flow (US1/US2) already
-delivers the core; parallelism is an amplifier.
+**Why this priority**: Valuable throughput gain, but the single-spec flow (US1/US2) already delivers
+the core; parallelism is an amplifier.
 
-**Independent Test**: author specs for 3 different tasks concurrently in cloud mode → all three
-are pushed to their tasks with no branch created and no file-system collision.
+**Independent Test**: author specs for 3 different tasks concurrently in cloud mode → all three are
+pushed to their tasks with no branch created and no file-system collision.
 
 **Acceptance Scenarios**:
 
-1. **Given** cloud mode, **When** specs for several tasks are authored concurrently, **Then**
-   each is pushed to its own task with no git branch and no shared-state collision.
+1. **Given** cloud mode, **When** specs for several tasks are authored concurrently, **Then** each
+   is pushed to its own task with no git branch and no shared-state collision.
 
 ---
 
 ### Edge Cases
 
-- **Local mode**: none of this lot's behaviour triggers — phases, task creation, and authoring
-  are byte-identical to today (no auto-pull, no auto-gen, no orchestration change).
-- **Pull-on-entry when the task has no spec yet**: the phase reports "no spec for this task"
-  clearly (from Lot 2's `spec pull`) rather than proceeding against nothing.
-- **Auto-generation failure**: a failed spec generation must not fail the task creation itself —
-  the task is created; the spec-gen error is surfaced separately and retryable.
-- **Parallel authoring with the same task twice**: idempotent (Lot 1 upsert) — the last push
-  wins on content, no duplication.
+- **Local mode**: none of this lot's behaviour triggers — phases, task creation, and authoring are
+  byte-identical to today (no auto-pull, no auto-gen, no orchestration change).
+- **Pull-on-entry when the task has no spec yet**: the phase reports "no spec for this task" clearly
+  (from Lot 2's `spec pull`) rather than proceeding against nothing.
+- **Auto-generation failure**: a failed spec generation must not fail the task creation itself — the
+  task is created; the spec-gen error is surfaced separately and retryable.
+- **Parallel authoring with the same task twice**: idempotent (Lot 1 upsert) — the last push wins on
+  content, no duplication.
 
-## Requirements *(mandatory)*
+## Requirements _(mandatory)_
 
 ### Functional Requirements
 
-- **FR-001**: In cloud mode, the consuming phases (`implement`, `review`, `analyze`, `tasks`)
-  MUST perform exactly one `spec pull <task>` at entry, before any agent reads the spec.
-- **FR-002**: Agents MUST continue to read the spec as local files (the materialised cache) —
-  no agent may be required to make a network call to read a spec.
+- **FR-001**: In cloud mode, the consuming phases (`implement`, `review`, `analyze`, `tasks`) MUST
+  perform exactly one `spec pull <task>` at entry, before any agent reads the spec.
+- **FR-002**: Agents MUST continue to read the spec as local files (the materialised cache) — no
+  agent may be required to make a network call to read a spec.
 - **FR-003**: In local mode, no phase MUST perform a pull; all phase behaviour MUST be
   byte-identical to the pre-feature CLI.
-- **FR-004**: A pull failure at phase entry MUST surface Lot 2's actionable error (reuse cache
-  if present) and MUST NOT let the phase proceed against an empty/partial spec.
-- **FR-005**: In cloud mode, task creation MUST support opt-in auto-generation of the task's
-  spec (via Lot 2's cloud `specify` path), **disabled by default**.
-- **FR-006**: Auto-generation failure MUST NOT fail the task creation; the error MUST be
-  surfaced separately and be retryable.
+- **FR-004**: A pull failure at phase entry MUST surface Lot 2's actionable error (reuse cache if
+  present) and MUST NOT let the phase proceed against an empty/partial spec.
+- **FR-005**: In cloud mode, task creation MUST support opt-in auto-generation of the task's spec
+  (via Lot 2's cloud `specify` path), **disabled by default**.
+- **FR-006**: Auto-generation failure MUST NOT fail the task creation; the error MUST be surfaced
+  separately and be retryable.
 - **FR-007**: Cloud-mode `specify` MUST remain branch-free so multiple specs can be authored
-  concurrently without git-branch collision or shared local state (this lot adds the guidance;
-  the branch-free behaviour ships in Lot 2).
+  concurrently without git-branch collision or shared local state (this lot adds the guidance; the
+  branch-free behaviour ships in Lot 2).
 - **FR-008**: The whole lot MUST NOT introduce any Cloud coupling beyond Lot 2's commands / the
   versioned HTTP API — no private-half identifier enters the public CLI (§ I).
 
-### Key Entities *(see Domain Model section below for full structure)*
+### Key Entities _(see Domain Model section below for full structure)_
 
 - **Phase entry hook**: the point at which a consuming phase materialises the spec.
 - **Auto-generation toggle**: the opt-in setting that couples task creation with spec-gen.
 
-## Domain Model *(mandatory)*
+## Domain Model _(mandatory)_
 
-**Bounded context:** Spec/phase orchestration (CLI) — making the cloud spec backend automatic
-across the workflow.
+**Bounded context:** Spec/phase orchestration (CLI) — making the cloud spec backend automatic across
+the workflow.
 
 **Vocabulary (Ubiquitous language):**
 
@@ -143,36 +151,37 @@ across the workflow.
 - **Local parity** — with the local backend, no auto-pull, no auto-gen, no orchestration change.
 - **No network-aware agents** — the only network touch in a phase is the single entry pull.
 - **Auto-gen is non-fatal** — it never fails task creation.
-- **API-only boundary** — all Cloud interaction goes through Lot 2's commands / the versioned API (§ I).
+- **API-only boundary** — all Cloud interaction goes through Lot 2's commands / the versioned API (§
+  I).
 
 **Out of scope (other bounded contexts touched but not owned here):**
 
 - **The `spec pull`/`push` commands, cloud `specify`, materialisation** — Lot 2 (owned there).
 - **Cloud store/API, Web UI** — Lots 1 & 3.
 
-## Success Criteria *(mandatory)*
+## Success Criteria _(mandatory)_
 
 ### Measurable Outcomes
 
 - **SC-001**: In cloud mode, a consuming phase materialises the spec exactly once at entry, and
   agents read only local files (zero agent network calls).
-- **SC-002**: In local mode, the full existing phase test suite passes unchanged (zero
-  regressions) — no pull, no auto-gen.
-- **SC-003**: With auto-generation enabled, creating a task yields a generated cloud spec with
-  no branch; disabled (default), task creation is unchanged.
+- **SC-002**: In local mode, the full existing phase test suite passes unchanged (zero regressions)
+  — no pull, no auto-gen.
+- **SC-003**: With auto-generation enabled, creating a task yields a generated cloud spec with no
+  branch; disabled (default), task creation is unchanged.
 - **SC-004**: A pull or auto-gen failure produces an actionable message and never a silent empty
   spec / failed task creation.
-- **SC-005**: Three specs can be authored concurrently in cloud mode, each pushed to its task,
-  with zero branches and zero file-system collisions.
+- **SC-005**: Three specs can be authored concurrently in cloud mode, each pushed to its task, with
+  zero branches and zero file-system collisions.
 - **SC-006**: No CLI source or wire payload references a private-half identifier (§ I).
 
 ## Assumptions
 
-- Lot 2's `spec pull`/`spec push` commands, cloud-mode `specify`, and the materialisation cache
-  are available (shipped).
-- The consuming phases are the four that read the spec (`implement`, `review`, `analyze`,
-  `tasks`); `specify` authors (Lot 2) and `merge`/`constitution`/etc. don't consume it.
-- Auto-generation is opt-in (default off) to avoid surprising task creation with heavy spec-gen;
-  the toggle lives with the project config (mirroring how backends are persisted).
+- Lot 2's `spec pull`/`spec push` commands, cloud-mode `specify`, and the materialisation cache are
+  available (shipped).
+- The consuming phases are the four that read the spec (`implement`, `review`, `analyze`, `tasks`);
+  `specify` authors (Lot 2) and `merge`/`constitution`/etc. don't consume it.
+- Auto-generation is opt-in (default off) to avoid surprising task creation with heavy spec-gen; the
+  toggle lives with the project config (mirroring how backends are persisted).
 - Parallel authoring is primarily guidance + relying on Lot 2's branch-free `specify`; no new
   compiled orchestration engine is required for v1.

--- a/.specnaut/specs/021-cli-phase-wiring/spec.md
+++ b/.specnaut/specs/021-cli-phase-wiring/spec.md
@@ -1,0 +1,178 @@
+# Feature Specification: Phase-entry spec pull, auto-generation & parallel orchestration
+
+**Feature Branch**: `021-cli-phase-wiring`
+**Created**: 2026-07-14
+**Status**: Draft
+**Input**: User description: "Lot 4 (cli#425) — wire the cloud spec backend into the phase flow: (1) each phase that consumes the spec (implement/review/analyze/tasks) does a single automatic `spec pull <task>` at entry in cloud mode, so agents read materialised files and no agent is network-aware; (2) auto-generate a task's spec at creation time (cloud mode, opt-in) so it's ready when implementation starts; (3) support authoring multiple specs in parallel — enabled by Lot 2's branch decoupling — without collisions."
+
+> **Design of record**: `docs/superpowers/specs/2026-07-14-cloud-hosted-specs-design.md` (monorepo). Backlog: epic `specnaut-monorepo#15`, this lot `specnaut-cli#425`. Depends on **Lot 2 (cli#424, shipped)** — the `spec push`/`spec pull` commands, cloud-mode `specify`, and the gitignored materialisation cache.
+> **Scope of THIS spec**: the phase-doc / workflow wiring that makes the cloud backend *automatic* (no manual `spec pull`), the opt-in auto-generation at task creation, and the parallel-authoring guidance. It ships mostly template/phase-doc edits + orchestration guidance, building on Lot 2's compiled commands.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Agents read the spec automatically at phase entry (Priority: P1)
+
+In cloud mode, when a phase that needs the spec runs — `implement`, `review`, `analyze`,
+`tasks` — the flow performs **one** `spec pull <task>` at the start, materialising the spec's
+tabs into the gitignored cache, so every downstream agent reads plain files. No agent has to
+know the spec lives in the cloud; no agent makes a network call.
+
+**Why this priority**: This is the payoff of the whole design — it neutralises the "every agent
+must fetch online" risk. Without it, cloud specs aren't usable in the phase flow.
+
+**Independent Test**: with cloud mode and a task whose spec is on Cloud, run a consuming phase →
+the cache is populated once at entry and the agents read the materialised files; running the
+same phase twice refreshes the cache without error.
+
+**Acceptance Scenarios**:
+
+1. **Given** cloud mode and a task with a cloud spec, **When** `implement` (or `review` /
+   `analyze` / `tasks`) starts, **Then** a single `spec pull <task>` runs first and the phase
+   proceeds against the materialised files.
+2. **Given** local mode, **When** any phase runs, **Then** no pull happens and behaviour is
+   byte-identical to today.
+3. **Given** cloud mode but the pull fails (offline/auth), **When** a phase starts, **Then** it
+   surfaces the actionable error from Lot 2's `spec pull` (reuse cache if present) and does not
+   proceed against an empty spec.
+
+---
+
+### User Story 2 - Auto-generate a task's spec at creation (Priority: P1)
+
+In cloud mode, creating a task can **also generate its specification immediately** (opt-in), so
+that when the task is later picked for implementation the spec is already written — no waiting.
+
+**Why this priority**: This is what unlocks "prepare many tasks' specs ahead of time"; it turns
+spec authoring from a blocking pre-step into background preparation.
+
+**Independent Test**: with cloud mode and auto-generation enabled, create a task → its cloud
+spec is generated and attached without a manual `specify` step; with it disabled, task creation
+is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** cloud mode with auto-generation enabled, **When** a task is created, **Then** its
+   spec is generated and pushed to that task (via Lot 2's cloud `specify` path) with no branch.
+2. **Given** auto-generation disabled (the default), **When** a task is created, **Then** no
+   spec is generated — task creation is unchanged.
+3. **Given** local mode, **When** a task is created, **Then** auto-generation never triggers.
+
+---
+
+### User Story 3 - Author multiple specs in parallel (Priority: P2)
+
+Because cloud-mode `specify` no longer creates a branch (Lot 2), several specs can be authored
+at once. This lot provides the guidance/orchestration so a user (or an agent fleet) can drive N
+task specs in parallel without git-branch collisions or shared local state.
+
+**Why this priority**: Valuable throughput gain, but the single-spec flow (US1/US2) already
+delivers the core; parallelism is an amplifier.
+
+**Independent Test**: author specs for 3 different tasks concurrently in cloud mode → all three
+are pushed to their tasks with no branch created and no file-system collision.
+
+**Acceptance Scenarios**:
+
+1. **Given** cloud mode, **When** specs for several tasks are authored concurrently, **Then**
+   each is pushed to its own task with no git branch and no shared-state collision.
+
+---
+
+### Edge Cases
+
+- **Local mode**: none of this lot's behaviour triggers — phases, task creation, and authoring
+  are byte-identical to today (no auto-pull, no auto-gen, no orchestration change).
+- **Pull-on-entry when the task has no spec yet**: the phase reports "no spec for this task"
+  clearly (from Lot 2's `spec pull`) rather than proceeding against nothing.
+- **Auto-generation failure**: a failed spec generation must not fail the task creation itself —
+  the task is created; the spec-gen error is surfaced separately and retryable.
+- **Parallel authoring with the same task twice**: idempotent (Lot 1 upsert) — the last push
+  wins on content, no duplication.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: In cloud mode, the consuming phases (`implement`, `review`, `analyze`, `tasks`)
+  MUST perform exactly one `spec pull <task>` at entry, before any agent reads the spec.
+- **FR-002**: Agents MUST continue to read the spec as local files (the materialised cache) —
+  no agent may be required to make a network call to read a spec.
+- **FR-003**: In local mode, no phase MUST perform a pull; all phase behaviour MUST be
+  byte-identical to the pre-feature CLI.
+- **FR-004**: A pull failure at phase entry MUST surface Lot 2's actionable error (reuse cache
+  if present) and MUST NOT let the phase proceed against an empty/partial spec.
+- **FR-005**: In cloud mode, task creation MUST support opt-in auto-generation of the task's
+  spec (via Lot 2's cloud `specify` path), **disabled by default**.
+- **FR-006**: Auto-generation failure MUST NOT fail the task creation; the error MUST be
+  surfaced separately and be retryable.
+- **FR-007**: Cloud-mode `specify` MUST remain branch-free so multiple specs can be authored
+  concurrently without git-branch collision or shared local state (this lot adds the guidance;
+  the branch-free behaviour ships in Lot 2).
+- **FR-008**: The whole lot MUST NOT introduce any Cloud coupling beyond Lot 2's commands / the
+  versioned HTTP API — no private-half identifier enters the public CLI (§ I).
+
+### Key Entities *(see Domain Model section below for full structure)*
+
+- **Phase entry hook**: the point at which a consuming phase materialises the spec.
+- **Auto-generation toggle**: the opt-in setting that couples task creation with spec-gen.
+
+## Domain Model *(mandatory)*
+
+**Bounded context:** Spec/phase orchestration (CLI) — making the cloud spec backend automatic
+across the workflow.
+
+**Vocabulary (Ubiquitous language):**
+
+- **Consuming phase** — a phase that reads the spec: `implement`, `review`, `analyze`, `tasks`.
+- **Phase-entry pull** — the single `spec pull <task>` a consuming phase runs first in cloud mode.
+- **Auto-generation** — generating a task's spec at creation time (opt-in, cloud mode).
+- **Materialised cache** — Lot 2's gitignored `.specnaut/specs/.cache/<task>/` the agents read.
+
+**Entities (have identity):**
+
+- **Workflow phase** — a phase doc; in cloud mode it gains a pull-on-entry step.
+- **Auto-generation setting** — the opt-in toggle (config/flag) governing task-creation spec-gen.
+
+**Value objects (no identity, immutable):**
+
+- **PhaseMode(local | cloud)** — derived from the persisted spec backend (Lot 2); selects the
+  rendered phase behaviour.
+
+**Invariants (rules the domain must never break):**
+
+- **Local parity** — with the local backend, no auto-pull, no auto-gen, no orchestration change.
+- **No network-aware agents** — the only network touch in a phase is the single entry pull.
+- **Auto-gen is non-fatal** — it never fails task creation.
+- **API-only boundary** — all Cloud interaction goes through Lot 2's commands / the versioned API (§ I).
+
+**Out of scope (other bounded contexts touched but not owned here):**
+
+- **The `spec pull`/`push` commands, cloud `specify`, materialisation** — Lot 2 (owned there).
+- **Cloud store/API, Web UI** — Lots 1 & 3.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In cloud mode, a consuming phase materialises the spec exactly once at entry, and
+  agents read only local files (zero agent network calls).
+- **SC-002**: In local mode, the full existing phase test suite passes unchanged (zero
+  regressions) — no pull, no auto-gen.
+- **SC-003**: With auto-generation enabled, creating a task yields a generated cloud spec with
+  no branch; disabled (default), task creation is unchanged.
+- **SC-004**: A pull or auto-gen failure produces an actionable message and never a silent empty
+  spec / failed task creation.
+- **SC-005**: Three specs can be authored concurrently in cloud mode, each pushed to its task,
+  with zero branches and zero file-system collisions.
+- **SC-006**: No CLI source or wire payload references a private-half identifier (§ I).
+
+## Assumptions
+
+- Lot 2's `spec pull`/`spec push` commands, cloud-mode `specify`, and the materialisation cache
+  are available (shipped).
+- The consuming phases are the four that read the spec (`implement`, `review`, `analyze`,
+  `tasks`); `specify` authors (Lot 2) and `merge`/`constitution`/etc. don't consume it.
+- Auto-generation is opt-in (default off) to avoid surprising task creation with heavy spec-gen;
+  the toggle lives with the project config (mirroring how backends are persisted).
+- Parallel authoring is primarily guidance + relying on Lot 2's branch-free `specify`; no new
+  compiled orchestration engine is required for v1.

--- a/.specnaut/specs/021-cli-phase-wiring/tasks.md
+++ b/.specnaut/specs/021-cli-phase-wiring/tasks.md
@@ -1,12 +1,12 @@
 # Tasks: Phase-entry spec pull, auto-generation & parallel orchestration
 
-**Input**: Design documents from `.specnaut/specs/021-cli-phase-wiring/`
-**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/phase-wiring.md, quickstart.md
-**Tests**: INCLUDED — golden local-parity (SC-002) + lock round-trip + cloud-render integration.
+**Input**: Design documents from `.specnaut/specs/021-cli-phase-wiring/` **Prerequisites**: plan.md,
+spec.md, research.md, data-model.md, contracts/phase-wiring.md, quickstart.md **Tests**: INCLUDED —
+golden local-parity (SC-002) + lock round-trip + cloud-render integration.
 
-**Organization**: grouped by user story. US1 (pull-on-entry) + US2 (auto-gen) are P1; US3
-(parallel guidance) is P2. Paths relative to `apps/specnaut-cli/`. Reuses Lot 2's shipped
-`renderSpecBackend` / `spec_backend_filter` / marker-block mechanism.
+**Organization**: grouped by user story. US1 (pull-on-entry) + US2 (auto-gen) are P1; US3 (parallel
+guidance) is P2. Paths relative to `apps/specnaut-cli/`. Reuses Lot 2's shipped `renderSpecBackend`
+/ `spec_backend_filter` / marker-block mechanism.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -14,21 +14,26 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm which phase docs `applySpecBackend`/`renderSpecBackend` currently process
-      (Lot 2 wired specify+implement). Note whether the filter's entry set must widen to
-      review/analyze/tasks.
+- [x] T001 Confirm which phase docs `applySpecBackend`/`renderSpecBackend` currently process (Lot 2
+      wired specify+implement). Note whether the filter's entry set must widen to
+      review/analyze/tasks. **Finding: no widening needed** — `applySpecBackend` guards on
+      `category === "phase"` (not on doc name), so it already renders `spec-backend=` markers in
+      EVERY phase doc; review/analyze/tasks simply had no markers yet. Only the stale doc comment
+      ("only specify/implement carry markers") was refreshed.
 
 ---
 
 ## Phase 2: Foundational
 
-- [ ] T002 Add `spec_autogen: boolean` to `src/domain/installed_lock.ts` (`spec_autogen` YAML
-      key, `specAutogen` field, `parseLock` defaults to `false` when absent — mirror
-      `spec_backend`). [FR-005]
-- [ ] T003 [P] Test `tests/unit/installed_lock_spec_autogen_test.ts` — round-trip; absent → false. [FR-005]
-- [ ] T004 If T001 found the filter narrowed: widen `spec_backend_filter.ts` /
-      `renderSpecBackend` to process all consuming phase docs (review/analyze/tasks). Keep local
-      render byte-identical.
+- [x] T002 Add `spec_autogen: boolean` to `src/domain/installed_lock.ts` (`spec_autogen` YAML key,
+      `specAutogen` field, `parseLock` defaults to `false` when absent — mirror `spec_backend`).
+      [FR-005]
+- [x] T003 [P] Test `tests/unit/installed_lock_spec_autogen_test.ts` — round-trip; absent → false.
+      [FR-005]
+- [x] T004 If T001 found the filter narrowed: widen `spec_backend_filter.ts` / `renderSpecBackend`
+      to process all consuming phase docs (review/analyze/tasks). Keep local render byte-identical.
+      **N/A** per T001 — the filter was never narrowed; refreshed only the `applySpecBackend` doc
+      comment to reflect the wider marker coverage. Local render proven byte-identical by T005.
 
 **Checkpoint**: lock field + render coverage ready.
 
@@ -37,18 +42,20 @@
 ## Phase 3: User Story 1 — Pull-on-entry (Priority: P1) 🎯 MVP
 
 ### Tests
-- [ ] T005 [P] [US1] Golden local-parity: `local`-rendered `review.md`/`analyze.md`/`tasks.md`
+
+- [x] T005 [P] [US1] Golden local-parity: `local`-rendered `review.md`/`analyze.md`/`tasks.md`
       byte-identical to pre-feature (EOL-agnostic, per Lot 2's lesson); extend the existing
       `spec_backend_filter_golden_test.ts` fixtures. [SC-002]
-- [ ] T006 [P] [US1] Integration: `cloud`-rendered implement/review/analyze/tasks contain a
-      single `spec pull <task>` step; `local` render does not. [SC-001]
+- [x] T006 [P] [US1] Integration: `cloud`-rendered implement/review/analyze/tasks contain a single
+      `spec pull <task>` step; `local` render does not. [SC-001]
 
 ### Implementation
-- [ ] T007 [US1] Add `spec-backend=cloud` pull-on-entry marker blocks to
-      `templates/core/skills/specnaut/phases/{implement,review,analyze,tasks}.md` per
-      contract §A (implement: pull precedes the Lot 2 `--branch-only` step); wrap the existing
-      content in the `spec-backend=local` block unchanged. Re-bundle. [FR-001/002/003/004]
-- [ ] T008 [US1] Sync the plugin mirror (`plugin/skills/specnaut/phases/*`) as Lot 2 did.
+
+- [x] T007 [US1] Add `spec-backend=cloud` pull-on-entry marker blocks to
+      `templates/core/skills/specnaut/phases/{implement,review,analyze,tasks}.md` per contract §A
+      (implement: pull precedes the Lot 2 `--branch-only` step); wrap the existing content in the
+      `spec-backend=local` block unchanged. Re-bundle. [FR-001/002/003/004]
+- [x] T008 [US1] Sync the plugin mirror (`plugin/skills/specnaut/phases/*`) as Lot 2 did.
 
 **Checkpoint**: consuming phases pull once at entry in cloud mode; local unchanged.
 
@@ -56,11 +63,11 @@
 
 ## Phase 4: User Story 2 — Auto-generation at task creation (Priority: P1)
 
-- [ ] T009 [US2] Add the auto-generation guidance (contract §B) to the task-creation skill/phase
+- [x] T009 [US2] Add the auto-generation guidance (contract §B) to the task-creation skill/phase
       doc(s): when `spec_autogen && cloud`, after creating a task also run cloud `specify` for it
       (branch-free); a failure is reported and non-fatal. Gate on `spec_autogen`. [FR-005/006]
-- [ ] T010 [P] [US2] Integration: with `spec_autogen: true` + cloud, the rendered guidance
-      includes the auto-gen step; with it false/absent or local, it does not. [SC-003]
+- [x] T010 [P] [US2] Integration: with `spec_autogen: true` + cloud, the rendered guidance includes
+      the auto-gen step; with it false/absent or local, it does not. [SC-003]
 
 **Checkpoint**: opt-in auto-gen wired, default off, non-fatal.
 
@@ -68,26 +75,29 @@
 
 ## Phase 5: User Story 3 — Parallel authoring (Priority: P2)
 
-- [ ] T011 [US3] Add the parallel-authoring guidance (contract §C) to the relevant skill/phase
-      doc — cloud `specify` is branch-free ⇒ N specs concurrently, no collision. [FR-007]
+- [x] T011 [US3] Add the parallel-authoring guidance (contract §C) to the relevant skill/phase doc —
+      cloud `specify` is branch-free ⇒ N specs concurrently, no collision. [FR-007]
 
 ---
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T012 [P] Integration: local mode end-to-end — no pull, no auto-gen, phase docs unchanged
-      (the existing phase suite stays green). [SC-002]
-- [ ] T013 Run `deno task lint` + `deno task test` + `deno task bundle` — all green (fmt:check
+- [x] T012 [P] Integration: local mode end-to-end — no pull, no auto-gen, phase docs unchanged (the
+      existing phase suite stays green). [SC-002]
+- [x] T013 Run `deno task lint` + `deno task test` + `deno task bundle` — all green (fmt:check
       included, per Lot 2's CI lesson). Update the release-audit smoke if it enumerates phase docs.
 
 ---
 
 ## Dependencies & order
+
 - Phase 2 blocks all. US1 is the MVP (pull-on-entry). US2/US3 are guidance layered on top.
 
 ## Parallel opportunities
+
 - T003/T005/T006 parallel; US2/US3 doc edits parallel once the render coverage (T004) lands.
 
 ## Suggested MVP
-**Phase 2 + US1** — cloud phases pull the spec automatically at entry, local provably unchanged.
-US2 (auto-gen) + US3 (parallel) complete the lot.
+
+**Phase 2 + US1** — cloud phases pull the spec automatically at entry, local provably unchanged. US2
+(auto-gen) + US3 (parallel) complete the lot.

--- a/.specnaut/specs/021-cli-phase-wiring/tasks.md
+++ b/.specnaut/specs/021-cli-phase-wiring/tasks.md
@@ -1,0 +1,93 @@
+# Tasks: Phase-entry spec pull, auto-generation & parallel orchestration
+
+**Input**: Design documents from `.specnaut/specs/021-cli-phase-wiring/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/phase-wiring.md, quickstart.md
+**Tests**: INCLUDED — golden local-parity (SC-002) + lock round-trip + cloud-render integration.
+
+**Organization**: grouped by user story. US1 (pull-on-entry) + US2 (auto-gen) are P1; US3
+(parallel guidance) is P2. Paths relative to `apps/specnaut-cli/`. Reuses Lot 2's shipped
+`renderSpecBackend` / `spec_backend_filter` / marker-block mechanism.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm which phase docs `applySpecBackend`/`renderSpecBackend` currently process
+      (Lot 2 wired specify+implement). Note whether the filter's entry set must widen to
+      review/analyze/tasks.
+
+---
+
+## Phase 2: Foundational
+
+- [ ] T002 Add `spec_autogen: boolean` to `src/domain/installed_lock.ts` (`spec_autogen` YAML
+      key, `specAutogen` field, `parseLock` defaults to `false` when absent — mirror
+      `spec_backend`). [FR-005]
+- [ ] T003 [P] Test `tests/unit/installed_lock_spec_autogen_test.ts` — round-trip; absent → false. [FR-005]
+- [ ] T004 If T001 found the filter narrowed: widen `spec_backend_filter.ts` /
+      `renderSpecBackend` to process all consuming phase docs (review/analyze/tasks). Keep local
+      render byte-identical.
+
+**Checkpoint**: lock field + render coverage ready.
+
+---
+
+## Phase 3: User Story 1 — Pull-on-entry (Priority: P1) 🎯 MVP
+
+### Tests
+- [ ] T005 [P] [US1] Golden local-parity: `local`-rendered `review.md`/`analyze.md`/`tasks.md`
+      byte-identical to pre-feature (EOL-agnostic, per Lot 2's lesson); extend the existing
+      `spec_backend_filter_golden_test.ts` fixtures. [SC-002]
+- [ ] T006 [P] [US1] Integration: `cloud`-rendered implement/review/analyze/tasks contain a
+      single `spec pull <task>` step; `local` render does not. [SC-001]
+
+### Implementation
+- [ ] T007 [US1] Add `spec-backend=cloud` pull-on-entry marker blocks to
+      `templates/core/skills/specnaut/phases/{implement,review,analyze,tasks}.md` per
+      contract §A (implement: pull precedes the Lot 2 `--branch-only` step); wrap the existing
+      content in the `spec-backend=local` block unchanged. Re-bundle. [FR-001/002/003/004]
+- [ ] T008 [US1] Sync the plugin mirror (`plugin/skills/specnaut/phases/*`) as Lot 2 did.
+
+**Checkpoint**: consuming phases pull once at entry in cloud mode; local unchanged.
+
+---
+
+## Phase 4: User Story 2 — Auto-generation at task creation (Priority: P1)
+
+- [ ] T009 [US2] Add the auto-generation guidance (contract §B) to the task-creation skill/phase
+      doc(s): when `spec_autogen && cloud`, after creating a task also run cloud `specify` for it
+      (branch-free); a failure is reported and non-fatal. Gate on `spec_autogen`. [FR-005/006]
+- [ ] T010 [P] [US2] Integration: with `spec_autogen: true` + cloud, the rendered guidance
+      includes the auto-gen step; with it false/absent or local, it does not. [SC-003]
+
+**Checkpoint**: opt-in auto-gen wired, default off, non-fatal.
+
+---
+
+## Phase 5: User Story 3 — Parallel authoring (Priority: P2)
+
+- [ ] T011 [US3] Add the parallel-authoring guidance (contract §C) to the relevant skill/phase
+      doc — cloud `specify` is branch-free ⇒ N specs concurrently, no collision. [FR-007]
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T012 [P] Integration: local mode end-to-end — no pull, no auto-gen, phase docs unchanged
+      (the existing phase suite stays green). [SC-002]
+- [ ] T013 Run `deno task lint` + `deno task test` + `deno task bundle` — all green (fmt:check
+      included, per Lot 2's CI lesson). Update the release-audit smoke if it enumerates phase docs.
+
+---
+
+## Dependencies & order
+- Phase 2 blocks all. US1 is the MVP (pull-on-entry). US2/US3 are guidance layered on top.
+
+## Parallel opportunities
+- T003/T005/T006 parallel; US2/US3 doc edits parallel once the render coverage (T004) lands.
+
+## Suggested MVP
+**Phase 2 + US1** — cloud phases pull the spec automatically at entry, local provably unchanged.
+US2 (auto-gen) + US3 (parallel) complete the lot.

--- a/plugin/skills/specnaut/phases/implement.md
+++ b/plugin/skills/specnaut/phases/implement.md
@@ -45,14 +45,15 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 <!-- BEGIN: spec-backend=cloud -->
 0. **Cloud spec setup** (spec backend = cloud): the spec lives on SpecNaut Cloud
-   and `/specnaut specify` created NO git branch. Before anything else:
+   and `/specnaut specify` created NO git branch. Before anything else, in this order:
+   - **Materialise the spec (pull-on-entry)** — run `specnaut spec pull <task>` ONCE
+     now; it writes the spec's tabs to the gitignored `.specnaut/specs/.cache/<task>/`.
+     Read the spec, plan, tasks, and the mandatory Domain Model block from that cache
+     directory instead of `.specnaut/specs/<n>/`. If the pull fails (offline/auth),
+     stop with its message — do not proceed against an empty spec.
    - **Create the feature branch now** — this is the decoupling point. Run
      `.specnaut/scripts/bash/create-new-feature.sh --branch-only "<feature description>"`
      (the `--branch-only` flag creates only the branch — no `.specnaut/specs/` dir).
-   - **Materialise the spec** so the steps below read plain files:
-     `specnaut spec pull <task>` writes `.specnaut/specs/.cache/<task>/`.
-   - Read the spec, plan, tasks, and the mandatory Domain Model block from that
-     cache directory instead of `.specnaut/specs/<n>/`.
 
 <!-- END: spec-backend=cloud -->
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").

--- a/plugin/skills/specnaut/phases/specify.md
+++ b/plugin/skills/specnaut/phases/specify.md
@@ -139,6 +139,12 @@ Given that feature description, do this:
    4. Persist the resolved task number to `.specnaut/feature.json`
       (`{ "linked_issue": <N>, "workflow_shape": "<lite|full>" }`) so downstream
       phases locate the spec. No `feature_directory` is written in cloud mode.
+
+   **Parallel authoring (cloud):** because cloud `specify` creates NO git branch and writes
+   NO shared `.specnaut/specs/` state, several task specs can be authored concurrently — drive
+   one `specify` per task in parallel (a user, or an agent fleet) with no git-branch collision
+   and no shared-state clash. Each spec is pushed to its own task independently (last write
+   wins per task, Lot 1 upsert).
 <!-- END: spec-backend=cloud -->
 
 4. Load `templates/spec-template.md` to understand required sections.

--- a/src/application/diff_project.ts
+++ b/src/application/diff_project.ts
@@ -78,6 +78,7 @@ export class DiffProjectUseCase {
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
       specBackend: lock.specBackend,
+      specAutogen: lock.specAutogen,
     });
 
     const results: DivergenceResult[] = [];

--- a/src/application/ports.ts
+++ b/src/application/ports.ts
@@ -162,11 +162,19 @@ export type BundleOptions = {
   readonly versionScheme: VersionScheme;
   /**
    * Which spec backend's conditional sections the phase docs should keep
-   * (spec 020). `specify.md` / `implement.md` carry `spec-backend=local|cloud`
-   * marker blocks rendered against this value at bundle time. `local` yields
-   * output byte-identical to the pre-feature CLI (FR-003).
+   * (spec 020). The consuming phase docs (`specify` / `implement` / `review` /
+   * `analyze` / `tasks`) carry `spec-backend=local|cloud` marker blocks rendered
+   * against this value at bundle time. `local` yields output byte-identical to
+   * the pre-feature CLI (FR-003).
    */
   readonly specBackend: SpecBackend;
+  /**
+   * Whether cloud-mode task creation should also auto-generate the task's spec
+   * (spec 021 / FR-005). Governs the `spec-autogen=on` guidance block in the
+   * backlog skill. Absent ⇒ `false` (opt-in, default off); the guidance only
+   * renders when `specAutogen && specBackend === "cloud"`.
+   */
+  readonly specAutogen?: boolean;
 };
 
 /**

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -104,6 +104,7 @@ export class UpgradeProjectUseCase {
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
       specBackend: lock.specBackend,
+      specAutogen: lock.specAutogen,
     });
 
     // Parent-managed targets inherit agentic files from the providing
@@ -205,6 +206,7 @@ export class UpgradeProjectUseCase {
           backlogBackend: lock.backlogBackend,
           versionScheme: lock.versionScheme,
           specBackend: lock.specBackend,
+          specAutogen: lock.specAutogen,
           templatesVersion: lock.templatesVersion,
           entries: lock.entries,
           ...(parentManaged ? { parentManaged: true as const } : {}),
@@ -341,6 +343,7 @@ export class UpgradeProjectUseCase {
       backlogBackend: lock.backlogBackend,
       versionScheme: lock.versionScheme,
       specBackend: lock.specBackend,
+      specAutogen: lock.specAutogen,
       templatesVersion,
       entries: updatedEntries,
       // Persist the (possibly re-derived) decision so future upgrades read it

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -70,11 +70,13 @@ export async function switchBacklogBackend(
     backlogBackend: newBackend,
     versionScheme: lock.versionScheme,
     specBackend: lock.specBackend,
+    specAutogen: lock.specAutogen,
   }));
   const oldBundle = dropAgentic(harness.mapBundle(CORE_BUNDLE, {
     backlogBackend: from,
     versionScheme: lock.versionScheme,
     specBackend: lock.specBackend,
+    specAutogen: lock.specAutogen,
   }));
 
   const writer = new DenoFsWriter();
@@ -140,6 +142,7 @@ export async function switchBacklogBackend(
     backlogBackend: newBackend,
     versionScheme: lock.versionScheme,
     specBackend: lock.specBackend,
+    specAutogen: lock.specAutogen,
     templatesVersion: lock.templatesVersion,
     entries: updatedEntries,
     // Preserve the parent-managed decision across a backend switch — dropping
@@ -291,6 +294,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
         backlogBackend: lockForDetection.backlogBackend,
         versionScheme: lockForDetection.versionScheme,
         specBackend: lockForDetection.specBackend,
+        specAutogen: lockForDetection.specAutogen,
       });
       const parentManaged = (parentManagedOverride ?? lockForDetection.parentManaged) ?? false;
       const bundleDests = parentManaged
@@ -376,6 +380,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
         backlogBackend: lock.backlogBackend,
         versionScheme: lock.versionScheme,
         specBackend: lock.specBackend,
+        specAutogen: lock.specAutogen,
       })
       : {};
     for (const action of preserves) {

--- a/src/domain/conditional_render.ts
+++ b/src/domain/conditional_render.ts
@@ -190,6 +190,91 @@ export function assertKnownSpecBackend(s: string): asserts s is SpecBackend {
   }
 }
 
+const SPEC_AUTOGEN_BEGIN_RE = /^\s*<!--\s*BEGIN:\s*spec-autogen=([a-zA-Z0-9_-]+)\s*-->\s*$/;
+const SPEC_AUTOGEN_END_RE = /^\s*<!--\s*END:\s*spec-autogen=([a-zA-Z0-9_-]+)\s*-->\s*$/;
+
+/**
+ * Strip spec-autogen-conditional sections from a Markdown source (spec 021).
+ *
+ * A third marker family, deliberately distinct from `backend=` (backlog) and
+ * `spec-backend=` (spec 020) so none of the three collide:
+ *   <!-- BEGIN: spec-autogen=on -->
+ *   ...guidance kept only when auto-generation is enabled...
+ *   <!-- END: spec-autogen=on -->
+ *
+ * `enabled` maps to the active token `"on"` (true) / `"off"` (false): the block
+ * whose token matches is preserved (markers stripped), the other is removed
+ * entirely. This gates the opt-in auto-gen guidance (FR-005) — `enabled` is the
+ * caller's `specAutogen && specBackend === "cloud"` decision, so `off` renders
+ * are byte-identical to a doc that never carried the block. A source with no
+ * `spec-autogen=` markers passes through unchanged.
+ *
+ * Throws on unmatched (BEGIN without END, END without BEGIN) or nested markers.
+ */
+export function renderSpecAutogen(source: string, enabled: boolean): string {
+  const active = enabled ? "on" : "off";
+  const lines = source.split("\n");
+  const out: string[] = [];
+  let insideFence = false;
+  let openToken: string | null = null;
+  let openLine = -1;
+  let keepBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (FENCE_RE.test(line)) {
+      insideFence = !insideFence;
+      if (openToken === null || keepBlock) out.push(line);
+      continue;
+    }
+
+    if (!insideFence) {
+      const beginMatch = line.match(SPEC_AUTOGEN_BEGIN_RE);
+      if (beginMatch) {
+        if (openToken !== null) {
+          throw new Error(
+            `nested spec-autogen marker at line ${i + 1}: BEGIN ${beginMatch[1]} ` +
+              `inside open block ${openToken} (started at line ${openLine + 1})`,
+          );
+        }
+        openToken = beginMatch[1];
+        openLine = i;
+        keepBlock = openToken === active;
+        continue;
+      }
+
+      const endMatch = line.match(SPEC_AUTOGEN_END_RE);
+      if (endMatch) {
+        if (openToken === null) {
+          throw new Error(
+            `unmatched END marker at line ${i + 1}: spec-autogen=${endMatch[1]}`,
+          );
+        }
+        if (endMatch[1] !== openToken) {
+          throw new Error(
+            `mismatched END marker at line ${i + 1}: expected spec-autogen=${openToken} ` +
+              `(opened at line ${openLine + 1}), got spec-autogen=${endMatch[1]}`,
+          );
+        }
+        openToken = null;
+        keepBlock = false;
+        continue;
+      }
+    }
+
+    if (openToken === null || keepBlock) out.push(line);
+  }
+
+  if (openToken !== null) {
+    throw new Error(
+      `unmatched BEGIN marker at line ${openLine + 1}: spec-autogen=${openToken}`,
+    );
+  }
+
+  return out.join("\n");
+}
+
 const SH_SCHEME_BEGIN_RE = /^\s*#\s*BEGIN:\s*scheme=([a-zA-Z0-9_-]+)\s*$/;
 const SH_SCHEME_END_RE = /^\s*#\s*END:\s*scheme=([a-zA-Z0-9_-]+)\s*$/;
 

--- a/src/domain/installed_lock.ts
+++ b/src/domain/installed_lock.ts
@@ -58,6 +58,17 @@ export type InstalledLock = {
    * `"local"` (FR-010, backward compatible). Sibling of `backlogBackend`.
    */
   readonly specBackend: SpecBackend;
+  /**
+   * Opt-in toggle (spec 021 / cli#425). When `true`, cloud-mode task creation
+   * ALSO auto-generates the new task's spec via the branch-free cloud `specify`
+   * path, so the spec is ready before implementation starts (FR-005). Absent in
+   * a pre-feature lock ⇒ `false` (default off — task creation is never surprised
+   * by heavy spec-gen). Mirrors `specBackend`'s default-on-absent; serialised
+   * only when enabled so existing locks stay byte-identical (cf. `parentManaged`).
+   * Read by the rendered task-creation guidance, which gates on
+   * `specAutogen && specBackend === "cloud"`.
+   */
+  readonly specAutogen?: boolean;
   readonly templatesVersion: string;
   readonly entries: ReadonlyMap<string, LockEntry>;
   /**
@@ -128,6 +139,11 @@ export function parseLock(yaml: string): InstalledLock {
     ? (rawSpecBackend as SpecBackend)
     : "local";
 
+  // Opt-in auto-generation toggle (spec 021 / FR-005). Absent ⇒ false (default
+  // off, mirroring the `spec_backend` default-on-absent). Only the literal
+  // `true` enables it; any other value (absent, false, garbage) ⇒ false.
+  const specAutogen = root.spec_autogen === true;
+
   const templatesVersion = root.templates_version;
   if (typeof templatesVersion !== "string") {
     throw new Error("missing top-level templates_version");
@@ -158,6 +174,7 @@ export function parseLock(yaml: string): InstalledLock {
     backlogBackend,
     versionScheme,
     specBackend,
+    specAutogen,
     templatesVersion,
     entries,
     ...(parentManaged ? { parentManaged } : {}),
@@ -181,6 +198,10 @@ export function serializeLock(lock: InstalledLock): string {
     backlog_backend: lock.backlogBackend,
     version_scheme: lock.versionScheme,
     spec_backend: lock.specBackend,
+    // Emit `spec_autogen` only when enabled (opt-in, spec 021), so a project
+    // that never turned it on keeps a byte-identical lock. Absent ⇒ false on
+    // read (mirrors `parent_managed`'s emit-when-set).
+    ...(lock.specAutogen ? { spec_autogen: true } : {}),
     // Emit `parent_managed` only when set so legacy/standalone locks stay
     // byte-for-byte identical to before this feature.
     ...(lock.parentManaged ? { parent_managed: true } : {}),

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -6,6 +6,7 @@ import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 
 function toAntigravityWorkflowMarkdown(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -73,7 +74,10 @@ export class AntigravityHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/claude_harness.ts
+++ b/src/infrastructure/harness/claude_harness.ts
@@ -5,6 +5,7 @@ import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 import { ensureSkillFrontmatter } from "./skill_folder.ts";
 
 function destinationFor(entry: CoreEntry): string {
@@ -57,7 +58,10 @@ export class ClaudeHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
 
       // Skill-folder categories ship as `.claude/skills/<name>/SKILL.md`.
       // Claude Code derives the skill name from the folder, but we inject

--- a/src/infrastructure/harness/codex_harness.ts
+++ b/src/infrastructure/harness/codex_harness.ts
@@ -8,6 +8,7 @@ import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 
 function parseAgentFrontmatter(
   content: string,
@@ -62,7 +63,10 @@ export class CodexHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -6,6 +6,7 @@ import { splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 
 function toCopilotInstructionMarkdown(entry: CoreEntry): string {
   const split = splitFrontmatter(entry.content);
@@ -51,7 +52,10 @@ export class CopilotHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/cursor_harness.ts
+++ b/src/infrastructure/harness/cursor_harness.ts
@@ -6,6 +6,7 @@ import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 
 function destinationFor(entry: CoreEntry): string {
   switch (entry.category) {
@@ -44,7 +45,10 @@ export class CursorHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -6,6 +6,7 @@ import { frontmatterField, splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 
 type PermissionValue = "allow" | "ask" | "deny" | { "*": "ask" | "allow" | "deny" };
 type PermissionMap = Record<string, PermissionValue>;
@@ -136,7 +137,10 @@ export class OpenCodeHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/infrastructure/harness/spec_autogen_filter.ts
+++ b/src/infrastructure/harness/spec_autogen_filter.ts
@@ -1,0 +1,23 @@
+import type { CoreEntry } from "../../domain/core_bundle.ts";
+import type { BundleOptions } from "../../application/ports.ts";
+import { renderSpecAutogen } from "../../domain/conditional_render.ts";
+
+/**
+ * Renders `<!-- BEGIN: spec-autogen=on -->` blocks in the `backlog-skill`
+ * entry against the opt-in auto-generation toggle (spec 021 / FR-005). The
+ * guidance is kept only when `specAutogen && specBackend === "cloud"` — auto-
+ * generation runs the branch-free cloud `specify` path, which only exists in
+ * cloud mode, so the spec backend is part of the gate. Every other category
+ * (and a disabled toggle) passes through unchanged, so a project that never
+ * enabled it sees byte-identical output. Sibling of {@link applySpecBackend}.
+ *
+ * Idempotent and pure — no IO, no Deno globals.
+ */
+export function applySpecAutogen(entry: CoreEntry, opts: BundleOptions): CoreEntry {
+  if (entry.category !== "backlog-skill") return entry;
+  const enabled = (opts.specAutogen ?? false) && opts.specBackend === "cloud";
+  return {
+    ...entry,
+    content: renderSpecAutogen(entry.content, enabled),
+  };
+}

--- a/src/infrastructure/harness/spec_backend_filter.ts
+++ b/src/infrastructure/harness/spec_backend_filter.ts
@@ -4,10 +4,12 @@ import { renderSpecBackend } from "../../domain/conditional_render.ts";
 
 /**
  * Renders `<!-- BEGIN: spec-backend=X -->` blocks in a `phase` entry against the
- * active spec backend (spec 020). Only `specify.md` / `implement.md` carry these
- * markers today; every other phase (and non-phase category) passes through
- * unchanged, so `local` output stays byte-identical to the pre-feature CLI
- * (FR-003). Sibling of {@link applyScheme}.
+ * active spec backend. `specify.md` / `implement.md` carry these markers since
+ * spec 020; `review.md` / `analyze.md` / `tasks.md` gained a cloud pull-on-entry
+ * block in spec 021. Every phase doc is filtered here (the guard is category,
+ * not name), and any phase without markers — plus every non-phase category —
+ * passes through unchanged, so `local` output stays byte-identical to the
+ * pre-feature CLI (FR-003). Sibling of {@link applyScheme}.
  *
  * Idempotent and pure — no IO, no Deno globals.
  */

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -6,6 +6,7 @@ import { splitFrontmatter } from "./frontmatter.ts";
 import { applyBackend, backlogScriptDestination } from "./backlog_filter.ts";
 import { applyScheme, phaseScriptDestination } from "./scheme_filter.ts";
 import { applySpecBackend } from "./spec_backend_filter.ts";
+import { applySpecAutogen } from "./spec_autogen_filter.ts";
 
 // Cascade ignores Claude-only frontmatter fields (e.g. `color:`). Strip them
 // before emission so they don't eat into the 12k-char workflow cap.
@@ -67,7 +68,10 @@ export class WindsurfHarness implements Harness {
     for (const raw of core) {
       const backendApplied = applyBackend(raw, opts);
       if (backendApplied === null) continue;
-      const entry = applySpecBackend(applyScheme(backendApplied, opts), opts);
+      const entry = applySpecAutogen(
+        applySpecBackend(applyScheme(backendApplied, opts), opts),
+        opts,
+      );
       // agent-memory and the agent-fleet README are Claude-only conventions;
       // other harnesses skip them.
       if (entry.category === "agent-memory" || entry.category === "agent-doc") continue;

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -472,6 +472,12 @@ Given that feature description, do this:
    4. Persist the resolved task number to \`.specnaut/feature.json\`
       (\`{ "linked_issue": <N>, "workflow_shape": "<lite|full>" }\`) so downstream
       phases locate the spec. No \`feature_directory\` is written in cloud mode.
+
+   **Parallel authoring (cloud):** because cloud \`specify\` creates NO git branch and writes
+   NO shared \`.specnaut/specs/\` state, several task specs can be authored concurrently — drive
+   one \`specify\` per task in parallel (a user, or an agent fleet) with no git-branch collision
+   and no shared-state clash. Each spec is pushed to its own task independently (last write
+   wins per task, Lot 1 upsert).
 <!-- END: spec-backend=cloud -->
 
 4. Load \`templates/spec-template.md\` to understand required sections.
@@ -965,6 +971,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run \`specnaut spec pull <task>\` ONCE now, before
+loading any design document. It writes the spec's tabs to the gitignored
+\`.specnaut/specs/.cache/<task>/\`; read the spec from there as files. If the pull fails
+(offline/auth), stop with its message — do not proceed against an empty spec.
+
+<!-- END: spec-backend=cloud -->
 1. **Setup**: Run \`{SCRIPT}\` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:
@@ -1172,6 +1185,13 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ## Execution Steps
 
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run \`specnaut spec pull <task>\` ONCE now, before
+loading any artifact. It writes the spec's tabs to the gitignored
+\`.specnaut/specs/.cache/<task>/\`; read the spec from there as files. If the pull fails
+(offline/auth), stop with its message — do not proceed against an empty spec.
+
+<!-- END: spec-backend=cloud -->
 ### 1. Initialize Analysis Context
 
 Run \`{SCRIPT}\` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
@@ -1419,14 +1439,15 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 <!-- BEGIN: spec-backend=cloud -->
 0. **Cloud spec setup** (spec backend = cloud): the spec lives on SpecNaut Cloud
-   and \`/specnaut specify\` created NO git branch. Before anything else:
+   and \`/specnaut specify\` created NO git branch. Before anything else, in this order:
+   - **Materialise the spec (pull-on-entry)** — run \`specnaut spec pull <task>\` ONCE
+     now; it writes the spec's tabs to the gitignored \`.specnaut/specs/.cache/<task>/\`.
+     Read the spec, plan, tasks, and the mandatory Domain Model block from that cache
+     directory instead of \`.specnaut/specs/<n>/\`. If the pull fails (offline/auth),
+     stop with its message — do not proceed against an empty spec.
    - **Create the feature branch now** — this is the decoupling point. Run
      \`.specnaut/scripts/bash/create-new-feature.sh --branch-only "<feature description>"\`
      (the \`--branch-only\` flag creates only the branch — no \`.specnaut/specs/\` dir).
-   - **Materialise the spec** so the steps below read plain files:
-     \`specnaut spec pull <task>\` writes \`.specnaut/specs/.cache/<task>/\`.
-   - Read the spec, plan, tasks, and the mandatory Domain Model block from that
-     cache directory instead of \`.specnaut/specs/<n>/\`.
 
 <!-- END: spec-backend=cloud -->
 1. Run \`{SCRIPT}\` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\\''m Groot' (or double-quote if possible: "I'm Groot").
@@ -1598,6 +1619,13 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run \`specnaut spec pull <task>\` ONCE now. It
+writes the spec's tabs to the gitignored \`.specnaut/specs/.cache/<task>/\`; read the spec
+from there as files. If the pull fails (offline/auth), stop with its message — do not
+proceed against an empty spec.
+
+<!-- END: spec-backend=cloud -->
 1. Identify files modified in the current feature branch:
    \`git diff --name-only \$(git merge-base HEAD main)\`
 2. Delegate structural review to parallel sub-agents via the \`review-coordinator\`.
@@ -9452,6 +9480,27 @@ subsystems, trigger phrases like "break down" / "phased" / "as an
 epic") and either auto-decomposes or proposes a concrete sub-task list
 — see the "Epic detection heuristic" section in
 \`.claude/agents/product-owner.md\`.
+
+<!-- BEGIN: spec-autogen=on -->
+## Auto-generate a task's spec at creation (cloud, opt-in)
+
+This project has \`spec_autogen: true\` in \`.specnaut/installed.lock\` and stores its specs on
+SpecNaut Cloud. So, immediately **after** creating a task, ALSO generate its spec: run the
+cloud \`specify\` flow for the new task (branch-free — no git branch, no local
+\`.specnaut/specs/\` files), so the spec is already written when the task is later picked for
+implementation. No waiting, no blocking pre-step.
+
+- Trigger it once per newly created task, right after the create succeeds — for a single
+  \`add.sh\` or for every task in a batch.
+- **Never fatal to task creation** — if spec generation fails (offline, auth, model error),
+  report it and continue; the task stays created and the spec-gen is retryable later by
+  running the cloud \`specify\` for that task by hand.
+- **Prepare many at once** — because cloud \`specify\` is branch-free, specs for several freshly
+  created tasks can be generated concurrently with no git-branch collision.
+
+When \`spec_autogen\` is absent/false, or the spec backend is not cloud, this step does not
+apply and task creation is unchanged.
+<!-- END: spec-autogen=on -->
 
 ## When NOT to use this skill
 

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -366,6 +366,27 @@ epic") and either auto-decomposes or proposes a concrete sub-task list
 — see the "Epic detection heuristic" section in
 `.claude/agents/product-owner.md`.
 
+<!-- BEGIN: spec-autogen=on -->
+## Auto-generate a task's spec at creation (cloud, opt-in)
+
+This project has `spec_autogen: true` in `.specnaut/installed.lock` and stores its specs on
+SpecNaut Cloud. So, immediately **after** creating a task, ALSO generate its spec: run the
+cloud `specify` flow for the new task (branch-free — no git branch, no local
+`.specnaut/specs/` files), so the spec is already written when the task is later picked for
+implementation. No waiting, no blocking pre-step.
+
+- Trigger it once per newly created task, right after the create succeeds — for a single
+  `add.sh` or for every task in a batch.
+- **Never fatal to task creation** — if spec generation fails (offline, auth, model error),
+  report it and continue; the task stays created and the spec-gen is retryable later by
+  running the cloud `specify` for that task by hand.
+- **Prepare many at once** — because cloud `specify` is branch-free, specs for several freshly
+  created tasks can be generated concurrently with no git-branch collision.
+
+When `spec_autogen` is absent/false, or the spec backend is not cloud, this step does not
+apply and task creation is unchanged.
+<!-- END: spec-autogen=on -->
+
 ## When NOT to use this skill
 
 - The user is implementing a backlog item — that's normal coding work;

--- a/templates/core/skills/specnaut/phases/analyze.md
+++ b/templates/core/skills/specnaut/phases/analyze.md
@@ -53,6 +53,13 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ## Execution Steps
 
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now, before
+loading any artifact. It writes the spec's tabs to the gitignored
+`.specnaut/specs/.cache/<task>/`; read the spec from there as files. If the pull fails
+(offline/auth), stop with its message — do not proceed against an empty spec.
+
+<!-- END: spec-backend=cloud -->
 ### 1. Initialize Analysis Context
 
 Run `{SCRIPT}` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:

--- a/templates/core/skills/specnaut/phases/implement.md
+++ b/templates/core/skills/specnaut/phases/implement.md
@@ -45,14 +45,15 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 <!-- BEGIN: spec-backend=cloud -->
 0. **Cloud spec setup** (spec backend = cloud): the spec lives on SpecNaut Cloud
-   and `/specnaut specify` created NO git branch. Before anything else:
+   and `/specnaut specify` created NO git branch. Before anything else, in this order:
+   - **Materialise the spec (pull-on-entry)** — run `specnaut spec pull <task>` ONCE
+     now; it writes the spec's tabs to the gitignored `.specnaut/specs/.cache/<task>/`.
+     Read the spec, plan, tasks, and the mandatory Domain Model block from that cache
+     directory instead of `.specnaut/specs/<n>/`. If the pull fails (offline/auth),
+     stop with its message — do not proceed against an empty spec.
    - **Create the feature branch now** — this is the decoupling point. Run
      `.specnaut/scripts/bash/create-new-feature.sh --branch-only "<feature description>"`
      (the `--branch-only` flag creates only the branch — no `.specnaut/specs/` dir).
-   - **Materialise the spec** so the steps below read plain files:
-     `specnaut spec pull <task>` writes `.specnaut/specs/.cache/<task>/`.
-   - Read the spec, plan, tasks, and the mandatory Domain Model block from that
-     cache directory instead of `.specnaut/specs/<n>/`.
 
 <!-- END: spec-backend=cloud -->
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").

--- a/templates/core/skills/specnaut/phases/review.md
+++ b/templates/core/skills/specnaut/phases/review.md
@@ -7,6 +7,13 @@ $ARGUMENTS
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now. It
+writes the spec's tabs to the gitignored `.specnaut/specs/.cache/<task>/`; read the spec
+from there as files. If the pull fails (offline/auth), stop with its message — do not
+proceed against an empty spec.
+
+<!-- END: spec-backend=cloud -->
 1. Identify files modified in the current feature branch:
    `git diff --name-only $(git merge-base HEAD main)`
 2. Delegate structural review to parallel sub-agents via the `review-coordinator`.

--- a/templates/core/skills/specnaut/phases/specify.md
+++ b/templates/core/skills/specnaut/phases/specify.md
@@ -139,6 +139,12 @@ Given that feature description, do this:
    4. Persist the resolved task number to `.specnaut/feature.json`
       (`{ "linked_issue": <N>, "workflow_shape": "<lite|full>" }`) so downstream
       phases locate the spec. No `feature_directory` is written in cloud mode.
+
+   **Parallel authoring (cloud):** because cloud `specify` creates NO git branch and writes
+   NO shared `.specnaut/specs/` state, several task specs can be authored concurrently — drive
+   one `specify` per task in parallel (a user, or an agent fleet) with no git-branch collision
+   and no shared-state clash. Each spec is pushed to its own task independently (last write
+   wins per task, Lot 1 upsert).
 <!-- END: spec-backend=cloud -->
 
 4. Load `templates/spec-template.md` to understand required sections.

--- a/templates/core/skills/specnaut/phases/tasks.md
+++ b/templates/core/skills/specnaut/phases/tasks.md
@@ -43,6 +43,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
+<!-- BEGIN: spec-backend=cloud -->
+**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now, before
+loading any design document. It writes the spec's tabs to the gitignored
+`.specnaut/specs/.cache/<task>/`; read the spec from there as files. If the pull fails
+(offline/auth), stop with its message — do not proceed against an empty spec.
+
+<!-- END: spec-backend=cloud -->
 1. **Setup**: Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:

--- a/tests/domain/conditional_render_spec_autogen_test.ts
+++ b/tests/domain/conditional_render_spec_autogen_test.ts
@@ -1,0 +1,80 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { renderSpecAutogen } from "../../src/domain/conditional_render.ts";
+
+// Spec 021 — renderSpecAutogen keeps a `spec-autogen=on` block only when
+// auto-generation is enabled, and strips it otherwise. Its markers are distinct
+// (`spec-autogen=`) so they never collide with backlog `backend=` or spec-020
+// `spec-backend=` markers.
+
+Deno.test("renderSpecAutogen keeps the on-block only when enabled", () => {
+  const src = [
+    "shared before",
+    "<!-- BEGIN: spec-autogen=on -->",
+    "AUTOGEN guidance",
+    "<!-- END: spec-autogen=on -->",
+    "shared after",
+  ].join("\n");
+
+  assertEquals(
+    renderSpecAutogen(src, true),
+    ["shared before", "AUTOGEN guidance", "shared after"].join("\n"),
+  );
+  assertEquals(
+    renderSpecAutogen(src, false),
+    ["shared before", "shared after"].join("\n"),
+  );
+});
+
+Deno.test("renderSpecAutogen is a no-op when no spec-autogen markers are present", () => {
+  const src = "plain line\nsecond line\n";
+  assertEquals(renderSpecAutogen(src, true), src);
+  assertEquals(renderSpecAutogen(src, false), src);
+});
+
+Deno.test("renderSpecAutogen leaves backlog `backend=` markers untouched (no collision)", () => {
+  const src = [
+    "<!-- BEGIN: backend=cloud -->",
+    "cloud backlog",
+    "<!-- END: backend=cloud -->",
+  ].join("\n");
+  assertEquals(renderSpecAutogen(src, true), src);
+  assertEquals(renderSpecAutogen(src, false), src);
+});
+
+Deno.test("renderSpecAutogen treats markers inside fenced code blocks as content", () => {
+  const src = [
+    "```",
+    "<!-- BEGIN: spec-autogen=on -->",
+    "not a marker",
+    "<!-- END: spec-autogen=on -->",
+    "```",
+  ].join("\n");
+  assertEquals(renderSpecAutogen(src, false), src);
+});
+
+Deno.test("renderSpecAutogen rejects unmatched / nested markers", () => {
+  assertThrows(
+    () => renderSpecAutogen("<!-- BEGIN: spec-autogen=on -->\noops\n", true),
+    Error,
+    "unmatched BEGIN",
+  );
+  assertThrows(
+    () => renderSpecAutogen("x\n<!-- END: spec-autogen=on -->\n", true),
+    Error,
+    "unmatched END",
+  );
+  assertThrows(
+    () =>
+      renderSpecAutogen(
+        [
+          "<!-- BEGIN: spec-autogen=on -->",
+          "<!-- BEGIN: spec-autogen=on -->",
+          "<!-- END: spec-autogen=on -->",
+          "<!-- END: spec-autogen=on -->",
+        ].join("\n"),
+        true,
+      ),
+    Error,
+    "nested spec-autogen marker",
+  );
+});

--- a/tests/domain/installed_lock_spec_autogen_test.ts
+++ b/tests/domain/installed_lock_spec_autogen_test.ts
@@ -1,0 +1,83 @@
+import { assertEquals } from "@std/assert";
+import {
+  type InstalledLock,
+  type LockEntry,
+  parseLock,
+  serializeLock,
+} from "../../src/domain/installed_lock.ts";
+
+// Spec 021 / FR-005 — the `spec_autogen` lock field: the opt-in toggle that
+// couples cloud-mode task creation with spec auto-generation. It round-trips
+// through serialize/parse and defaults to `false` when absent (backward-
+// compatible). Mirrors the `spec_backend` default-on-absent coverage, but is
+// serialised only when enabled (like `parent_managed`) so a project that never
+// turned it on keeps a byte-identical lock.
+
+function lockWith(specAutogen: boolean | undefined): InstalledLock {
+  return {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "cloud",
+    ...(specAutogen === undefined ? {} : { specAutogen }),
+    templatesVersion: "1.0.0",
+    entries: new Map<string, LockEntry>([
+      ["CLAUDE.md", {
+        sha256: "aaa",
+        installedAt: "2026-07-14T00:00:00Z",
+        templatesVersion: "1.0.0",
+      }],
+    ]),
+  };
+}
+
+Deno.test("serializeLock emits spec_autogen: true and parseLock round-trips it", () => {
+  const yaml = serializeLock(lockWith(true));
+  assertEquals(yaml.includes("spec_autogen: true"), true);
+  assertEquals(parseLock(yaml).specAutogen, true);
+});
+
+Deno.test("serializeLock omits spec_autogen when false (byte-identical to pre-feature lock)", () => {
+  const yaml = serializeLock(lockWith(false));
+  assertEquals(yaml.includes("spec_autogen"), false);
+  assertEquals(parseLock(yaml).specAutogen, false);
+});
+
+Deno.test("serializeLock omits spec_autogen when absent on the lock object", () => {
+  const yaml = serializeLock(lockWith(undefined));
+  assertEquals(yaml.includes("spec_autogen"), false);
+  assertEquals(parseLock(yaml).specAutogen, false);
+});
+
+Deno.test("parseLock defaults spec_autogen to false when absent (FR-005)", () => {
+  const v2 = `version: 2
+harness: claude
+spec_backend: cloud
+templates_version: 0.7.0
+entries: {}
+`;
+  assertEquals(parseLock(v2).specAutogen, false);
+});
+
+Deno.test("parseLock reads spec_autogen: true", () => {
+  const v2 = `version: 2
+harness: claude
+spec_backend: cloud
+spec_autogen: true
+templates_version: 0.7.0
+entries: {}
+`;
+  assertEquals(parseLock(v2).specAutogen, true);
+});
+
+Deno.test("parseLock coerces a non-true spec_autogen value to false", () => {
+  const v2 = `version: 2
+harness: claude
+spec_backend: cloud
+spec_autogen: yes-please
+templates_version: 0.7.0
+entries: {}
+`;
+  assertEquals(parseLock(v2).specAutogen, false);
+});

--- a/tests/fixtures/analyze_local_golden.md
+++ b/tests/fixtures/analyze_local_golden.md
@@ -53,13 +53,6 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ## Execution Steps
 
-<!-- BEGIN: spec-backend=cloud -->
-**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now, before
-loading any artifact. It writes the spec's tabs to the gitignored
-`.specnaut/specs/.cache/<task>/`; read the spec from there as files. If the pull fails
-(offline/auth), stop with its message — do not proceed against an empty spec.
-
-<!-- END: spec-backend=cloud -->
 ### 1. Initialize Analysis Context
 
 Run `{SCRIPT}` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:

--- a/tests/fixtures/review_local_golden.md
+++ b/tests/fixtures/review_local_golden.md
@@ -7,13 +7,6 @@ $ARGUMENTS
 
 ## Outline
 
-<!-- BEGIN: spec-backend=cloud -->
-**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now. It
-writes the spec's tabs to the gitignored `.specnaut/specs/.cache/<task>/`; read the spec
-from there as files. If the pull fails (offline/auth), stop with its message — do not
-proceed against an empty spec.
-
-<!-- END: spec-backend=cloud -->
 1. Identify files modified in the current feature branch:
    `git diff --name-only $(git merge-base HEAD main)`
 2. Delegate structural review to parallel sub-agents via the `review-coordinator`.

--- a/tests/fixtures/tasks_local_golden.md
+++ b/tests/fixtures/tasks_local_golden.md
@@ -43,13 +43,6 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-<!-- BEGIN: spec-backend=cloud -->
-**Materialise the spec (cloud backend):** run `specnaut spec pull <task>` ONCE now, before
-loading any design document. It writes the spec's tabs to the gitignored
-`.specnaut/specs/.cache/<task>/`; read the spec from there as files. If the pull fails
-(offline/auth), stop with its message — do not proceed against an empty spec.
-
-<!-- END: spec-backend=cloud -->
 1. **Setup**: Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:

--- a/tests/infrastructure/harness/spec_autogen_filter_test.ts
+++ b/tests/infrastructure/harness/spec_autogen_filter_test.ts
@@ -1,0 +1,59 @@
+import { assertEquals } from "@std/assert";
+import { applySpecAutogen } from "../../../src/infrastructure/harness/spec_autogen_filter.ts";
+import type { CoreEntry } from "../../../src/domain/core_bundle.ts";
+import type { BundleOptions } from "../../../src/application/ports.ts";
+
+// Spec 021 — applySpecAutogen gates the `spec-autogen=on` guidance in the
+// backlog skill on `specAutogen && specBackend === "cloud"`, and leaves every
+// other category (and toggled-off render) untouched.
+
+const skillContent = [
+  "shared",
+  "<!-- BEGIN: spec-autogen=on -->",
+  "AUTOGEN",
+  "<!-- END: spec-autogen=on -->",
+].join("\n");
+
+function backlogSkill(): CoreEntry {
+  return {
+    category: "backlog-skill",
+    name: "backlog",
+    suffix: null,
+    content: skillContent,
+    executable: false,
+  };
+}
+
+function opts(specBackend: "local" | "cloud", specAutogen?: boolean): BundleOptions {
+  return { backlogBackend: "cloud", versionScheme: "semver", specBackend, specAutogen };
+}
+
+Deno.test("applySpecAutogen keeps the guidance only when specAutogen && cloud", () => {
+  assertEquals(
+    applySpecAutogen(backlogSkill(), opts("cloud", true)).content.includes("AUTOGEN"),
+    true,
+  );
+  assertEquals(
+    applySpecAutogen(backlogSkill(), opts("cloud", false)).content.includes("AUTOGEN"),
+    false,
+  );
+  assertEquals(
+    applySpecAutogen(backlogSkill(), opts("local", true)).content.includes("AUTOGEN"),
+    false,
+  );
+  // Absent toggle defaults to off.
+  assertEquals(applySpecAutogen(backlogSkill(), opts("cloud")).content.includes("AUTOGEN"), false);
+});
+
+Deno.test("applySpecAutogen only transforms `backlog-skill` entries; other categories pass through", () => {
+  const phase: CoreEntry = {
+    category: "phase",
+    name: "tasks",
+    suffix: "tasks.md",
+    content: skillContent,
+    executable: false,
+  };
+  // A phase entry with the same markers is returned content-untouched even when
+  // the toggle would otherwise strip the block.
+  assertEquals(applySpecAutogen(phase, opts("cloud", false)).content, skillContent);
+});

--- a/tests/infrastructure/harness/spec_backend_filter_golden_test.ts
+++ b/tests/infrastructure/harness/spec_backend_filter_golden_test.ts
@@ -5,13 +5,15 @@ import { renderSpecBackend } from "../../../src/domain/conditional_render.ts";
 import { applySpecBackend } from "../../../src/infrastructure/harness/spec_backend_filter.ts";
 import type { CoreEntry } from "../../../src/domain/core_bundle.ts";
 
-// Spec 020 / SC-002 / FR-003 — LOCAL PARITY. The golden fixtures under
-// tests/fixtures/*_local_golden.md are byte-for-byte copies of specify.md /
-// implement.md as they shipped BEFORE this feature added `spec-backend=` marker
-// blocks. This test proves the `local`-rendered phase docs are byte-identical to
-// that pre-feature output — the mechanical guarantee that a `local` project sees
-// zero behaviour change. If a future edit legitimately changes the local content,
-// re-capture the fixture in the same commit; an accidental drift fails here.
+// Spec 020 + 021 / SC-002 / FR-003 — LOCAL PARITY. The golden fixtures under
+// tests/fixtures/*_local_golden.md are byte-for-byte copies of the phase docs as
+// they shipped BEFORE `spec-backend=` marker blocks were added: specify.md /
+// implement.md (spec 020) and review.md / analyze.md / tasks.md (spec 021, the
+// cloud pull-on-entry blocks). This test proves the `local`-rendered phase docs
+// are byte-identical to that pre-feature output — the mechanical guarantee that a
+// `local` project sees zero behaviour change. If a future edit legitimately
+// changes the local content, re-capture the fixture in the same commit; an
+// accidental drift fails here.
 
 function abs(rel: string): string {
   return fromFileUrl(new URL(`../../${rel}`, import.meta.url));
@@ -23,7 +25,7 @@ function phaseEntry(name: string): CoreEntry {
   return e;
 }
 
-for (const name of ["specify", "implement"]) {
+for (const name of ["specify", "implement", "review", "analyze", "tasks"]) {
   Deno.test(`${name}.md rendered for spec-backend=local is byte-identical to the pre-feature bundle`, async () => {
     // EOL-agnostic: a released binary always embeds LF (the bundle is compiled
     // from committed LF source), but Windows CI regenerates the bundle from a
@@ -49,8 +51,8 @@ for (const name of ["specify", "implement"]) {
   });
 }
 
-Deno.test("cloud render diverges from local for both phase docs (markers are consumed)", () => {
-  for (const name of ["specify", "implement"]) {
+Deno.test("cloud render diverges from local for every marked phase doc (markers are consumed)", () => {
+  for (const name of ["specify", "implement", "review", "analyze", "tasks"]) {
     const entry = phaseEntry(name);
     assertNotEquals(
       renderSpecBackend(entry.content, "cloud"),

--- a/tests/integration/phase_wiring_test.ts
+++ b/tests/integration/phase_wiring_test.ts
@@ -1,0 +1,121 @@
+import { assertEquals } from "@std/assert";
+import { ClaudeHarness } from "../../src/infrastructure/harness/claude_harness.ts";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import type { BundleOptions } from "../../src/application/ports.ts";
+
+// Spec 021 — end-to-end phase wiring through the real harness pipeline
+// (applyBackend → applyScheme → applySpecBackend → applySpecAutogen). We drive
+// the Claude harness because its destinations are the canonical
+// `.claude/skills/...` tree; the render logic is harness-agnostic.
+
+const harness = new ClaudeHarness();
+
+function bundle(opts: BundleOptions): Record<string, string> {
+  const b = harness.mapBundle(CORE_BUNDLE, opts);
+  return Object.fromEntries(Object.entries(b).map(([k, v]) => [k, v.content]));
+}
+
+const CONSUMING = ["implement", "review", "analyze", "tasks"] as const;
+const phaseDest = (name: string) => `.claude/skills/specnaut/phases/${name}.md`;
+const BACKLOG_SKILL = ".claude/skills/backlog/SKILL.md";
+const AUTOGEN_HEADING = "## Auto-generate a task's spec at creation";
+
+function countPulls(s: string): number {
+  return (s.match(/specnaut spec pull <task>/g) ?? []).length;
+}
+
+// US1 / SC-001 / T006 — in cloud mode each consuming phase materialises the spec
+// exactly once at entry; in local mode no pull is emitted at all.
+Deno.test("T006 cloud render: each consuming phase doc pulls the spec exactly once at entry", () => {
+  const b = bundle({ backlogBackend: "cloud", versionScheme: "semver", specBackend: "cloud" });
+  for (const name of CONSUMING) {
+    const doc = b[phaseDest(name)];
+    assertEquals(
+      countPulls(doc),
+      1,
+      `${name}.md (cloud) must contain exactly one \`spec pull <task>\` step`,
+    );
+    assertEquals(doc.includes("spec-backend="), false, `${name}.md leaked a spec-backend marker`);
+  }
+});
+
+Deno.test("T006 local render: no consuming phase doc emits a spec pull", () => {
+  const b = bundle({ backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  for (const name of CONSUMING) {
+    const doc = b[phaseDest(name)];
+    assertEquals(countPulls(doc), 0, `${name}.md (local) must not pull — FR-003 local parity`);
+  }
+});
+
+// US2 / SC-003 / T010 — the auto-generation guidance renders only when
+// `spec_autogen && spec_backend === "cloud"`; it is absent for every other combo.
+Deno.test("T010 auto-gen guidance renders only with spec_autogen: true AND cloud", () => {
+  const has = (opts: BundleOptions) => bundle(opts)[BACKLOG_SKILL].includes(AUTOGEN_HEADING);
+
+  // enabled + cloud → present
+  assertEquals(
+    has({
+      backlogBackend: "cloud",
+      versionScheme: "semver",
+      specBackend: "cloud",
+      specAutogen: true,
+    }),
+    true,
+  );
+  // enabled but LOCAL spec backend → absent (auto-gen runs cloud `specify`)
+  assertEquals(
+    has({
+      backlogBackend: "cloud",
+      versionScheme: "semver",
+      specBackend: "local",
+      specAutogen: true,
+    }),
+    false,
+  );
+  // cloud but toggle off → absent
+  assertEquals(
+    has({
+      backlogBackend: "cloud",
+      versionScheme: "semver",
+      specBackend: "cloud",
+      specAutogen: false,
+    }),
+    false,
+  );
+  // cloud but toggle absent (default off) → absent
+  assertEquals(
+    has({ backlogBackend: "cloud", versionScheme: "semver", specBackend: "cloud" }),
+    false,
+  );
+});
+
+Deno.test("T010 the backlog skill never leaks a raw spec-autogen marker in any render", () => {
+  for (const specAutogen of [true, false]) {
+    for (const specBackend of ["local", "cloud"] as const) {
+      const doc = bundle({
+        backlogBackend: "cloud",
+        versionScheme: "semver",
+        specBackend,
+        specAutogen,
+      })[BACKLOG_SKILL];
+      assertEquals(doc.includes("spec-autogen="), false);
+      assertEquals(doc.includes("BEGIN: spec-autogen"), false);
+    }
+  }
+});
+
+// SC-002 / T012 — a fully local project (default, no cloud, no autogen) sees no
+// pull anywhere and no auto-gen guidance: byte-for-byte the pre-feature workflow.
+Deno.test("T012 local end-to-end: no pull in any phase doc and no auto-gen guidance", () => {
+  const b = bundle({ backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
+  for (const [dest, content] of Object.entries(b)) {
+    if (dest.startsWith(".claude/skills/specnaut/phases/")) {
+      assertEquals(
+        countPulls(content),
+        0,
+        `${dest} pulled in local mode — the local workflow must be unchanged`,
+      );
+    }
+  }
+  assertEquals(b[BACKLOG_SKILL].includes(AUTOGEN_HEADING), false);
+});


### PR DESCRIPTION
Closes #425 · **Final** lot of the cloud-hosted specifications epic (specnaut-monorepo#15). Depends on **Lot 2 (cli#424, shipped)**.

## What
Makes the cloud spec backend **automatic** across the phase flow, reusing Lot 2's shipped `spec-backend` marker-block mechanism. Design under `.specnaut/specs/021-cli-phase-wiring/`.

## Changes
- **Pull-on-entry**: `spec-backend=cloud` blocks in `implement`/`review`/`analyze`/`tasks` run one `specnaut spec pull <task>` before agents read the spec — agents keep reading local files, no network-aware agents. `implement`'s pull precedes the Lot 2 `--branch-only` step. Local blocks are byte-identical to pre-feature.
- **Opt-in auto-generation**: a new `spec_autogen` lock field (default off) + a distinct `spec-autogen=on` render dimension (`renderSpecAutogen` + `spec_autogen_filter` wired into all 7 harnesses). Guidance in the backlog skill, gated on `spec_autogen && spec_backend==cloud`, **non-fatal** (never fails task creation).
- **Parallel-authoring guidance**: cloud `specify` is branch-free (Lot 2) → N specs concurrently, no collision.
- Plugin mirror synced.

## Key invariant results
- **Local parity (FR-003)**: golden tests prove `review`/`analyze`/`tasks` `local`-render is byte-identical to `origin/main` (EOL-agnostic). `implement`/`specify` parity retained.
- **§ I**: the only Cloud touch in the docs is `spec pull` / cloud `specify` — no private-half identifier.

## Validation
`deno task fmt:check` clean · `deno task lint` clean (245 files) · `deno task test` **1134 passed** · `deno task bundle` regenerated.

## Agent adoption

```prompt
Wire the cloud spec backend into the phase flow, reusing the existing spec-backend marker-block mechanism: (1) each consuming phase (implement/review/analyze/tasks) runs one `specnaut spec pull <task>` at entry in cloud mode so agents read materialised files; (2) an opt-in `spec_autogen` lock field (default off) with a spec-autogen=on render dimension across all harnesses drives cloud `specify` at task creation, non-fatal; (3) a parallel-authoring guidance note. Keep local-mode rendering byte-identical (golden tests, EOL-agnostic), and touch Cloud only through the versioned commands (no private-half identifier).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)