### PR TITLE
docs: stop AGENTS.md describing shipped behaviour as planned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ generated files.**
 
 3. **`backlog` command + Product Owner agent** — a task backlog system (index `tasks/backlog.md` +
    `tasks/backlog/NNN-slug.md` files with typed frontmatter) managed by a PO agent shipped in the
-   templates, with a sync script to a remote backend (GitHub Issues + Project V2 in v1; GitLab /
-   Bitbucket planned). Upstream has no notion of a product backlog.
+   templates, with sync to a remote backend selected per project (see **Locked decisions** below for
+   the authoritative source). Upstream has no notion of a product backlog.
 
 ## What Specnaut is not
 
@@ -88,16 +88,19 @@ it cost.
 
 - **Language**: **Deno** (TypeScript, native compile via `deno compile`, zero-deps standard library,
   official `denoland/skills` for dev velocity).
-- **v0.2 scope — multi-harness ready**:
-  - Two target harnesses: **Claude Code** (default, `.claude/` + `.specnaut/`) and **Cursor**
-    (`.cursor/skills/` + `.cursor/rules/` + `.specnaut/`) — single harness per invocation, selected
-    via `--ai claude|cursor`
+- **Multi-harness by design**:
+  - **Claude Code** is the default target (`.claude/` + `.specnaut/`); one harness per invocation,
+    selected via `--ai`. The registered set is authoritative in `src/cli/harnesses.ts` — read it
+    there rather than trusting a list in prose. `specnaut init --help` prints the current values.
   - CLI surface and behaviour equivalent to upstream `specify init`
   - The **3 differentiating features embedded by default**: auto-chain, `review` phase, backlog +
     Product Owner agent
-- **Backlog storage**: local Markdown files (index + one file per task) + one-way sync script to
-  GitHub Issues/Project V2 via `gh`. GitLab/Bitbucket in v2+.
-- **Additional harnesses** (Codex, Copilot, Windsurf, OpenCode, Antigravity, …): v0.3+.
+- **Backlog storage**: selectable per project via `--backlog`, defaulting to local Markdown files
+  (index + one file per task). Registered backends live in `src/domain/backlog_strategies/`;
+  `specnaut init --help` prints the current values. Bitbucket is not implemented.
+- **Adding a harness is additive**: a new adapter under `src/infrastructure/harness/`, registered in
+  `src/cli/harnesses.ts`. Nothing in the CLI surface or the template bundle is harness-specific by
+  default — divergence is opt-in, per adapter.
 
 ## Methodology Specnaut implements
 


### PR DESCRIPTION
Closes #439.

## Why this is worth a PR

`AGENTS.md` is the first thing every agent session reads. A stale "not built yet" line does not sit there harmlessly — it makes an agent propose building what already exists, or drop a harness from a compatibility matrix because it believes it is unimplemented.

Not hypothetical: the `v0.3+` line misled a subagent brief in this repo's own workspace earlier today.

## Three claims, all false against the code

| Claim in AGENTS.md | Reality |
|---|---|
| "Two target harnesses … `--ai claude\|cursor`" | `src/cli/harnesses.ts` registers **seven**: claude, cursor, codex, windsurf, copilot, opencode, antigravity |
| "GitLab/Bitbucket in v2+" | `src/domain/backlog_strategies/` has github, gitlab, local, cloud. Only **Bitbucket** is genuinely absent |
| "Additional harnesses …: v0.3+" | all shipped |

## The fix

Durable phrasing per constitution § VIII — point at the registries and at `specnaut init --help` rather than restate a list that drifts the moment an adapter lands:

- the harness set is authoritative in `src/cli/harnesses.ts`
- the backend set is authoritative in `src/domain/backlog_strategies/`
- adding a harness is described as what it actually is — an additive adapter, with divergence opt-in per adapter

The one bullet that was still true (Deno as the language) is untouched, and the section is not restructured — the ticket put that out of scope.

## One line beyond the ticket's scope

The ticket scoped the scan to **Locked decisions**. I also fixed a line in "The 3 differences from upstream" that still called GitLab "planned". Strictly wider than asked, but leaving it would have had the same file contradict itself three paragraphs apart.

## Verification

`grep -nE 'v0\.[0-9]|v1\.[0-9]|v2\+|in v[0-9]' AGENTS.md` now returns nothing — no pinned-version claims remain in the file.

`deno fmt --check`, `deno lint` clean. 1178 tests pass (documentation-only change; nothing else is touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV