### PR TITLE
feat(backlog): name items by number and title, with a resolved link

### DIFF
--- a/plugin/agents/developer.md
+++ b/plugin/agents/developer.md
@@ -4,7 +4,7 @@ description: Senior developer that implements tasks from tasks.md, fixes review 
 model: opus
 effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
-skills: workflow-contract, handoff-protocol
+skills: workflow-contract, handoff-protocol, backlog-reference-contract
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true

--- a/plugin/agents/product-owner.md
+++ b/plugin/agents/product-owner.md
@@ -4,6 +4,7 @@ description: Product Owner and business guardian. Owns the product backlog, all 
 model: opus
 effort: medium
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: backlog-reference-contract
 maxTurns: 30
 color: cyan
 ---

--- a/plugin/agents/workflow-manager.md
+++ b/plugin/agents/workflow-manager.md
@@ -4,7 +4,7 @@ description: Orchestrates multi-phase feature delivery across specialist agents.
 model: sonnet
 effort: low
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
-skills: workflow-contract, handoff-protocol
+skills: workflow-contract, handoff-protocol, backlog-reference-contract
 maxTurns: 60
 color: purple
 ---

--- a/plugin/skills/backlog-reference-contract/SKILL.md
+++ b/plugin/skills/backlog-reference-contract/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: backlog-reference-contract
+description: Defines how a backlog item is named when shown to the user — number, title, and a backend-resolved link. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# backlog-reference-contract
+
+This skill defines the **backlog reference** — the way a task, user story, or
+epic is written whenever it is shown to the user. It exists so the rule is
+stated **once**. Every agent, skill, phase, command, and project document that
+mentions an item points here; none of them restates it.
+
+A bare `#42` is opaque. The reader has to leave the conversation and look the
+item up in the tracker just to know what the sentence is about — and worse, to
+decide whether to approve an action taken on it. The number identifies the item
+to the tracker; the title identifies it to the human.
+
+## Format
+
+```text
+[#<number> — <title>](<url>)      link resolves
+#<number> — <title>               no url resolvable
+#<number>                         title unavailable — last resort only
+```
+
+Examples:
+
+```text
+[#42 — Add pagination to the export endpoint](https://github.com/acme/my-app/issues/42)
+#42 — Add pagination to the export endpoint
+```
+
+## Rules
+
+- **Never a number alone** when the title is available. The pair is the unit.
+- **Title verbatim.** Do not paraphrase, re-case, or summarise it. Truncate only
+  past 80 characters, with a trailing `…`.
+- **Link the whole pair**, not just the number — the title is the click target a
+  reader actually aims at.
+- **Applies to every rendering**: prose, tables, lists, status blocks, commit
+  bodies, and prompts that ask the user to approve something. A confirmation
+  prompt naming a bare number is the worst case, because the user is being asked
+  to authorise an action on an item they cannot identify.
+- **One reference per mention is enough.** In a table, the reference belongs in
+  one column; do not repeat the number in a neighbouring one.
+- **Never fabricate a URL.** If it cannot be resolved from configuration, fall
+  back — see below. A wrong link is worse than no link.
+
+## Resolving the URL
+
+The backlog backend is whatever the project configured. Each backend's
+`skills/backlog/scripts/<backend>/_config.sh` exports the coordinates and a
+`item_url <number>` helper — **use that helper**; do not assemble URLs by hand
+and do not re-derive them per surface.
+
+| Backend | Resolves to | From |
+|---|---|---|
+| `github` | `https://github.com/<repo>/issues/<n>` | `repo` |
+| `gitlab` | `<host>/<path>/-/issues/<n>` | `host` + `project_id` |
+| `local` | relative path `.specnaut/backlog/<n>-<slug>.md` | the task file on disk |
+| `cloud` | *no link* — see below | — |
+
+**GitLab `project_id` is dual-form.** It is either a numeric id or a
+`group/project` path. The path form links directly. The numeric form is resolved
+to a path once via `glab api projects/<id>` → `path_with_namespace`; if that
+call fails, degrade rather than guess.
+
+**Cloud has no browser URL today** and is deliberately deferred. Its config
+carries an API base and a project key, and the task payloads expose no web
+address. So cloud takes the no-link fallback: number and title, no link. This is
+defined behaviour, not an unimplemented branch.
+
+> **Never construct a browser URL from the API host.** An API base is not a web
+> origin; the guess is wrong more often than right, and a wrong link sends the
+> user somewhere that does not exist. When the Cloud side ships a web address as
+> a field on the task payload, this branch renders it — no change to the shape
+> above.
+
+## Degradation
+
+Resolution is best-effort and must never block. Walk down until something works:
+
+1. `[#<n> — <title>](<url>)` — full reference.
+2. `#<n> — <title>` — URL unresolvable: unknown backend, missing or half-filled
+   config, a backend with no web address, or a failed lookup.
+3. `#<n>` — the title itself is unavailable. Last resort.
+
+Never raise an error, never stall a workflow, and never omit the reference
+entirely because it could not be made perfect. A degraded reference is still
+more useful than none.

--- a/plugin/skills/specnaut/phases/groom.md
+++ b/plugin/skills/specnaut/phases/groom.md
@@ -181,6 +181,11 @@ that is missing the next expected artefact:
 
 This is also read-only; never delete or modify spec files.
 
+**`<backlog-reference>`** below means a reference built per the
+`backlog-reference-contract` skill: the number **and** the title, wrapped in a
+backend-resolved link — never a bare `#<num>`. Read that contract for the format
+and the degradation ladder; do not restate it here.
+
 ## Output format
 
 End with a single summary block. **The per-ticket lines and the
@@ -204,20 +209,20 @@ Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarificatio
             <R> body rewrites, <S> sized, <Z> prioritised
 
 Per-ticket:
-  ↳ #<num> "<short title>" → promoted/comment/closure-recommended
+  ↳ <backlog-reference> → promoted/comment/closure-recommended
        size=<X> + priority=<P> (field)
-  ↳ #<num> "<short title>" → comment
+  ↳ <backlog-reference> → comment
        size=<X> (field) + priority=P3 (label fallback — no native option)
   ↳ ...
 
 ⚠ size / priority missing:
-  ↳ #<num> "<short title>" — <reason: e.g. gh label create failed (rate-limited)>
+  ↳ <backlog-reference> — <reason: e.g. gh label create failed (rate-limited)>
   ↳ ...
   (omit this whole section when K == 0)
 
 ⚠ Roadmap dates missing (GitHub backend, soft):
-  ↳ #<num> "<short title>" — Ready since <date>, no target date set
-  ↳ #<num> "<short title>" — In progress, no start date set
+  ↳ <backlog-reference> — Ready since <date>, no target date set
+  ↳ <backlog-reference> — In progress, no start date set
   ↳ ...
   (omit this whole section when no dates are missing)
 

--- a/plugin/skills/specnaut/phases/merge.md
+++ b/plugin/skills/specnaut/phases/merge.md
@@ -34,7 +34,9 @@ $ARGUMENTS
    3. **github + gitlab only** — run `bash .specnaut/scripts/backlog/cascade-check.sh <linked_issue>`.
       Exit 11 means the parent has open sub-issues; do NOT close. Report the open children to the
       user and stop (the issue stays in `In progress` / `Ready` until the children are closed).
-   4. Ask the user: "Close issue #<linked_issue> on the board now? (yes/no)". On `no`, skip the
+   4. Ask the user to confirm, naming the item per the `backlog-reference-contract`
+      skill — number, title, and a resolved link, never a bare number. The user is being
+      asked to authorise an action on an item they must be able to identify. On `no`, skip the
       rest of step 8 — leave the column flip to a future run or to a manual `move.sh`.
    5. On `yes`, run `bash .specnaut/scripts/backlog/move.sh <linked_issue> Done`. This is the
       mechanical column flip — `move.sh` is idempotent and the working contract permits the merge

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -1754,7 +1754,9 @@ If Overall = PASS, surface the STOP #2 summary block defined in
    3. **github + gitlab only** — run \`bash .specnaut/scripts/backlog/cascade-check.sh <linked_issue>\`.
       Exit 11 means the parent has open sub-issues; do NOT close. Report the open children to the
       user and stop (the issue stays in \`In progress\` / \`Ready\` until the children are closed).
-   4. Ask the user: "Close issue #<linked_issue> on the board now? (yes/no)". On \`no\`, skip the
+   4. Ask the user to confirm, naming the item per the \`backlog-reference-contract\`
+      skill — number, title, and a resolved link, never a bare number. The user is being
+      asked to authorise an action on an item they must be able to identify. On \`no\`, skip the
       rest of step 8 — leave the column flip to a future run or to a manual \`move.sh\`.
    5. On \`yes\`, run \`bash .specnaut/scripts/backlog/move.sh <linked_issue> Done\`. This is the
       mechanical column flip — \`move.sh\` is idempotent and the working contract permits the merge
@@ -2295,6 +2297,11 @@ that is missing the next expected artefact:
 
 This is also read-only; never delete or modify spec files.
 
+**\`<backlog-reference>\`** below means a reference built per the
+\`backlog-reference-contract\` skill: the number **and** the title, wrapped in a
+backend-resolved link — never a bare \`#<num>\`. Read that contract for the format
+and the degradation ladder; do not restate it here.
+
 ## Output format
 
 End with a single summary block. **The per-ticket lines and the
@@ -2318,20 +2325,20 @@ Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarificatio
             <R> body rewrites, <S> sized, <Z> prioritised
 
 Per-ticket:
-  ↳ #<num> "<short title>" → promoted/comment/closure-recommended
+  ↳ <backlog-reference> → promoted/comment/closure-recommended
        size=<X> + priority=<P> (field)
-  ↳ #<num> "<short title>" → comment
+  ↳ <backlog-reference> → comment
        size=<X> (field) + priority=P3 (label fallback — no native option)
   ↳ ...
 
 ⚠ size / priority missing:
-  ↳ #<num> "<short title>" — <reason: e.g. gh label create failed (rate-limited)>
+  ↳ <backlog-reference> — <reason: e.g. gh label create failed (rate-limited)>
   ↳ ...
   (omit this whole section when K == 0)
 
 ⚠ Roadmap dates missing (GitHub backend, soft):
-  ↳ #<num> "<short title>" — Ready since <date>, no target date set
-  ↳ #<num> "<short title>" — In progress, no start date set
+  ↳ <backlog-reference> — Ready since <date>, no target date set
+  ↳ <backlog-reference> — In progress, no start date set
   ↳ ...
   (omit this whole section when no dates are missing)
 
@@ -6357,6 +6364,106 @@ HANDOFF_TARGET: developer | review-coordinator | qa-tester | product-owner | wor
   },
   {
     category: "skill",
+    name: "backlog-reference-contract",
+    suffix: null,
+    content: `---
+name: backlog-reference-contract
+description: Defines how a backlog item is named when shown to the user — number, title, and a backend-resolved link. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# backlog-reference-contract
+
+This skill defines the **backlog reference** — the way a task, user story, or
+epic is written whenever it is shown to the user. It exists so the rule is
+stated **once**. Every agent, skill, phase, command, and project document that
+mentions an item points here; none of them restates it.
+
+A bare \`#42\` is opaque. The reader has to leave the conversation and look the
+item up in the tracker just to know what the sentence is about — and worse, to
+decide whether to approve an action taken on it. The number identifies the item
+to the tracker; the title identifies it to the human.
+
+## Format
+
+\`\`\`text
+[#<number> — <title>](<url>)      link resolves
+#<number> — <title>               no url resolvable
+#<number>                         title unavailable — last resort only
+\`\`\`
+
+Examples:
+
+\`\`\`text
+[#42 — Add pagination to the export endpoint](https://github.com/acme/my-app/issues/42)
+#42 — Add pagination to the export endpoint
+\`\`\`
+
+## Rules
+
+- **Never a number alone** when the title is available. The pair is the unit.
+- **Title verbatim.** Do not paraphrase, re-case, or summarise it. Truncate only
+  past 80 characters, with a trailing \`…\`.
+- **Link the whole pair**, not just the number — the title is the click target a
+  reader actually aims at.
+- **Applies to every rendering**: prose, tables, lists, status blocks, commit
+  bodies, and prompts that ask the user to approve something. A confirmation
+  prompt naming a bare number is the worst case, because the user is being asked
+  to authorise an action on an item they cannot identify.
+- **One reference per mention is enough.** In a table, the reference belongs in
+  one column; do not repeat the number in a neighbouring one.
+- **Never fabricate a URL.** If it cannot be resolved from configuration, fall
+  back — see below. A wrong link is worse than no link.
+
+## Resolving the URL
+
+The backlog backend is whatever the project configured. Each backend's
+\`skills/backlog/scripts/<backend>/_config.sh\` exports the coordinates and a
+\`item_url <number>\` helper — **use that helper**; do not assemble URLs by hand
+and do not re-derive them per surface.
+
+| Backend | Resolves to | From |
+|---|---|---|
+| \`github\` | \`https://github.com/<repo>/issues/<n>\` | \`repo\` |
+| \`gitlab\` | \`<host>/<path>/-/issues/<n>\` | \`host\` + \`project_id\` |
+| \`local\` | relative path \`.specnaut/backlog/<n>-<slug>.md\` | the task file on disk |
+| \`cloud\` | *no link* — see below | — |
+
+**GitLab \`project_id\` is dual-form.** It is either a numeric id or a
+\`group/project\` path. The path form links directly. The numeric form is resolved
+to a path once via \`glab api projects/<id>\` → \`path_with_namespace\`; if that
+call fails, degrade rather than guess.
+
+**Cloud has no browser URL today** and is deliberately deferred. Its config
+carries an API base and a project key, and the task payloads expose no web
+address. So cloud takes the no-link fallback: number and title, no link. This is
+defined behaviour, not an unimplemented branch.
+
+> **Never construct a browser URL from the API host.** An API base is not a web
+> origin; the guess is wrong more often than right, and a wrong link sends the
+> user somewhere that does not exist. When the Cloud side ships a web address as
+> a field on the task payload, this branch renders it — no change to the shape
+> above.
+
+## Degradation
+
+Resolution is best-effort and must never block. Walk down until something works:
+
+1. \`[#<n> — <title>](<url>)\` — full reference.
+2. \`#<n> — <title>\` — URL unresolvable: unknown backend, missing or half-filled
+   config, a backend with no web address, or a failed lookup.
+3. \`#<n>\` — the title itself is unavailable. Last resort.
+
+Never raise an error, never stall a workflow, and never omit the reference
+entirely because it could not be made perfect. A degraded reference is still
+more useful than none.
+`,
+    executable: false,
+    backend: null,
+    skipIfExists: false,
+  },
+  {
+    category: "skill",
     name: "handoff-protocol",
     suffix: null,
     content: `---
@@ -6525,6 +6632,8 @@ argument-hint: [list|next|add|update|estimate|status|groom|brief] [args]
 | \`brief <id>\`        | Generate PO business brief                  |
 | \`<number>\`          | Show details for task NNN                   |
 
+**Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
+
 ## Rules
 
 1. **Every invocation MUST go through the \`product-owner\` agent** — even
@@ -6582,6 +6691,7 @@ description: Product Owner and business guardian. Owns the product backlog, all 
 model: opus
 effort: medium
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: backlog-reference-contract
 maxTurns: 30
 color: cyan
 ---
@@ -6864,7 +6974,7 @@ description: Senior developer that implements tasks from tasks.md, fixes review 
 model: opus
 effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
-skills: workflow-contract, handoff-protocol
+skills: workflow-contract, handoff-protocol, backlog-reference-contract
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true
@@ -7439,7 +7549,7 @@ description: Orchestrates multi-phase feature delivery across specialist agents.
 model: sonnet
 effort: low
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
-skills: workflow-contract, handoff-protocol
+skills: workflow-contract, handoff-protocol, backlog-reference-contract
 maxTurns: 60
 color: purple
 ---
@@ -9184,6 +9294,8 @@ next?", "move task X to in-progress", or any backlog mutation. The exact
 flow depends on the backend chosen at \`specnaut init\` (or the most recent
 \`specnaut upgrade --backlog <name>\`).
 
+**Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
+
 ## All mutations go through the Product Owner agent
 
 The main session does **not** run the scripts directly. Dispatch the
@@ -10206,6 +10318,15 @@ REPO_OWNER="\${REPO%%/*}"
 REPO_NAME="\${REPO##*/}"
 
 export REPO REPO_OWNER REPO_NAME PROJECT_NUMBER
+
+# Browser URL for one item, per \`backlog-reference-contract\`. Prints nothing
+# when it cannot be resolved — callers degrade to "#<n> — <title>" rather than
+# guessing. Never fails: a reference must never block a workflow.
+item_url() {
+  [ -n "\${1:-}" ] || return 0
+  [ -n "\$REPO" ] || return 0
+  echo "https://github.com/\$REPO/issues/\$1"
+}
 `,
     executable: true,
     backend: "github",
@@ -11193,6 +11314,34 @@ fi
 # accepts either a numeric id or a "group/project" path.
 export GITLAB_HOST="\$HOST"
 export PROJECT_ID
+
+# Browser URL for one item, per \`backlog-reference-contract\`. Prints nothing
+# when it cannot be resolved — callers degrade rather than guessing. Never
+# fails: a reference must never block a workflow.
+#
+# \`project_id\` is dual-form. A "group/project" path links directly; a numeric id
+# has no browser path, so it is resolved once through the API. If that lookup
+# fails there is no honest URL to emit, so emit none.
+_GITLAB_PATH_CACHE=""
+item_url() {
+  [ -n "\${1:-}" ] || return 0
+  local path="\$PROJECT_ID"
+  case "\$PROJECT_ID" in
+    *[!0-9]*) ;;                       # already a path — use as-is
+    *)
+      if [ -n "\$_GITLAB_PATH_CACHE" ]; then
+        path="\$_GITLAB_PATH_CACHE"
+      else
+        path=\$(glab api "projects/\$PROJECT_ID" 2>/dev/null \\
+          | sed -n 's/.*"path_with_namespace"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' \\
+          | head -1) || path=""
+        [ -n "\$path" ] || return 0
+        _GITLAB_PATH_CACHE="\$path"
+      fi
+      ;;
+  esac
+  echo "\${HOST%/}/\$path/-/issues/\$1"
+}
 `,
     executable: true,
     backend: "gitlab",
@@ -11576,6 +11725,18 @@ fi
 API_BASE="\${API_URL%/}/api/v1"
 
 export API_URL API_TOKEN PROJECT_KEY API_BASE
+
+# Cloud has no browser URL yet: the config carries an API base, and the task
+# payloads expose no web address. Per \`backlog-reference-contract\` this is the
+# documented no-link fallback, not an oversight — callers render
+# "#<n> — <title>" with no link.
+#
+# NEVER derive a browser URL from \$API_URL. An API base is not a web origin, and
+# a wrong link sends the user somewhere that does not exist. When the payload
+# gains a web-address field, read it here.
+item_url() {
+  return 0
+}
 `,
     executable: true,
     backend: "cloud",
@@ -19104,6 +19265,8 @@ _(List your non-negotiable rules — layering, DI, error handling, security.)_
 
 _(Naming, testing, commits, branches.)_
 
+**Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
+
 ## Project-specific gotchas
 
 _(Sharp edges new contributors must know.)_
@@ -19144,6 +19307,8 @@ export const HARNESS_STATIC: Record<string, Record<string, TemplateFile>> = {
 - **Agents**: specialized agents live in \`.claude/agents/\`.
 - **Backlog**: managed via \`/backlog\` — when the project uses the local
   Markdown backend, see \`.specnaut/backlog.md\`.
+
+**Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
 
 ## Optional integrations
 
@@ -19974,6 +20139,8 @@ exit 0
 - **Backlog**: managed via the \`/specnaut groom\` workflow — when the
   project uses the local Markdown backend, see \`.specnaut/backlog.md\`.
 
+**Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
+
 ## Optional integrations
 
 These are Codex CLI features Specnaut does NOT configure by default, but
@@ -20081,6 +20248,8 @@ clarifications needed) STOP #2 (pre-merge validation)
 - \`/specnaut-agent-qa-tester\` — QA + test writing
 - \`/specnaut-agent-workflow-manager\` — long-running orchestration
 - \`/specnaut-agent-devops-sre\` — cloud infrastructure, CI/CD, observability
+
+**Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
 
 ## Project context
 

--- a/templates/core/agents/developer.md
+++ b/templates/core/agents/developer.md
@@ -4,7 +4,7 @@ description: Senior developer that implements tasks from tasks.md, fixes review 
 model: opus
 effort: xhigh
 tools: Read, Write, Edit, Grep, Glob, Bash
-skills: workflow-contract, handoff-protocol
+skills: workflow-contract, handoff-protocol, backlog-reference-contract
 permissionMode: acceptEdits
 maxTurns: 80
 disable-model-invocation: true

--- a/templates/core/agents/product-owner.md
+++ b/templates/core/agents/product-owner.md
@@ -4,6 +4,7 @@ description: Product Owner and business guardian. Owns the product backlog, all 
 model: opus
 effort: medium
 tools: Read, Write, Edit, Grep, Glob, Bash
+skills: backlog-reference-contract
 maxTurns: 30
 color: cyan
 ---

--- a/templates/core/agents/workflow-manager.md
+++ b/templates/core/agents/workflow-manager.md
@@ -4,7 +4,7 @@ description: Orchestrates multi-phase feature delivery across specialist agents.
 model: sonnet
 effort: low
 tools: Read, Grep, Glob, Bash, Agent(product-owner, developer, review-coordinator, qa-tester)
-skills: workflow-contract, handoff-protocol
+skills: workflow-contract, handoff-protocol, backlog-reference-contract
 maxTurns: 60
 color: purple
 ---

--- a/templates/core/commands/backlog.md
+++ b/templates/core/commands/backlog.md
@@ -23,6 +23,8 @@ $ARGUMENTS
 | `brief <id>`        | Generate PO business brief                  |
 | `<number>`          | Show details for task NNN                   |
 
+**Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
+
 ## Rules
 
 1. **Every invocation MUST go through the `product-owner` agent** — even

--- a/templates/core/root/AGENTS.md
+++ b/templates/core/root/AGENTS.md
@@ -16,6 +16,8 @@ _(List your non-negotiable rules — layering, DI, error handling, security.)_
 
 _(Naming, testing, commits, branches.)_
 
+**Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
+
 ## Project-specific gotchas
 
 _(Sharp edges new contributors must know.)_

--- a/templates/core/skills/backlog-reference-contract/SKILL.md
+++ b/templates/core/skills/backlog-reference-contract/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: backlog-reference-contract
+description: Defines how a backlog item is named when shown to the user — number, title, and a backend-resolved link. Preloaded, not user-invocable.
+user-invocable: false
+---
+
+# backlog-reference-contract
+
+This skill defines the **backlog reference** — the way a task, user story, or
+epic is written whenever it is shown to the user. It exists so the rule is
+stated **once**. Every agent, skill, phase, command, and project document that
+mentions an item points here; none of them restates it.
+
+A bare `#42` is opaque. The reader has to leave the conversation and look the
+item up in the tracker just to know what the sentence is about — and worse, to
+decide whether to approve an action taken on it. The number identifies the item
+to the tracker; the title identifies it to the human.
+
+## Format
+
+```text
+[#<number> — <title>](<url>)      link resolves
+#<number> — <title>               no url resolvable
+#<number>                         title unavailable — last resort only
+```
+
+Examples:
+
+```text
+[#42 — Add pagination to the export endpoint](https://github.com/acme/my-app/issues/42)
+#42 — Add pagination to the export endpoint
+```
+
+## Rules
+
+- **Never a number alone** when the title is available. The pair is the unit.
+- **Title verbatim.** Do not paraphrase, re-case, or summarise it. Truncate only
+  past 80 characters, with a trailing `…`.
+- **Link the whole pair**, not just the number — the title is the click target a
+  reader actually aims at.
+- **Applies to every rendering**: prose, tables, lists, status blocks, commit
+  bodies, and prompts that ask the user to approve something. A confirmation
+  prompt naming a bare number is the worst case, because the user is being asked
+  to authorise an action on an item they cannot identify.
+- **One reference per mention is enough.** In a table, the reference belongs in
+  one column; do not repeat the number in a neighbouring one.
+- **Never fabricate a URL.** If it cannot be resolved from configuration, fall
+  back — see below. A wrong link is worse than no link.
+
+## Resolving the URL
+
+The backlog backend is whatever the project configured. Each backend's
+`skills/backlog/scripts/<backend>/_config.sh` exports the coordinates and a
+`item_url <number>` helper — **use that helper**; do not assemble URLs by hand
+and do not re-derive them per surface.
+
+| Backend | Resolves to | From |
+|---|---|---|
+| `github` | `https://github.com/<repo>/issues/<n>` | `repo` |
+| `gitlab` | `<host>/<path>/-/issues/<n>` | `host` + `project_id` |
+| `local` | relative path `.specnaut/backlog/<n>-<slug>.md` | the task file on disk |
+| `cloud` | *no link* — see below | — |
+
+**GitLab `project_id` is dual-form.** It is either a numeric id or a
+`group/project` path. The path form links directly. The numeric form is resolved
+to a path once via `glab api projects/<id>` → `path_with_namespace`; if that
+call fails, degrade rather than guess.
+
+**Cloud has no browser URL today** and is deliberately deferred. Its config
+carries an API base and a project key, and the task payloads expose no web
+address. So cloud takes the no-link fallback: number and title, no link. This is
+defined behaviour, not an unimplemented branch.
+
+> **Never construct a browser URL from the API host.** An API base is not a web
+> origin; the guess is wrong more often than right, and a wrong link sends the
+> user somewhere that does not exist. When the Cloud side ships a web address as
+> a field on the task payload, this branch renders it — no change to the shape
+> above.
+
+## Degradation
+
+Resolution is best-effort and must never block. Walk down until something works:
+
+1. `[#<n> — <title>](<url>)` — full reference.
+2. `#<n> — <title>` — URL unresolvable: unknown backend, missing or half-filled
+   config, a backend with no web address, or a failed lookup.
+3. `#<n>` — the title itself is unavailable. Last resort.
+
+Never raise an error, never stall a workflow, and never omit the reference
+entirely because it could not be made perfect. A degraded reference is still
+more useful than none.

--- a/templates/core/skills/backlog/SKILL.md
+++ b/templates/core/skills/backlog/SKILL.md
@@ -11,6 +11,8 @@ next?", "move task X to in-progress", or any backlog mutation. The exact
 flow depends on the backend chosen at `specnaut init` (or the most recent
 `specnaut upgrade --backlog <name>`).
 
+**Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
+
 ## All mutations go through the Product Owner agent
 
 The main session does **not** run the scripts directly. Dispatch the

--- a/templates/core/skills/backlog/scripts/cloud/_config.sh
+++ b/templates/core/skills/backlog/scripts/cloud/_config.sh
@@ -48,3 +48,15 @@ fi
 API_BASE="${API_URL%/}/api/v1"
 
 export API_URL API_TOKEN PROJECT_KEY API_BASE
+
+# Cloud has no browser URL yet: the config carries an API base, and the task
+# payloads expose no web address. Per `backlog-reference-contract` this is the
+# documented no-link fallback, not an oversight — callers render
+# "#<n> — <title>" with no link.
+#
+# NEVER derive a browser URL from $API_URL. An API base is not a web origin, and
+# a wrong link sends the user somewhere that does not exist. When the payload
+# gains a web-address field, read it here.
+item_url() {
+  return 0
+}

--- a/templates/core/skills/backlog/scripts/github/_config.sh
+++ b/templates/core/skills/backlog/scripts/github/_config.sh
@@ -36,3 +36,12 @@ REPO_OWNER="${REPO%%/*}"
 REPO_NAME="${REPO##*/}"
 
 export REPO REPO_OWNER REPO_NAME PROJECT_NUMBER
+
+# Browser URL for one item, per `backlog-reference-contract`. Prints nothing
+# when it cannot be resolved — callers degrade to "#<n> — <title>" rather than
+# guessing. Never fails: a reference must never block a workflow.
+item_url() {
+  [ -n "${1:-}" ] || return 0
+  [ -n "$REPO" ] || return 0
+  echo "https://github.com/$REPO/issues/$1"
+}

--- a/templates/core/skills/backlog/scripts/gitlab/_config.sh
+++ b/templates/core/skills/backlog/scripts/gitlab/_config.sh
@@ -35,3 +35,31 @@ fi
 # accepts either a numeric id or a "group/project" path.
 export GITLAB_HOST="$HOST"
 export PROJECT_ID
+
+# Browser URL for one item, per `backlog-reference-contract`. Prints nothing
+# when it cannot be resolved — callers degrade rather than guessing. Never
+# fails: a reference must never block a workflow.
+#
+# `project_id` is dual-form. A "group/project" path links directly; a numeric id
+# has no browser path, so it is resolved once through the API. If that lookup
+# fails there is no honest URL to emit, so emit none.
+_GITLAB_PATH_CACHE=""
+item_url() {
+  [ -n "${1:-}" ] || return 0
+  local path="$PROJECT_ID"
+  case "$PROJECT_ID" in
+    *[!0-9]*) ;;                       # already a path — use as-is
+    *)
+      if [ -n "$_GITLAB_PATH_CACHE" ]; then
+        path="$_GITLAB_PATH_CACHE"
+      else
+        path=$(glab api "projects/$PROJECT_ID" 2>/dev/null \
+          | sed -n 's/.*"path_with_namespace"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+          | head -1) || path=""
+        [ -n "$path" ] || return 0
+        _GITLAB_PATH_CACHE="$path"
+      fi
+      ;;
+  esac
+  echo "${HOST%/}/$path/-/issues/$1"
+}

--- a/templates/core/skills/backlog/scripts/local/_config.sh
+++ b/templates/core/skills/backlog/scripts/local/_config.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Helper for the local (Markdown) backlog backend.
+#
+# `specnaut init --backlog local` writes no backlog-config.yml at all — the
+# local backend is identified by that file's *absence* — so unlike the other
+# backends there is nothing to read. This helper exists to give the local
+# backend the same `item_url` surface as the others, per
+# `backlog-reference-contract`.
+#
+# Sourced by the other local-backend scripts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BACKLOG_DIR="$ROOT/.specnaut/backlog"
+INDEX="$ROOT/.specnaut/backlog.md"
+
+export ROOT BACKLOG_DIR INDEX
+
+# A Markdown backlog has no browser URL, but it does have a file — so emit a
+# repo-relative path that a harness can open. Prints nothing when no task file
+# matches. Never fails: a reference must never block a workflow.
+item_url() {
+  [ -n "${1:-}" ] || return 0
+  local padded
+  padded=$(printf '%03d' "$1" 2>/dev/null) || return 0
+  local candidate
+  for candidate in "$BACKLOG_DIR/$padded"-*.md; do
+    [ -e "$candidate" ] || continue
+    echo ".specnaut/backlog/$(basename "$candidate")"
+    return 0
+  done
+  return 0
+}

--- a/templates/core/skills/specnaut/phases/groom.md
+++ b/templates/core/skills/specnaut/phases/groom.md
@@ -181,6 +181,11 @@ that is missing the next expected artefact:
 
 This is also read-only; never delete or modify spec files.
 
+**`<backlog-reference>`** below means a reference built per the
+`backlog-reference-contract` skill: the number **and** the title, wrapped in a
+backend-resolved link — never a bare `#<num>`. Read that contract for the format
+and the degradation ladder; do not restate it here.
+
 ## Output format
 
 End with a single summary block. **The per-ticket lines and the
@@ -204,20 +209,20 @@ Backlog:    <N> items reviewed, <P> promoted to Ready, <C> awaiting clarificatio
             <R> body rewrites, <S> sized, <Z> prioritised
 
 Per-ticket:
-  ↳ #<num> "<short title>" → promoted/comment/closure-recommended
+  ↳ <backlog-reference> → promoted/comment/closure-recommended
        size=<X> + priority=<P> (field)
-  ↳ #<num> "<short title>" → comment
+  ↳ <backlog-reference> → comment
        size=<X> (field) + priority=P3 (label fallback — no native option)
   ↳ ...
 
 ⚠ size / priority missing:
-  ↳ #<num> "<short title>" — <reason: e.g. gh label create failed (rate-limited)>
+  ↳ <backlog-reference> — <reason: e.g. gh label create failed (rate-limited)>
   ↳ ...
   (omit this whole section when K == 0)
 
 ⚠ Roadmap dates missing (GitHub backend, soft):
-  ↳ #<num> "<short title>" — Ready since <date>, no target date set
-  ↳ #<num> "<short title>" — In progress, no start date set
+  ↳ <backlog-reference> — Ready since <date>, no target date set
+  ↳ <backlog-reference> — In progress, no start date set
   ↳ ...
   (omit this whole section when no dates are missing)
 

--- a/templates/core/skills/specnaut/phases/merge.md
+++ b/templates/core/skills/specnaut/phases/merge.md
@@ -34,7 +34,9 @@ $ARGUMENTS
    3. **github + gitlab only** — run `bash .specnaut/scripts/backlog/cascade-check.sh <linked_issue>`.
       Exit 11 means the parent has open sub-issues; do NOT close. Report the open children to the
       user and stop (the issue stays in `In progress` / `Ready` until the children are closed).
-   4. Ask the user: "Close issue #<linked_issue> on the board now? (yes/no)". On `no`, skip the
+   4. Ask the user to confirm, naming the item per the `backlog-reference-contract`
+      skill — number, title, and a resolved link, never a bare number. The user is being
+      asked to authorise an action on an item they must be able to identify. On `no`, skip the
       rest of step 8 — leave the column flip to a future run or to a manual `move.sh`.
    5. On `yes`, run `bash .specnaut/scripts/backlog/move.sh <linked_issue> Done`. This is the
       mechanical column flip — `move.sh` is idempotent and the working contract permits the merge

--- a/templates/harness-specific/claude/CLAUDE.md
+++ b/templates/harness-specific/claude/CLAUDE.md
@@ -8,6 +8,8 @@
 - **Backlog**: managed via `/backlog` — when the project uses the local
   Markdown backend, see `.specnaut/backlog.md`.
 
+**Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
+
 ## Optional integrations
 
 These are Claude Code features Specnaut does NOT configure by default, but

--- a/templates/harness-specific/codex/AGENTS.md
+++ b/templates/harness-specific/codex/AGENTS.md
@@ -8,6 +8,8 @@
 - **Backlog**: managed via the `/specnaut groom` workflow — when the
   project uses the local Markdown backend, see `.specnaut/backlog.md`.
 
+**Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
+
 ## Optional integrations
 
 These are Codex CLI features Specnaut does NOT configure by default, but

--- a/templates/harness-specific/cursor/specify-rules.mdc
+++ b/templates/harness-specific/cursor/specify-rules.mdc
@@ -42,6 +42,8 @@ clarifications needed) STOP #2 (pre-merge validation)
 - `/specnaut-agent-workflow-manager` — long-running orchestration
 - `/specnaut-agent-devops-sre` — cloud infrastructure, CI/CD, observability
 
+**Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
+
 ## Project context
 
 - Constitution lives at `.specnaut/memory/constitution.md` — treat as non-negotiable rules.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -38,6 +38,7 @@
     { "category": "skill", "name": "verification-before-completion", "source": "core/skills/verification-before-completion/SKILL.md" },
     { "category": "skill", "name": "brainstorming", "source": "core/skills/brainstorming/SKILL.md" },
     { "category": "skill", "name": "workflow-contract", "source": "core/skills/workflow-contract/SKILL.md" },
+    { "category": "skill", "name": "backlog-reference-contract", "source": "core/skills/backlog-reference-contract/SKILL.md" },
     { "category": "skill", "name": "handoff-protocol", "source": "core/skills/handoff-protocol/SKILL.md" },
     { "category": "skill", "name": "review-findings-contract", "source": "core/skills/review-findings-contract/SKILL.md" },
     { "category": "skill", "name": "qa-report-contract", "source": "core/skills/qa-report-contract/SKILL.md" },

--- a/tests/integration/init_codex_test.ts
+++ b/tests/integration/init_codex_test.ts
@@ -95,11 +95,11 @@ Deno.test("specnaut init --ai codex scaffolds a Codex layout", async () => {
     // writing-plans (A1) + requesting-code-review (A3) +
     // using-specnaut bootstrap (B6) + subagent-driven-development (A2) +
     // executing-plans (A4) + verification-before-completion (A5) +
-    // brainstorming (A6) + 4 output-contract skills (#378:
+    // brainstorming (A6) + 5 output-contract skills (#378 + #445:
     // workflow-contract, handoff-protocol, review-findings-contract,
-    // qa-report-contract) + code-audit (#379) + 5 per-axis audit skills
+    // qa-report-contract, backlog-reference-contract) + code-audit (#379) + 5 per-axis audit skills
     // (#380: arch-audit, sec-audit, perf-audit, dep-audit, a11y-audit) +
-    // status-audit (#381) = 21 (specnaut-auto removed in #409).
+    // status-audit (#381) = 22 (specnaut-auto removed in #409).
     // The audit-security phase (#303) lands under specnaut/phases/, not as a
     // top-level skill — no bump there. code-audit's scope script ships under
     // .specnaut/scripts/code-audit/, not as a skill folder; status-audit's
@@ -107,7 +107,7 @@ Deno.test("specnaut init --ai codex scaffolds a Codex layout", async () => {
     const agentsSkillsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".agents/skills")),
     )).length;
-    assertEquals(agentsSkillsCount, 21);
+    assertEquals(agentsSkillsCount, 22);
     const codexAgentsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".codex/agents")),
     )).length;

--- a/tests/integration/init_copilot_test.ts
+++ b/tests/integration/init_copilot_test.ts
@@ -91,20 +91,21 @@ Deno.test("specnaut init --ai copilot scaffolds a Copilot layout", async () => {
     // requesting-code-review (#273) + using-specnaut (#282) +
     // subagent-driven-development (#272) + executing-plans (#274) +
     // verification-before-completion (#275) + brainstorming (#276) +
-    // 4 output-contract skills (#378: workflow-contract, handoff-protocol,
-    // review-findings-contract, qa-report-contract) + code-audit (#379) +
+    // 5 output-contract skills (#378 + #445: workflow-contract,
+    // handoff-protocol, review-findings-contract, qa-report-contract,
+    // backlog-reference-contract) + code-audit (#379) +
     // 5 per-axis audit skills (#380: arch-audit, sec-audit, perf-audit,
     // dep-audit, a11y-audit) + status-audit (#381) +
     // backlog + 15 agents (11 original + performance-auditor #304 +
     // a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
-    // #322) = 57 (specnaut-auto removed in #409). code-audit's scope script
+    // #322) = 58 (specnaut-auto removed in #409). code-audit's scope script
     // ships under .specnaut/scripts/code-audit/, not as a flattened instruction file;
     // status-audit's schema doc ships to .specnaut/logs/README.md, also not
     // flattened here.
     const instructionsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".github/instructions")),
     )).length;
-    assertEquals(instructionsCount, 57);
+    assertEquals(instructionsCount, 58);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specnaut/memory/constitution.md")), true);

--- a/tests/integration/init_windsurf_test.ts
+++ b/tests/integration/init_windsurf_test.ts
@@ -83,20 +83,21 @@ Deno.test("specnaut init --ai windsurf scaffolds a Windsurf layout", async () =>
     // requesting-code-review (#273) + using-specnaut (#282) +
     // subagent-driven-development (#272) + executing-plans (#274) +
     // verification-before-completion (#275) + brainstorming (#276) +
-    // 4 output-contract skills (#378: workflow-contract, handoff-protocol,
-    // review-findings-contract, qa-report-contract) + code-audit (#379) +
+    // 5 output-contract skills (#378 + #445: workflow-contract,
+    // handoff-protocol, review-findings-contract, qa-report-contract,
+    // backlog-reference-contract) + code-audit (#379) +
     // 5 per-axis audit skills (#380: arch-audit, sec-audit, perf-audit,
     // dep-audit, a11y-audit) + status-audit (#381) +
     // backlog + 15 agent workflows (11 original + performance-auditor #304
     // + a11y-auditor #305 + architecture-auditor #321 + dependency-auditor
-    // #322) = 57 (specnaut-auto removed in #409). code-audit's scope script
+    // #322) = 58 (specnaut-auto removed in #409). code-audit's scope script
     // ships under .specnaut/scripts/code-audit/, not as a flattened workflow file;
     // status-audit's schema doc ships to .specnaut/logs/README.md, also not
     // flattened here.
     const workflowsCount = (await Array.fromAsync(
       Deno.readDir(join(root, ".windsurf/workflows")),
     )).length;
-    assertEquals(workflowsCount, 57);
+    assertEquals(workflowsCount, 58);
 
     // Shared (cross-harness)
     assertEquals(await exists(join(root, ".specnaut/memory/constitution.md")), true);

--- a/tests/templates/agent_output_contracts_test.ts
+++ b/tests/templates/agent_output_contracts_test.ts
@@ -4,7 +4,7 @@ import type { CoreEntry } from "../../src/domain/core_bundle.ts";
 
 /**
  * Locks the two halves of feature 012 (machine-readable agent output contracts)
- * together: the four contract skills must ship in the bundle as
+ * together: the contract skills must ship in the bundle as
  * `user-invocable: false`, AND every wired agent's bundled content must carry
  * the exact `skills:` preload entries from the research.md mapping table. If a
  * contract drops out of the bundle, or an agent loses its preload line, one of
@@ -12,12 +12,13 @@ import type { CoreEntry } from "../../src/domain/core_bundle.ts";
  * silently (FR-002, SC-001, SC-004).
  */
 
-/** The four contract skills, by bundled `name`. Identity = name (data-model.md). */
+/** The contract skills, by bundled `name`. Identity = name (data-model.md). */
 const CONTRACT_SKILLS = [
   "workflow-contract",
   "handoff-protocol",
   "review-findings-contract",
   "qa-report-contract",
+  "backlog-reference-contract",
 ] as const;
 
 /** Authoritative wired-agent → contracts mapping (research.md). */
@@ -30,9 +31,12 @@ const AGENT_WIRING: Record<string, readonly string[]> = {
   "code-reviewer": ["review-findings-contract", "workflow-contract"],
   "test-reviewer": ["review-findings-contract", "workflow-contract"],
   "review-coordinator": ["workflow-contract", "handoff-protocol", "review-findings-contract"],
-  "developer": ["workflow-contract", "handoff-protocol"],
-  "workflow-manager": ["workflow-contract", "handoff-protocol"],
+  "developer": ["workflow-contract", "handoff-protocol", "backlog-reference-contract"],
+  "workflow-manager": ["workflow-contract", "handoff-protocol", "backlog-reference-contract"],
   "qa-tester": ["qa-report-contract", "workflow-contract"],
+  // The single biggest emitter of backlog references — and, until now, the
+  // only wired agent with no `skills:` line at all.
+  "product-owner": ["backlog-reference-contract"],
 };
 
 function skillEntry(name: string): CoreEntry | undefined {
@@ -63,7 +67,7 @@ function skillsField(frontmatterBody: string): string[] {
     .filter((s) => s.length > 0);
 }
 
-// (a) The four contracts are in CORE_BUNDLE and each is user-invocable: false.
+// (a) The contracts are in CORE_BUNDLE and each is user-invocable: false.
 for (const name of CONTRACT_SKILLS) {
   Deno.test(`contract skill "${name}" is bundled as a skill`, () => {
     const entry = skillEntry(name);

--- a/tests/templates/backlog_reference_contract_test.ts
+++ b/tests/templates/backlog_reference_contract_test.ts
@@ -1,0 +1,222 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { CORE_BUNDLE, HARNESS_STATIC } from "../../src/templates_bundle.ts";
+import { fromFileUrl } from "@std/path";
+
+/**
+ * Locks the backlog-reference rule to a single canonical home.
+ *
+ * The deliverable is explicitly NOT the rule repeated across the fleet: it is
+ * one copy plus a reference mechanism. Two channels pick it up — agents through
+ * their `skills:` frontmatter, and everything else through a one-line pointer —
+ * and neither may restate the rule. The non-duplication test below is what
+ * keeps that true past the first release.
+ */
+
+const CONTRACT = "backlog-reference-contract";
+
+/**
+ * Load-bearing sentences from the contract. Each must appear in exactly ONE
+ * bundled entry — the contract itself. A second copy anywhere turns this red.
+ */
+const LOAD_BEARING = [
+  "**Never a number alone** when the title is available.",
+  "**Never fabricate a URL.**",
+  "Title verbatim.",
+  "A degraded reference is still",
+];
+
+/** Agents that emit backlog references and pick the contract up via `skills:`. */
+const CHANNEL_A = ["product-owner", "developer", "workflow-manager"] as const;
+
+/** Bundled surfaces with no frontmatter preloading — they carry a pointer. */
+const CHANNEL_B_CORE: ReadonlyArray<{ category: string; name: string }> = [
+  { category: "backlog-skill", name: "backlog" },
+  { category: "backlog-cmd", name: "backlog" },
+  { category: "phase", name: "groom" },
+  { category: "phase", name: "merge" },
+  { category: "project-root", name: "root" },
+  // `specify` is deliberately absent. Windsurf renders each phase as a Cascade
+  // workflow capped at 12 000 characters, and specify.md already sits ~40 chars
+  // under it — any pointer pushes it over. Its backlog mentions are `linked_issue`
+  // plumbing (storing the number in feature.json) rather than user-facing
+  // references, and the agents that do the talking are wired through Channel A,
+  // so the rule still reaches the output. Revisit if specify.md is ever trimmed.
+];
+
+/** Harness rules files, which ship through HARNESS_STATIC rather than the core bundle. */
+const CHANNEL_B_STATIC: ReadonlyArray<{ harness: string; dest: string }> = [
+  { harness: "claude", dest: ".claude/CLAUDE.md" },
+  { harness: "codex", dest: ".codex/AGENTS.md" },
+  { harness: "cursor", dest: ".cursor/rules/specify-rules.mdc" },
+];
+
+function entry(category: string, name: string) {
+  return CORE_BUNDLE.find((e) => e.category === category && e.name === name);
+}
+
+Deno.test("the contract ships as a preloaded, non-invocable skill", () => {
+  const e = entry("skill", CONTRACT);
+  assert(e, `${CONTRACT} missing from CORE_BUNDLE`);
+  assert(/^user-invocable:\s*false\s*$/m.test(e.content));
+  assertStringIncludes(e.content, "Preloaded, not user-invocable.");
+});
+
+Deno.test("the rule's substance lives in exactly one bundled entry", () => {
+  for (const sentence of LOAD_BEARING) {
+    const core = CORE_BUNDLE.filter((e) => e.content.includes(sentence));
+    const staticHits = Object.entries(HARNESS_STATIC).flatMap(([h, files]) =>
+      Object.entries(files)
+        .filter(([, f]) => f.content.includes(sentence))
+        .map(([dest]) => `${h}:${dest}`)
+    );
+    const where = [...core.map((e) => `${e.category}/${e.name}`), ...staticHits];
+    assertEquals(
+      where.length,
+      1,
+      `"${sentence}" must appear once (the contract), found in: ${where.join(", ") || "nowhere"}`,
+    );
+    assertEquals(where[0], `skill/${CONTRACT}`);
+  }
+});
+
+Deno.test("Channel A — every reference-emitting agent preloads the contract", () => {
+  for (const name of CHANNEL_A) {
+    const e = entry("agent", name);
+    assert(e, `agent ${name} missing from CORE_BUNDLE`);
+    const fm = e.content.match(/^---\n([\s\S]*?)\n---/);
+    assert(fm, `agent ${name} has no frontmatter`);
+    const line = fm[1].split("\n").find((l) => /^skills:\s/.test(l));
+    assert(line, `agent ${name} must have a \`skills:\` line — it emits backlog references`);
+    assertStringIncludes(line, CONTRACT);
+  }
+});
+
+Deno.test("Channel B — every non-preloading surface carries the pointer", () => {
+  for (const { category, name } of CHANNEL_B_CORE) {
+    const e = entry(category, name);
+    assert(e, `${category}/${name} missing from CORE_BUNDLE`);
+    assertStringIncludes(
+      e.content,
+      CONTRACT,
+      `${category}/${name} mentions backlog items but does not point at the contract`,
+    );
+  }
+  for (const { harness, dest } of CHANNEL_B_STATIC) {
+    const file = HARNESS_STATIC[harness]?.[dest];
+    assert(file, `${harness} ${dest} missing from HARNESS_STATIC`);
+    assertStringIncludes(file.content, CONTRACT, `${harness} ${dest} lacks the pointer`);
+  }
+});
+
+Deno.test("groom.md's local restatement was replaced, not left beside the pointer", () => {
+  const e = entry("phase", "groom")!;
+  assert(
+    !e.content.includes('#<num> "<short title>"'),
+    "groom.md must not keep its own partial statement of the rule alongside the pointer",
+  );
+  assertStringIncludes(e.content, "<backlog-reference>");
+});
+
+Deno.test("merge.md's confirmation prompt no longer names a bare number", () => {
+  const e = entry("phase", "merge")!;
+  assert(
+    !e.content.includes('"Close issue #<linked_issue> on the board now?'),
+    "the approval prompt must name the item per the contract, not by bare number",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Behaviour of the per-backend `item_url` helpers.
+// ---------------------------------------------------------------------------
+
+const SCRIPTS = "../../templates/core/skills/backlog/scripts";
+
+/**
+ * Lays a backend's scripts out so `_config.sh` resolves a project root three
+ * levels up, and drops the given backlog-config.yml beside it.
+ */
+async function backendHarness(backend: string, config: string | null): Promise<string> {
+  const tmp = await Deno.makeTempDir({ prefix: `item-url-${backend}-` });
+  const dir = `${tmp}/backlog/scripts/${backend}`;
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.mkdir(`${tmp}/.specnaut`, { recursive: true });
+  const src = fromFileUrl(new URL(`${SCRIPTS}/${backend}/_config.sh`, import.meta.url));
+  await Deno.copyFile(src, `${dir}/_config.sh`);
+  if (config !== null) {
+    await Deno.writeTextFile(`${tmp}/.specnaut/backlog-config.yml`, config);
+  }
+  return tmp;
+}
+
+/**
+ * `_config.sh` resolves the project root from `dirname "$0"`, so it must be
+ * sourced *by a script in the same directory* — sourcing it from `bash -c`
+ * would make `$0` "bash" and break the lookup. This wrapper is how the real
+ * backend scripts consume it.
+ */
+async function runItemUrl(
+  tmp: string,
+  backend: string,
+  args: string,
+): Promise<{ code: number; out: string }> {
+  const dir = `${tmp}/backlog/scripts/${backend}`;
+  await Deno.writeTextFile(
+    `${dir}/probe.sh`,
+    `#!/usr/bin/env bash\nset -euo pipefail\n. "$(dirname "$0")/_config.sh"\n${args}\n`,
+  );
+  const { code, stdout } = await new Deno.Command("bash", {
+    args: [`${dir}/probe.sh`],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return { code, out: new TextDecoder().decode(stdout).trim() };
+}
+
+async function itemUrl(tmp: string, backend: string, num: string): Promise<string> {
+  const { out } = await runItemUrl(tmp, backend, `item_url ${num}`);
+  return out;
+}
+
+Deno.test("github item_url builds the issue URL from `repo`", async () => {
+  const tmp = await backendHarness("github", 'repo: "acme/my-app"\nproject_number: 7\n');
+  assertEquals(await itemUrl(tmp, "github", "42"), "https://github.com/acme/my-app/issues/42");
+});
+
+Deno.test("cloud item_url emits nothing — the documented no-link fallback", async () => {
+  // Cloud carries an API base, not a web origin. Deriving one would send the
+  // user somewhere that does not exist, so the contract says: no link.
+  const src = await Deno.readTextFile(
+    fromFileUrl(new URL(`${SCRIPTS}/cloud/_config.sh`, import.meta.url)),
+  );
+  assertStringIncludes(src, "item_url()");
+  assert(
+    !/item_url\(\)[\s\S]{0,400}\$API_URL[^\n]*echo/.test(src),
+    "cloud item_url must never build a URL from the API host",
+  );
+});
+
+Deno.test("local item_url resolves the task file, and stays quiet when absent", async () => {
+  const tmp = await backendHarness("local", null);
+  await Deno.mkdir(`${tmp}/.specnaut/backlog`, { recursive: true });
+  await Deno.writeTextFile(`${tmp}/.specnaut/backlog/007-add-pagination.md`, "# task\n");
+
+  assertEquals(
+    await itemUrl(tmp, "local", "7"),
+    ".specnaut/backlog/007-add-pagination.md",
+    "a Markdown backlog has no browser URL, but it does have a file",
+  );
+  assertEquals(await itemUrl(tmp, "local", "999"), "", "no task file ⇒ no link, no error");
+});
+
+Deno.test("item_url never fails, whatever the state", async () => {
+  // Degradation must never block a workflow: every helper exits 0 even with a
+  // missing argument or an unresolvable item.
+  for (const backend of ["github", "local"]) {
+    const tmp = await backendHarness(
+      backend,
+      backend === "github" ? 'repo: "acme/my-app"\nproject_number: 7\n' : null,
+    );
+    const { code } = await runItemUrl(tmp, backend, 'item_url\nitem_url ""');
+    assertEquals(code, 0, `${backend} item_url must not fail on a missing argument`);
+  }
+});

--- a/tests/templates/contract_schema_consistency_test.ts
+++ b/tests/templates/contract_schema_consistency_test.ts
@@ -26,6 +26,12 @@ function skillContent(name: string): string {
  * invariants. Substrings are matched verbatim against the canonical contract.
  */
 const SCHEMA_MARKERS: Record<string, string[]> = {
+  "backlog-reference-contract": [
+    "[#<number> — <title>](<url>)",
+    "**Never a number alone** when the title is available.",
+    "**Never fabricate a URL.**",
+    "Never construct a browser URL from the API host.",
+  ],
   "workflow-contract": [
     "WORKFLOW STATUS",
     "STATE: in_progress | blocked | awaiting_review | awaiting_qa | awaiting_user | done | failed",


### PR DESCRIPTION
Implements all three children of epic #442 — closes #445, #446, #447.

## Why

A bare `#42` is opaque. The reader has to leave the conversation and look the item up just to know what the sentence is about — and worse, to decide whether to approve an action taken on it. `merge.md` step 8 was the sharpest case: it asked the user to authorise closing an item they could not identify.

The deliverable is explicitly **not** the rule repeated across the fleet. One canonical copy, plus a mechanism for everything else to reference it.

## What

**The contract (#445)** — `backlog-reference-contract`, a preloaded non-user-invocable skill, sibling to the four existing contracts:

```
[#<number> — <title>](<url>)      link resolves
#<number> — <title>               no url resolvable
#<number>                         title unavailable — last resort only
```

Plus the degradation ladder: never error, never block, never fabricate a URL.

**Resolution (#446)** — an `item_url` helper per backend, in the `_config.sh` each already has:

| Backend | Resolves | Note |
|---|---|---|
| github | `https://github.com/<repo>/issues/<n>` | from `repo` |
| gitlab | `<host>/<path>/-/issues/<n>` | `project_id` is dual-form — a `group/project` path links directly; a numeric id is resolved once via the API and **degrades** if that fails |
| local | `.specnaut/backlog/<n>-<slug>.md` | no browser URL, but there is a file |
| cloud | *no link* | documented fallback |

The local backend had **no `_config.sh` at all**; it has one now.

On cloud: its config carries an API base, not a web origin. Deriving one would send the user somewhere that does not exist, so the contract says no link — defined behaviour, asserted by test, not an unimplemented branch. A test also asserts `item_url` never builds a URL from `$API_URL`.

**Rollout (#447), two channels, zero duplication** — agents pick the contract up through `skills:` frontmatter (`product-owner`, the single biggest emitter, had **no such line at all**). Surfaces with no preloading carry a one-line pointer and nothing else. `groom.md`'s own partial statement of the rule was **replaced** by the pointer, not left beside it.

## The test that makes this hold

A **non-duplication** test asserts the rule's load-bearing sentences appear in exactly one bundled entry — everything else may only name the contract. Mutation-checked: restating one sentence in `backlog/SKILL.md` turns it red, removing it turns it green. Without this the duplication returns within two releases.

A **coverage** test pins both channels, so a newly added agent or phase cannot silently ship a bare number.

## One deliberate exclusion

`specify.md` carries no pointer. Windsurf renders each phase as a Cascade workflow **capped at 12 000 characters**, and specify.md already sits ~40 under it — any pointer pushes it over (measured: 12 333). Its backlog mentions are `linked_issue` plumbing rather than user-facing references, and the agents that do the talking are wired through Channel A, so the rule still reaches the output. The reason is recorded in the test inventory, not just here.

That constraint also shrank the pointer from a five-line paragraph to a genuine one-liner across all six surfaces — which is what the ticket asked for in the first place.

## Verification

`deno fmt --check`, `deno lint`, `deno check` clean. **1174 tests pass** (10 new).

Scaffolded claude / cursor / windsurf end to end: exactly one contract file each, 11 referencing surfaces, `item_url` present in the scaffolded `_config.sh`.

Integration skill counts bumped 21→22 and 57→58 for the new contract skill, with the explanatory comments updated rather than just the numbers.

## Agent adoption

`specnaut upgrade` installs a `backlog-reference-contract` skill that defines how a backlog item is named when shown to you: number **and** title, wrapped in a backend-resolved link, never a bare `#<num>`. The bundled agents and skills already reference it. If your project has its own agents, reviewers, or rules files that mention tickets, point them at the contract — do not restate it, since a second copy is exactly what the contract exists to prevent.

```prompt
Read `.specnaut/skills/backlog-reference-contract/SKILL.md` (or
`.claude/skills/backlog-reference-contract/SKILL.md`) to learn the rule.

Then audit my project for surfaces that mention backlog items but do not yet
follow it:
  - `.claude/agents/*.md` — add `backlog-reference-contract` to the `skills:`
    frontmatter line, creating the line if absent
  - skills, commands, phases, `AGENTS.md`, `CLAUDE.md`, and harness rules
    files — add a ONE-LINE pointer naming the contract, and nothing else

Do not copy any of the rule's text into these files. If any of them already
states part of the rule locally, replace that statement with the pointer
rather than leaving both. Open a PR with the changes.
```

## Out of scope

- The numbering scheme, and how references are stored in `feature.json` or commit messages. This is an output convention.
- Rendering titles in the CLI binary's own stdout — the binary does not read the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV