### PR TITLE
test(backlog): cover gitlab item_url, the one backend left unexercised

### DIFF
--- a/tests/templates/backlog_reference_contract_test.ts
+++ b/tests/templates/backlog_reference_contract_test.ts
@@ -195,6 +195,64 @@ Deno.test("cloud item_url emits nothing — the documented no-link fallback", as
   );
 });
 
+/**
+ * GitLab is the only backend whose helper does real work: `project_id` is
+ * dual-form, and the numeric form has no browser path, so it must be resolved
+ * through the API. These stub `glab` to exercise all three paths offline.
+ */
+async function gitlabHarness(projectId: string, glabBody: string): Promise<string> {
+  const tmp = await backendHarness(
+    "gitlab",
+    `host: "https://gitlab.example.com"\nproject_id: "${projectId}"\n`,
+  );
+  await Deno.mkdir(`${tmp}/bin`, { recursive: true });
+  await Deno.writeTextFile(`${tmp}/bin/glab`, `#!/usr/bin/env bash\n${glabBody}\n`);
+  await Deno.chmod(`${tmp}/bin/glab`, 0o755);
+  return tmp;
+}
+
+async function gitlabItemUrl(tmp: string, num: string): Promise<{ code: number; out: string }> {
+  const dir = `${tmp}/backlog/scripts/gitlab`;
+  await Deno.writeTextFile(
+    `${dir}/probe.sh`,
+    `#!/usr/bin/env bash\nset -euo pipefail\nexport PATH="${tmp}/bin:$PATH"\n` +
+      `. "$(dirname "$0")/_config.sh"\nitem_url ${num}\n`,
+  );
+  const { code, stdout } = await new Deno.Command("bash", {
+    args: [`${dir}/probe.sh`],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return { code, out: new TextDecoder().decode(stdout).trim() };
+}
+
+Deno.test("gitlab item_url links directly when project_id is a path", async () => {
+  // The path form needs no lookup, so the stub refuses to be called at all.
+  const tmp = await gitlabHarness("acme/my-app", 'echo "glab must not be called" >&2; exit 1');
+  const { code, out } = await gitlabItemUrl(tmp, "42");
+  assertEquals(code, 0);
+  assertEquals(out, "https://gitlab.example.com/acme/my-app/-/issues/42");
+});
+
+Deno.test("gitlab item_url resolves a numeric project_id through the API", async () => {
+  const tmp = await gitlabHarness(
+    "1234",
+    `echo '{"id":1234,"path_with_namespace":"acme/my-app"}'`,
+  );
+  const { code, out } = await gitlabItemUrl(tmp, "42");
+  assertEquals(code, 0);
+  assertEquals(out, "https://gitlab.example.com/acme/my-app/-/issues/42");
+});
+
+Deno.test("gitlab item_url degrades when the numeric lookup fails", async () => {
+  // No honest URL exists here, so the contract says emit none — and, above all,
+  // do not guess a path from the id.
+  const tmp = await gitlabHarness("1234", 'echo "401 unauthorized" >&2; exit 1');
+  const { code, out } = await gitlabItemUrl(tmp, "42");
+  assertEquals(out, "", "a failed lookup must yield no link, not a guessed one");
+  assertEquals(code, 0, "degradation must never fail the caller");
+});
+
 Deno.test("local item_url resolves the task file, and stays quiet when absent", async () => {
   const tmp = await backendHarness("local", null);
   await Deno.mkdir(`${tmp}/.specnaut/backlog`, { recursive: true });

--- a/tests/templates/backlog_reference_contract_test.ts
+++ b/tests/templates/backlog_reference_contract_test.ts
@@ -215,11 +215,16 @@ async function gitlabItemUrl(tmp: string, num: string): Promise<{ code: number; 
   const dir = `${tmp}/backlog/scripts/gitlab`;
   await Deno.writeTextFile(
     `${dir}/probe.sh`,
-    `#!/usr/bin/env bash\nset -euo pipefail\nexport PATH="${tmp}/bin:$PATH"\n` +
-      `. "$(dirname "$0")/_config.sh"\nitem_url ${num}\n`,
+    `#!/usr/bin/env bash\nset -euo pipefail\n. "$(dirname "$0")/_config.sh"\nitem_url ${num}\n`,
   );
+  // PATH goes through the process environment, not an `export` inside the
+  // script: on Windows, bash converts an inherited PATH to POSIX form at
+  // startup, but a native path assigned inside the script is left as-is and the
+  // stub becomes unfindable. That failure is silent here — the helper degrades
+  // to no output — so the degradation case would pass for the wrong reason.
   const { code, stdout } = await new Deno.Command("bash", {
     args: [`${dir}/probe.sh`],
+    env: { PATH: `${tmp}/bin:${Deno.env.get("PATH")}` },
     stdout: "piped",
     stderr: "piped",
   }).output();
@@ -247,10 +252,15 @@ Deno.test("gitlab item_url resolves a numeric project_id through the API", async
 Deno.test("gitlab item_url degrades when the numeric lookup fails", async () => {
   // No honest URL exists here, so the contract says emit none — and, above all,
   // do not guess a path from the id.
-  const tmp = await gitlabHarness("1234", 'echo "401 unauthorized" >&2; exit 1');
+  const tmp = await gitlabHarness(
+    "1234",
+    'echo "ran" > "$(dirname "$0")/../called"; echo "401 unauthorized" >&2; exit 1',
+  );
   const { code, out } = await gitlabItemUrl(tmp, "42");
   assertEquals(out, "", "a failed lookup must yield no link, not a guessed one");
   assertEquals(code, 0, "degradation must never fail the caller");
+  // Guard against a false pass: an unfindable stub also yields empty output.
+  await Deno.stat(`${tmp}/called`);
 });
 
 Deno.test("local item_url resolves the task file, and stays quiet when absent", async () => {


### PR DESCRIPTION
Follow-up to #448, closing a coverage gap in my own work — surfaced during the epic's closure verification.

## Why

#448 added an `item_url` helper to all four backends but tested only three. GitLab was the omission, and it is the only helper that does real work:

```bash
case "$PROJECT_ID" in
  *[!0-9]*) ;;          # already a group/project path — use as-is
  *)                    # numeric id has no browser path — resolve it
esac
```

## The three cases

All offline, against a stubbed `glab`:

| Case | Asserts |
|---|---|
| `project_id` is a path | links directly — and the stub **fails loudly if called**, proving no needless API round-trip |
| `project_id` is numeric | resolves `path_with_namespace` and builds the URL from it |
| the lookup fails | emits **no** link, and still exits 0 |

The third is the one that matters. Without the `[ -n "$path" ] || return 0` guard, the helper emits `https://gitlab.example.com//-/issues/42` — a link that looks plausible and goes nowhere. The contract is explicit that a wrong link is worse than no link.

**Mutation-checked:** removing that guard turns the degradation case red; restoring it turns it green. The test exercises the guard, not the fixture.

## Verification

`deno fmt --check`, `deno lint` clean. **1177 tests pass** (3 new).

Test-only change — no template, script, or bundle content is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV