### PR TITLE
Restore the breaking-change marker lost from the v2.0.0 range

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,89 @@
+# Upgrading Specnaut
+
+## 1.x → 2.0.0
+
+The workflow chain went from **nine chainable phases and five flags** to **five and one**. Run
+`specnaut upgrade` in each scaffolded project; it removes the files this version no longer ships.
+
+### Phases that no longer exist
+
+An old phase name now prints the phase index and stops. There are no aliases — this is a clean
+break.
+
+| Gone                    | Where its work happens now                                                                       |
+| :---------------------- | :----------------------------------------------------------------------------------------------- |
+| `/specnaut brainstorm`  | `/specnaut plan`, step 1 — the discovery dialogue, run only when the input is too vague to plan. |
+| `/specnaut specify`     | `/specnaut plan` — the same document, sections 1–4.                                              |
+| `/specnaut clarify`     | `/specnaut plan`, step 8 — questions asked one at a time at the stop, before any code exists.    |
+| `/specnaut analyze`     | **Replaced, not moved.** See below.                                                              |
+| `/specnaut checklist`   | `plan.md`'s success criteria and decision table.                                                 |
+| `/specnaut list-skills` | Read `.specnaut/installed.lock` directly.                                                        |
+
+The chain is now:
+
+```
+plan → tasks → implement → review → merge
+```
+
+### Flags that no longer exist
+
+`--once`, `--continue`, `--lite` and `--full` are removed, along with the lite-chain concept and the
+`lite-heuristic` contract doc. **`--manual` is the only surviving flag.**
+
+Re-entry needs no flag: invoking a phase whose downstream artefacts already exist runs one-shot;
+invoking one whose downstream artefacts are absent chains. `workflow_shape` is gone from
+`.specnaut/feature.json`; an existing file carrying it is ignored, not an error.
+
+### Artefacts: eight files down to two
+
+A feature now produces exactly `plan.md` and `tasks.md`.
+
+`spec.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/` and `checklists/` are no
+longer generated, and `spec-template.md` and `checklist-template.md` no longer ship. Where their
+content matters it lives in `plan.md` — the domain model in section 6, interface contracts in
+section 8.
+
+**Your existing spec directories are left on disk untouched.** Nothing migrates them, and the `plan`
+phase reads whatever is there without failing. Migrate them by hand if you want the new shape, or
+leave them; they are a record of work already done.
+
+### What replaces the rigour that was removed
+
+This is the part a shorter phase list hides. `analyze` was **replaced**, not dropped.
+
+With one planning document there are no artefacts left to hold in agreement, so a cross-artefact
+consistency check has nothing to check. Its successor runs _earlier_ and costs less:
+
+- **A binding decision table** in `plan.md` — every rule the feature introduces, its **single home**
+  (a file path, never a layer), and what would count as a second spelling. The implementer may not
+  move a decision out of its home without the plan being amended first.
+- **Two audits of the plan itself**, dispatched concurrently **before a line of code exists** —
+  `architecture-auditor` and `security-auditor`. Their findings are written back into `plan.md`:
+  either the plan changes, or it records why the objection was accepted.
+
+Architecture found at review time is architecture rebuilt. This moves that discovery to where
+changing your mind is still free.
+
+### Two stops, and no third
+
+The chain stops at exactly two points: the **end of `plan`**, where you approve the architecture and
+answer the open questions, and the **review verdict**, which _is_ the merge request. Every other
+boundary is crossed automatically.
+
+Only a CRITICAL or HIGH finding buys another fix cycle; MEDIUM and LOW go to the backlog and the
+branch ships.
+
+### Merge now squashes by scope
+
+`/specnaut merge` performs the squash itself: **one commit per scope**, not one per branch. The
+feature, its generated artefacts, unrelated configuration, docs, and any fix to a pre-existing
+defect each get their own commit — the last one carrying **its own** backlog id, not the feature's.
+
+If your default branch is protected, the local fast-forward path will not work; the phase does not
+implement a forge-side path.
+
+### Known gap
+
+`AGENTS.md` is scaffolded with `skipIfExists`, so **`specnaut upgrade` will not add the two-stop
+section to a project that already has one** — only a fresh `specnaut init` gets it. Overwriting a
+file you own would be worse than the gap. Copy the section from a fresh scaffold if you want it.

--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -296,6 +296,36 @@ export type FormatOpts = {
   adoptionEntries?: AdoptionEntry[];
 };
 
+/**
+ * True when `tag` is a major release — `vX.0.0` with X >= 1.
+ *
+ * A major with no breaking commit in range is almost always a lost marker
+ * rather than a genuinely non-breaking major. That is not hypothetical: the
+ * v2.0.0 marker was an EMPTY commit, and `git rebase` drops empty commits
+ * silently, so a verified generator fix said nothing about whether its input
+ * survived the merge. Hence {@link breakingGuardWarning}.
+ */
+export function isMajorTag(tag: string): boolean {
+  const m = tag.match(/^v?(\d+)\.0\.0$/);
+  return m !== null && Number(m[1]) >= 1;
+}
+
+/**
+ * Returns the warning a major release with no breaking marker must emit, or
+ * `null` when there is nothing to warn about.
+ */
+export function breakingGuardWarning(
+  commits: Classified[],
+  toTag: string,
+): string | null {
+  if (!isMajorTag(toTag)) return null;
+  if (commits.some((c) => c.category === "breaking")) return null;
+  return `${toTag} is a major release but no commit in range carries the ` +
+    `Conventional Commits breaking marker (\`type(scope)!:\`). Either the ` +
+    `bump is wrong, or the marker was lost — note that an empty marker commit ` +
+    `is dropped by \`git rebase\`, so carry it on a commit with real content.`;
+}
+
 export function formatChangelog(commits: Classified[], opts: FormatOpts): string {
   const features = commits.filter((c) => c.category === "feat");
   const fixes = commits.filter((c) => c.category === "fix");
@@ -441,6 +471,15 @@ async function main() {
       console.error(
         `gen-changelog: ${failures.length} PR-body retrieval failure(s) under --strict — refusing to write a partial Adoption guide.`,
       );
+      Deno.exit(1);
+    }
+  }
+
+  const guard = breakingGuardWarning(classified, to);
+  if (guard) {
+    console.error(`gen-changelog: ${guard}`);
+    if (strict) {
+      console.error("gen-changelog: refusing to write notes for a major with no breaking marker.");
       Deno.exit(1);
     }
   }

--- a/tests/scripts/gen_changelog_test.ts
+++ b/tests/scripts/gen_changelog_test.ts
@@ -1,9 +1,11 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  breakingGuardWarning,
   type Classified,
   classifyCommit,
   collapseTrailingIssueRefs,
   formatChangelog,
+  isMajorTag,
 } from "../../scripts/gen-changelog.ts";
 
 Deno.test("classifyCommit categorises feat:", () => {
@@ -694,4 +696,33 @@ Deno.test("no breaking commits means no breaking section at all", () => {
   const commits = [{ hash: "a1", subject: "feat: something ordinary" }].map(classifyCommit);
   const out = formatChangelog(commits, { fromTag: "v1.0.0", toTag: "v1.1.0" });
   assertEquals(out.includes("Breaking changes"), false);
+});
+
+// #467 — the v2.0.0 marker was an EMPTY commit, and `git rebase` drops empty
+// commits silently. The generator fix was verified; its input was not. These
+// pin the guard that turns that silence into a message.
+Deno.test("isMajorTag recognises a major release and nothing else", () => {
+  for (const tag of ["v2.0.0", "2.0.0", "v10.0.0"]) {
+    assertEquals(isMajorTag(tag), true, tag);
+  }
+  for (const tag of ["v2.1.0", "v2.0.1", "v0.0.0", "v1.21.0", "not-a-tag"]) {
+    assertEquals(isMajorTag(tag), false, tag);
+  }
+});
+
+Deno.test("a major with no breaking marker warns, and names the empty-commit trap", () => {
+  const commits = [{ hash: "a1", subject: "feat: something ordinary" }].map(classifyCommit);
+  const warning = breakingGuardWarning(commits, "v2.0.0");
+  assert(warning !== null, "a major with no breaking commit must warn");
+  assertStringIncludes(warning, "major release");
+  // The actionable half: without it the warning says what, not what to do.
+  assertStringIncludes(warning, "git rebase");
+});
+
+Deno.test("the guard stays silent when it should", () => {
+  const breaking = [{ hash: "a1", subject: "feat!: removes a phase" }].map(classifyCommit);
+  assertEquals(breakingGuardWarning(breaking, "v2.0.0"), null, "major WITH a marker is fine");
+
+  const ordinary = [{ hash: "a1", subject: "feat: adds a phase" }].map(classifyCommit);
+  assertEquals(breakingGuardWarning(ordinary, "v2.1.0"), null, "a minor needs no marker");
 });


### PR DESCRIPTION
Closes #467

Blocks the v2.0.0 release. Caught before the tag was cut, so it costs one PR instead of a retag.

## What went wrong

#460 fixed the changelog generator to classify `type(scope)!:` as a breaking change, and verified it. But the #455–#459 commits had already landed without the marker, so I added `feat(454)!:` as an **empty** commit to carry the classification.

`git rebase` **drops empty commits silently.** `gh pr merge --rebase` dropped it. It is reachable only from the deleted branch; `main` has zero breaking markers across `v1.21.0..HEAD`, and the v2.0.0 notes would have shipped with no breaking section at all — on the release that removes six phases and four flags.

The general lesson, which is the part worth keeping: **a verified fix says nothing about whether its input survived.** I checked the generator, not the range.

## The fix, in two parts

**The marker now carries content.** `UPGRADING.md` is a real document in the place a user actually looks — removed phases and where each one's work went, removed flags, the two surviving artefacts and the fact that existing spec directories are left untouched, the two stops, the scope-based squash, and the known `AGENTS.md` gap (#466) rather than letting an upgrading user find it as a silent absence.

Its longest section is **what replaces the rigour that was removed**, because that is what a shorter phase list hides: a reader who sees nine phases become five concludes rigour was dropped. It was moved earlier — to a binding decision table and two audits that run against the plan before a line of code exists, where changing your mind is still free.

**A guard so this cannot recur silently.** `breakingGuardWarning` fires when the target is `vX.0.0` (X ≥ 1) and no commit in range carries a marker. It names both causes — wrong bump, or lost marker — and the specific trap, so nobody has to rediscover that empty commits do not survive a rebase. Under `--strict`, which is how the release workflow runs it, it refuses to write the notes.

`isMajorTag` is deliberately narrow: a v0 major is not a compatibility promise anyone made.

## Verified against the real thing, not reasoned about

Before this PR, on `main`:

```
gen-changelog: v2.0.0 is a major release but no commit in range carries the
Conventional Commits breaking marker (`type(scope)!:`). Either the bump is
wrong, or the marker was lost — note that an empty marker commit is dropped
by `git rebase`, so carry it on a commit with real content.
```

With `62bf1f1` in range the warning goes quiet and the notes lead with **⚠ Breaking changes**.

`deno task test` → **1197 passed, 0 failed** (3 new locks on the guard). `deno fmt --check`, `deno lint`, `deno check` clean.

## Merging this one

This PR carries a non-empty `!` commit, so `--rebase` preserves it. **Do not squash-merge it** — that would collapse the marker and the guard into one subject and lose the classification again.