### PR TITLE
Realign tests, goldens, plugin manifests and ship the major bump

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "specnaut",
-  "version": "1.21.0",
+  "version": "2.0.0",
   "description": "Spec-driven workflow, slash commands, and sub-agents for AI coding harnesses — Specnaut's bundled skill library, agents, and the SessionStart bootstrap that makes the agent skill-aware on every turn.",
   "author": {
     "name": "MakerLabs",
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "Specnaut",
     "shortDescription": "Spec-driven planning, TDD, review, and delivery workflows for coding agents",
-    "longDescription": "Specnaut turns vague ideas into shipped features through a disciplined pipeline: brainstorming → writing-plans → subagent-driven-development (or executing-plans inline) → requesting-code-review → verification-before-completion. The bundled router skill (/specnaut) orchestrates the spec-kit greenfield flow (specify → plan → tasks → analyze → implement → review → merge) and 11 specialised sub-agents handle backlog ops, security, QA, DevOps, and more. Inspired by obra/superpowers (MIT) with explicit Specnaut-native integration with backlogs (GitHub/GitLab/local), constitutional governance, and a Claude/Cursor/Codex/Gemini/OpenCode/Copilot multi-harness distribution.",
+    "longDescription": "Specnaut turns vague ideas into shipped features through a disciplined pipeline: brainstorming → writing-plans → subagent-driven-development (or executing-plans inline) → requesting-code-review → verification-before-completion. The bundled router skill (/specnaut) orchestrates the spec-kit greenfield flow (plan → tasks → implement → review → merge, with the plan audited for architecture and security before any code exists) and 11 specialised sub-agents handle backlog ops, security, QA, DevOps, and more. Inspired by obra/superpowers (MIT) with explicit Specnaut-native integration with backlogs (GitHub/GitLab/local), constitutional governance, and a Claude/Cursor/Codex/Gemini/OpenCode/Copilot multi-harness distribution.",
     "developerName": "MakerLabs",
     "category": "Coding",
     "capabilities": ["Interactive", "Read", "Write"],

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "specnaut",
   "displayName": "Specnaut",
   "description": "Spec-driven planning, TDD, review, and delivery workflows for coding agents — bundled skills, sub-agents, and a SessionStart bootstrap that makes the agent skill-aware on every turn.",
-  "version": "1.21.0",
+  "version": "2.0.0",
   "author": {
     "name": "MakerLabs",
     "url": "https://github.com/mkrlabs"

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@specnaut/cli",
-  "version": "1.21.0",
+  "version": "2.0.0",
   "tasks": {
     "bundle": "deno run --allow-read --allow-write scripts/bundle-templates.ts",
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/main.ts",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "specnaut-plugin",
   "description": "Specnaut's auto-chained spec-driven workflow, slash commands, and sub-agents for Claude Code — the same content the binary scaffolds, available as a versioned plugin.",
-  "version": "1.21.0",
+  "version": "2.0.0",
   "author": {
     "name": "MakerLabs"
   },

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,17 +2,17 @@
 
 This is the Claude Code plugin distribution of [Specnaut](https://specnaut.com). It ships the same
 slash-commands and sub-agents that the `specnaut` binary scaffolds into projects — just as a
-user-scope plugin instead. `/specnaut specify "<feature>"` auto-chains the full workflow by default;
+user-scope plugin instead. `/specnaut plan "<feature>"` auto-chains the full workflow by default;
 pass `--manual` to opt out.
 
 ## What's in here
 
-| Path                                                                                                                                        | Contents                                                              |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specnaut-plugin`, lockstep with the binary version) |
-| `skills/{specify,plan,tasks,implement,analyze,review,merge,constitution,checklist,clarify}/SKILL.md`                                        | The 10 Specnaut slash-commands — `/specnaut-plugin:specify`, etc.     |
-| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                      |
-| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specnaut-plugin:groom`                                |
+| Path                                                                                                                                        | Contents                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `.claude-plugin/plugin.json`                                                                                                                | Plugin manifest (`specnaut-plugin`, lockstep with the binary version)                                                                  |
+| `skills/specnaut/phases/*.md`                                                                                                               | The phase reference docs the router loads on demand — `plan`, `tasks`, `implement`, `review`, `merge`, plus the out-of-band utilities. |
+| `agents/{code-reviewer,developer,devops-sre,product-owner,qa-tester,review-coordinator,security-auditor,test-reviewer,workflow-manager}.md` | 9 sub-agents available to invoke in plugin scope                                                                                       |
+| `skills/groom/SKILL.md`                                                                                                                     | Groom skill — `/specnaut-plugin:groom`                                                                                                 |
 
 The full plugin migration shipped in v0.12.x (issue
 [#73](https://github.com/specnaut/specnaut-cli/issues/73)). When the plugin is installed and the
@@ -25,7 +25,7 @@ uninstalled.
 ### Known caveat: handoff IDs
 
 The 10 command SKILL.md files include `handoffs:` frontmatter that references peer commands by their
-**binary-scaffolded** IDs (`specnaut-plan`, `specnaut-clarify`, …). In plugin scope those IDs are
+**binary-scaffolded** IDs (`specnaut-plan`, `specnaut-review`, …). In plugin scope those IDs are
 `specnaut-plugin:plan` etc., so the clickable handoff buttons may not resolve. For the full handoff
 UX today, use the binary-scaffolded copies (run `specnaut init`) — the plugin versions are the
 discoverability layer, not the polished workflow. Handoff rewriting is a known follow-up task on
@@ -36,8 +36,8 @@ discoverability layer, not the polished workflow. Handoff rewriting is a known f
 - The plugin is **user-scope** and **versioned** — installed once, available across all your
   projects, updates via `/plugin update`.
 - The binary's `specnaut init` scaffolds **project-scope** copies — you can customize them
-  per-project, and they ship with shorter slash-command names (e.g. `/specify` instead of
-  `/specnaut-plugin:specify`).
+  per-project, and they ship with shorter slash-command names (e.g. `/specnaut plan` instead of
+  `/specnaut-plugin:specnaut plan`).
 - Backlog skill, hooks, and `.specnaut/` files stay binary-owned because they read project-state at
   runtime.
 
@@ -55,7 +55,7 @@ To test changes to the plugin without publishing:
 claude --plugin-dir /path/to/specnaut/plugin
 ```
 
-Then invoke any plugin skill: `/specnaut-plugin:specnaut specify "…"`.
+Then invoke any plugin skill: `/specnaut-plugin:specnaut plan "…"`.
 
 ## Versioning
 

--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -6,7 +6,7 @@
 //
 // Pure helpers (`classifyCommit`, `formatChangelog`) are exported for tests.
 
-export type Category = "feat" | "fix" | "chore" | "skip";
+export type Category = "breaking" | "feat" | "fix" | "chore" | "skip";
 
 export type Commit = {
   hash: string;
@@ -31,7 +31,7 @@ const CHORE_PREFIXES = new Set([
   "build",
 ]);
 const RELEASE_BUMP_RE = /^chore:\s*release\s+v\d+\.\d+\.\d+/;
-const PREFIX_RE = /^(\w+)(\([^)]+\))?!?:\s*(.+)$/;
+const PREFIX_RE = /^(\w+)(\([^)]+\))?(!)?:\s*(.+)$/;
 
 export function classifyCommit(commit: Commit): Classified {
   const subject = commit.subject.trim();
@@ -43,8 +43,15 @@ export function classifyCommit(commit: Commit): Classified {
     return { ...commit, category: "chore", cleanedSubject: capitalize(subject) };
   }
   const type = m[1].toLowerCase();
-  const rest = collapseTrailingIssueRefs(m[3]);
+  const rest = collapseTrailingIssueRefs(m[4]);
   const cleanedSubject = capitalize(rest);
+  // Conventional Commits marks a breaking change with `!` before the colon.
+  // The `!` used to be swallowed by the prefix pattern, so a major release
+  // listed its breaking changes as ordinary features — the one thing a reader
+  // upgrading across a major MUST not have to infer.
+  if (m[3] === "!") {
+    return { ...commit, category: "breaking", cleanedSubject };
+  }
   if (FEATURE_PREFIXES.has(type)) {
     return { ...commit, category: "feat", cleanedSubject };
   }
@@ -296,6 +303,14 @@ export function formatChangelog(commits: Classified[], opts: FormatOpts): string
 
   const sections: string[] = [];
   sections.push(`## What's changed in ${opts.toTag}`);
+  const breaking = commits.filter((c) => c.category === "breaking");
+  if (breaking.length > 0) {
+    // First, and never inside a <details>. Someone skimming a major release
+    // must hit this before anything else.
+    sections.push(
+      "### ⚠ Breaking changes\n\n" + breaking.map(formatBullet).join("\n"),
+    );
+  }
 
   if (commits.length === 0) {
     sections.push("_No user-facing changes since the previous release._");

--- a/src/domain/spec/spec_step.ts
+++ b/src/domain/spec/spec_step.ts
@@ -1,7 +1,7 @@
 // The opaque unit of a specification exchanged with SpecNaut Cloud (spec 020).
 //
 // A step is one named markdown section of a spec — the framework phase
-// (`specify`, `plan`, `tasks`, …). It is deliberately opaque to the cloud: only
+// (`plan`, `tasks`, …). It is deliberately opaque to the cloud: only
 // `key`, `name`, `order`, and `body` cross the wire. This is the SOLE shape that
 // crosses the OSS↔Cloud boundary for specs (constitution § I) — no CLI framework
 // identifier, no private-half type, ever travels with it.
@@ -9,8 +9,8 @@
 /**
  * One ordered, named markdown section of a specification.
  *
- * - `key`   — stable slug the cloud upserts on (e.g. `"specify"`, `"plan"`).
- * - `name`  — human-readable tab label (e.g. `"Specify"`).
+ * - `key`   — stable slug the cloud upserts on (e.g. `"plan"`, `"tasks"`).
+ * - `name`  — human-readable tab label (e.g. `"Plan"`).
  * - `order` — 1-based display / materialisation order.
  * - `body`  — the raw markdown content.
  */

--- a/src/domain/version.ts
+++ b/src/domain/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.21.0";
+export const VERSION = "2.0.0";

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2,7 +2,7 @@
 import type { CoreBundle } from "./domain/core_bundle.ts";
 import type { TemplateFile } from "./domain/template.ts";
 
-export const TEMPLATES_VERSION = "1.21.0";
+export const TEMPLATES_VERSION = "2.0.0";
 
 export const CORE_BUNDLE: CoreBundle = [
   {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.21.0",
+  "version": "2.0.0",
   "core": [
     { "category": "skill", "name": "specnaut", "source": "core/skills/specnaut/SKILL.md" },
     { "category": "phase", "name": "plan", "suffix": "plan.md", "source": "core/skills/specnaut/phases/plan.md" },

--- a/tests/integration/upgrade_removed_phases_test.ts
+++ b/tests/integration/upgrade_removed_phases_test.ts
@@ -1,0 +1,127 @@
+import { assert, assertEquals } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+/**
+ * #460 — `specnaut upgrade` must leave no orphan behind from the phases #455
+ * deleted.
+ *
+ * The removal machinery is lock-driven and already existed: a lock entry that
+ * is no longer in the new bundle becomes a `remove` action when the file is
+ * still on disk. What did NOT exist is a test proving it for THIS set of files,
+ * and "the mechanism is generic so it must work" is exactly the assumption that
+ * ships a project still carrying `phases/specify.md` next to a router that no
+ * longer routes to it — a stale file an agent can still read and act on.
+ *
+ * So this simulates a pre-#455 install honestly: real files on disk, real
+ * entries in the lock with real hashes, then a real upgrade.
+ */
+
+const REMOVED_PHASES = [
+  "brainstorm",
+  "specify",
+  "clarify",
+  "analyze",
+  "checklist",
+  "list-skills",
+  "lite-heuristic",
+] as const;
+
+const REMOVED_TEMPLATES = [
+  ".specnaut/templates/spec-template.md",
+  ".specnaut/templates/checklist-template.md",
+] as const;
+
+async function runSpecnaut(args: string[], cwd: string) {
+  const { code, stdout, stderr } = await new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", "--allow-run", "--allow-env", MAIN, ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+async function sha256(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+Deno.test("upgrade removes every phase and template #455/#457 deleted, leaving no orphan", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "specnaut-upgrade-orphan-" });
+  try {
+    const init = await runSpecnaut(
+      ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"],
+      dir,
+    );
+    assertEquals(init.code, 0, `init failed: ${init.stderr}`);
+
+    // Simulate the pre-#455 install: the files exist on disk AND are recorded
+    // in the lock. Both halves matter — an unrecorded file is not an orphan the
+    // upgrade owns, it is a user file, and deleting it would be a bug.
+    const planted: string[] = [
+      ...REMOVED_PHASES.map((n) => `.claude/skills/specnaut/phases/${n}.md`),
+      ...REMOVED_TEMPLATES,
+    ];
+
+    const lockPath = join(dir, ".specnaut/installed.lock");
+    let lock = await Deno.readTextFile(lockPath);
+    const body = `# placeholder for a phase this version no longer ships\n`;
+    const hash = await sha256(body);
+
+    for (const rel of planted) {
+      const abs = join(dir, rel);
+      await Deno.mkdir(join(abs, ".."), { recursive: true });
+      await Deno.writeTextFile(abs, body);
+      lock += `  ${rel}:\n    sha256: ${hash}\n    installed_at: "2026-01-01T00:00:00Z"\n` +
+        `    templates_version: 1.0.0\n`;
+    }
+    await Deno.writeTextFile(lockPath, lock);
+
+    for (const rel of planted) {
+      assertEquals(await exists(join(dir, rel)), true, `setup failed to plant ${rel}`);
+    }
+
+    const up = await runSpecnaut(["upgrade", "--force"], dir);
+    assertEquals(up.code, 0, `upgrade failed: ${up.stderr}`);
+
+    for (const rel of planted) {
+      assertEquals(
+        await exists(join(dir, rel)),
+        false,
+        `${rel} survived the upgrade — a stale phase doc an agent can still read`,
+      );
+    }
+
+    // And the surviving set is intact: removal must not overshoot.
+    for (
+      const rel of [
+        ".claude/skills/specnaut/SKILL.md",
+        ".claude/skills/specnaut/phases/plan.md",
+        ".claude/skills/specnaut/phases/plan-audits.md",
+        ".claude/skills/specnaut/phases/tasks.md",
+        ".claude/skills/specnaut/phases/implement.md",
+        ".claude/skills/specnaut/phases/review.md",
+        ".claude/skills/specnaut/phases/merge.md",
+        ".specnaut/templates/plan-template.md",
+        ".specnaut/templates/tasks-template.md",
+      ]
+    ) {
+      assertEquals(await exists(join(dir, rel)), true, `${rel} must survive the upgrade`);
+    }
+
+    // The lock is the audit trail: it must no longer claim the removed files.
+    const after = await Deno.readTextFile(lockPath);
+    for (const rel of planted) {
+      assert(!after.includes(rel), `lock still records the removed ${rel}`);
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/scripts/gen_changelog_test.ts
+++ b/tests/scripts/gen_changelog_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import {
   type Classified,
   classifyCommit,
@@ -30,9 +30,13 @@ Deno.test("classifyCommit categorises fix(scope):", () => {
   assertEquals(r.cleanedSubject, "Handle missing tty");
 });
 
+// #460 — this test previously asserted `category === "feat"`, pinning the very
+// behaviour that made a major release unreadable: the `!` was swallowed and the
+// breaking change appeared among ordinary features. The marker now decides the
+// category, which is what Conventional Commits means by it.
 Deno.test("classifyCommit handles breaking-change marker (feat!:)", () => {
   const r = classifyCommit({ hash: "abc", subject: "feat!: rewire ports" });
-  assertEquals(r.category, "feat");
+  assertEquals(r.category, "breaking");
   assertEquals(r.cleanedSubject, "Rewire ports");
 });
 
@@ -641,4 +645,53 @@ Deno.test("C5: a single failed outcome amid legitimate absences is the only thin
   assertEquals(failures.length, 1);
   assertEquals(failures[0].prNum, 603);
   assertStringIncludes(failures[0].reason, "ECONNRESET");
+});
+
+// #460 — a major release must not make the reader infer what broke.
+// The `!` marker was previously swallowed by the prefix pattern, so a breaking
+// change was listed as an ordinary feature.
+Deno.test("a `!` before the colon classifies the commit as breaking", () => {
+  for (
+    const subject of [
+      "feat(455)!: remove four phases",
+      "feat!: remove four phases",
+      "refactor(457)!: cut the artefacts",
+    ]
+  ) {
+    assertEquals(classifyCommit({ hash: "h", subject }).category, "breaking", subject);
+  }
+});
+
+Deno.test("a `!`-marked commit keeps its subject intact, without the marker", () => {
+  const c = classifyCommit({ hash: "h", subject: "feat(455)!: remove four phases" });
+  assertEquals(c.cleanedSubject, "Remove four phases");
+});
+
+Deno.test("breaking changes lead the notes and are never hidden in a <details>", () => {
+  const commits = [
+    { hash: "a1", subject: "chore: housekeeping" },
+    { hash: "a2", subject: "feat(456): fold specify into plan" },
+    { hash: "a3", subject: "feat(455)!: remove four phases" },
+  ].map(classifyCommit);
+  const out = formatChangelog(commits, { fromTag: "v1.21.0", toTag: "v2.0.0" });
+
+  assertStringIncludes(out, "### ⚠ Breaking changes");
+  // Ahead of every other section, so a skim cannot miss it.
+  assert(
+    out.indexOf("### ⚠ Breaking changes") < out.indexOf("### Features"),
+    "breaking changes must come before features",
+  );
+  // The chore section is collapsed; this one must not be.
+  const breakingIdx = out.indexOf("### ⚠ Breaking changes");
+  const detailsIdx = out.indexOf("<details>");
+  assert(
+    detailsIdx === -1 || detailsIdx > breakingIdx,
+    "breaking changes must not be inside a <details>",
+  );
+});
+
+Deno.test("no breaking commits means no breaking section at all", () => {
+  const commits = [{ hash: "a1", subject: "feat: something ordinary" }].map(classifyCommit);
+  const out = formatChangelog(commits, { fromTag: "v1.0.0", toTag: "v1.1.0" });
+  assertEquals(out.includes("Breaking changes"), false);
 });


### PR DESCRIPTION
Closes #460

Last CLI child of #454. Builds on #461, #462, #463 and #464.

## The bump

`1.21.0 → 2.0.0`, all six version files in lockstep — `deno.json`, `src/domain/version.ts`, `plugin/.claude-plugin/plugin.json`, `templates/manifest.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`. **No tag is created here.** Releasing is a separate, deliberate act.

## A defect found while writing the changelog criterion

`PREFIX_RE` matched `!?` **without capturing it**, so the Conventional Commits breaking marker was parsed and thrown away. A `feat(455)!:` commit landed under "Features", indistinguishable from an additive change.

I confirmed this against the real notes rather than reasoning about it — before the fix, `v2.0.0` previewed with *"Reduce the router to five phases and one flag"* sitting among ordinary features, with no breaking section at all. On the release that removes six phases and four flags.

Fixed: the marker now decides the category, and breaking changes **lead** the notes — first section, never inside the collapsed `<details>` the chores use. An existing test asserted `feat!:` classified as `"feat"`; it pinned the defect, so it is **flipped with a comment saying so**, not deleted.

## The marker commit, and why it is empty

The breaking changes landed across #455–#459 **before** `!` support existed, so those commits were written without it and now sit on `main`. Rewording them means rewriting published history, which I am not doing unasked.

So `feat(454)!:` is an empty commit that records the classification. Its body is the actual upgrade note — removed phases and where each one's work went, removed flags, removed artefacts, and explicitly **what replaces the removed rigour**, because a reader who sees only a shorter phase list will conclude rigour was dropped when it was moved earlier.

## Orphan cleanup: proven, not assumed

The removal machinery is lock-driven and already existed — an entry no longer in the bundle becomes a `remove` when the file is still on disk. What did **not** exist is a test proving it for this set of files, and *"the mechanism is generic so it must work"* is exactly the assumption that ships a project still carrying `phases/specify.md` next to a router that no longer routes to it: a stale file an agent can still read and act on.

The new test simulates a pre-#455 install honestly — real files on disk, real lock entries with real hashes — then upgrades and checks three things: the nine removed files are gone, **the surviving set is untouched** (removal must not overshoot), and the lock no longer claims what it deleted. It passes.

## Manifests and comments

The Codex manifest still advertised the nine-phase chain in full; `plugin/README.md` listed ten per-phase skill folders that no longer exist and used `/specify` as its example; `spec_step.ts` used `"specify"` as its worked example of a step key. None are covered by a test, which is why they drifted — they are read by people and by marketplace listings.

## Two things NOT done here, deliberately

**No tag, no release.** The release is irreversible and fires the cross-platform build, the GitHub Release and the Homebrew tap bump. It needs an explicit go.

**`specnaut-web#11` must land after that release, not before.** The bundled `specnaut-expert` agent points harnesses at `https://specnaut.com/llms.txt` as canonical, and that page still documents all nine phases — so after the bump every scaffolded project's expert agent is authoritatively told a chain that no longer exists. Publishing the rewrite *before* the release would invert the drift rather than fix it.

## Verification

`deno task test` → **1194 passed, 0 failed**. `deno fmt --check`, `deno lint`, `deno check` clean.