### PR TITLE
fix(init): drop the detached backend benefit note from the pickers

### DIFF
--- a/src/cli/backlog_picker.ts
+++ b/src/cli/backlog_picker.ts
@@ -11,15 +11,6 @@ export const DEFAULT_BACKLOG_BACKEND: BacklogBackend = "cloud";
 /** Suffix on the default backend's line — signals it's the recommended pick. */
 const RECOMMENDED_MARKER = " — recommended (default)";
 
-/**
- * One-line "why this is the recommended default" note, shown once above the
- * choices for whichever backend is the default. Keyed by backend so it stays
- * correct if the default ever moves.
- */
-const DEFAULT_BACKEND_NOTE: Partial<Record<BacklogBackend, string>> = {
-  cloud: "Specnaut Cloud: hosted online Kanban — shareable, real-time, no local file upkeep.",
-};
-
 export type BacklogPickerIO = {
   readLine: () => string | null;
   log: (s: string) => void;
@@ -33,8 +24,6 @@ export function pickBacklogBackend(io: BacklogPickerIO): BacklogBackend {
     const marker = s.key === DEFAULT_BACKLOG_BACKEND ? RECOMMENDED_MARKER : "";
     io.log(`  ${i + 1}) ${s.displayName}${marker}`);
   }
-  const note = DEFAULT_BACKEND_NOTE[DEFAULT_BACKLOG_BACKEND];
-  if (note) io.log(`  ↳ ${note}`);
   while (true) {
     const raw = (io.readLine() ?? "").trim();
     if (raw === "") return DEFAULT_BACKLOG_BACKEND;
@@ -64,10 +53,6 @@ export async function pickBacklogBackendInteractive(
       ? `${s.displayName}${RECOMMENDED_MARKER}`
       : s.displayName,
   }));
-  // Printed once above the menu; the picker's redraw only rewinds over the
-  // menu frame, so this benefit line stays put.
-  const note = DEFAULT_BACKEND_NOTE[DEFAULT_BACKLOG_BACKEND];
-  if (note) io.write(`  ↳ ${note}\n`);
   return await selectInteractive(
     items,
     defaultIdx >= 0 ? defaultIdx : 0,

--- a/src/cli/spec_picker.ts
+++ b/src/cli/spec_picker.ts
@@ -7,15 +7,6 @@ export const DEFAULT_SPEC_BACKEND: SpecBackend = "cloud";
 /** Suffix on the default backend's line — signals it's the recommended pick. */
 const RECOMMENDED_MARKER = " — recommended (default)";
 
-/**
- * One-line "why this is the recommended default" note, shown once above the
- * choices for whichever backend is the default. Keyed by backend so it stays
- * correct if the default ever moves.
- */
-const DEFAULT_BACKEND_NOTE: Partial<Record<SpecBackend, string>> = {
-  cloud: "SpecNaut Cloud: hosted specs — parallelisable (no branch per spec), shareable.",
-};
-
 export type SpecPickerIO = {
   readLine: () => string | null;
   log: (s: string) => void;
@@ -34,8 +25,6 @@ export function pickSpecBackend(io: SpecPickerIO): SpecBackend {
     const marker = s.key === DEFAULT_SPEC_BACKEND ? RECOMMENDED_MARKER : "";
     io.log(`  ${i + 1}) ${s.displayName}${marker}`);
   }
-  const note = DEFAULT_BACKEND_NOTE[DEFAULT_SPEC_BACKEND];
-  if (note) io.log(`  ↳ ${note}`);
   while (true) {
     const raw = (io.readLine() ?? "").trim();
     if (raw === "") return DEFAULT_SPEC_BACKEND;
@@ -67,10 +56,6 @@ export async function pickSpecBackendInteractive(
     key: s.key,
     label: s.key === DEFAULT_SPEC_BACKEND ? `${s.displayName}${RECOMMENDED_MARKER}` : s.displayName,
   }));
-  // Printed once above the menu; the picker's redraw only rewinds over the
-  // menu frame, so this benefit line stays put.
-  const note = DEFAULT_BACKEND_NOTE[DEFAULT_SPEC_BACKEND];
-  if (note) io.write(`  ↳ ${note}\n`);
   return await selectInteractive(
     items,
     defaultIdx >= 0 ? defaultIdx : 0,

--- a/tests/cli/backlog_picker_test.ts
+++ b/tests/cli/backlog_picker_test.ts
@@ -39,11 +39,10 @@ Deno.test("pickBacklogBackend defaults to cloud on empty input", () => {
   assertEquals(pickBacklogBackend(io), "cloud");
   assertEquals(DEFAULT_BACKLOG_BACKEND, "cloud");
   const all = log.join("\n");
-  // Cloud is listed first, marked recommended (default), with a benefit note;
-  // the other backends remain listed.
+  // Cloud is listed first, marked recommended (default); the other backends
+  // remain listed. No extra benefit note — the marker carries the recommendation.
   assertEquals(all.includes("Specnaut Cloud"), true);
   assertEquals(all.includes("recommended (default)"), true);
-  assertEquals(all.includes("hosted online Kanban"), true);
   assertEquals(all.includes("Local Markdown"), true);
   assertEquals(all.includes("GitHub"), true);
 });

--- a/tests/cli/spec_picker_test.ts
+++ b/tests/cli/spec_picker_test.ts
@@ -41,8 +41,8 @@ Deno.test("pickSpecBackend defaults to cloud on empty input", () => {
   assertEquals(pickSpecBackend(io), "cloud");
   assertEquals(DEFAULT_SPEC_BACKEND, "cloud");
   const all = log.join("\n");
-  // Cloud is listed first, marked recommended (default), with a benefit note;
-  // local remains a first-class listed choice.
+  // Cloud is listed first, marked recommended (default); local remains a
+  // first-class listed choice. No extra benefit note.
   assertEquals(all.includes("SpecNaut Cloud"), true);
   assertEquals(all.includes("recommended (default)"), true);
   assertEquals(all.includes("Local Markdown"), true);


### PR DESCRIPTION
## What

Removes the standalone `↳ …` benefit note from the **backlog** and **spec** backend pickers during `specnaut init`.

## Why

The note was emitted *before* `selectInteractive` drew its title, so it rendered **above** the `Choose your backlog backend` prompt — directly under the harness list. It read as if it described the just-completed **harness** selection, not the **Cloud backend** it was meant for. Pure noise, wrong place:

```
  ) Antigravity
↳ Specnaut Cloud: hosted online Kanban — shareable, real-time, no local file upkeep.   ← detached, confusing
Choose your backlog backend (↑/↓ to move, …):
  ) Specnaut Cloud (real-time API — browser login) — recommended (default)
```

The `— recommended (default)` marker sits on the option line itself and already carries the recommendation, attached to the right place. The extra line added rows for nothing.

## Changes

- `src/cli/backlog_picker.ts` — drop `DEFAULT_BACKEND_NOTE` + both note prints (numeric + interactive).
- `src/cli/spec_picker.ts` — same removal (identical pattern added in Lot 2).
- Tests — remove the now-stale `hosted online Kanban` assertion; refresh comments.

After: each picker shows only its title + options; the recommended pick is marked inline.

## Testing

- `deno task fmt:check` · `deno task lint` — clean
- `deno task test` — **1134 passed / 0 failed**
- Rendered a fresh `init` in the sandbox — no stray `↳` line between pickers.

## Agent adoption

None. Interactive `init` prompts are human-facing terminal output; agents pass `--ai` / `--backlog` / `--spec-backend` flags non-interactively and never see the picker menus. No agent-visible surface, template, or contract changes.