### PR TITLE
Release readiness: name the break in the notes, stop a promise v2.0.0 breaks

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,8 +2,17 @@
 
 ## 1.x → 2.0.0
 
-The workflow chain went from **nine chainable phases and five flags** to **five and one**. Run
-`specnaut upgrade` in each scaffolded project; it removes the files this version no longer ships.
+### At a glance
+
+| Before                                                | After                                                 |
+| :---------------------------------------------------- | :---------------------------------------------------- |
+| 9 chainable phases                                    | **5** — `plan → tasks → implement → review → merge`   |
+| 5 chain flags                                         | **1** — `--manual`                                    |
+| up to 8 files per feature                             | **2** — `plan.md` + `tasks.md`                        |
+| stops when clarification is needed, then before merge | **exactly 2** — end of `plan`, and the review verdict |
+
+Run `specnaut upgrade` in each scaffolded project; it removes the files this version no longer
+ships. Nothing migrates your existing spec directories — they are left on disk untouched.
 
 ### Phases that no longer exist
 

--- a/src/domain/deprecation.ts
+++ b/src/domain/deprecation.ts
@@ -15,4 +15,4 @@ export function isLegacyInvocation(execPath: string): boolean {
 export const LEGACY_INVOCATION_WARNING =
   "warning: the 'specflow' command is deprecated — use 'specnaut' instead. " +
   "Run 'specnaut self-update' (or reinstall) to get the renamed binary; " +
-  "the 'specflow' alias will be removed in the next major release.";
+  "the 'specflow' alias will be removed in a future major release.";


### PR DESCRIPTION
Two findings from the pre-release advisory pass on `v2.0.0`. Neither is a pipeline defect — the pipeline was verified correct for a major, including a live `--strict` dry run of the exact commit range.

## 1. The breaking-changes section named the fix, not the break

`v2.0.0`'s notes rendered as one bullet: *"Add UPGRADING.md for the 1.x → 2.0.0 break."* That is a commit subject about the remedy. The actual substance — nine phases to five, eight artefacts to two, five flags to one — sat below the fold under **Features**.

So a reader skimming the top of a major release still had to infer what changed, which is precisely what the #467 guard exists to prevent. **The guard could not catch this**: it verifies that *a* marker exists, not that the marker *says* anything. Worth knowing as a limit of that check rather than assuming it covers the whole failure.

Fixed by carrying the summary in the subject, where the notes read it, and adding an at-a-glance table at the top of `UPGRADING.md` so the same four facts are the first thing an upgrader sees.

Before:

```
### ⚠ Breaking changes
- Add UPGRADING.md for the 1.x → 2.0.0 break
```

After:

```
### ⚠ Breaking changes
- Nine phases become five, eight artefacts become two, five flags become one
- Add UPGRADING.md for the 1.x → 2.0.0 break
```

## 2. A promise this release breaks on arrival

The `specflow` deprecation notice said the alias *"will be removed in the next major release"*. **This is that release, and it does not remove the alias** — it is still wired through `main.ts`, `credential_store.ts` and `keychain_backend.ts`.

A promise a release breaks the moment it ships is worse than no promise. Reworded to "a future major release"; actually removing the alias stays a separate, deliberate decision.

## Not addressed here

The advisory also flagged **#466** (`AGENTS.md` ships `skipIfExists`, so `specnaut upgrade` never delivers the two-stop section to existing projects — exactly the population a major upgrade touches). That is a product-readiness call about what ships, not something to decide inside a PR. It is Kevin's.

Two low findings are left alone deliberately: a stale comment in `release.yml:263-267` naming the wrong Codex sync destination (pre-existing, comment-only), and the structurally-blind private-advisories check (documented in the workflow itself, by design).

## Verification

`deno task test` → 1197 passed, 0 failed. `deno fmt --check`, `deno lint` clean. Notes previewed against the real range: 26 commits kept, breaking section leads with the summary.