### PR TITLE
Link UPGRADING.md from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ to drive a spec-driven workflow inside your project. It adds three things upstre
 - **Product backlog** — Markdown index + one file per task with structured frontmatter, a Product
   Owner agent for management, one-way sync to GitHub Issues/Project V2
 
+> **Upgrading from 1.x?** The phase chain changed. Read [UPGRADING.md](UPGRADING.md) before running
+> `specnaut upgrade`.
+
 ## What Specnaut is not
 
 Specnaut does not talk to any LLM. Specnaut does not orchestrate any agent. You need a compatible AI


### PR DESCRIPTION
One line, cut before the v2.0.0 tag.

`UPGRADING.md` landed in #468 but nothing linked to it — it was reachable only from the GitHub release page. Anyone who upgrades by running `specnaut upgrade` without reading a release page would never see it.

That matters more than a normal discoverability nit: `UPGRADING.md` § "Known gap" is the documented mitigation that makes #466 (the `AGENTS.md` upgrade gap) non-blocking for this release. **A guide nobody reaches is not a mitigation.**

`deno task test` → 1197 passed, 0 failed.