### PR TITLE
chore(release): v1.20.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specnaut",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Spec-driven workflow, slash commands, and sub-agents for AI coding harnesses — Specnaut's bundled skill library, agents, and the SessionStart bootstrap that makes the agent skill-aware on every turn.",
   "author": {
     "name": "MakerLabs",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "specnaut",
   "displayName": "Specnaut",
   "description": "Spec-driven planning, TDD, review, and delivery workflows for coding agents — bundled skills, sub-agents, and a SessionStart bootstrap that makes the agent skill-aware on every turn.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "author": {
     "name": "MakerLabs",
     "url": "https://github.com/mkrlabs"

--- a/.specnaut/specs/012-agent-output-contracts/research.md
+++ b/.specnaut/specs/012-agent-output-contracts/research.md
@@ -22,8 +22,8 @@ out of the user-facing skill list while still loadable by agents and discoverabl
 - _Inline the contract text into each agent body_ — rejected: 8 copies of each block schema drift
   apart the first time one is edited; defeats the "single schema both sides agree on" goal (FR-002).
 - _A new bespoke frontmatter field (e.g. `contracts:`)_ — rejected: `skills:` is the established
-  Claude Code preload field and what the reference project uses; inventing a parallel field adds surface for no
-  gain.
+  Claude Code preload field and what the reference project uses; inventing a parallel field adds
+  surface for no gain.
 
 ## Decision 2 — Bundle inclusion and test strategy
 

--- a/.specnaut/specs/012-agent-output-contracts/spec.md
+++ b/.specnaut/specs/012-agent-output-contracts/spec.md
@@ -2,10 +2,10 @@
 
 **Feature Branch**: `012-agent-output-contracts` **Created**: 2026-06-12 **Status**: Draft
 **Input**: User description: "Machine-readable agent output contracts for the Specflow CLI bundled
-fleet (mechanism A from the the reference project audit-team port, epic mkrlabs/specflow-monorepo#12). Add four
-user-invocable:false contract skills to the bundled template set and wire the existing
-auditor/review/qa/developer agents to preload them, so their output carries normalized fenced blocks
-parsable by downstream tooling."
+fleet (mechanism A from the the reference project audit-team port, epic
+mkrlabs/specflow-monorepo#12). Add four user-invocable:false contract skills to the bundled template
+set and wire the existing auditor/review/qa/developer agents to preload them, so their output
+carries normalized fenced blocks parsable by downstream tooling."
 
 ## User Scenarios & Testing _(mandatory)_
 
@@ -255,14 +255,14 @@ it.
 
 ## Assumptions
 
-- The contract format is ported faithfully from the proven `the reference project` system; field names and
-  allowed values follow that source unless a Specflow-specific role name differs (e.g. handoff
-  targets are Specflow's agent names).
+- The contract format is ported faithfully from the proven `the reference project` system; field
+  names and allowed values follow that source unless a Specflow-specific role name differs (e.g.
+  handoff targets are Specflow's agent names).
 - Contracts are scoped to the named agent roles, not applied globally — agents outside the wired set
   intentionally produce no blocks.
 - "Preload" is expressed through the existing bundled-agent definition mechanism (a frontmatter
-  declaration on the agent), consistent with how the reference project wires it; the exact field is an
-  implementation detail for the plan.
+  declaration on the agent), consistent with how the reference project wires it; the exact field is
+  an implementation detail for the plan.
 - Distribution reuses Specflow's existing `init` / `upgrade` bundling and the established
   customisation-preservation behaviour (spec 011); this feature adds files to the bundle and does
   not change the upgrade machinery.

--- a/.specnaut/specs/013-code-audit/research.md
+++ b/.specnaut/specs/013-code-audit/research.md
@@ -36,9 +36,9 @@ has no docs-only carve-out). Accessibility deploys iff `FRONTEND_COUNT > 0`. Dep
 `DEP_COUNT > 0`. Every skip is recorded in the report with its reason. Mapping table is
 authoritative in data-model.md.
 
-**Rationale**: Matches the issue's "skip a seat when its category signal is zero" and the the reference project
-default-team behaviour (architecture mandatory; a11y/dep gated on signals). Keeps the audit
-proportional.
+**Rationale**: Matches the issue's "skip a seat when its category signal is zero" and the the
+reference project default-team behaviour (architecture mandatory; a11y/dep gated on signals). Keeps
+the audit proportional.
 
 **Alternatives considered**: deploy all five always — rejected: wastes an accessibility pass on a
 pure-backend scope and dilutes the report (the issue explicitly wants signal-gated seats).
@@ -53,9 +53,9 @@ framing (judge the shape of merged work, not per-line PR review) — the same au
 report + the aggregated `REVIEW SUMMARY`. The parallel-in-one-message rule is stated explicitly (it
 is the SC-003 contract).
 
-**Rationale**: Directly ports the the reference project `/code-audit` orchestration. Reuses the existing auditor
-agents (now emitting the canonical REVIEW SUMMARY from #378), so synthesis parses verdicts/counts
-mechanically rather than from prose.
+**Rationale**: Directly ports the the reference project `/code-audit` orchestration. Reuses the
+existing auditor agents (now emitting the canonical REVIEW SUMMARY from #378), so synthesis parses
+verdicts/counts mechanically rather than from prose.
 
 ## Decision 4 — Bundle inclusion (confirmed manifest-driven from #378)
 

--- a/.specnaut/specs/013-code-audit/spec.md
+++ b/.specnaut/specs/013-code-audit/spec.md
@@ -1,11 +1,11 @@
 # Feature Specification: High-altitude multi-seat parallel audit (`/code-audit`)
 
 **Feature Branch**: `013-code-audit` **Created**: 2026-06-13 **Status**: Draft **Input**: User
-description: "Headline multi-seat parallel audit skill `/code-audit` (mechanism B of the the reference project
-audit-team port, epic mkrlabs/specflow-monorepo#12). A scope-collection script resolves an audit
-scope on `main` and emits category signals; the skill dispatches the relevant auditor agents IN
-PARALLEL, then synthesizes one deduplicated, priority-ranked report with an aggregated REVIEW
-SUMMARY. Read-only; complements /specflow audit <axis>."
+description: "Headline multi-seat parallel audit skill `/code-audit` (mechanism B of the the
+reference project audit-team port, epic mkrlabs/specflow-monorepo#12). A scope-collection script
+resolves an audit scope on `main` and emits category signals; the skill dispatches the relevant
+auditor agents IN PARALLEL, then synthesizes one deduplicated, priority-ranked report with an
+aggregated REVIEW SUMMARY. Read-only; complements /specflow audit <axis>."
 
 ## User Scenarios & Testing _(mandatory)_
 

--- a/.specnaut/specs/014-per-axis-audit-skills/research.md
+++ b/.specnaut/specs/014-per-axis-audit-skills/research.md
@@ -10,9 +10,9 @@ message; (2) resolve the file/commit list for that scope (`--path` = subtree via
 dispatch the ONE matching auditor agent with the scope + an audit framing; (4) return the agent's
 findings inline (it emits REVIEW SUMMARY). No file written.
 
-**Rationale**: Mirrors the reference project's thin `/perf-audit` shape. A single-axis dispatch needs only the
-scope's file/commit list, not the category signals — so no shell script is required and there is
-nothing to unit-test at the bash level. Keeps the five skills genuinely thin.
+**Rationale**: Mirrors the reference project's thin `/perf-audit` shape. A single-axis dispatch
+needs only the scope's file/commit list, not the category signals — so no shell script is required
+and there is nothing to unit-test at the bash level. Keeps the five skills genuinely thin.
 
 **Alternatives considered**: reuse `collect-audit-scope.sh` (#379) for scope resolution — viable for
 `--path`/`--range`/whole, but it emits category signals these skills don't use and lacks `--diff`;

--- a/.specnaut/specs/014-per-axis-audit-skills/spec.md
+++ b/.specnaut/specs/014-per-axis-audit-skills/spec.md
@@ -2,11 +2,11 @@
 
 **Feature Branch**: `014-per-axis-audit-skills` **Created**: 2026-06-13 **Status**: Draft **Input**:
 User description: "Per-axis scope-targeted audit-dispatch skills (mechanism B, second shape, of the
-the reference project audit-team port, epic mkrlabs/specflow-monorepo#12). Five thin skills — /arch-audit,
-/sec-audit, /perf-audit, /dep-audit, /a11y-audit — each resolves an optional scope (--path / --range
-/ --diff / whole repo) and dispatches the matching auditor agent, which emits a REVIEW SUMMARY. No
-dated report file (that stays /specflow audit <axis>'s job). Complementary fast, targeted entry
-point."
+the reference project audit-team port, epic mkrlabs/specflow-monorepo#12). Five thin skills —
+/arch-audit, /sec-audit, /perf-audit, /dep-audit, /a11y-audit — each resolves an optional scope
+(--path / --range / --diff / whole repo) and dispatches the matching auditor agent, which emits a
+REVIEW SUMMARY. No dated report file (that stays /specflow audit <axis>'s job). Complementary fast,
+targeted entry point."
 
 ## User Scenarios & Testing _(mandatory)_
 
@@ -176,8 +176,8 @@ output.
 - The five auditor agents exist and emit the canonical `REVIEW SUMMARY` (mechanism A / #378,
   merged).
 - These are Claude-Code orchestrator skills: scope resolution + single-agent dispatch are
-  instructions to the lead, mirroring the the reference project `/perf-audit` shape; no shell script is required
-  (scope is resolved with simple git commands described in the skill, or — for
+  instructions to the lead, mirroring the the reference project `/perf-audit` shape; no shell script
+  is required (scope is resolved with simple git commands described in the skill, or — for
   `--path`/`--range`/whole — may reuse the `collect-audit-scope.sh` from #379 if convenient, but the
   file/commit list is all that is needed, not the category signals).
 - Distribution reuses the bundle/manifest path; these are markdown-only skills (no `scripts/`), so

--- a/.specnaut/specs/015-status-ledger/research.md
+++ b/.specnaut/specs/015-status-ledger/research.md
@@ -38,10 +38,10 @@ dependency the scaffolded project may not have. The data determinism lives in th
 (unit-tested); the report is a reasoning task well-suited to the lead. Matches the AC's "skill that
 reads and reports".
 
-**Alternatives considered**: ship an `audit_workflow.mjs`-style parser (as the reference project did) — rejected
-for the CLI: runtime-dependency + cross-project portability cost outweighs determinism for a
-read-only human-facing report. (Mechanism-A's hook captures the structured data; the report needn't
-be a program.)
+**Alternatives considered**: ship an `audit_workflow.mjs`-style parser (as the reference project
+did) — rejected for the CLI: runtime-dependency + cross-project portability cost outweighs
+determinism for a read-only human-facing report. (Mechanism-A's hook captures the structured data;
+the report needn't be a program.)
 
 ## Decision 3 — Schema doc + distribution
 

--- a/.specnaut/specs/015-status-ledger/spec.md
+++ b/.specnaut/specs/015-status-ledger/spec.md
@@ -1,12 +1,12 @@
 # Feature Specification: Structured status ledger + `/status-audit` + `/loop` supervision
 
 **Feature Branch**: `015-status-ledger` **Created**: 2026-06-13 **Status**: Draft **Input**: User
-description: "Mechanism C of the the reference project audit-team port (epic mkrlabs/specflow-monorepo#12).
-Enrich the log-subagent hook to capture the machine-readable contract-block fields (from #378) into
-.specnaut/logs/agents.jsonl, add a /status-audit skill that reads the ledger and reports session
-health (blocked / stale / done-but-criteria-unmet / missing-handoffs / verdict summary), document
-the ledger schema, and document the /loop 5m /status-audit supervision pattern for long-running
-headless work."
+description: "Mechanism C of the the reference project audit-team port (epic
+mkrlabs/specflow-monorepo#12). Enrich the log-subagent hook to capture the machine-readable
+contract-block fields (from #378) into .specnaut/logs/agents.jsonl, add a /status-audit skill that
+reads the ledger and reports session health (blocked / stale / done-but-criteria-unmet /
+missing-handoffs / verdict summary), document the ledger schema, and document the /loop 5m
+/status-audit supervision pattern for long-running headless work."
 
 ## User Scenarios & Testing _(mandatory)_
 

--- a/.specnaut/specs/016-agent-effort-rubric/research.md
+++ b/.specnaut/specs/016-agent-effort-rubric/research.md
@@ -13,10 +13,11 @@ contracts/effort-map.md):
 - **high** (design / higher-order reasoning): ui-ux-designer.
 - **xhigh** (coding / agentic / operates infra): developer, qa-tester, devops-sre.
 
-**Rationale**: Mirrors the reference project's rubric. Orchestrators are fire-and-forget → cheapest; auditors/
-reviewers produce bounded structured findings → medium; design needs more reasoning → high; agents
-that write code across many files / run suites / operate infra → xhigh. The rubric's `architect` and
-`product-manager` entries don't apply — those are monorepo-root agents, not in the CLI bundle.
+**Rationale**: Mirrors the reference project's rubric. Orchestrators are fire-and-forget → cheapest;
+auditors/ reviewers produce bounded structured findings → medium; design needs more reasoning →
+high; agents that write code across many files / run suites / operate infra → xhigh. The rubric's
+`architect` and `product-manager` entries don't apply — those are monorepo-root agents, not in the
+CLI bundle.
 
 **Alternatives considered**: low for the per-axis-scoped auditors — but a bundled auditor agent is a
 single entity serving both the report flow and scoped dispatch; medium is the right single value for

--- a/.specnaut/specs/016-agent-effort-rubric/spec.md
+++ b/.specnaut/specs/016-agent-effort-rubric/spec.md
@@ -1,11 +1,12 @@
 # Feature Specification: Per-agent `effort` tuning rubric
 
 **Feature Branch**: `016-agent-effort-rubric` **Created**: 2026-06-13 **Status**: Draft **Input**:
-User description: "Mechanism D of the the reference project audit-team port (epic mkrlabs/specflow-monorepo#12).
-Give every bundled agent an explicit `effort:` frontmatter field (low|medium|high|xhigh) per a
-documented rubric — low for pure orchestrators, medium for report-generating auditors/reviewers +
-product-owner, high for design/architecture, xhigh for coding/agentic agents — and add an agents
-README explaining the compound cost/quality rationale. No agent left without `effort:`."
+User description: "Mechanism D of the the reference project audit-team port (epic
+mkrlabs/specflow-monorepo#12). Give every bundled agent an explicit `effort:` frontmatter field
+(low|medium|high|xhigh) per a documented rubric — low for pure orchestrators, medium for
+report-generating auditors/reviewers + product-owner, high for design/architecture, xhigh for
+coding/agentic agents — and add an agents README explaining the compound cost/quality rationale. No
+agent left without `effort:`."
 
 ## User Scenarios & Testing _(mandatory)_
 

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@specnaut/cli",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "tasks": {
     "bundle": "deno run --allow-read --allow-write scripts/bundle-templates.ts",
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/main.ts",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "specnaut-plugin",
   "description": "Specnaut's auto-chained spec-driven workflow, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "author": {
     "name": "MakerLabs"
   },

--- a/src/domain/version.ts
+++ b/src/domain/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.19.0";
+export const VERSION = "1.20.0";

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2,7 +2,7 @@
 import type { CoreBundle } from "./domain/core_bundle.ts";
 import type { TemplateFile } from "./domain/template.ts";
 
-export const TEMPLATES_VERSION = "1.19.0";
+export const TEMPLATES_VERSION = "1.20.0";
 
 export const CORE_BUNDLE: CoreBundle = [
   {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.19.0",
+  "version": "1.20.0",
   "core": [
     { "category": "skill", "name": "specnaut", "source": "core/skills/specnaut/SKILL.md" },
     { "category": "phase", "name": "brainstorm", "suffix": "brainstorm.md", "source": "core/skills/specnaut/phases/brainstorm.md" },


### PR DESCRIPTION
Replacement release cut from the rewritten, clean history.

`v1.14.0`–`v1.19.0` carry immutable GitHub Releases whose tags pin the pre-rewrite lineage — a plain `git clone` still resurrects it. Those releases are being deleted; GitHub permanently burns those version numbers, so the line continues at `v1.20.0`.

No functional change: version bump + regenerated template bundle only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)