### PR TITLE
feat(specify): surface Claude Artifacts in specs for UX/UI projects (#431)

### DIFF
--- a/plugin/skills/specnaut/phases/specify.md
+++ b/plugin/skills/specnaut/phases/specify.md
@@ -242,6 +242,12 @@ Given that feature description, do this:
 
 - **Mandatory sections**: complete for every feature.
 - **Optional sections**: include only when relevant; remove inapplicable sections entirely (don't leave "N/A").
+- **Front-end / UX-UI features**: when the project has a front-end surface,
+  keep the optional `## Visual Prototyping with Claude Artifacts` section
+  (detect the surface with the SAME signals the accessibility gate uses — the
+  `a11y-auditor` FE-surface list; don't invent a new heuristic). No front-end
+  surface → remove that section: a back-end/CLI-only spec must not mention
+  artifacts.
 
 ### For AI Generation
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -575,6 +575,12 @@ Given that feature description, do this:
 
 - **Mandatory sections**: complete for every feature.
 - **Optional sections**: include only when relevant; remove inapplicable sections entirely (don't leave "N/A").
+- **Front-end / UX-UI features**: when the project has a front-end surface,
+  keep the optional \`## Visual Prototyping with Claude Artifacts\` section
+  (detect the surface with the SAME signals the accessibility gate uses — the
+  \`a11y-auditor\` FE-surface list; don't invent a new heuristic). No front-end
+  surface → remove that section: a back-end/CLI-only spec must not mention
+  artifacts.
 
 ### For AI Generation
 
@@ -12971,6 +12977,36 @@ above so projects that later migrate to a remote backend keep continuity.
 - [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
 - [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
 - [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]
+
+## Visual Prototyping with Claude Artifacts *(optional — front-end / UX-UI features only)*
+
+<!--
+  ACTION REQUIRED — CONDITIONAL SECTION.
+  Keep this section ONLY when the project has a front-end / UX-UI surface.
+  Detect that surface with the SAME signal list the accessibility gate uses
+  (see the \`a11y-auditor\` agent — do NOT invent a new heuristic). Any of:
+    - \`.html\` / \`.htm\` files
+    - \`.jsx\` / \`.tsx\` files
+    - \`.vue\` / \`.svelte\` / \`.astro\` files
+    - a \`public/\`, \`src/app/\`, \`src/pages/\`, \`src/routes/\`, or \`pages/\`
+      directory containing markup
+    - a \`package.json\` listing a front-end framework dep (react, vue, svelte,
+      solid-js, preact, lit, astro, @angular/core, qwik)
+  If NONE of those signals are present, REMOVE this entire section — a
+  back-end / CLI-only spec must not mention artifacts (mirror the
+  "remove inapplicable sections entirely" rule for optional sections).
+-->
+
+For the user-facing flows above, you can use **Claude Artifacts** to make the
+proposed UX tangible before any code is written — rendered mockups, interactive
+prototypes, state/flow diagrams, and side-by-side layout comparisons a
+stakeholder can react to directly.
+
+- Turn a User Story's acceptance scenarios into an interactive artifact (a
+  clickable mockup or a diagram of the flow) to validate the intended
+  experience early, then fold the feedback back into this spec.
+- What artifacts are and how to use them: <https://support.claude.com/en/articles/9487310-what-are-artifacts-and-how-to-use-them>
+- Artifacts in Claude Code: <https://code.claude.com/docs/en/artifacts>
 `,
     executable: false,
     backend: null,

--- a/templates/core/skills/specnaut/phases/specify.md
+++ b/templates/core/skills/specnaut/phases/specify.md
@@ -242,6 +242,12 @@ Given that feature description, do this:
 
 - **Mandatory sections**: complete for every feature.
 - **Optional sections**: include only when relevant; remove inapplicable sections entirely (don't leave "N/A").
+- **Front-end / UX-UI features**: when the project has a front-end surface,
+  keep the optional `## Visual Prototyping with Claude Artifacts` section
+  (detect the surface with the SAME signals the accessibility gate uses — the
+  `a11y-auditor` FE-surface list; don't invent a new heuristic). No front-end
+  surface → remove that section: a back-end/CLI-only spec must not mention
+  artifacts.
 
 ### For AI Generation
 

--- a/templates/core/specnaut/templates/spec-template.md
+++ b/templates/core/specnaut/templates/spec-template.md
@@ -156,3 +156,33 @@
 - [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
 - [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
 - [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]
+
+## Visual Prototyping with Claude Artifacts *(optional — front-end / UX-UI features only)*
+
+<!--
+  ACTION REQUIRED — CONDITIONAL SECTION.
+  Keep this section ONLY when the project has a front-end / UX-UI surface.
+  Detect that surface with the SAME signal list the accessibility gate uses
+  (see the `a11y-auditor` agent — do NOT invent a new heuristic). Any of:
+    - `.html` / `.htm` files
+    - `.jsx` / `.tsx` files
+    - `.vue` / `.svelte` / `.astro` files
+    - a `public/`, `src/app/`, `src/pages/`, `src/routes/`, or `pages/`
+      directory containing markup
+    - a `package.json` listing a front-end framework dep (react, vue, svelte,
+      solid-js, preact, lit, astro, @angular/core, qwik)
+  If NONE of those signals are present, REMOVE this entire section — a
+  back-end / CLI-only spec must not mention artifacts (mirror the
+  "remove inapplicable sections entirely" rule for optional sections).
+-->
+
+For the user-facing flows above, you can use **Claude Artifacts** to make the
+proposed UX tangible before any code is written — rendered mockups, interactive
+prototypes, state/flow diagrams, and side-by-side layout comparisons a
+stakeholder can react to directly.
+
+- Turn a User Story's acceptance scenarios into an interactive artifact (a
+  clickable mockup or a diagram of the flow) to validate the intended
+  experience early, then fold the feedback back into this spec.
+- What artifacts are and how to use them: <https://support.claude.com/en/articles/9487310-what-are-artifacts-and-how-to-use-them>
+- Artifacts in Claude Code: <https://code.claude.com/docs/en/artifacts>

--- a/tests/fixtures/specify_local_golden.md
+++ b/tests/fixtures/specify_local_golden.md
@@ -203,6 +203,12 @@ Given that feature description, do this:
 
 - **Mandatory sections**: complete for every feature.
 - **Optional sections**: include only when relevant; remove inapplicable sections entirely (don't leave "N/A").
+- **Front-end / UX-UI features**: when the project has a front-end surface,
+  keep the optional `## Visual Prototyping with Claude Artifacts` section
+  (detect the surface with the SAME signals the accessibility gate uses — the
+  `a11y-auditor` FE-surface list; don't invent a new heuristic). No front-end
+  surface → remove that section: a back-end/CLI-only spec must not mention
+  artifacts.
 
 ### For AI Generation
 

--- a/tests/templates/artifacts_in_specs_test.ts
+++ b/tests/templates/artifacts_in_specs_test.ts
@@ -1,0 +1,89 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import type { CoreEntry } from "../../src/domain/core_bundle.ts";
+
+/**
+ * #431 — Surface Claude Artifacts in generated specs for UX/UI projects.
+ *
+ * When a spec is authored for a project with a front-end / UX-UI surface, the
+ * generated spec must mention Claude Artifacts as a way to visualise the
+ * feature, with links to the public docs. When NO front-end surface exists the
+ * section is removed entirely — a back-end/CLI-only spec stays artifact-free.
+ *
+ * These locks live on the bundled template content so the guidance can't drift
+ * out of the shipped binary. Two load-bearing surfaces carry it:
+ *   - the `spec-template.md` skeleton (the optional, conditional section), and
+ *   - the `specify` phase doc (the reuse-the-a11y-gate instruction).
+ *
+ * The gate MUST reuse the accessibility auditor's front-end-surface signal
+ * list (not a second heuristic) — that reuse is the acceptance criterion.
+ */
+
+const DOCS_HELP =
+  "https://support.claude.com/en/articles/9487310-what-are-artifacts-and-how-to-use-them";
+const DOCS_CODE = "https://code.claude.com/docs/en/artifacts";
+
+function specTemplate(): CoreEntry | undefined {
+  return CORE_BUNDLE.find(
+    (e) =>
+      e.category === "spec-root" &&
+      e.suffix === "templates/spec-template.md",
+  );
+}
+
+function specifyPhase(): CoreEntry | undefined {
+  return CORE_BUNDLE.find((e) => e.category === "phase" && e.name === "specify");
+}
+
+Deno.test("spec-template ships the Claude Artifacts section with public docs links", () => {
+  const entry = specTemplate();
+  assert(entry, "expected the spec-template.md spec-root entry in CORE_BUNDLE");
+  const { content } = entry;
+  assertStringIncludes(content, "Visual Prototyping with Claude Artifacts");
+  assertStringIncludes(
+    content,
+    DOCS_HELP,
+    "spec-template must link the public 'what are artifacts' doc",
+  );
+  assertStringIncludes(
+    content,
+    DOCS_CODE,
+    "spec-template must link the Claude Code artifacts doc",
+  );
+});
+
+Deno.test("spec-template gates the Artifacts section on a front-end surface (a11y signal reuse)", () => {
+  const { content } = specTemplate()!;
+  // Marked optional + conditional so a non-FE spec drops it entirely.
+  assertStringIncludes(content, "optional — front-end / UX-UI features only");
+  assertStringIncludes(content, "CONDITIONAL SECTION");
+  // Reuses the accessibility gate's mechanism — not a new heuristic.
+  assertStringIncludes(
+    content,
+    "a11y-auditor",
+    "the gate must defer to the accessibility auditor's FE-surface signal list",
+  );
+  // The remove-if-none instruction is what keeps back-end/CLI specs artifact-free.
+  const lower = content.toLowerCase();
+  assert(
+    lower.includes("remove this entire section") ||
+      lower.includes("remove this section"),
+    "spec-template must instruct removing the section when no FE surface exists",
+  );
+});
+
+Deno.test("specify phase reinforces the FE gate by reusing the a11y-auditor signals", () => {
+  const entry = specifyPhase();
+  assert(entry, "expected the specify phase entry in CORE_BUNDLE");
+  const { content } = entry;
+  assertStringIncludes(content, "Visual Prototyping with Claude Artifacts");
+  assertStringIncludes(
+    content,
+    "a11y-auditor",
+    "specify must point spec authors at the accessibility gate's signal list",
+  );
+  // A back-end/CLI-only spec must be told NOT to mention artifacts. (The
+  // trailing "artifacts" may wrap to the next line in the source prose, so
+  // anchor on the contiguous instruction fragment.)
+  assertStringIncludes(content, "must not mention");
+});


### PR DESCRIPTION
Closes #431.

## Why
For front-end / UX-UI features, a static markdown spec under-serves the user. Claude Artifacts can render mockups, interactive prototypes, and flow diagrams that make a feature tangible and easy to validate *before* any code is written. The CLI already gates behaviour on FE-surface detection (the accessibility audit), so a "project has a UX/UI surface" signal is an established pattern to reuse.

## What
When a spec is authored for a project **with a front-end surface**, the generated spec now carries an optional **`## Visual Prototyping with Claude Artifacts`** section that points the reader at the public artifacts docs.

- **`spec-template.md`** — new optional, clearly-marked *conditional* section. Carries the detail + two public docs links (`support.claude.com` "what are artifacts", `code.claude.com` "artifacts in Claude Code").
- **`specify.md`** phase doc — terse reinforcement of the gate. Kept lean on purpose: `specnaut-specify.md` is the largest Windsurf Cascade workflow and sits near the 12k-char cap, so the bulk of the guidance lives in the template (not a Windsurf workflow).
- **Gate reuses the accessibility mechanism** — the SAME front-end-surface signal list the `a11y-auditor` uses (`.html`/`.jsx`/`.tsx`/`.vue`/`.svelte`/`.astro`, an app/pages/routes markup dir, or a `package.json` FE-framework dep). No new heuristic.
- **No FE surface → section removed entirely.** A back-end / CLI-only spec stays artifact-free (mirrors the "remove inapplicable sections" rule).

## Boundary (§ I)
Only the **public** Claude Artifacts product and its **public** docs are referenced — nothing from the private Cloud half. The user's original "artefacts côté cloud" means Claude's hosted Artifacts (claude.ai), not `specnaut-cloud`.

## Tests
- `tests/templates/artifacts_in_specs_test.ts` (new) — locks the bundled `spec-template` + `specify` content: the section ships, both docs links are present, the gate defers to `a11y-auditor`, and the remove-if-no-FE instruction is present.
- Plugin copy + local golden kept byte-identical; `deno task bundle` regenerated.
- Full suite: **1137 passed**. `deno fmt --check` + `deno lint` clean.

## Agent adoption

`/specnaut specify` now adds an optional **Visual Prototyping with Claude Artifacts** section to generated specs when your project has a front-end / UX-UI surface (detected via the same signals the accessibility gate uses). Specs authored **before** this upgrade won't have it retroactively — run the prompt below to backfill any in-flight UX/UI specs, and to update any project-local spec-template override you maintain.

```prompt
Check whether this project has a front-end surface (any of: .html/.htm,
.jsx/.tsx, .vue/.svelte/.astro files; a public/, src/app/, src/pages/,
src/routes/, or pages/ markup dir; or a package.json listing react, vue,
svelte, solid-js, preact, lit, astro, @angular/core, or qwik).

If it does:
  1. For each in-flight spec under .specnaut/specs/*/spec.md that lacks a
     "## Visual Prototyping with Claude Artifacts" section, add one after
     Assumptions that points the reader at Claude Artifacts for visualising
     the UX, with links to the public artifacts docs.
  2. If you keep a customised .specnaut/templates/spec-template.md override,
     mirror the same optional, FE-gated section into it.

If this project has NO front-end surface, do nothing — a back-end/CLI-only
spec must stay artifact-free.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)