### PR TITLE
fix(backlog): bundle the backend scripts that were authored but never registered

### DIFF
--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -11982,6 +11982,111 @@ fi
     skipIfExists: false,
   },
   {
+    category: "backlog-script",
+    name: "columns",
+    suffix: "columns.sh",
+    content: `#!/usr/bin/env bash
+# Print the board's column layout (order + name) — the live stage list the
+# product-owner reasons about on the Cloud backend. Names come straight from
+# the board, so a renamed/reordered column is reflected with no code change.
+#
+# Usage: columns.sh
+set -euo pipefail
+
+# shellcheck source=./_config.sh
+. "\$(dirname "\$0")/_config.sh"
+
+AUTH=(-H "Authorization: Bearer \$API_TOKEN")
+RESP=\$(curl -fsS "\$API_BASE/columns?projectKey=\$PROJECT_KEY" "\${AUTH[@]}")
+
+echo "\$RESP" | jq -r '.columns | sort_by(.order)[] | "  \\(.order)\\t\\(.name)"'
+`,
+    executable: true,
+    backend: "cloud",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
+    name: "reconcile",
+    suffix: "reconcile.sh",
+    content: `#!/usr/bin/env bash
+# Poll Specnaut Cloud for board stage transitions since the last run and emit
+# them for the product-owner to act on — the CLI half of the poll/reconcile
+# model (no webhook, no daemon).
+#
+# A per-project cursor is stored at \`.specnaut/.cloud-cursor-<KEY>\`. Each call
+# drains every transition newer than the cursor (following \`hasMore\`) and
+# advances it. Output is one machine-readable line per transition:
+#
+#   CREATED <number> -> <toStage>
+#   MOVED   <number> <fromStage> -> <toStage>
+#
+# The product-owner maps each line to a stage hook (see the agent doc,
+# "Cloud stage reconcile"). Re-running is safe: delivery is at-least-once and
+# the PO's hooks are idempotent. First run with no cursor replays the whole
+# history — pass \`--reset\` to drop the cursor, or \`--seek-end\` to fast-forward
+# past existing history without acting (bootstrap a fresh board).
+#
+# Usage: reconcile.sh [--reset] [--seek-end] [--limit N]
+set -euo pipefail
+
+# shellcheck source=./_config.sh
+. "\$(dirname "\$0")/_config.sh"
+
+LIMIT=100
+RESET=0
+SEEK_END=0
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --reset) RESET=1; shift ;;
+    --seek-end) SEEK_END=1; shift ;;
+    --limit) LIMIT="\${2:?--limit needs a value}"; shift 2 ;;
+    *) echo "usage: reconcile.sh [--reset] [--seek-end] [--limit N]" >&2; exit 2 ;;
+  esac
+done
+
+STATE="\$ROOT/.specnaut/.cloud-cursor-\$PROJECT_KEY"
+AUTH=(-H "Authorization: Bearer \$API_TOKEN")
+
+[ "\$RESET" = "1" ] && rm -f "\$STATE"
+
+CURSOR=""
+[ -f "\$STATE" ] && CURSOR="\$(cat "\$STATE")"
+
+while :; do
+  URL="\$API_BASE/activity?projectKey=\$PROJECT_KEY&limit=\$LIMIT"
+  if [ -n "\$CURSOR" ]; then
+    URL="\$URL&cursor=\$(printf '%s' "\$CURSOR" | jq -sRr @uri)"
+  fi
+
+  RESP=\$(curl -fsS "\$URL" "\${AUTH[@]}")
+  if ! echo "\$RESP" | jq -e '.ok' >/dev/null 2>&1; then
+    echo "✗ reconcile failed: \$RESP" >&2
+    exit 1
+  fi
+
+  # In seek-end mode we only advance the cursor, never emit transitions.
+  if [ "\$SEEK_END" != "1" ]; then
+    echo "\$RESP" | jq -r '
+      .events[]
+      | if .kind == "created"
+        then "CREATED \\(.number) -> \\(.toStage // "—")"
+        else "MOVED \\(.number) \\(.fromStage // "—") -> \\(.toStage // "—")"
+        end
+    '
+  fi
+
+  CURSOR=\$(echo "\$RESP" | jq -r '.cursor // empty')
+  [ -n "\$CURSOR" ] && printf '%s' "\$CURSOR" > "\$STATE"
+
+  [ "\$(echo "\$RESP" | jq -r '.hasMore')" = "true" ] || break
+done
+`,
+    executable: true,
+    backend: "cloud",
+    skipIfExists: false,
+  },
+  {
     category: "skill",
     name: "code-audit",
     suffix: null,

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -9685,6 +9685,48 @@ apply and task creation is unchanged.
   },
   {
     category: "backlog-script",
+    name: "_config",
+    suffix: "_config.sh",
+    content: `#!/usr/bin/env bash
+# Helper for the local (Markdown) backlog backend.
+#
+# \`specnaut init --backlog local\` writes no backlog-config.yml at all — the
+# local backend is identified by that file's *absence* — so unlike the other
+# backends there is nothing to read. This helper exists to give the local
+# backend the same \`item_url\` surface as the others, per
+# \`backlog-reference-contract\`.
+#
+# Sourced by the other local-backend scripts.
+set -euo pipefail
+
+ROOT="\$(cd "\$(dirname "\$0")/../../.." && pwd)"
+BACKLOG_DIR="\$ROOT/.specnaut/backlog"
+INDEX="\$ROOT/.specnaut/backlog.md"
+
+export ROOT BACKLOG_DIR INDEX
+
+# A Markdown backlog has no browser URL, but it does have a file — so emit a
+# repo-relative path that a harness can open. Prints nothing when no task file
+# matches. Never fails: a reference must never block a workflow.
+item_url() {
+  [ -n "\${1:-}" ] || return 0
+  local padded
+  padded=\$(printf '%03d' "\$1" 2>/dev/null) || return 0
+  local candidate
+  for candidate in "\$BACKLOG_DIR/\$padded"-*.md; do
+    [ -e "\$candidate" ] || continue
+    echo ".specnaut/backlog/\$(basename "\$candidate")"
+    return 0
+  done
+  return 0
+}
+`,
+    executable: true,
+    backend: "local",
+    skipIfExists: false,
+  },
+  {
+    category: "backlog-script",
     name: "list",
     suffix: "list.sh",
     content: `#!/usr/bin/env bash

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -103,6 +103,8 @@
     { "category": "backlog-script", "name": "add", "suffix": "add.sh", "source": "core/skills/backlog/scripts/cloud/add.sh", "executable": true, "backend": "cloud" },
     { "category": "backlog-script", "name": "move", "suffix": "move.sh", "source": "core/skills/backlog/scripts/cloud/move.sh", "executable": true, "backend": "cloud" },
     { "category": "backlog-script", "name": "clarify-comment", "suffix": "clarify-comment.sh", "source": "core/skills/backlog/scripts/cloud/clarify-comment.sh", "executable": true, "backend": "cloud" },
+    { "category": "backlog-script", "name": "columns", "suffix": "columns.sh", "source": "core/skills/backlog/scripts/cloud/columns.sh", "executable": true, "backend": "cloud" },
+    { "category": "backlog-script", "name": "reconcile", "suffix": "reconcile.sh", "source": "core/skills/backlog/scripts/cloud/reconcile.sh", "executable": true, "backend": "cloud" },
 
     { "category": "skill", "name": "code-audit", "source": "core/skills/code-audit/SKILL.md" },
     { "category": "spec-root", "name": "specify", "suffix": "scripts/code-audit/collect-audit-scope.sh", "source": "core/skills/code-audit/scripts/collect-audit-scope.sh", "executable": true },

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -70,6 +70,7 @@
 
 
     { "category": "backlog-skill", "name": "backlog", "source": "core/skills/backlog/SKILL.md" },
+    { "category": "backlog-script", "name": "_config", "suffix": "_config.sh", "source": "core/skills/backlog/scripts/local/_config.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "list", "suffix": "list.sh", "source": "core/skills/backlog/scripts/local/list.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "view", "suffix": "view.sh", "source": "core/skills/backlog/scripts/local/view.sh", "executable": true, "backend": "local" },
     { "category": "backlog-script", "name": "add", "suffix": "add.sh", "source": "core/skills/backlog/scripts/local/add.sh", "executable": true, "backend": "local" },

--- a/tests/templates/backlog_reference_contract_test.ts
+++ b/tests/templates/backlog_reference_contract_test.ts
@@ -177,6 +177,31 @@ async function itemUrl(tmp: string, backend: string, num: string): Promise<strin
   return out;
 }
 
+Deno.test("every authored backend script is registered in the manifest", async () => {
+  // A script can be authored, referenced, and silently absent from every
+  // install: the bundler only emits what the manifest lists. `local/_config.sh`
+  // shipped that way. The tests above read template source directly, so they
+  // cannot catch it — this one reads the manifest.
+  const manifest = JSON.parse(
+    await Deno.readTextFile(fromFileUrl(new URL("../../templates/manifest.json", import.meta.url))),
+  ) as { core: Array<{ source?: string }> };
+  const registered = new Set(manifest.core.map((e) => e.source).filter(Boolean));
+
+  const root = fromFileUrl(new URL(`${SCRIPTS}/`, import.meta.url));
+  for await (const backend of Deno.readDir(root)) {
+    if (!backend.isDirectory) continue;
+    for await (const file of Deno.readDir(`${root}${backend.name}`)) {
+      if (!file.isFile || !file.name.endsWith(".sh")) continue;
+      const source = `core/skills/backlog/scripts/${backend.name}/${file.name}`;
+      assert(
+        registered.has(source),
+        `${source} is authored but not in templates/manifest.json — it will ` +
+          `never be bundled and never scaffolded`,
+      );
+    }
+  }
+});
+
 Deno.test("github item_url builds the issue URL from `repo`", async () => {
   const tmp = await backendHarness("github", 'repo: "acme/my-app"\nproject_number: 7\n');
   assertEquals(await itemUrl(tmp, "github", "42"), "https://github.com/acme/my-app/issues/42");


### PR DESCRIPTION
Blocks the v1.21.0 release. Found by the release preflight's smoke-coverage audit, not by the test suite.

## Three files were authored, documented, referenced — and never shipped

The bundler only emits what `templates/manifest.json` lists. These were missing from it, so they were never bundled and never scaffolded into any project:

| File | Why it matters |
|---|---|
| `local/_config.sh` | **From #448.** The local backend's `item_url` helper did not exist in any user's project. |
| `cloud/columns.sh` | `skills/backlog/SKILL.md` documents it at `.specnaut/scripts/backlog/columns.sh` and tells the product-owner to resolve stage names against it. Pre-existing. |
| `cloud/reconcile.sh` | The poll/reconcile feed that `product-owner.md:93` instructs the agent to run. Pre-existing. |

A cloud user following the bundled instructions was being pointed at two files that do not exist.

## Why the test suite missed it

Every existing assertion reads the **authored template source** — and the authored file was always there. Nothing read the manifest, which is the thing that decides what ships.

The new test closes that: it walks `templates/core/skills/backlog/scripts/*/` and asserts every `.sh` appears in the manifest. It was written for `local/_config.sh` and found the other two on its first run.

This is the same defect class as #441 (`using-specnaut/references/`), which is still open — a file authored, referenced, and silently absent from every install.

## Smoke coverage

The preflight audit also flagged four surfaces changed by #444/#448 with no smoke assertion. Added to the monorepo's sandbox scripts (separate repo, committed there):

- `smoke-features.sh` — `backlog.md` points at the contract, **and does not restate it**
- `smoke-backlog-github.sh` — `_config.sh` defines `item_url` and builds the issue URL from `$REPO`
- `smoke-backlog-gitlab.sh` — dual-form `project_id` resolution, and the degrade-on-failure guard
- `smoke-backlog-local.sh` — `_config.sh` is *scaffolded* (not merely authored), defines `item_url`, emits a backlog path

## Verification

`deno fmt --check`, `deno lint` clean. **1178 tests pass** (1 new).

Scaffolded a `--backlog local` project end to end: `_config.sh` is present in `.specnaut/scripts/backlog/`, and `item_url 1` resolves `.specnaut/backlog/001-first-item.md`.

Smoke audit: **0 coverage gaps, 0 stale assertions** (was 4 and 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV