### PR TITLE
fix(changelog): collapse redundant double PR reference in release notes (#433)

### DIFF
--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -43,7 +43,7 @@ export function classifyCommit(commit: Commit): Classified {
     return { ...commit, category: "chore", cleanedSubject: capitalize(subject) };
   }
   const type = m[1].toLowerCase();
-  const rest = m[3];
+  const rest = collapseTrailingIssueRefs(m[3]);
   const cleanedSubject = capitalize(rest);
   if (FEATURE_PREFIXES.has(type)) {
     return { ...commit, category: "feat", cleanedSubject };
@@ -60,6 +60,16 @@ export function classifyCommit(commit: Commit): Classified {
 function capitalize(s: string): string {
   if (!s) return s;
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// GitHub's squash-merge appends the PR number `(#pr)` to a subject whose PR
+// title already carried the linked issue `(#issue)`, producing a redundant
+// `... (#issue) (#pr)` tail. Collapse a run of 2+ adjacent trailing refs down
+// to the last one — the PR number, matching `extractPrNumber` — so release
+// notes read with a single clean link. A lone trailing `(#N)` is left as-is.
+const TRAILING_DOUBLE_REF_RE = /(?:\s*\(#\d+\))+(\s\(#\d+\))\s*$/;
+export function collapseTrailingIssueRefs(subject: string): string {
+  return subject.replace(TRAILING_DOUBLE_REF_RE, "$1");
 }
 
 const ADOPTION_HEADER_RE = /^## Agent adoption\b/m;

--- a/tests/scripts/gen_changelog_test.ts
+++ b/tests/scripts/gen_changelog_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { type Classified, classifyCommit, formatChangelog } from "../../scripts/gen-changelog.ts";
+import {
+  type Classified,
+  classifyCommit,
+  collapseTrailingIssueRefs,
+  formatChangelog,
+} from "../../scripts/gen-changelog.ts";
 
 Deno.test("classifyCommit categorises feat:", () => {
   const r = classifyCommit({ hash: "abc", subject: "feat: add antigravity harness" });
@@ -29,6 +34,41 @@ Deno.test("classifyCommit handles breaking-change marker (feat!:)", () => {
   const r = classifyCommit({ hash: "abc", subject: "feat!: rewire ports" });
   assertEquals(r.category, "feat");
   assertEquals(r.cleanedSubject, "Rewire ports");
+});
+
+Deno.test("collapseTrailingIssueRefs collapses a double PR reference to the last one", () => {
+  // The exact v1.19.0 case: PR title carried the issue (#431), squash appended (#432).
+  assertEquals(
+    collapseTrailingIssueRefs("surface Claude Artifacts (#431) (#432)"),
+    "surface Claude Artifacts (#432)",
+  );
+});
+
+Deno.test("collapseTrailingIssueRefs collapses a triple reference to the last one", () => {
+  assertEquals(
+    collapseTrailingIssueRefs("do a thing (#1) (#2) (#3)"),
+    "do a thing (#3)",
+  );
+});
+
+Deno.test("collapseTrailingIssueRefs leaves a single trailing reference untouched", () => {
+  assertEquals(
+    collapseTrailingIssueRefs("do a thing (#432)"),
+    "do a thing (#432)",
+  );
+});
+
+Deno.test("collapseTrailingIssueRefs leaves a subject with no reference untouched", () => {
+  assertEquals(collapseTrailingIssueRefs("do a thing"), "do a thing");
+});
+
+Deno.test("classifyCommit collapses the double PR reference in cleanedSubject", () => {
+  const r = classifyCommit({
+    hash: "abc",
+    subject: "feat(specify): surface Claude Artifacts (#431) (#432)",
+  });
+  assertEquals(r.category, "feat");
+  assertEquals(r.cleanedSubject, "Surface Claude Artifacts (#432)");
 });
 
 Deno.test("classifyCommit buckets refactor/docs/test/ci/style/perf/build as chore", () => {


### PR DESCRIPTION
Closes #433.

## Why
When a PR title already carries the linked issue `(#issue)` and GitHub's squash-merge appends the PR number `(#pr)`, the squash commit subject ends with a redundant double parenthetical. v1.19.0's feature line rendered as **"Surface Claude Artifacts in specs for UX/UI projects (#431) (#432)"**. `scripts/gen-changelog.ts` already extracts the *trailing* PR number correctly (`extractPrNumber`), but its `cleanedSubject` kept both refs, so published release notes showed the double. Purely cosmetic (both are valid links) — but it recurs on every release where an author put the issue# in the PR title.

## What
`collapseTrailingIssueRefs()` collapses a run of **2+ adjacent trailing** issue/PR refs `(#a) (#b)` down to the **last** one (the PR number, consistent with `extractPrNumber`). Wired into `classifyCommit` before capitalising, so it applies to the rendered feat/fix line.

- Double → single: `… (#431) (#432)` → `… (#432)`
- Triple → single: `… (#1) (#2) (#3)` → `… (#3)`
- A lone `(#N)` is left untouched; a subject with no ref is untouched.
- No change to bucket classification or `--strict` behavior.

## Tests
`tests/scripts/gen_changelog_test.ts` — 5 new cases (incl. the exact v1.19.0 subject through `classifyCommit`). Full suite **1142 passed**; `deno fmt`/`lint` clean.

## Out of scope
The already-published v1.19.0 notes / git history — tags are immutable and the double ref is harmless. This only prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)