### PR TITLE
fix(templates): ship the harness tool reference that the skill points at

### DIFF
--- a/plugin/skills/using-specnaut/SKILL.md
+++ b/plugin/skills/using-specnaut/SKILL.md
@@ -26,8 +26,8 @@ always take precedence over a skill's defaults. If the user says
 ## How to invoke a Specnaut skill
 
 Use the harness's `Skill` tool (Claude Code) or the equivalent
-(`skill` on Codex/OpenCode/Copilot — see
-`references/<harness>-tools.md` for your harness).
+(`skill` on Codex/OpenCode/Copilot — see "Tool-name differences across
+harnesses" below for where your harness's mapping lives).
 
 The skill content is loaded into your context. Follow it directly — do
 not re-read the file with `Read`.
@@ -59,7 +59,7 @@ below) and never appear as user commands.
 ## Specnaut agent registry
 
 Dispatch these via `Task({ subagent_type: "<name>", ... })` (or your
-harness's equivalent — see `references/<harness>-tools.md`).
+harness's equivalent — see the tool reference described below).
 
 | Agent | When to dispatch |
 |---|---|
@@ -110,17 +110,22 @@ Claude Code, Codex CLI, Codex App, Cursor, OpenCode, GitHub Copilot
 CLI. Each harness uses different tool names — `Read` vs `read_file`,
 `Task` vs `spawn_agent`, etc.
 
-Before invoking any tool, consult the right reference:
+Before invoking any tool, consult the right reference. Where it lives
+depends on how this skill reached you:
 
-- Claude Code (baseline) → `references/claude-tools.md`
-- Codex → `references/codex-tools.md`
-- Cursor → `references/cursor-tools.md`
-- OpenCode → `references/opencode-tools.md`
-- Copilot CLI → `references/copilot-tools.md`
+- **Scaffolded into a project** (`specnaut init --ai <harness>`) — the
+  harness was fixed at scaffold time, so exactly one reference ships and
+  it is already yours: read `.specnaut/harness-tools.md` and stop.
+- **Loaded from the plugin distribution** — the harness is not known in
+  advance, so every reference ships side by side. Pick yours from
+  `references/{claude,codex,cursor,opencode,copilot}-tools.md`, detecting
+  the harness from env hints (`CLAUDE_PLUGIN_ROOT`, `CURSOR_*`,
+  `CODEX_*`, …) or from the tool list in your current context.
 
-Auto-detect the running harness by looking for env hints
-(`CLAUDE_PLUGIN_ROOT`, `CURSOR_*`, `CODEX_*`, etc.) or by inspecting
-the available tool list in your current context.
+If neither path yields a file, no mapping is recorded for your harness:
+fall back to the baseline names above and check them against the tools
+you can actually see. Never guess a tool name that is not in your
+context.
 
 ## Red flags — these thoughts mean "stop and check for a skill"
 

--- a/src/infrastructure/harness/antigravity_harness.ts
+++ b/src/infrastructure/harness/antigravity_harness.ts
@@ -1,4 +1,5 @@
 import type { BundleOptions, Harness } from "../../application/ports.ts";
+import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
@@ -103,6 +104,12 @@ export class AntigravityHarness implements Harness {
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
         ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
+    }
+    // Layer the harness's own static files last, so a harness-specific file
+    // wins over anything the core bundle mapped to the same destination.
+    const staticFiles = HARNESS_STATIC[this.key] ?? {};
+    for (const [dest, file] of Object.entries(staticFiles)) {
+      out[dest] = file;
     }
     return out;
   }

--- a/src/infrastructure/harness/copilot_harness.ts
+++ b/src/infrastructure/harness/copilot_harness.ts
@@ -1,4 +1,5 @@
 import type { BundleOptions, Harness } from "../../application/ports.ts";
+import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { skillFolderName } from "./skill_folder.ts";
@@ -71,6 +72,12 @@ export class CopilotHarness implements Harness {
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
         ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
+    }
+    // Layer the harness's own static files last, so a harness-specific file
+    // wins over anything the core bundle mapped to the same destination.
+    const staticFiles = HARNESS_STATIC[this.key] ?? {};
+    for (const [dest, file] of Object.entries(staticFiles)) {
+      out[dest] = file;
     }
     return out;
   }

--- a/src/infrastructure/harness/opencode_harness.ts
+++ b/src/infrastructure/harness/opencode_harness.ts
@@ -1,4 +1,5 @@
 import type { BundleOptions, Harness } from "../../application/ports.ts";
+import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { ensureSkillFrontmatter, skillFolderName } from "./skill_folder.ts";
@@ -166,6 +167,12 @@ export class OpenCodeHarness implements Harness {
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
         ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
+    }
+    // Layer the harness's own static files last, so a harness-specific file
+    // wins over anything the core bundle mapped to the same destination.
+    const staticFiles = HARNESS_STATIC[this.key] ?? {};
+    for (const [dest, file] of Object.entries(staticFiles)) {
+      out[dest] = file;
     }
     return out;
   }

--- a/src/infrastructure/harness/windsurf_harness.ts
+++ b/src/infrastructure/harness/windsurf_harness.ts
@@ -1,4 +1,5 @@
 import type { BundleOptions, Harness } from "../../application/ports.ts";
+import { HARNESS_STATIC } from "../../templates_bundle.ts";
 import type { CoreBundle, CoreEntry } from "../../domain/core_bundle.ts";
 import type { Bundle } from "../../domain/template.ts";
 import { skillFolderName } from "./skill_folder.ts";
@@ -81,6 +82,12 @@ export class WindsurfHarness implements Harness {
         ...(entry.category === "mergeable-project-root" ? { mergeBlock: "gitignore" } : {}),
         ...(entry.skipIfExists ? { skipIfExists: true as const } : {}),
       };
+    }
+    // Layer the harness's own static files last, so a harness-specific file
+    // wins over anything the core bundle mapped to the same destination.
+    const staticFiles = HARNESS_STATIC[this.key] ?? {};
+    for (const [dest, file] of Object.entries(staticFiles)) {
+      out[dest] = file;
     }
     return out;
   }

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -5196,8 +5196,8 @@ always take precedence over a skill's defaults. If the user says
 ## How to invoke a Specnaut skill
 
 Use the harness's \`Skill\` tool (Claude Code) or the equivalent
-(\`skill\` on Codex/OpenCode/Copilot — see
-\`references/<harness>-tools.md\` for your harness).
+(\`skill\` on Codex/OpenCode/Copilot — see "Tool-name differences across
+harnesses" below for where your harness's mapping lives).
 
 The skill content is loaded into your context. Follow it directly — do
 not re-read the file with \`Read\`.
@@ -5229,7 +5229,7 @@ below) and never appear as user commands.
 ## Specnaut agent registry
 
 Dispatch these via \`Task({ subagent_type: "<name>", ... })\` (or your
-harness's equivalent — see \`references/<harness>-tools.md\`).
+harness's equivalent — see the tool reference described below).
 
 | Agent | When to dispatch |
 |---|---|
@@ -5280,17 +5280,22 @@ Claude Code, Codex CLI, Codex App, Cursor, OpenCode, GitHub Copilot
 CLI. Each harness uses different tool names — \`Read\` vs \`read_file\`,
 \`Task\` vs \`spawn_agent\`, etc.
 
-Before invoking any tool, consult the right reference:
+Before invoking any tool, consult the right reference. Where it lives
+depends on how this skill reached you:
 
-- Claude Code (baseline) → \`references/claude-tools.md\`
-- Codex → \`references/codex-tools.md\`
-- Cursor → \`references/cursor-tools.md\`
-- OpenCode → \`references/opencode-tools.md\`
-- Copilot CLI → \`references/copilot-tools.md\`
+- **Scaffolded into a project** (\`specnaut init --ai <harness>\`) — the
+  harness was fixed at scaffold time, so exactly one reference ships and
+  it is already yours: read \`.specnaut/harness-tools.md\` and stop.
+- **Loaded from the plugin distribution** — the harness is not known in
+  advance, so every reference ships side by side. Pick yours from
+  \`references/{claude,codex,cursor,opencode,copilot}-tools.md\`, detecting
+  the harness from env hints (\`CLAUDE_PLUGIN_ROOT\`, \`CURSOR_*\`,
+  \`CODEX_*\`, …) or from the tool list in your current context.
 
-Auto-detect the running harness by looking for env hints
-(\`CLAUDE_PLUGIN_ROOT\`, \`CURSOR_*\`, \`CODEX_*\`, etc.) or by inspecting
-the available tool list in your current context.
+If neither path yields a file, no mapping is recorded for your harness:
+fall back to the baseline names above and check them against the tools
+you can actually see. Never guess a tool name that is not in your
+context.
 
 ## Red flags — these thoughts mean "stop and check for a skill"
 
@@ -20273,6 +20278,60 @@ exit 0
 `,
       executable: true,
     },
+    ".specnaut/harness-tools.md": {
+      content: `# Claude Code — baseline tool reference
+
+Specnaut skills are authored using **Claude Code tool names** as the lingua
+franca. This file documents the canonical Claude Code tool set that other
+harness adapters (\`codex-tools.md\`, \`cursor-tools.md\`,
+\`opencode-tools.md\`, \`copilot-tools.md\`) translate.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/using-superpowers/references/\`. Re-implemented for
+> Specnaut's harness coverage.
+
+## Canonical tool set
+
+| Tool | Purpose |
+|---|---|
+| \`Read\` | Read a file from disk; supports image / PDF / notebook formats. |
+| \`Write\` | Write or overwrite a file from scratch. |
+| \`Edit\` | Exact-string replace in a file (must Read first). |
+| \`Bash\` | Run a shell command in the project working directory. |
+| \`Skill\` | Invoke another skill by name (\`Skill({skill: "<name>", args: "…"})\`). |
+| \`Task\` | Dispatch a subagent for a delegated task (\`Task({subagent_type: "general-purpose", description: "…", prompt: "…"})\`). |
+| \`TodoWrite\` | Persist a checklist for multi-step work. |
+| \`WebSearch\` | Search the web for current information. |
+| \`WebFetch\` | Fetch a URL and process it with a prompt. |
+| \`Grep\` / \`Glob\` | Search file contents or file paths. |
+
+## Conventions used by Specnaut skills
+
+- **File paths** are always absolute, except inside markdown documentation
+  where project-relative paths read better.
+- **Subagents** spawned via \`Task\` receive precisely the context they need —
+  never the controller's full history. See the
+  [\`subagent-driven-development\`](../../subagent-driven-development/SKILL.md)
+  skill for the dispatch pattern.
+- **Skills** invoked via \`Skill\` are listed in the harness-provided
+  "available skills" registry; only use names that appear there.
+- **Slash commands** the user types (\`/specnaut plan\`, \`/backlog …\`) are
+  resolved by the harness to a skill invocation — Specnaut itself never
+  registers raw commands outside the skill layer.
+
+## When this file is the wrong reference
+
+You are on Claude Code only. If you are running in:
+- Codex CLI / App → see \`codex-tools.md\`
+- Cursor → see \`cursor-tools.md\`
+- OpenCode → see \`opencode-tools.md\`
+- GitHub Copilot CLI → see \`copilot-tools.md\`
+
+The \`using-specnaut\` bootstrap skill auto-detects the running harness and
+loads the right reference at session start.
+`,
+      executable: false,
+    },
   },
   "codex": {
     ".codex/AGENTS.md": {
@@ -20349,6 +20408,156 @@ Each \`/goal\` run loads the full prompt, so keep it focused.
 `,
       executable: false,
     },
+    ".specnaut/harness-tools.md": {
+      content: `# Codex CLI / Codex App — tool reference
+
+Specnaut skills are authored using **Claude Code tool names**. This file
+maps every Claude Code tool to its Codex equivalent so a skill that says
+\`Use Task to dispatch a subagent\` reads correctly when Specnaut runs
+inside Codex.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/using-superpowers/references/codex-tools.md\`.
+> Re-implemented for Specnaut.
+
+## Tool mapping
+
+| Claude Code | Codex | Notes |
+|---|---|---|
+| \`Read\` | \`read_file\` | Same argument shape (\`path\`). |
+| \`Write\` | \`write_file\` | Same shape; pass \`content\`. |
+| \`Edit\` | \`apply_patch\` | Codex uses a unified-diff style patch tool; the Edit semantic (old_string → new_string) maps to a one-hunk patch. |
+| \`Bash\` | \`shell\` | Same shape; Codex's \`shell\` runs in the workspace cwd. |
+| \`Skill\` | \`skill\` | Codex exposes a native \`skill\` tool — pass the skill name and args. |
+| \`Task\` | \`spawn_agent\` / \`wait_agent\` / \`close_agent\` | Three-step protocol: spawn, wait for completion, close. Wrap in a helper if you dispatch frequently. |
+| \`TodoWrite\` | \`update_plan\` | Codex's planner exposes a structured update API; pass the full updated plan, not deltas. |
+| \`WebSearch\` | \`web.search\` | Available only if the user has enabled web tools. |
+| \`WebFetch\` | \`web.fetch\` | Same. |
+| \`Grep\` | \`shell\` invoking \`grep\` / \`rg\` | No native grep tool — shell out. |
+| \`Glob\` | \`shell\` invoking \`find\` / \`fd\` | No native glob tool — shell out. |
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads \`Use Task to dispatch a code reviewer subagent\` should,
+on Codex, expand to:
+
+\`\`\`
+id = spawn_agent(agent_type="code-reviewer", prompt="<full prompt>")
+result = wait_agent(id, timeout=900)
+close_agent(id)
+\`\`\`
+
+If the wait times out, decide whether to retry or to surface the partial
+result to the user.
+
+## Idiom differences worth noting
+
+- **Plan updates** are heavyweight on Codex — \`update_plan\` rewrites the
+  full plan each call. Don't call it per-step; call it at task boundaries.
+- **\`apply_patch\`** rejects malformed patches more strictly than Claude
+  Code's \`Edit\`. Always confirm a Read of the target file before patching.
+- **Subagent timeout** defaults vary; pass \`timeout=\` explicitly for any
+  dispatch you expect to take > 5 minutes.
+
+## Manifest pointer
+
+For the Codex marketplace adapter (\`.codex-plugin/plugin.json\`), the
+canonical install entry is:
+
+\`\`\`
+/plugins  → search "specnaut" → install
+\`\`\`
+
+(Once Specnaut ships to the Codex marketplace; see issue #277.)
+`,
+      executable: false,
+    },
+  },
+  "copilot": {
+    ".specnaut/harness-tools.md": {
+      content: `# GitHub Copilot CLI — tool reference
+
+Specnaut skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its GitHub Copilot CLI equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/using-superpowers/references/copilot-tools.md\`.
+> Re-implemented for Specnaut.
+
+## Tool mapping
+
+| Claude Code | Copilot CLI | Notes |
+|---|---|---|
+| \`Read\` | \`read\` | Same shape. |
+| \`Write\` | \`write\` | Same. |
+| \`Edit\` | \`edit\` | Same. |
+| \`Bash\` | \`bash\` | Same. |
+| \`Skill\` | \`skill\` | Native — invokes a registered plugin skill. |
+| \`Task\` | \`task\` with \`agent_type\` parameter | Copilot's task tool takes \`agent_type\` to select a subagent (similar to Claude Code's \`subagent_type\`). |
+| \`TodoWrite\` | \`sql\` with built-in \`todos\` table | Copilot exposes a SQLite-backed durable state via the \`sql\` tool; the \`todos\` table is its checklist primitive. |
+| \`WebSearch\` | \`web_search\` | Same. |
+| \`WebFetch\` | \`web_fetch\` | Same. |
+| \`Grep\` | \`grep\` | Same. |
+| \`Glob\` | \`glob\` | Same. |
+
+## Plugin marketplace
+
+Copilot CLI distributes plugins through a **marketplace repository** — a
+separate GitHub repo registered with \`copilot plugin marketplace add\`.
+The Specnaut marketplace (see issue #281) lives at
+\`specnaut/specnaut-cli-marketplace\` (planned) and registers Specnaut as
+\`specnaut@specnaut-marketplace\`.
+
+Install flow for end users:
+
+\`\`\`bash
+copilot plugin marketplace add specnaut/specnaut-cli-marketplace
+copilot plugin install specnaut@specnaut-marketplace
+\`\`\`
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads \`Use Task to dispatch a code reviewer subagent\` should,
+on Copilot CLI, expand to:
+
+\`\`\`
+task({
+  agent_type: "code-reviewer",
+  description: "Review changes against the plan",
+  prompt: "<full prompt>"
+})
+\`\`\`
+
+The agent runs in an isolated context and returns when complete. The
+calling skill gets the subagent's final report as the tool's return
+value.
+
+## Idiom differences worth noting
+
+- **\`sql\` for state.** Copilot's \`TodoWrite\` equivalent is a structured
+  database insert/update. Skill prose that says "track this in a TODO
+  list" needs the adapter to translate to a \`sql\` insert into the
+  \`todos\` table. The \`using-specnaut\` bootstrap skill explains the
+  schema.
+- **No \`WebFetch\` slug.** Copilot uses \`web_fetch\` (snake_case) where
+  Claude Code uses \`WebFetch\` (PascalCase). The mapping is the only
+  difference — the semantics are identical.
+- **SessionStart hook.** Copilot's hook system uses
+  \`{"additionalContext": "..."}\` as the injection format (SDK standard).
+  The Specnaut Copilot SessionStart hook (see #282) reads the
+  \`using-specnaut\` bootstrap skill and emits this shape at session
+  boot.
+
+## Auto-activation
+
+Copilot honors the same \`description:\` frontmatter contract as Claude
+Code and Cursor — when the user's prompt matches phrases in a skill's
+\`description:\` field, Copilot invokes the skill. The SessionStart hook
+(once #282 lands) ensures \`using-specnaut\` is loaded so the agent knows
+which Specnaut skill to pick for which user phrasing.
+`,
+      executable: false,
+    },
   },
   "cursor": {
     ".cursor/rules/specify-rules.mdc": {
@@ -20406,6 +20615,159 @@ clarifications needed) STOP #2 (pre-merge validation)
 - Project conventions: \`AGENTS.md\` at project root.
 
 Read the constitution and AGENTS.md before starting any significant work.
+`,
+      executable: false,
+    },
+    ".specnaut/harness-tools.md": {
+      content: `# Cursor — tool reference
+
+Specnaut skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its Cursor Agent equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`skills/using-superpowers/references/\`. Re-implemented for
+> Specnaut.
+
+## Tool mapping
+
+| Claude Code | Cursor Agent | Notes |
+|---|---|---|
+| \`Read\` | \`read_file\` | Cursor's read tool returns the file with line numbers. |
+| \`Write\` | \`edit_file\` (full overwrite) | Cursor uses one \`edit_file\` tool for both create and edit; pass the full new content. |
+| \`Edit\` | \`edit_file\` (partial) | Same tool, pass a precise edit specification. |
+| \`Bash\` | \`run_terminal_cmd\` | Same shape; pass \`command\` + \`is_background\`. |
+| \`Skill\` | \`Skill\` | Cursor's Agent plugin format exposes a native \`Skill\` tool with the same shape as Claude Code. |
+| \`Task\` | \`Task\` via Agent plugin | Cursor supports subagent dispatch when the plugin declares \`agents\` in its manifest. |
+| \`TodoWrite\` | \`todo_write\` | Cursor's todo tool, semantically equivalent. |
+| \`WebSearch\` | \`web_search\` | Same. |
+| \`WebFetch\` | \`web_search\` + manual read | Cursor doesn't expose a separate URL-fetch tool; use \`web_search\` then \`read_file\` on the result if it's local. |
+| \`Grep\` / \`Glob\` | \`grep_search\` / \`file_search\` | Cursor exposes both natively with similar arguments. |
+
+## Idiom differences worth noting
+
+- **\`edit_file\` is unified.** Cursor doesn't distinguish \`Write\` (create
+  new) from \`Edit\` (modify existing); the same tool does both based on
+  whether the path exists. Skill authors should still write "create" or
+  "modify" in prose for clarity to other harnesses.
+- **Hooks live in \`hooks-cursor.json\`**, not \`hooks.json\`. Cursor uses
+  \`snake_case\` field names (\`session_start\`, \`pre_tool_use\`) where
+  Claude Code uses \`camelCase\` (\`SessionStart\`, \`PreToolUse\`). The
+  Specnaut Cursor adapter handles the translation; skill content stays
+  uniform.
+- **Plugin manifest** uses \`.cursor-plugin/plugin.json\` with keys
+  \`{skills, agents, commands, hooks}\` (see issue #278 for the adapter).
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads \`Use Task to dispatch a code reviewer subagent\` works
+on Cursor identically to Claude Code, **provided the plugin's
+\`.cursor-plugin/plugin.json\` declares \`agents: "./agents/"\`**. Without
+that declaration, Cursor's Agent doesn't see the subagent definitions
+and the dispatch falls back to inline execution.
+
+## Auto-activation
+
+Cursor honors the same \`description:\` frontmatter contract as Claude
+Code — when the user's prompt matches phrases in a skill's \`description:\`
+field, Cursor invokes the skill automatically. The \`SessionStart\` hook
+(via \`hooks-cursor.json\`) injects the \`using-specnaut\` bootstrap skill
+to make Specnaut skill-aware on every turn.
+`,
+      executable: false,
+    },
+  },
+  "opencode": {
+    ".specnaut/harness-tools.md": {
+      content: `# OpenCode — tool reference
+
+Specnaut skills are authored using **Claude Code tool names**. This file
+maps each Claude Code tool to its OpenCode equivalent.
+
+> Inspired by [obra/superpowers v5.1.0](https://github.com/obra/superpowers)
+> (MIT) — \`.opencode/plugins/superpowers.js\` adapter and inline tool
+> mappings. Re-implemented for Specnaut.
+
+## Tool mapping
+
+| Claude Code | OpenCode | Notes |
+|---|---|---|
+| \`Read\` | \`read\` | OpenCode's read tool. |
+| \`Write\` | \`write\` | Same. |
+| \`Edit\` | \`edit\` | Same. |
+| \`Bash\` | \`bash\` | Same shape. |
+| \`Skill\` | \`skill\` | OpenCode exposes a native skill-invocation tool, lowercase. |
+| \`Task\` | \`@\`-mention subagent | OpenCode uses \`@<agent-name>\` syntax to dispatch subagents declared by the plugin. |
+| \`TodoWrite\` | \`todowrite\` | Lowercase variant. |
+| \`WebSearch\` | \`websearch\` | Lowercase. |
+| \`WebFetch\` | \`webfetch\` | Lowercase. |
+| \`Grep\` | \`grep\` | Same. |
+| \`Glob\` | \`glob\` | Same. |
+
+## Plugin shape — JavaScript adapter
+
+OpenCode plugins ship as JavaScript files (not JSON manifests). The
+Specnaut adapter (see issue #280) lives at
+\`.opencode/plugins/specnaut.js\` and registers itself via OpenCode's
+plugin loader:
+
+\`\`\`javascript
+// Pseudo-shape based on superpowers' adapter pattern.
+module.exports = function specnaut(config) {
+  const skillsDir = path.join(__dirname, "../../skills");
+  config.skills = config.skills || {};
+  config.skills.paths = config.skills.paths || [];
+  if (!config.skills.paths.includes(skillsDir)) {
+    config.skills.paths.push(skillsDir);
+  }
+  // Hook the SessionStart event to inject the using-specnaut bootstrap.
+  config.experimental = config.experimental || {};
+  config.experimental.chat = config.experimental.chat || {};
+  config.experimental.chat.messages = config.experimental.chat.messages || {};
+  // ...
+};
+\`\`\`
+
+Concrete implementation lands in #280.
+
+## Install instructions
+
+Add to the user's \`opencode.json\`:
+
+\`\`\`json
+{
+  "plugin": [
+    "specnaut@git+https://github.com/specnaut/specnaut-cli.git"
+  ]
+}
+\`\`\`
+
+OpenCode fetches the repo, runs the adapter at session start, and the
+Specnaut skills register themselves.
+
+## Subagent dispatch — concrete pattern
+
+A skill that reads \`Use Task to dispatch a code reviewer subagent\` should,
+on OpenCode, expand to:
+
+\`\`\`
+@code-reviewer Please review the following code change against the plan:
+[paste full prompt content]
+\`\`\`
+
+The \`@\`-mention triggers the subagent declared in the plugin's \`agents/\`
+directory. Wait for the response in the same chat thread.
+
+## Idiom differences worth noting
+
+- **No JSON manifest.** OpenCode's plugin system is code-driven, not
+  declarative. The adapter has to perform skill registration imperatively
+  in its function body.
+- **Skills resolved by path.** OpenCode reads \`config.skills.paths\` and
+  walks each directory for \`SKILL.md\` files. Specnaut's skills live under
+  the plugin repo's \`skills/\` directory and are auto-discovered.
+- **Lowercase tool names** throughout. Skill prose that says "use the
+  Bash tool" still works because OpenCode's LLM understands the mapping,
+  but the actual tool name in JSON tool-use blocks is \`bash\`.
 `,
       executable: false,
     },

--- a/templates/core/skills/using-specnaut/SKILL.md
+++ b/templates/core/skills/using-specnaut/SKILL.md
@@ -26,8 +26,8 @@ always take precedence over a skill's defaults. If the user says
 ## How to invoke a Specnaut skill
 
 Use the harness's `Skill` tool (Claude Code) or the equivalent
-(`skill` on Codex/OpenCode/Copilot — see
-`references/<harness>-tools.md` for your harness).
+(`skill` on Codex/OpenCode/Copilot — see "Tool-name differences across
+harnesses" below for where your harness's mapping lives).
 
 The skill content is loaded into your context. Follow it directly — do
 not re-read the file with `Read`.
@@ -59,7 +59,7 @@ below) and never appear as user commands.
 ## Specnaut agent registry
 
 Dispatch these via `Task({ subagent_type: "<name>", ... })` (or your
-harness's equivalent — see `references/<harness>-tools.md`).
+harness's equivalent — see the tool reference described below).
 
 | Agent | When to dispatch |
 |---|---|
@@ -110,17 +110,22 @@ Claude Code, Codex CLI, Codex App, Cursor, OpenCode, GitHub Copilot
 CLI. Each harness uses different tool names — `Read` vs `read_file`,
 `Task` vs `spawn_agent`, etc.
 
-Before invoking any tool, consult the right reference:
+Before invoking any tool, consult the right reference. Where it lives
+depends on how this skill reached you:
 
-- Claude Code (baseline) → `references/claude-tools.md`
-- Codex → `references/codex-tools.md`
-- Cursor → `references/cursor-tools.md`
-- OpenCode → `references/opencode-tools.md`
-- Copilot CLI → `references/copilot-tools.md`
+- **Scaffolded into a project** (`specnaut init --ai <harness>`) — the
+  harness was fixed at scaffold time, so exactly one reference ships and
+  it is already yours: read `.specnaut/harness-tools.md` and stop.
+- **Loaded from the plugin distribution** — the harness is not known in
+  advance, so every reference ships side by side. Pick yours from
+  `references/{claude,codex,cursor,opencode,copilot}-tools.md`, detecting
+  the harness from env hints (`CLAUDE_PLUGIN_ROOT`, `CURSOR_*`,
+  `CODEX_*`, …) or from the tool list in your current context.
 
-Auto-detect the running harness by looking for env hints
-(`CLAUDE_PLUGIN_ROOT`, `CURSOR_*`, `CODEX_*`, etc.) or by inspecting
-the available tool list in your current context.
+If neither path yields a file, no mapping is recorded for your harness:
+fall back to the baseline names above and check them against the tools
+you can actually see. Never guess a tool name that is not in your
+context.
 
 ## Red flags — these thoughts mean "stop and check for a skill"
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -167,6 +167,11 @@
     { "harness": "claude", "destination": ".claude/hooks/check-backlog-prereqs.sh", "source": "harness-specific/claude/hooks/check-backlog-prereqs.sh", "executable": true },
     { "harness": "codex", "destination": ".codex/AGENTS.md", "source": "harness-specific/codex/AGENTS.md" },
     { "harness": "codex", "destination": ".codex/goal.md", "source": "harness-specific/codex/goal.md" },
-    { "harness": "cursor", "destination": ".cursor/rules/specify-rules.mdc", "source": "harness-specific/cursor/specify-rules.mdc" }
+    { "harness": "cursor", "destination": ".cursor/rules/specify-rules.mdc", "source": "harness-specific/cursor/specify-rules.mdc" },
+    { "harness": "claude", "destination": ".specnaut/harness-tools.md", "source": "core/skills/using-specnaut/references/claude-tools.md" },
+    { "harness": "codex", "destination": ".specnaut/harness-tools.md", "source": "core/skills/using-specnaut/references/codex-tools.md" },
+    { "harness": "copilot", "destination": ".specnaut/harness-tools.md", "source": "core/skills/using-specnaut/references/copilot-tools.md" },
+    { "harness": "cursor", "destination": ".specnaut/harness-tools.md", "source": "core/skills/using-specnaut/references/cursor-tools.md" },
+    { "harness": "opencode", "destination": ".specnaut/harness-tools.md", "source": "core/skills/using-specnaut/references/opencode-tools.md" }
   ]
 }

--- a/tests/infrastructure/harness/opencode_harness_test.ts
+++ b/tests/infrastructure/harness/opencode_harness_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { OpenCodeHarness } from "../../../src/infrastructure/harness/opencode_harness.ts";
 import type { CoreBundle } from "../../../src/domain/core_bundle.ts";
 
@@ -54,7 +54,9 @@ Deno.test("router skill emits to .opencode/skills/specnaut/SKILL.md", () => {
     specBackend: "local",
   });
   const dest = ".opencode/skills/specnaut/SKILL.md";
-  assertEquals(Object.keys(bundle), [dest]);
+  // Presence, not exclusivity: mapBundle also layers the harness's static
+  // files, so the key set is no longer a single entry.
+  assert(dest in bundle, `expected ${dest} in the bundle`);
   assertStringIncludes(bundle[dest].content, "name: specnaut");
 });
 
@@ -65,7 +67,9 @@ Deno.test("phase emits to .opencode/skills/specnaut/phases/<name>.md", () => {
     specBackend: "local",
   });
   const dest = ".opencode/skills/specnaut/phases/specify.md";
-  assertEquals(Object.keys(bundle), [dest]);
+  // Presence, not exclusivity: mapBundle also layers the harness's static
+  // files, so the key set is no longer a single entry.
+  assert(dest in bundle, `expected ${dest} in the bundle`);
   assertStringIncludes(bundle[dest].content, "Body content");
 });
 
@@ -82,7 +86,7 @@ Deno.test("backlog-cmd emits to .opencode/commands/backlog.md", () => {
     versionScheme: "semver",
     specBackend: "local",
   });
-  assertEquals(Object.keys(bundle), [".opencode/commands/backlog.md"]);
+  assert(".opencode/commands/backlog.md" in bundle);
 });
 
 Deno.test("agent emits to .opencode/agents/specnaut-<name>.md with mode: subagent", () => {
@@ -90,7 +94,9 @@ Deno.test("agent emits to .opencode/agents/specnaut-<name>.md with mode: subagen
     agentEntry("developer", "Read, Write, Edit, Grep, Glob, Bash"),
   ], { backlogBackend: "local", versionScheme: "semver", specBackend: "local" });
   const dest = ".opencode/agents/specnaut-developer.md";
-  assertEquals(Object.keys(bundle), [dest]);
+  // Presence, not exclusivity: mapBundle also layers the harness's static
+  // files, so the key set is no longer a single entry.
+  assert(dest in bundle, `expected ${dest} in the bundle`);
   assertStringIncludes(bundle[dest].content, "description: developer agent");
   assertStringIncludes(bundle[dest].content, "mode: subagent");
   assertStringIncludes(bundle[dest].content, "permission:");
@@ -167,7 +173,9 @@ Deno.test("skill emits to .opencode/skills/specnaut-<name>/SKILL.md with name+de
     specBackend: "local",
   });
   const dest = ".opencode/skills/specnaut-auto/SKILL.md";
-  assertEquals(Object.keys(bundle), [dest]);
+  // Presence, not exclusivity: mapBundle also layers the harness's static
+  // files, so the key set is no longer a single entry.
+  assert(dest in bundle, `expected ${dest} in the bundle`);
   assertStringIncludes(bundle[dest].content, "name: specnaut-auto");
   assertStringIncludes(bundle[dest].content, "description: specnaut-auto skill");
 });
@@ -178,7 +186,7 @@ Deno.test("router skill named 'specnaut' is not double-prefixed", () => {
     versionScheme: "semver",
     specBackend: "local",
   });
-  assertEquals(Object.keys(bundle), [".opencode/skills/specnaut/SKILL.md"]);
+  assert(".opencode/skills/specnaut/SKILL.md" in bundle);
 });
 
 Deno.test("spec-root and project-root pass through unchanged", () => {

--- a/tests/templates/harness_tool_reference_test.ts
+++ b/tests/templates/harness_tool_reference_test.ts
@@ -1,0 +1,125 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import { HARNESSES } from "../../src/cli/harnesses.ts";
+import type { Harness } from "../../src/application/ports.ts";
+
+/**
+ * `using-specnaut/SKILL.md` tells the agent to read a tool-name mapping before
+ * invoking anything. For a long time it named `references/<harness>-tools.md`,
+ * files that were authored but never registered — so every scaffolded project
+ * shipped an instruction pointing at nothing (#441).
+ *
+ * The fix hinges on a fact the old text obscured: `specnaut init --ai <harness>`
+ * fixes the harness at scaffold time, so exactly ONE mapping is ever relevant.
+ * It ships at a harness-neutral path, `.specnaut/harness-tools.md`, which also
+ * sidesteps the folder/flat split — Windsurf and Copilot flatten a skill into a
+ * single file and have nowhere to put a `references/` directory.
+ *
+ * The plugin distribution is the other case: there the harness is unknown, so
+ * all five references ship side by side and the agent detects its own. Both
+ * paths are described in the skill, and both must actually resolve.
+ */
+
+const SCAFFOLDED_PATH = ".specnaut/harness-tools.md";
+
+/** Harnesses with a recorded tool mapping. */
+const MAPPED = ["claude", "codex", "copilot", "cursor", "opencode"] as const;
+
+/**
+ * What a harness actually writes into a project. Asserting on HARNESS_STATIC
+ * instead would be testing the wrong layer: four harnesses did not read it at
+ * all, so an entry could be registered, pass every check, and reach nobody.
+ */
+function scaffolded(h: Harness): Record<string, { content: string }> {
+  return h.mapBundle([], { backend: "local" } as never) as Record<
+    string,
+    { content: string }
+  >;
+}
+
+function harness(key: string): Harness {
+  const h = HARNESSES.find((x) => x.key === key);
+  assert(h, `harness ${key} is not registered`);
+  return h;
+}
+
+function skill(name: string) {
+  const e = CORE_BUNDLE.find(
+    (x) => (x.category === "skill" || x.category === "backlog-skill") && x.name === name,
+  );
+  assert(e, `skill ${name} missing from CORE_BUNDLE`);
+  return e;
+}
+
+Deno.test("every mapped harness scaffolds its tool reference", () => {
+  for (const h of MAPPED) {
+    const file = scaffolded(harness(h))[SCAFFOLDED_PATH];
+    assert(file, `${h} must scaffold ${SCAFFOLDED_PATH}`);
+    assert(file.content.length > 0, `${h}'s tool reference is empty`);
+  }
+});
+
+Deno.test("each harness gets its own mapping, not another's", () => {
+  // A copy-paste in the manifest would be invisible otherwise: the file would
+  // ship, the guard would pass, and the agent would read the wrong tool names.
+  for (const h of MAPPED) {
+    const content = scaffolded(harness(h))[SCAFFOLDED_PATH].content;
+    const others = MAPPED.filter((o) => o !== h);
+    const matchesOwn = new RegExp(h, "i").test(content);
+    assert(matchesOwn, `${h}'s scaffolded reference does not mention ${h}`);
+    // The baseline (claude) is legitimately cited by the others as the
+    // reference point they map away from, so only assert the reverse.
+    if (h === "claude") {
+      for (const o of others) {
+        assert(
+          !new RegExp(`^#\\s.*${o}`, "im").test(content),
+          `claude's reference is titled for ${o}`,
+        );
+      }
+    }
+  }
+});
+
+Deno.test("harnesses with no mapping ship none, and the skill says so", () => {
+  // Windsurf and Antigravity have no recorded mapping. Shipping nothing is
+  // correct — what would be wrong is an instruction to read a file that is not
+  // there, which is the original defect.
+  const unmapped = HARNESSES.map((h) => h.key).filter(
+    (k) => !(MAPPED as readonly string[]).includes(k),
+  );
+  assert(unmapped.length > 0, "expected at least one unmapped harness");
+  for (const k of unmapped) {
+    assert(
+      !scaffolded(harness(k))[SCAFFOLDED_PATH],
+      `${k} has no recorded mapping and must not ship one`,
+    );
+  }
+
+  const body = skill("using-specnaut").content;
+  assertStringIncludes(
+    body,
+    "If neither path yields a file",
+    "the skill must state what to do when no mapping exists, or an unmapped " +
+      "harness is left with a dangling instruction — the original defect",
+  );
+});
+
+Deno.test("the skill names both distributions' paths", () => {
+  const body = skill("using-specnaut").content;
+  // Scaffolded: one file, already correct for this project.
+  assertStringIncludes(body, SCAFFOLDED_PATH);
+  // Plugin: all five side by side, agent detects its own.
+  assertStringIncludes(body, "references/{claude,codex,cursor,opencode,copilot}-tools.md");
+});
+
+Deno.test("the skill no longer points at an unqualified references/ path", () => {
+  // The original defect was `references/<harness>-tools.md` written as though
+  // it always resolved. Every surviving mention must sit in the plugin branch.
+  const body = skill("using-specnaut").content;
+  const mentions = [...body.matchAll(/`references\/[^`]+`/g)].map((m) => m[0]);
+  assertEquals(
+    mentions,
+    ["`references/{claude,codex,cursor,opencode,copilot}-tools.md`"],
+    "a references/ path is named outside the plugin-distribution branch",
+  );
+});

--- a/tests/templates/manifest_registration_test.ts
+++ b/tests/templates/manifest_registration_test.ts
@@ -10,9 +10,9 @@ import { walk } from "@std/fs";
  *
  * This is not hypothetical. Four instances shipped that way:
  *
- *   - `using-specnaut/SKILL.md` points at five `references/*-tools.md` files;
- *     none is registered, so the skill instructs users to read files that do
- *     not exist (tracked by #441).
+ *   - `using-specnaut/SKILL.md` pointed at five `references/*-tools.md`
+ *     files that were never registered, so every scaffolded project shipped a
+ *     skill instructing the agent to read files that did not exist (#441).
  *   - `backlog/scripts/local/_config.sh` (#450) — the local backend's
  *     `item_url` helper existed in no project.
  *   - `backlog/scripts/cloud/columns.sh` and `reconcile.sh` (#450) — both
@@ -40,13 +40,6 @@ const NOT_SHIPPED: ReadonlyArray<{ path: string; why: string }> = [
     why: "documentation of the alias_of/overlays convention, for humans reading " +
       "this repo. Its own description says Specnaut never installs it.",
   },
-  // The five below are a real defect, not a design choice — a skill can ship
-  // only its own SKILL.md today, so there is no mechanism to carry them.
-  // Pinned here so the gap stays visible and cannot grow while #441 is open.
-  ...["claude", "codex", "copilot", "cursor", "opencode"].map((h) => ({
-    path: `core/skills/using-specnaut/references/${h}-tools.md`,
-    why: `referenced by using-specnaut/SKILL.md but unshippable until #441 lands`,
-  })),
 ];
 
 async function authoredFiles(): Promise<string[]> {


### PR DESCRIPTION
Closes #441.

## The defect

`using-specnaut/SKILL.md` told the agent to read `references/<harness>-tools.md` **before invoking any tool**. Those five files were authored but never registered in the manifest, so every scaffolded project shipped an instruction pointing at nothing.

## The insight that made it small

The ticket framed the hard part as the folder/flat split: Windsurf and Copilot flatten a skill into a single file and have nowhere to put a `references/` directory, and Copilot could not be skipped because `copilot-tools.md` is one of the five.

That problem dissolves once you notice what the old text obscured: **`specnaut init --ai <harness>` fixes the harness at scaffold time, so exactly one mapping is ever relevant.** Shipping that one file to a harness-neutral `.specnaut/harness-tools.md` needs no new mechanism — `harness_static` already carries a per-harness file to an arbitrary destination — and nothing lands in a skill folder, so no harness needs one.

The plugin distribution is the other case, and it already worked: there the harness is unknown, all five ship side by side, and the agent detects its own. `SKILL.md` now describes **both** paths rather than one, and says what to do when neither yields a file — Windsurf and Antigravity have no recorded mapping, and inventing tool names for them would be worse than saying so plainly.

No file was moved, so the plugin's byte-identical sync pairs are untouched.

## A latent trap this surfaced

Only `claude`, `cursor` and `codex` layered `HARNESS_STATIC` in `mapBundle`. **Copilot, opencode, windsurf and antigravity ignored it entirely** — a registered entry for them was silently dropped. Declared, not delivered: the same class as the bug being fixed, and invisible because none of the four had an entry until now.

It was caught by scaffolding all seven for real, *after* a green test suite:

```
copilot      (no mapping — correct)     ← wrong: copilot HAS a mapping
opencode     (no mapping — correct)     ← wrong
```

My first test asserted on `HARNESS_STATIC`, the data structure — it passed while shipping nothing. It now asserts through `mapBundle`, which is what actually reaches a project. All four harnesses layer statics.

## Verification

```
claude       # Claude Code — baseline tool reference
cursor       # Cursor — tool reference
codex        # Codex CLI / Codex App — tool reference
copilot      # GitHub Copilot CLI — tool reference
opencode     # OpenCode — tool reference
windsurf     (no mapping — correct)
antigravity  (no mapping — correct)
```

`deno fmt --check`, `deno lint`, `deno check` clean. **1185 tests pass** (5 new).

New tests: each mapped harness scaffolds its reference; each gets **its own** mapping, not a neighbour's (a manifest copy-paste would otherwise ship silently and the agent would read the wrong tool names); unmapped harnesses ship none *and* the skill states the fallback; both distributions' paths are named; and no unqualified `references/` path survives outside the plugin branch.

**Removes the five `NOT_SHIPPED` entries pinned in #452** — the guard now proves these files ship instead of excusing their absence, which was that ticket's stated exit condition.

## Incidental

Four opencode assertions compared the entire bundle key set against a single destination. They now assert presence: `mapBundle` legitimately layers static files on top, and they were written when opencode had none.

## Agent adoption

`specnaut upgrade` now installs `.specnaut/harness-tools.md` — the tool-name mapping for the harness your project was scaffolded with. The bundled `using-specnaut` skill already points at it. Previously it pointed at files that were never installed, so any local copy of that instruction is stale.

```prompt
Search my project for instructions that tell an agent to read a tool-name
reference at `references/<harness>-tools.md` — check `.claude/`, `.cursor/`,
`.codex/`, `.opencode/`, `.github/instructions/`, `AGENTS.md` and `CLAUDE.md`.

Those files were never installed. Replace each reference with
`.specnaut/harness-tools.md`, which is the mapping for this project's harness.
If `.specnaut/harness-tools.md` does not exist, this harness has no recorded
mapping: remove the instruction rather than leaving it dangling, and note that
the baseline Claude Code tool names apply. Open a PR with the changes.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV