### PR TITLE
test(templates): fail the build on any unregistered template file

### DIFF
--- a/tests/templates/backlog_reference_contract_test.ts
+++ b/tests/templates/backlog_reference_contract_test.ts
@@ -177,31 +177,6 @@ async function itemUrl(tmp: string, backend: string, num: string): Promise<strin
   return out;
 }
 
-Deno.test("every authored backend script is registered in the manifest", async () => {
-  // A script can be authored, referenced, and silently absent from every
-  // install: the bundler only emits what the manifest lists. `local/_config.sh`
-  // shipped that way. The tests above read template source directly, so they
-  // cannot catch it — this one reads the manifest.
-  const manifest = JSON.parse(
-    await Deno.readTextFile(fromFileUrl(new URL("../../templates/manifest.json", import.meta.url))),
-  ) as { core: Array<{ source?: string }> };
-  const registered = new Set(manifest.core.map((e) => e.source).filter(Boolean));
-
-  const root = fromFileUrl(new URL(`${SCRIPTS}/`, import.meta.url));
-  for await (const backend of Deno.readDir(root)) {
-    if (!backend.isDirectory) continue;
-    for await (const file of Deno.readDir(`${root}${backend.name}`)) {
-      if (!file.isFile || !file.name.endsWith(".sh")) continue;
-      const source = `core/skills/backlog/scripts/${backend.name}/${file.name}`;
-      assert(
-        registered.has(source),
-        `${source} is authored but not in templates/manifest.json — it will ` +
-          `never be bundled and never scaffolded`,
-      );
-    }
-  }
-});
-
 Deno.test("github item_url builds the issue URL from `repo`", async () => {
   const tmp = await backendHarness("github", 'repo: "acme/my-app"\nproject_number: 7\n');
   assertEquals(await itemUrl(tmp, "github", "42"), "https://github.com/acme/my-app/issues/42");

--- a/tests/templates/manifest_registration_test.ts
+++ b/tests/templates/manifest_registration_test.ts
@@ -52,7 +52,10 @@ const NOT_SHIPPED: ReadonlyArray<{ path: string; why: string }> = [
 async function authoredFiles(): Promise<string[]> {
   const out: string[] = [];
   for await (const entry of walk(TEMPLATES, { includeDirs: false })) {
-    const rel = entry.path.slice(TEMPLATES.length);
+    // `walk` yields native separators; the manifest's `source` values are
+    // always POSIX. Without this the comparison never matches on Windows and
+    // every file reads as unregistered.
+    const rel = entry.path.slice(TEMPLATES.length).replaceAll("\\", "/");
     if (rel === "manifest.json") continue;
     out.push(rel);
   }

--- a/tests/templates/manifest_registration_test.ts
+++ b/tests/templates/manifest_registration_test.ts
@@ -1,0 +1,113 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { walk } from "@std/fs";
+
+/**
+ * Every file authored under `templates/` must be registered in
+ * `templates/manifest.json`, because the bundler emits only what the manifest
+ * lists. An unregistered file is authored, reviewable, greppable — and absent
+ * from every user's project.
+ *
+ * This is not hypothetical. Four instances shipped that way:
+ *
+ *   - `using-specnaut/SKILL.md` points at five `references/*-tools.md` files;
+ *     none is registered, so the skill instructs users to read files that do
+ *     not exist (tracked by #441).
+ *   - `backlog/scripts/local/_config.sh` (#450) — the local backend's
+ *     `item_url` helper existed in no project.
+ *   - `backlog/scripts/cloud/columns.sh` and `reconcile.sh` (#450) — both
+ *     documented in SKILL.md and invoked by the product-owner agent, neither
+ *     ever scaffolded.
+ *
+ * The existing suite could not catch any of them: every other assertion reads
+ * the authored template source, and the authored file was always there.
+ * Nothing read the manifest, which is what decides what ships.
+ */
+
+const TEMPLATES = fromFileUrl(new URL("../../templates/", import.meta.url));
+
+/**
+ * Files that are deliberately authored but never scaffolded. Each entry needs
+ * a reason: this list is the escape hatch, so it must not grow silently.
+ */
+const NOT_SHIPPED: ReadonlyArray<{ path: string; why: string }> = [
+  {
+    path: ".gitkeep",
+    why: "git artifact keeping the directory tracked; not content",
+  },
+  {
+    path: "core/skills/alias-example/SKILL.md",
+    why: "documentation of the alias_of/overlays convention, for humans reading " +
+      "this repo. Its own description says Specnaut never installs it.",
+  },
+  // The five below are a real defect, not a design choice — a skill can ship
+  // only its own SKILL.md today, so there is no mechanism to carry them.
+  // Pinned here so the gap stays visible and cannot grow while #441 is open.
+  ...["claude", "codex", "copilot", "cursor", "opencode"].map((h) => ({
+    path: `core/skills/using-specnaut/references/${h}-tools.md`,
+    why: `referenced by using-specnaut/SKILL.md but unshippable until #441 lands`,
+  })),
+];
+
+async function authoredFiles(): Promise<string[]> {
+  const out: string[] = [];
+  for await (const entry of walk(TEMPLATES, { includeDirs: false })) {
+    const rel = entry.path.slice(TEMPLATES.length);
+    if (rel === "manifest.json") continue;
+    out.push(rel);
+  }
+  return out.sort();
+}
+
+async function registeredSources(): Promise<Set<string>> {
+  const manifest = JSON.parse(
+    await Deno.readTextFile(`${TEMPLATES}manifest.json`),
+  ) as { core: Array<{ source?: string }>; harness_static: Array<{ source?: string }> };
+  return new Set(
+    [...manifest.core, ...manifest.harness_static]
+      .map((e) => e.source)
+      .filter((s): s is string => Boolean(s)),
+  );
+}
+
+Deno.test("every authored template file is registered in the manifest", async () => {
+  const registered = await registeredSources();
+  const allowed = new Set(NOT_SHIPPED.map((e) => e.path));
+
+  const unregistered = (await authoredFiles())
+    .filter((f) => !registered.has(f) && !allowed.has(f));
+
+  assertEquals(
+    unregistered,
+    [],
+    "authored under templates/ but absent from manifest.json — these will " +
+      "never be bundled and never scaffolded. Register them, or add them to " +
+      "NOT_SHIPPED with a reason:\n  " + unregistered.join("\n  "),
+  );
+});
+
+Deno.test("the not-shipped allowlist has no dead entries", async () => {
+  // An entry that no longer matches a file is stale: it would silently permit
+  // a future file at that path to go unregistered.
+  const authored = new Set(await authoredFiles());
+  for (const { path } of NOT_SHIPPED) {
+    assert(
+      authored.has(path),
+      `NOT_SHIPPED lists ${path}, which no longer exists under templates/ — ` +
+        `remove the entry`,
+    );
+  }
+});
+
+Deno.test("the not-shipped allowlist does not contradict the manifest", async () => {
+  // A file cannot be both registered and declared never-shipped; that reads as
+  // a deliberate exclusion while actually shipping.
+  const registered = await registeredSources();
+  for (const { path } of NOT_SHIPPED) {
+    assert(
+      !registered.has(path),
+      `${path} is registered in the manifest AND listed as never shipped — ` +
+        `drop the NOT_SHIPPED entry`,
+    );
+  }
+});


### PR DESCRIPTION
Closes the defect class that produced #450 and still holds #441 open.

## The class

The bundler emits only what `templates/manifest.json` lists. An unregistered file is authored, reviewable, greppable — and **absent from every user's project**. Four have shipped that way:

| File | Consequence |
|---|---|
| `using-specnaut/references/*-tools.md` (×5) | the skill instructs users to read files that do not exist — still open as #441 |
| `backlog/scripts/local/_config.sh` | the local backend's `item_url` existed in no project |
| `backlog/scripts/cloud/columns.sh` | documented in `SKILL.md`, never scaffolded |
| `backlog/scripts/cloud/reconcile.sh` | `product-owner.md:93` tells the agent to run it; it was never there |

**Why the suite could not catch them:** every existing assertion reads the authored *template source*, and the authored file was always there. Nothing read the manifest — which is the thing that decides what ships.

## The guard

Walks `templates/` and asserts every file is registered. A full scan today finds exactly **7** unregistered files, of which 5 are #441 and 2 are legitimate:

| Exclusion | Reason |
|---|---|
| `.gitkeep` | git artifact, not content |
| `alias-example/SKILL.md` | its own `description` says *"Specnaut itself never installs this file — it lives in the Specnaut repo as documentation"* |
| the five `*-tools.md` | a real defect, not a design choice — no mechanism exists to carry skill-local files. Pinned so the gap stays **visible** and cannot grow while #441 is open |

Two further tests keep the allowlist from rotting: an entry pointing at a file that no longer exists is **stale** (it would silently permit a future file at that path), and an entry that is *also* registered is a **contradiction** — it reads as a deliberate exclusion while actually shipping.

## Supersedes

The backlog-scripts-only assertion added in #450 is removed. Keeping both would be exactly the duplication this class of guard exists to prevent.

## Verification

`deno fmt --check`, `deno lint` clean. **1180 tests pass.**

Mutation-checked: unregistering `cloud/columns.sh` turns the guard red; restoring it turns it green.

Note this makes #441 **enforced rather than merely tracked** — the five files are now pinned in a list a reviewer must consciously edit, instead of being invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV