### PR TITLE
Enforce the two stops and stop the chain stalling between phases

### DIFF
--- a/plugin/skills/specnaut/phases/auto-chain.md
+++ b/plugin/skills/specnaut/phases/auto-chain.md
@@ -1,206 +1,170 @@
 # Auto-chain control
 
-This file carries the chain mechanics that the `/specnaut` router follows
-when chain mode is engaged. The router reads it after a chainable phase
-(`brainstorm`, `specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`,
-`review`) completes — unless `--manual` or `--once` was passed, or downstream
-artefacts indicate one-shot intent.
+This file carries the chain mechanics the `/specnaut` router follows after a chainable phase
+(`plan`, `tasks`, `implement`, `review`) completes — unless `--manual` was passed, or downstream
+artefacts indicate the user is re-running a single step.
 
-## Default flow
+## The flow
 
 ```
-(brainstorm) → specify → clarify → plan → tasks → analyze → implement → review → merge
-                         ▲                                                        ▲
-                         STOP #1 (only if clarifications needed)                  STOP #2 (pre-merge validation)
+plan → tasks → implement → review → merge
+  ▲                                   ▲
+  STOP 1                              STOP 2
+  (always, at the end of plan)        (the review verdict IS the merge request)
 ```
 
-`brainstorm` is the optional step 0 (see `phases/brainstorm.md`). It runs
-only when the user invokes `/specnaut brainstorm` because the idea is still
-fuzzy; on design approval it always chains into `specify`, which then drives
-the rest of the flow. Entering at `specify` skips it.
+## There are EXACTLY TWO stops. There is no third.
 
-## Lite chain
+1. **The end of `plan`.** Always. The architecture is presented as a proposal with the alternatives
+   that were rejected and why; both audits' findings are presented **separately**; the open
+   questions are asked **one at a time**. See `phases/plan.md` step 8.
+2. **The review verdict.** Its findings are triaged, then the merge is requested. There is no
+   separate pre-merge stop — the verdict and the merge question are the same moment.
 
-For small, single-file features (markdown documentation, agent
-definitions, README/AGENTS/CLAUDE/CHANGELOG tweaks), the chain runs in
-a lighter shape that skips `clarify` and `tasks`:
+`merge` is never automatic. It is asked for — **unless the user already said to merge**, in which
+case that is their instruction and it is followed without a second confirmation.
 
-```
-specify → plan → analyze → implement → review → merge
-                                                  ▲
-                                                  STOP #2 (pre-merge validation)
-```
+## ⛔ NEVER stop at a boundary that is not one of the two
 
-STOP #1 (clarification checkpoint) is **n/a in lite mode** — no
-`clarify` phase runs, so there are no `[NEEDS CLARIFICATION]` markers
-to resolve mid-chain. The `phases/specify.md` procedure makes informed
-guesses for ambiguities and notes them in the spec's Assumptions
-section rather than blocking on user questions. STOP #2 behaves
-identically to the full chain.
+It applies to **every** hand-off in the chain, not just one:
 
-**Shape selection** happens once, in `phases/specify.md`:
-- The router's `--lite` / `--full` flag (parsed in `SKILL.md` step 1)
-  forces the shape and skips any heuristic / prompt.
-- Otherwise, `phases/specify.md` scores the brief against
-  `phases/lite-heuristic.md`. If the score crosses the threshold, the
-  user is prompted once; if not, full chain runs silently.
-- The chosen shape is persisted to `.specnaut/feature.json` as
-  `workflow_shape: "lite" | "full"`.
+| Boundary | What happens |
+| :--- | :--- |
+| user answers the last question at STOP 1 → `tasks` | invoked in the same turn |
+| `tasks` commits the breakdown → `implement` | invoked in the same turn |
+| gates green, tree frozen → `review` | invoked in the same turn |
+| `review` returns findings | **STOP 2** — triage, then the merge request |
 
-At every chain transition below, read `workflow_shape` from
-`.specnaut/feature.json`. When the field is absent (legacy
-`feature.json`), treat as `"full"`.
+No question, no proposal, no menu, at any of those arrows.
+
+None of these is a reason to stop, and each one gets used as one:
+
+| The excuse | Why it is not a reason |
+| :--- | :--- |
+| "That's a lot of tasks — confirm first?" | The size was known when the chain started. The user chose the work at STOP 1. |
+| "MVP only, or the whole thing?" | The plan states both. Build the full path; the MVP is a checkpoint inside it, not a fork to offer. |
+| "This is where the real code gets written." | Yes. That is the point of the chain. |
+| "The audits found a lot — re-confirm scope?" | The findings were folded into the plan and the plan was approved. That approval covers what the plan now says. |
+| "The user has been checkpointing each step." | Answering a question is not a request to be asked another one. |
+
+Asking again after STOP 1 **re-litigates a decision the user already made**, and it costs them the
+thing the chain exists to give: they approve an architecture once, and get an implemented, reviewed
+branch back. A chain that halts at every phase boundary is a slower manual workflow wearing a
+skill's name.
 
 ## Per-phase behavior
 
-After each phase completes successfully, immediately invoke the next phase via
-the `Skill` tool (or the platform equivalent). Do not emit a user-facing "ready
-for next step?" prompt. A one-line `✓ <phase> complete — proceeding to <next>`
-log is sufficient.
+After each phase completes successfully, **invoke the next phase yourself, in the same turn**, via
+the `Skill` tool (or the platform equivalent). Not a suggestion, not a command printed for the user
+to paste — your own next action. A one-line `✓ <phase> complete — proceeding to <next>` log is
+sufficient, and it is a **statement, never a question**.
 
-The **next phase** depends on the chain shape recorded in
-`.specnaut/feature.json` (`workflow_shape`):
-
-| Current phase | Next (full) | Next (lite) |
-|---|---|---|
-| `brainstorm` | `specify`   | `specify`   |
-| `specify`   | `clarify`   | `plan`      |
-| `clarify`   | `plan`      | n/a (lite never runs clarify) |
-| `plan`      | `tasks`     | `analyze`   |
-| `tasks`     | `analyze`   | n/a (lite never runs tasks)   |
-| `analyze`   | `implement` | `implement` |
-| `implement` | `review`    | `review`    |
-| `review`    | STOP #2 → `merge` | STOP #2 → `merge` |
-
-When `workflow_shape` is absent from `feature.json`, treat as `"full"`.
-
-## STOP #1 — Clarification checkpoint
-
-Applies only when `workflow_shape == "full"`. Lite mode does not run
-`clarify`, so there is no STOP #1 in lite chains.
-
-After `/specnaut clarify` finishes:
-
-- If zero `[NEEDS CLARIFICATION]` markers remain in `spec.md`, continue silently
-  to `/specnaut plan`.
-- If markers remain, present the top 3 questions to the user (per the
-  `/specnaut clarify` format) and wait for answers. Once the spec is updated,
-  resume the chain automatically.
+| Current phase | Next |
+|---|---|
+| `plan` | `tasks` — invoked in the same turn as the user's last answer at STOP 1 |
+| `tasks` | `implement` — invoked in the same turn as the dossier commit |
+| `implement` | `review` — invoked in the same turn the gates go green and the tree is frozen |
+| `review` | **STOP 2** — triage, then the merge request |
 
 ## Silent gates
 
-These phases run without user interruption unless they fail hard or surface
-CRITICAL findings:
+These run without user interruption unless they fail hard:
 
-- `/specnaut plan` — generates plan + research + data-model + contracts + quickstart.
-- `/specnaut tasks` — generates tasks.md.
-- `/specnaut analyze` — cross-artifact consistency check. On LOW/MEDIUM findings,
-  log a summary and continue. On CRITICAL findings, stop and surface them.
-- `/specnaut implement` — runs the developer → review-coordinator → qa-tester
-  pipeline. Has its own internal fix loop for review findings; do not intercept.
-- `/specnaut review` — final quality scan.
+- `plan` — up to its own STOP 1, which is not a chain decision but part of the phase.
+- `tasks` — generates `tasks.md`.
+- `implement` — runs the developer → review-coordinator → qa-tester pipeline. It has its own
+  internal fix loop; do not intercept it.
+- `review` — the quality battery on a frozen tree.
 
 ## Plan approval checkpoint (remote mode only)
 
-After `/specnaut plan` completes and **before** chaining into `/specnaut tasks`, check remote mode
+After `plan` completes and **before** chaining into `tasks`, check remote mode
 (`specnaut gate status`):
 
 - **Exit 0** (remote on) — raise a plan-approval gate and suspend:
   `specnaut gate raise --type plan_approval --title "Approve the plan for <feature>" --payload '{"summary":"<plan summary>","planRef":"<plan.md path>","context":"<short>"}'`.
-  exit 0 + `{"approved":true}` → resume into `/specnaut tasks`; exit 0 +
-  `{"approved":false}` → halt and report the rejection + any `note` (revise);
-  exit 3/4/1 → halt cleanly with the reason; exit 5 → report `specnaut cloud login`
-  is needed and fall back to the default below. **Never proceed to `tasks` without
-  an explicit approval.**
-- **Non-zero** (remote off / not Cloud-linked — the default) — `plan` stays a
-  silent gate: continue straight to `/specnaut tasks` exactly as today (no gate,
-  no prompt, no behavioural change).
+  exit 0 + `{"approved":true}` → resume into `tasks`; exit 0 + `{"approved":false}` → halt and
+  report the rejection + any `note`; exit 3/4/1 → halt cleanly with the reason; exit 5 → report
+  `specnaut cloud login` is needed and fall back to the default below. **Never proceed to `tasks`
+  without an explicit approval.**
+- **Non-zero** (remote off / not Cloud-linked — the default) — STOP 1 is the local approval and the
+  chain continues straight into `tasks`.
 
-## STOP #2 — Pre-merge validation
+## STOP 2 — the review verdict
 
-After `/specnaut review` passes, ALWAYS stop and present a compact summary
-before invoking `/specnaut merge`. The summary must include:
+After `review` completes, present a compact summary:
 
 - Feature name and branch
 - Files created / modified (count + key paths)
 - Tests added and full-suite status
-- Known deviations from tasks.md and rationale
-- Open risks / deferred items
+- Known deviations from `tasks.md` and the rationale
+- Open risks / deferred findings
 - One-line business outcome
 
 Then resolve the approval:
 
-- **Remote mode** (run `specnaut gate status`; exit 0 ⇒ on) — raise a
-  `merge_approval` gate instead of a terminal prompt:
+- **Remote mode** (`specnaut gate status` exit 0) — raise a `merge_approval` gate instead of a
+  terminal prompt:
   `specnaut gate raise --type merge_approval --title "Approve merge of <feature>" --payload '{"summary":"<change summary>","prUrl":"<pr/diff ref>","context":"<short>"}'`.
-  Branch on the result: exit 0 + `{"approved":true}` → invoke `/specnaut merge`;
-  exit 0 + `{"approved":false}` → halt on the branch and report the rejection +
-  any `note` (comment-and-revise); exit 3/4 (timeout/cancelled) or 1 → halt
-  cleanly with the reason; exit 5 → report `specnaut cloud login` is needed and
-  fall back to the local prompt below. **Never merge without an explicit approval.**
-- **Local mode** (default, gate status non-zero) — ask explicitly:
-  "Ready to merge? (yes to run /specnaut merge, no to stay on the branch)". Wait for
-  explicit confirmation. On "yes", invoke `/specnaut merge`.
+  exit 0 + `{"approved":true}` → invoke `merge`; exit 0 + `{"approved":false}` → halt on the branch
+  and report the rejection + any `note`; exit 3/4 (timeout/cancelled) or 1 → halt cleanly with the
+  reason; exit 5 → report `specnaut cloud login` is needed and fall back to the local prompt below.
+  **Never merge without an explicit approval.**
+- **Local mode** (default) — ask once: "Ready to merge? (yes to run `/specnaut merge`, no to stay on
+  the branch)". On "yes", invoke `merge`.
+
+### Triage, and the rule that ends the loop
+
+**Only a CRITICAL or HIGH finding buys another fix cycle.** MEDIUM and LOW go to the backlog and the
+branch ships.
+
+Those fix cycles run **inside** this stop. Do not ask again between each one — the user asked for a
+working branch, not for a vote on every round.
+
+A reviewer reports **harm, not labels**: sort each finding into *"would hurt a user, a maintainer,
+or the data if shipped"* versus *"should be better"*, and choose by the harm rather than the
+severity word. **"Nothing here would hurt anyone" is a valid and valuable verdict**, not a failure
+to find things.
+
+Justifying another round with "the last one found something" is not a reason — it is always true,
+and **a loop with no exit criterion does not terminate**. Two habits produce the runaway: treating a
+severity as a label to be cleared rather than asking what harm it describes, and re-reviewing
+because the previous review was not empty.
 
 After merge, the chain ends.
 
-## Mid-chain re-entry
+## Re-entry, without a flag
 
-When the user invokes any phase other than `specify` directly (e.g.
-`/specnaut plan 042`, `/specnaut implement 042`), apply this
-context-aware default:
+When the user invokes a phase directly (`/specnaut implement`, `/specnaut review`), decide from what
+is on disk:
 
-- **Downstream artefacts missing** → chain. The user is resuming an
-  interrupted flow (long session, fresh shell after compaction, manual
-  review between early phases). Continue through the remaining phases →
-  STOP #2 with the same checkpoints as the entry-point flow.
-- **Downstream artefacts present** → one-shot. The user is re-running a
-  single phase (regenerate `plan.md` after a tweak, re-analyse after a
-  spec edit). Do NOT cascade.
+- **Downstream artefacts missing** → chain. The user is resuming an interrupted flow (a long
+  session, a fresh shell after compaction). Continue through the remaining phases to STOP 2.
+- **Downstream artefacts present** → one-shot. The user is re-running a single phase (regenerating
+  `plan.md` after a tweak).
 
-"Downstream artefacts" means files under `.specnaut/specs/<feature>/`
-produced by phases AFTER the one being invoked:
+"Downstream artefacts" means files under the feature directory produced by phases **after** the one
+being invoked:
 
 | Invoked phase | Downstream artefacts to check |
 |---|---|
-| `clarify`   | `plan.md`, `tasks.md` |
-| `plan`      | `tasks.md`, `data-model.md`, `contracts/`, `quickstart.md` |
-| `tasks`     | `tasks.md` markings beyond the initial generation, or any task marked done |
-| `analyze`   | nothing (analyze is a read-only gate; treat as one-shot unless `--continue`) |
-| `implement` | a merged PR, a `review.md`, or task completion past 50% |
-| `review`    | nothing past review (chain-tail is just `merge`); treat as one-shot unless `--continue` |
-
-If any listed artefact is present, infer one-shot intent. If all are
-absent, chain.
-
-### Explicit overrides
-
-The router-level flags `--continue` and `--once` override the
-artefact-detection default. They are mutually exclusive with each other
-and with `--manual`:
-
-- `--continue` — force the chain regardless of artefact state. Useful
-  when you want to regenerate a phase AND cascade downstream work
-  afterwards (e.g. tweak `plan.md`, then re-run `tasks → analyze →
-  implement → review` from scratch).
-- `--once` — force one-shot regardless. Useful when downstream
-  artefacts haven't been generated yet but you only want to run this
-  single phase right now (e.g. inspect the spec before authorising
-  the rest of the chain).
+| `plan` | `tasks.md` |
+| `tasks` | any task in `tasks.md` marked done |
+| `implement` | a merged PR, or task completion past 50% |
+| `review` | nothing past review (the chain tail is just `merge`) — treat as one-shot |
 
 ## Failure handling
 
-- Hard failure in a silent gate (plan/tasks/analyze/implement/review): stop,
-  surface the error, ask the user how to proceed. Do not silently retry.
-- Task-level blockers reported by the developer agent during `implement`: the
-  implement workflow has its own fix loop; do not intercept.
-- `clarify` producing more than 5 questions: present the top 3 per the
-  `/specnaut clarify` quota; the rest can be asked later.
+- Hard failure in a silent gate: stop, surface the error, ask how to proceed. Do not silently retry.
+- Task-level blockers reported during `implement`: that phase has its own fix loop; do not
+  intercept.
+- **Genuinely blocked is not the same as stopped.** If something truly blocks part of the work, say
+  what is blocked in one or two sentences, implement everything that is not blocked, and name the
+  remainder. Stopping with nothing built is reserved for the case where proceeding under any
+  assumption would be unsafe or would make the work useless if wrong.
 
 ## Context budget
 
-Long features (≥13 story points or ≥30 tasks) may exhaust context during
-`/specnaut implement`. If compaction occurs mid-chain, inform the user and
-let them resume from a fresh session — the artefact-detection default
-above will pick up where the previous run stopped, or they can pass
-`--continue` explicitly.
+Long features (≥13 story points or ≥30 tasks) may exhaust context during `implement`. If compaction
+occurs mid-chain, say so and let the user resume from a fresh session — the re-entry detection above
+picks up where the previous run stopped.

--- a/plugin/skills/specnaut/phases/implement.md
+++ b/plugin/skills/specnaut/phases/implement.md
@@ -177,3 +177,21 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
         EXECUTE_COMMAND: {command}
         ```
     - If no hooks are registered or `.specnaut/extensions.yml` does not exist, skip silently
+
+## Ending this phase — freeze, then INVOKE `review`, same turn
+
+**An implementation that has not been through review is not finished.** `review` is this phase's
+mandatory last act, not a separate thing the user has to ask for.
+
+1. **Freeze the tree.** Reviewers and suites read the working tree live, and only you know whether
+   it is still moving. Name the commit, stop every implementer agent still holding the tree, then
+   gate. A lingering agent row is a live teammate, not a leftover — it can write into a tree
+   somebody is about to freeze.
+2. **Invoke `review` yourself, in the same turn.** Your own next action.
+
+**This boundary is not a stop.** "The audits found a lot, should I re-confirm scope?" is not a
+reason — the findings were folded into the plan and the plan was approved, and that approval covers
+what the plan now says. Neither is "the user has been checkpointing each step": answering a question
+is not a request to be asked another one.
+
+Pause only when the run was started with `--manual`.

--- a/plugin/skills/specnaut/phases/review.md
+++ b/plugin/skills/specnaut/phases/review.md
@@ -61,6 +61,20 @@ specific check that failed (or the full quality gate if the fix is broad).
 Repeat until only MEDIUM / LOW remain OR a fix has cycled twice without
 resolution — in the latter case, stop and escalate to the user.
 
+**Do not ask the user between cycles.** The fix loop runs inside STOP #2; they
+asked for a working branch, not for a vote on every round.
+
+**Report harm, not labels.** Sort each finding into *"would hurt a user, a
+maintainer, or the data if shipped"* versus *"should be better"*, and choose by
+the harm rather than the severity word. A finding labelled HIGH that describes a
+lost log line is not worth a cycle; one labelled MEDIUM that loses data is.
+**"Nothing here would hurt anyone" is a valid and valuable verdict**, not a
+failure to find things.
+
+**MEDIUM and LOW go to the backlog and the branch ships.** Re-reviewing because
+the last review found *something* is not a reason — it is always true, and a loop
+with no exit criterion does not terminate.
+
 ## Phase 4 — Final report
 
 Emit a single report in this exact structure:

--- a/plugin/skills/specnaut/phases/tasks.md
+++ b/plugin/skills/specnaut/phases/tasks.md
@@ -197,3 +197,22 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Ending this phase — INVOKE `implement`, same turn
+
+Commit the breakdown, then **invoke `implement` yourself, in the same turn**. Your own next action —
+not a suggestion, not a command printed for the user to paste.
+
+```bash
+git add <feature-dir>/tasks.md && git commit -m "tasks(<id>): <what the feature does>"
+```
+
+Commit **before** handing off: a worktree runs off committed HEAD, and an uncommitted breakdown is
+invisible to whoever needs it.
+
+**The boundary between `tasks` and `implement` is not a stop.** The size of the breakdown is not a
+reason to stop — it was known when the chain started, and the user chose the work at the plan stop.
+Neither is "this is where the real code gets written": yes, and that is the point of the chain. The
+chain has exactly two stops and this is neither of them; see `phases/auto-chain.md`.
+
+Pause only when the run was started with `--manual`.

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -647,6 +647,25 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Ending this phase — INVOKE \`implement\`, same turn
+
+Commit the breakdown, then **invoke \`implement\` yourself, in the same turn**. Your own next action —
+not a suggestion, not a command printed for the user to paste.
+
+\`\`\`bash
+git add <feature-dir>/tasks.md && git commit -m "tasks(<id>): <what the feature does>"
+\`\`\`
+
+Commit **before** handing off: a worktree runs off committed HEAD, and an uncommitted breakdown is
+invisible to whoever needs it.
+
+**The boundary between \`tasks\` and \`implement\` is not a stop.** The size of the breakdown is not a
+reason to stop — it was known when the chain started, and the user chose the work at the plan stop.
+Neither is "this is where the real code gets written": yes, and that is the point of the chain. The
+chain has exactly two stops and this is neither of them; see \`phases/auto-chain.md\`.
+
+Pause only when the run was started with \`--manual\`.
 `,
     executable: false,
     backend: null,
@@ -835,6 +854,24 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
         EXECUTE_COMMAND: {command}
         \`\`\`
     - If no hooks are registered or \`.specnaut/extensions.yml\` does not exist, skip silently
+
+## Ending this phase — freeze, then INVOKE \`review\`, same turn
+
+**An implementation that has not been through review is not finished.** \`review\` is this phase's
+mandatory last act, not a separate thing the user has to ask for.
+
+1. **Freeze the tree.** Reviewers and suites read the working tree live, and only you know whether
+   it is still moving. Name the commit, stop every implementer agent still holding the tree, then
+   gate. A lingering agent row is a live teammate, not a leftover — it can write into a tree
+   somebody is about to freeze.
+2. **Invoke \`review\` yourself, in the same turn.** Your own next action.
+
+**This boundary is not a stop.** "The audits found a lot, should I re-confirm scope?" is not a
+reason — the findings were folded into the plan and the plan was approved, and that approval covers
+what the plan now says. Neither is "the user has been checkpointing each step": answering a question
+is not a request to be asked another one.
+
+Pause only when the run was started with \`--manual\`.
 `,
     executable: false,
     backend: null,
@@ -906,6 +943,20 @@ specific check that failed (or the full quality gate if the fix is broad).
 
 Repeat until only MEDIUM / LOW remain OR a fix has cycled twice without
 resolution — in the latter case, stop and escalate to the user.
+
+**Do not ask the user between cycles.** The fix loop runs inside STOP #2; they
+asked for a working branch, not for a vote on every round.
+
+**Report harm, not labels.** Sort each finding into *"would hurt a user, a
+maintainer, or the data if shipped"* versus *"should be better"*, and choose by
+the harm rather than the severity word. A finding labelled HIGH that describes a
+lost log line is not worth a cycle; one labelled MEDIUM that loses data is.
+**"Nothing here would hurt anyone" is a valid and valuable verdict**, not a
+failure to find things.
+
+**MEDIUM and LOW go to the backlog and the branch ships.** Re-reviewing because
+the last review found *something* is not a reason — it is always true, and a loop
+with no exit criterion does not terminate.
 
 ## Phase 4 — Final report
 
@@ -1789,6 +1840,34 @@ plan → tasks → implement → review → merge
 \`merge\` is never automatic. It is asked for — **unless the user already said to merge**, in which
 case that is their instruction and it is followed without a second confirmation.
 
+## ⛔ NEVER stop at a boundary that is not one of the two
+
+It applies to **every** hand-off in the chain, not just one:
+
+| Boundary | What happens |
+| :--- | :--- |
+| user answers the last question at STOP 1 → \`tasks\` | invoked in the same turn |
+| \`tasks\` commits the breakdown → \`implement\` | invoked in the same turn |
+| gates green, tree frozen → \`review\` | invoked in the same turn |
+| \`review\` returns findings | **STOP 2** — triage, then the merge request |
+
+No question, no proposal, no menu, at any of those arrows.
+
+None of these is a reason to stop, and each one gets used as one:
+
+| The excuse | Why it is not a reason |
+| :--- | :--- |
+| "That's a lot of tasks — confirm first?" | The size was known when the chain started. The user chose the work at STOP 1. |
+| "MVP only, or the whole thing?" | The plan states both. Build the full path; the MVP is a checkpoint inside it, not a fork to offer. |
+| "This is where the real code gets written." | Yes. That is the point of the chain. |
+| "The audits found a lot — re-confirm scope?" | The findings were folded into the plan and the plan was approved. That approval covers what the plan now says. |
+| "The user has been checkpointing each step." | Answering a question is not a request to be asked another one. |
+
+Asking again after STOP 1 **re-litigates a decision the user already made**, and it costs them the
+thing the chain exists to give: they approve an architecture once, and get an implemented, reviewed
+branch back. A chain that halts at every phase boundary is a slower manual workflow wearing a
+skill's name.
+
 ## Per-phase behavior
 
 After each phase completes successfully, **invoke the next phase yourself, in the same turn**, via
@@ -1849,6 +1928,24 @@ Then resolve the approval:
   **Never merge without an explicit approval.**
 - **Local mode** (default) — ask once: "Ready to merge? (yes to run \`/specnaut merge\`, no to stay on
   the branch)". On "yes", invoke \`merge\`.
+
+### Triage, and the rule that ends the loop
+
+**Only a CRITICAL or HIGH finding buys another fix cycle.** MEDIUM and LOW go to the backlog and the
+branch ships.
+
+Those fix cycles run **inside** this stop. Do not ask again between each one — the user asked for a
+working branch, not for a vote on every round.
+
+A reviewer reports **harm, not labels**: sort each finding into *"would hurt a user, a maintainer,
+or the data if shipped"* versus *"should be better"*, and choose by the harm rather than the
+severity word. **"Nothing here would hurt anyone" is a valid and valuable verdict**, not a failure
+to find things.
+
+Justifying another round with "the last one found something" is not a reason — it is always true,
+and **a loop with no exit criterion does not terminate**. Two habits produce the runaway: treating a
+severity as a label to be cleared rather than asking what harm it describes, and re-reviewing
+because the previous review was not empty.
 
 After merge, the chain ends.
 
@@ -17982,6 +18079,48 @@ _(List your non-negotiable rules — layering, DI, error handling, security.)_
 _(Naming, testing, commits, branches.)_
 
 **Backlog references** follow the \`backlog-reference-contract\` skill — read it; never restate it here.
+
+## The Specnaut chain has exactly two stops
+
+*Owned by Specnaut — this section is not a placeholder to fill in. Edit the rest freely.*
+
+\`plan → tasks → implement → review → merge\`. It stops at exactly two points, and no third:
+
+1. **The end of \`plan\`** — the architecture is presented with the alternatives that were rejected,
+   both audits' findings are presented separately, and the open questions are asked one at a time.
+2. **The review verdict** — which *is* the merge request. There is no separate pre-merge stop.
+
+Every other boundary is crossed by **invoking the next phase yourself, in the same turn** — your own
+next action, never a command printed for someone to paste:
+
+| Boundary | What happens |
+| :--- | :--- |
+| last question answered → \`tasks\` | invoked in the same turn |
+| breakdown committed → \`implement\` | invoked in the same turn |
+| gates green, tree frozen → \`review\` | invoked in the same turn |
+| \`review\` returns findings | **STOP** — triage, then the merge request |
+
+None of these is a reason to stop, and each one gets used as one:
+
+| The excuse | Why it is not a reason |
+| :--- | :--- |
+| "That's a lot of tasks — confirm first?" | The size was known when the chain started. |
+| "MVP only, or the whole thing?" | The plan states both. The MVP is a checkpoint inside the full path, not a fork to offer. |
+| "This is where the real code gets written." | Yes. That is the point of the chain. |
+| "The audits found a lot — re-confirm scope?" | They were folded into the plan, and the plan was approved. |
+| "They've been checkpointing each step." | Answering a question is not a request to be asked another one. |
+
+**Genuinely blocked is not the same as stopped.** If something truly blocks part of the work, say
+what is blocked in one or two sentences, implement everything that is not blocked, and name the
+remainder. Stopping with nothing built is reserved for the case where proceeding under any
+assumption would be unsafe or would make the work useless if wrong. "I would like confirmation" is
+not that case.
+
+**Only a CRITICAL or HIGH finding buys another fix cycle**; MEDIUM and LOW go to the backlog and the
+branch ships. Those cycles run inside the second stop — don't ask again between each one.
+
+\`merge\` is never automatic. It is asked for — **unless the user already said to merge**, in which
+case that is their instruction and it is followed without a second confirmation.
 
 ## Project-specific gotchas
 

--- a/templates/core/root/AGENTS.md
+++ b/templates/core/root/AGENTS.md
@@ -18,6 +18,48 @@ _(Naming, testing, commits, branches.)_
 
 **Backlog references** follow the `backlog-reference-contract` skill — read it; never restate it here.
 
+## The Specnaut chain has exactly two stops
+
+*Owned by Specnaut — this section is not a placeholder to fill in. Edit the rest freely.*
+
+`plan → tasks → implement → review → merge`. It stops at exactly two points, and no third:
+
+1. **The end of `plan`** — the architecture is presented with the alternatives that were rejected,
+   both audits' findings are presented separately, and the open questions are asked one at a time.
+2. **The review verdict** — which *is* the merge request. There is no separate pre-merge stop.
+
+Every other boundary is crossed by **invoking the next phase yourself, in the same turn** — your own
+next action, never a command printed for someone to paste:
+
+| Boundary | What happens |
+| :--- | :--- |
+| last question answered → `tasks` | invoked in the same turn |
+| breakdown committed → `implement` | invoked in the same turn |
+| gates green, tree frozen → `review` | invoked in the same turn |
+| `review` returns findings | **STOP** — triage, then the merge request |
+
+None of these is a reason to stop, and each one gets used as one:
+
+| The excuse | Why it is not a reason |
+| :--- | :--- |
+| "That's a lot of tasks — confirm first?" | The size was known when the chain started. |
+| "MVP only, or the whole thing?" | The plan states both. The MVP is a checkpoint inside the full path, not a fork to offer. |
+| "This is where the real code gets written." | Yes. That is the point of the chain. |
+| "The audits found a lot — re-confirm scope?" | They were folded into the plan, and the plan was approved. |
+| "They've been checkpointing each step." | Answering a question is not a request to be asked another one. |
+
+**Genuinely blocked is not the same as stopped.** If something truly blocks part of the work, say
+what is blocked in one or two sentences, implement everything that is not blocked, and name the
+remainder. Stopping with nothing built is reserved for the case where proceeding under any
+assumption would be unsafe or would make the work useless if wrong. "I would like confirmation" is
+not that case.
+
+**Only a CRITICAL or HIGH finding buys another fix cycle**; MEDIUM and LOW go to the backlog and the
+branch ships. Those cycles run inside the second stop — don't ask again between each one.
+
+`merge` is never automatic. It is asked for — **unless the user already said to merge**, in which
+case that is their instruction and it is followed without a second confirmation.
+
 ## Project-specific gotchas
 
 _(Sharp edges new contributors must know.)_

--- a/templates/core/skills/specnaut/phases/auto-chain.md
+++ b/templates/core/skills/specnaut/phases/auto-chain.md
@@ -24,6 +24,34 @@ plan → tasks → implement → review → merge
 `merge` is never automatic. It is asked for — **unless the user already said to merge**, in which
 case that is their instruction and it is followed without a second confirmation.
 
+## ⛔ NEVER stop at a boundary that is not one of the two
+
+It applies to **every** hand-off in the chain, not just one:
+
+| Boundary | What happens |
+| :--- | :--- |
+| user answers the last question at STOP 1 → `tasks` | invoked in the same turn |
+| `tasks` commits the breakdown → `implement` | invoked in the same turn |
+| gates green, tree frozen → `review` | invoked in the same turn |
+| `review` returns findings | **STOP 2** — triage, then the merge request |
+
+No question, no proposal, no menu, at any of those arrows.
+
+None of these is a reason to stop, and each one gets used as one:
+
+| The excuse | Why it is not a reason |
+| :--- | :--- |
+| "That's a lot of tasks — confirm first?" | The size was known when the chain started. The user chose the work at STOP 1. |
+| "MVP only, or the whole thing?" | The plan states both. Build the full path; the MVP is a checkpoint inside it, not a fork to offer. |
+| "This is where the real code gets written." | Yes. That is the point of the chain. |
+| "The audits found a lot — re-confirm scope?" | The findings were folded into the plan and the plan was approved. That approval covers what the plan now says. |
+| "The user has been checkpointing each step." | Answering a question is not a request to be asked another one. |
+
+Asking again after STOP 1 **re-litigates a decision the user already made**, and it costs them the
+thing the chain exists to give: they approve an architecture once, and get an implemented, reviewed
+branch back. A chain that halts at every phase boundary is a slower manual workflow wearing a
+skill's name.
+
 ## Per-phase behavior
 
 After each phase completes successfully, **invoke the next phase yourself, in the same turn**, via
@@ -84,6 +112,24 @@ Then resolve the approval:
   **Never merge without an explicit approval.**
 - **Local mode** (default) — ask once: "Ready to merge? (yes to run `/specnaut merge`, no to stay on
   the branch)". On "yes", invoke `merge`.
+
+### Triage, and the rule that ends the loop
+
+**Only a CRITICAL or HIGH finding buys another fix cycle.** MEDIUM and LOW go to the backlog and the
+branch ships.
+
+Those fix cycles run **inside** this stop. Do not ask again between each one — the user asked for a
+working branch, not for a vote on every round.
+
+A reviewer reports **harm, not labels**: sort each finding into *"would hurt a user, a maintainer,
+or the data if shipped"* versus *"should be better"*, and choose by the harm rather than the
+severity word. **"Nothing here would hurt anyone" is a valid and valuable verdict**, not a failure
+to find things.
+
+Justifying another round with "the last one found something" is not a reason — it is always true,
+and **a loop with no exit criterion does not terminate**. Two habits produce the runaway: treating a
+severity as a label to be cleared rather than asking what harm it describes, and re-reviewing
+because the previous review was not empty.
 
 After merge, the chain ends.
 

--- a/templates/core/skills/specnaut/phases/implement.md
+++ b/templates/core/skills/specnaut/phases/implement.md
@@ -177,3 +177,21 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
         EXECUTE_COMMAND: {command}
         ```
     - If no hooks are registered or `.specnaut/extensions.yml` does not exist, skip silently
+
+## Ending this phase — freeze, then INVOKE `review`, same turn
+
+**An implementation that has not been through review is not finished.** `review` is this phase's
+mandatory last act, not a separate thing the user has to ask for.
+
+1. **Freeze the tree.** Reviewers and suites read the working tree live, and only you know whether
+   it is still moving. Name the commit, stop every implementer agent still holding the tree, then
+   gate. A lingering agent row is a live teammate, not a leftover — it can write into a tree
+   somebody is about to freeze.
+2. **Invoke `review` yourself, in the same turn.** Your own next action.
+
+**This boundary is not a stop.** "The audits found a lot, should I re-confirm scope?" is not a
+reason — the findings were folded into the plan and the plan was approved, and that approval covers
+what the plan now says. Neither is "the user has been checkpointing each step": answering a question
+is not a request to be asked another one.
+
+Pause only when the run was started with `--manual`.

--- a/templates/core/skills/specnaut/phases/review.md
+++ b/templates/core/skills/specnaut/phases/review.md
@@ -61,6 +61,20 @@ specific check that failed (or the full quality gate if the fix is broad).
 Repeat until only MEDIUM / LOW remain OR a fix has cycled twice without
 resolution — in the latter case, stop and escalate to the user.
 
+**Do not ask the user between cycles.** The fix loop runs inside STOP #2; they
+asked for a working branch, not for a vote on every round.
+
+**Report harm, not labels.** Sort each finding into *"would hurt a user, a
+maintainer, or the data if shipped"* versus *"should be better"*, and choose by
+the harm rather than the severity word. A finding labelled HIGH that describes a
+lost log line is not worth a cycle; one labelled MEDIUM that loses data is.
+**"Nothing here would hurt anyone" is a valid and valuable verdict**, not a
+failure to find things.
+
+**MEDIUM and LOW go to the backlog and the branch ships.** Re-reviewing because
+the last review found *something* is not a reason — it is always true, and a loop
+with no exit criterion does not terminate.
+
 ## Phase 4 — Final report
 
 Emit a single report in this exact structure:

--- a/templates/core/skills/specnaut/phases/tasks.md
+++ b/templates/core/skills/specnaut/phases/tasks.md
@@ -197,3 +197,22 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Ending this phase — INVOKE `implement`, same turn
+
+Commit the breakdown, then **invoke `implement` yourself, in the same turn**. Your own next action —
+not a suggestion, not a command printed for the user to paste.
+
+```bash
+git add <feature-dir>/tasks.md && git commit -m "tasks(<id>): <what the feature does>"
+```
+
+Commit **before** handing off: a worktree runs off committed HEAD, and an uncommitted breakdown is
+invisible to whoever needs it.
+
+**The boundary between `tasks` and `implement` is not a stop.** The size of the breakdown is not a
+reason to stop — it was known when the chain started, and the user chose the work at the plan stop.
+Neither is "this is where the real code gets written": yes, and that is the point of the chain. The
+chain has exactly two stops and this is neither of them; see `phases/auto-chain.md`.
+
+Pause only when the run was started with `--manual`.

--- a/tests/fixtures/implement_local_golden.md
+++ b/tests/fixtures/implement_local_golden.md
@@ -164,3 +164,21 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
         EXECUTE_COMMAND: {command}
         ```
     - If no hooks are registered or `.specnaut/extensions.yml` does not exist, skip silently
+
+## Ending this phase — freeze, then INVOKE `review`, same turn
+
+**An implementation that has not been through review is not finished.** `review` is this phase's
+mandatory last act, not a separate thing the user has to ask for.
+
+1. **Freeze the tree.** Reviewers and suites read the working tree live, and only you know whether
+   it is still moving. Name the commit, stop every implementer agent still holding the tree, then
+   gate. A lingering agent row is a live teammate, not a leftover — it can write into a tree
+   somebody is about to freeze.
+2. **Invoke `review` yourself, in the same turn.** Your own next action.
+
+**This boundary is not a stop.** "The audits found a lot, should I re-confirm scope?" is not a
+reason — the findings were folded into the plan and the plan was approved, and that approval covers
+what the plan now says. Neither is "the user has been checkpointing each step": answering a question
+is not a request to be asked another one.
+
+Pause only when the run was started with `--manual`.

--- a/tests/fixtures/review_local_golden.md
+++ b/tests/fixtures/review_local_golden.md
@@ -54,6 +54,20 @@ specific check that failed (or the full quality gate if the fix is broad).
 Repeat until only MEDIUM / LOW remain OR a fix has cycled twice without
 resolution — in the latter case, stop and escalate to the user.
 
+**Do not ask the user between cycles.** The fix loop runs inside STOP #2; they
+asked for a working branch, not for a vote on every round.
+
+**Report harm, not labels.** Sort each finding into *"would hurt a user, a
+maintainer, or the data if shipped"* versus *"should be better"*, and choose by
+the harm rather than the severity word. A finding labelled HIGH that describes a
+lost log line is not worth a cycle; one labelled MEDIUM that loses data is.
+**"Nothing here would hurt anyone" is a valid and valuable verdict**, not a
+failure to find things.
+
+**MEDIUM and LOW go to the backlog and the branch ships.** Re-reviewing because
+the last review found *something* is not a reason — it is always true, and a loop
+with no exit criterion does not terminate.
+
 ## Phase 4 — Final report
 
 Emit a single report in this exact structure:

--- a/tests/fixtures/tasks_local_golden.md
+++ b/tests/fixtures/tasks_local_golden.md
@@ -190,3 +190,22 @@ Every task MUST strictly follow this format:
   - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
   - Each phase should be a complete, independently testable increment
 - **Final Phase**: Polish & Cross-Cutting Concerns
+
+## Ending this phase — INVOKE `implement`, same turn
+
+Commit the breakdown, then **invoke `implement` yourself, in the same turn**. Your own next action —
+not a suggestion, not a command printed for the user to paste.
+
+```bash
+git add <feature-dir>/tasks.md && git commit -m "tasks(<id>): <what the feature does>"
+```
+
+Commit **before** handing off: a worktree runs off committed HEAD, and an uncommitted breakdown is
+invisible to whoever needs it.
+
+**The boundary between `tasks` and `implement` is not a stop.** The size of the breakdown is not a
+reason to stop — it was known when the chain started, and the user chose the work at the plan stop.
+Neither is "this is where the real code gets written": yes, and that is the point of the chain. The
+chain has exactly two stops and this is neither of them; see `phases/auto-chain.md`.
+
+Pause only when the run was started with `--manual`.

--- a/tests/templates/chain_stops_test.ts
+++ b/tests/templates/chain_stops_test.ts
@@ -1,0 +1,103 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import type { CoreEntry } from "../../src/domain/core_bundle.ts";
+
+/**
+ * #458 — the chain has exactly two stops, and it must not stall between phases.
+ *
+ * The rule is written in TWO places on purpose, and the reason is mechanical:
+ * a phase file is only read once that phase is already running, so the rule
+ * arrives *after* the decision to stop. The scaffolded `AGENTS.md` is always in
+ * context, and is the only place the rule can PREVENT the stall rather than
+ * describe it. A future reader will mistake this for duplication — these locks
+ * are what stop them acting on that.
+ *
+ * The observed failure was specific: the chain stops just before implementing,
+ * to ask permission it was already given at the plan stop.
+ */
+
+function phase(name: string): CoreEntry {
+  const e = CORE_BUNDLE.find((x) => x.category === "phase" && x.name === name);
+  if (!e) throw new Error(`missing phase entry: ${name}`);
+  return e;
+}
+
+function rootAgents(): CoreEntry {
+  const e = CORE_BUNDLE.find(
+    (x) => x.category === "project-root" && x.suffix === "AGENTS.md",
+  );
+  if (!e) throw new Error("missing root AGENTS.md entry");
+  return e;
+}
+
+// The five sentences that have actually been used to stall the chain. Each must
+// be refused in writing, in BOTH carriers — quoting the excuse is what lets a
+// model recognise its own reasoning instead of rationalising past a generality.
+const EXCUSES: ReadonlyArray<[label: string, fragment: string]> = [
+  ["task count", "lot of tasks"],
+  ["MVP fork", "MVP"],
+  ["real code", "real code gets written"],
+  ["audit scope", "re-confirm scope"],
+  ["checkpointing", "checkpointing each step"],
+];
+
+Deno.test("the scaffolded AGENTS.md carries the two-stop rule — it is the always-loaded carrier", () => {
+  const { content } = rootAgents();
+  assertStringIncludes(content, "exactly two stops");
+  assertStringIncludes(content, "no third");
+  // Both stops named, so neither can be quietly dropped.
+  assertStringIncludes(content, "The end of `plan`");
+  assertStringIncludes(content, "The review verdict");
+  assertStringIncludes(content, "no separate pre-merge stop");
+  // The positive instruction, not just the prohibition.
+  assertStringIncludes(content, "in the same turn");
+  // Blocked-is-not-stopped, and the exit criterion.
+  assertStringIncludes(content, "Genuinely blocked");
+  assertStringIncludes(content, "CRITICAL or HIGH");
+  // Standing merge authorisation is not re-collected.
+  assertStringIncludes(content, "without a second confirmation");
+});
+
+Deno.test("AGENTS.md refuses every excuse that has been used to stall the chain", () => {
+  const { content } = rootAgents();
+  for (const [label, fragment] of EXCUSES) {
+    assertStringIncludes(content, fragment, `AGENTS.md must refuse the "${label}" excuse`);
+  }
+});
+
+Deno.test("auto-chain.md carries the same rule for the phase that is already running", () => {
+  const { content } = phase("auto-chain");
+  assertStringIncludes(content, "EXACTLY TWO stops");
+  for (const [label, fragment] of EXCUSES) {
+    assertStringIncludes(content, fragment, `auto-chain.md must refuse the "${label}" excuse`);
+  }
+  // The triage rule that terminates the review loop.
+  assertStringIncludes(content, "does not terminate");
+  assertStringIncludes(content, "would hurt a user");
+});
+
+Deno.test("every chaining phase ends by invoking the next one itself", () => {
+  // The gap this closes: the instruction used to live only in auto-chain.md,
+  // which a running phase may never load.
+  for (const [name, next] of [["tasks", "implement"], ["implement", "review"]] as const) {
+    const { content } = phase(name);
+    assertStringIncludes(
+      content,
+      `INVOKE \`${next}\``,
+      `${name}.md must end by invoking ${next} itself`,
+    );
+    assertStringIncludes(content, "same turn", `${name}.md must say "same turn"`);
+    assert(
+      content.includes("is not a stop"),
+      `${name}.md must state that its closing boundary is not a stop`,
+    );
+  }
+});
+
+Deno.test("review.md does not re-ask between fix cycles and reports harm, not labels", () => {
+  const { content } = phase("review");
+  assertStringIncludes(content, "Do not ask the user between cycles");
+  assertStringIncludes(content, "harm, not labels");
+  assertStringIncludes(content, "valid and valuable verdict");
+  assertStringIncludes(content, "does not terminate");
+});


### PR DESCRIPTION
Closes #458

Third child of #454. Builds on #461 and #462.

## The failure this closes

The chain's promise is that you approve an architecture once and get an implemented, reviewed branch back. The observed failure is specific: it stops just before implementing, to ask permission it was already given at the plan stop.

## Why the rule is in two places, deliberately

**A phase file is only read once that phase is already running** — so its rule arrives *after* the decision to stop. The scaffolded `AGENTS.md` is always in context, and is the only carrier that can **prevent** the stall rather than describe it.

The `AGENTS.md` section says this in-file, and `chain_stops_test.ts` opens with it, because the next reader will otherwise see duplication and delete one copy.

## What lands

**`AGENTS.md`** (scaffolded into every project) gains a Specnaut-owned section — marked as such so a user filling in the surrounding placeholders doesn't read it as one of theirs. It carries both stops named individually, the boundary table, the five excuses with why each is not a reason, blocked-is-not-stopped, the exit criterion, and that standing merge authorisation is not re-collected.

**Each phase now ends by invoking the next one itself.** This was the actual gap: the instruction lived only in `auto-chain.md`. `tasks.md` and `implement.md` now close with an explicit `INVOKE <next>` and name why their own boundary is not a stop. `implement.md` also spells out the freeze that must precede review — a lingering agent is a live teammate that can write into a tree somebody is about to freeze.

**The review loop gets an exit criterion.** Only CRITICAL or HIGH buys another cycle; MEDIUM and LOW go to the backlog and the branch ships. Those cycles run **inside** the stop without re-asking. And a reviewer reports **harm, not labels** — "nothing here would hurt anyone" is a valid verdict, and justifying another round with "the last one found something" is always true and therefore is not a reason. A loop with no exit criterion does not terminate.

## The excuses are quoted verbatim, on purpose

| The excuse | Why it is not a reason |
| :--- | :--- |
| "That's a lot of tasks — confirm first?" | The size was known when the chain started. |
| "MVP only, or the whole thing?" | The plan states both. The MVP is a checkpoint inside the full path, not a fork to offer. |
| "This is where the real code gets written." | Yes. That is the point of the chain. |
| "The audits found a lot — re-confirm scope?" | They were folded into the plan, and the plan was approved. |
| "They've been checkpointing each step." | Answering a question is not a request to be asked another one. |

A model recognises its own reasoning in a quoted sentence in a way a general "do not stop" never achieves. `chain_stops_test.ts` asserts each of the five in **both** carriers.

## Known limitation, not fixed here

`AGENTS.md` ships with `skipIfExists: true`, so **an existing project running `specnaut upgrade` will not receive this section** — only fresh `specnaut init` projects get it. That is the correct default (the file is the user's to own), but it means the always-loaded carrier is missing exactly where the chain is already in use. Worth a decision during #460's upgrade work; I have not widened this PR to cover it.

## Verification

`deno task test` → **1182 passed, 0 failed** (5 new locks). `deno fmt --check`, `deno lint`, `deno check` clean.

Local renders under the 12,000-char Windsurf cap: `plan` 10,836 · `implement` 10,484 · `tasks` 9,923 · `auto-chain` 8,527 · `review` 4,211.

## Agent adoption

The chain now stops at exactly two points: the **end of `plan`**, where you approve the architecture and answer the open questions, and the **review verdict**, which *is* the merge request. Every other boundary is crossed automatically. The rule is written into the scaffolded `AGENTS.md` because that file is always in context — a phase file is only read once that phase is already running, which is after the decision to stall has been taken. Wording elsewhere in your project that tells an agent to pause for approval will fight it.

```prompt
Read `AGENTS.md`, `CLAUDE.md` and `.claude/agents/*.md` in this project and find
any instruction that tells an agent to stop, confirm, or ask permission between
phases of the Specnaut chain — for example "confirm before implementing", "ask
before writing code", "check in after planning", or a checklist that requires
approval at each step.

The chain has exactly two stops: the end of `plan`, and the review verdict.
Everything between them is crossed by invoking the next phase in the same turn.

Rewrite or delete anything that contradicts that, and leave a one-line note
saying why. A contradiction in an always-loaded file is precisely what makes the
chain stall, so being explicit matters more than being brief.

Report what you changed. If you find nothing contradictory, say so — do not
invent an edit.
```
