### PR TITLE
fix(release): publish the Adoption guide, which has never once rendered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
       - name: Sync to Codex marketplace fork (#277 / B1)
         if: ${{ !cancelled() && steps.release.outcome == 'success' }}
         # Mirrors the Specnaut plugin content into
-        # `mkrlabs/plugins:plugins/specnaut/`. A human rebases that
+        # `specnaut/specnaut-plugins:plugins/specnaut/`. A human rebases that
         # fork's PR into upstream `openai/plugins` for the actual
         # marketplace publish. If CODEX_SYNC_TOKEN is unset, the
         # script emits a workflow ::warning and exits 0 — the release

--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -84,19 +84,47 @@ const NEXT_H2_RE = /^## /m;
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 const PROMPT_FENCE_RE = /^```prompt\s*$/m;
 
+const FENCED_BLOCK_RE = /```[\s\S]*?```/g;
+const INLINE_CODE_RE = /`[^`\n]*`/g;
+// Private-use sentinel rather than NUL: same "cannot occur in real prose"
+// property without tripping the control-character lint. Any pre-existing
+// occurrence is stripped from the input first, so the index can never slip.
+const SENTINEL = "\uE000";
+const PLACEHOLDER_RE = /\uE000(\d+)\uE000/g;
+
 /**
- * Strip HTML comments from a string, looping until idempotent so that
- * nested or malformed patterns like `<!-- foo <!-- bar -->` leave no residue.
+ * Strip HTML comments that are *markup*, leaving alone any that are *content*.
+ *
+ * The strip exists to drop the PR template's `<!-- placeholder -->` hints. But
+ * an HTML comment inside a code span or fenced block is something the author is
+ * deliberately showing the reader — and Specnaut's own managed-section fence is
+ * literally an HTML comment, so an adoption prompt teaching users about
+ * `<!-- --- Specnaut: … --- -->` had its subject matter deleted out of it,
+ * leaving empty backticks and instructions to look for nothing.
+ *
+ * Code regions are lifted out, the remainder is stripped to a fixed point
+ * (catching nested/malformed runs like `<!-- foo <!-- bar -->`), then the code
+ * is put back exactly as written.
  */
 function stripHtmlComments(s: string): string {
-  // Repeated pass to catch overlapping / nested patterns.
+  const preserved: string[] = [];
+  // Indexed placeholders, not positional ones: the two lifting passes push in
+  // their own order while the placeholders sit interleaved in the document, so
+  // restoring by order of appearance swaps a code span for a fenced block.
+  const lift = (text: string, re: RegExp) =>
+    text.replace(re, (m) => `${SENTINEL}${preserved.push(m) - 1}${SENTINEL}`);
+
+  // Fenced blocks first: an inline-code pass would otherwise chew through the
+  // backtick runs that delimit them.
+  let current = lift(lift(s.replaceAll(SENTINEL, ""), FENCED_BLOCK_RE), INLINE_CODE_RE);
+
   let prev: string;
-  let current = s;
   do {
     prev = current;
     current = current.replace(HTML_COMMENT_RE, "");
   } while (current !== prev);
-  return current;
+
+  return current.replace(PLACEHOLDER_RE, (_m, idx) => preserved[Number(idx)]);
 }
 
 /**
@@ -121,7 +149,25 @@ export function extractAdoption(body: string): string | null {
 
   const cleaned = stripHtmlComments(section).trim();
   if (!PROMPT_FENCE_RE.test(cleaned)) return null;
-  return cleaned;
+  return truncateAfterPrompt(cleaned);
+}
+
+/**
+ * Cut the section after the closing fence of its ```prompt block.
+ *
+ * `CONTRIBUTING.md` defines the shape as prose first, one ```prompt block
+ * second — so the block's closing fence IS the end of the guide. Without this,
+ * a section that happens to be the last `## ` in the PR body swallows whatever
+ * follows it, and the tooling footer every PR carries ends up printed inside
+ * the published release notes as if it were adoption guidance.
+ */
+function truncateAfterPrompt(section: string): string {
+  const open = section.match(PROMPT_FENCE_RE);
+  if (!open || open.index === undefined) return section;
+  const afterOpen = open.index + open[0].length;
+  const close = section.slice(afterOpen).match(/^```\s*$/m);
+  if (!close || close.index === undefined) return section;
+  return section.slice(0, afterOpen + close.index + close[0].length).trimEnd();
 }
 
 const PR_NUMBER_RE = /\s\(#(\d+)\)\s*$/;
@@ -134,6 +180,75 @@ export function extractPrNumber(subject: string): number | null {
   const m = subject.match(PR_NUMBER_RE);
   if (!m) return null;
   return parseInt(m[1], 10);
+}
+
+/**
+ * The three-way result of resolving a commit back to its PR.
+ *
+ * Same discipline as {@link PrBodyOutcome}, for the same reason: "this commit
+ * has no PR" and "we could not ask" must never collapse into one value. That
+ * collapse is what made the previous gap invisible.
+ */
+export type PrRefOutcome =
+  | { kind: "resolved"; prNum: number }
+  | { kind: "absent" }
+  | { kind: "failed"; reason: string };
+
+/**
+ * Injection seam for SHA → PR resolution. The real implementation is the
+ * `gh`-backed {@link resolvePrFromSha}; tests pass a fake.
+ */
+export type PrNumberResolver = (hash: string) => Promise<PrRefOutcome>;
+
+const PR_SHA_CACHE = new Map<string, PrRefOutcome>();
+
+/**
+ * Resolve the PR a commit belongs to from its SHA, via
+ * `gh api repos/{owner}/{repo}/commits/<sha>/pulls`.
+ *
+ * This exists because this repository **rebase-merges**. A squash merge stamps
+ * `(#NNN)` onto the subject and {@link extractPrNumber} finds it; a rebase does
+ * not, so every rebased `feat` commit looked like a commit with no PR — the
+ * documented "no entry, no failure" path — and its Agent adoption section was
+ * dropped without a word. CI has been rejecting `feat:` PRs that omit that
+ * section while no release body has ever carried one.
+ *
+ * GitHub keeps the association across the rewrite, so the post-rebase SHA still
+ * resolves. Cached per process, failures included.
+ */
+export async function resolvePrFromSha(hash: string): Promise<PrRefOutcome> {
+  const cached = PR_SHA_CACHE.get(hash);
+  if (cached !== undefined) return cached;
+  const cmd = new Deno.Command("gh", {
+    args: [
+      "api",
+      `repos/{owner}/{repo}/commits/${hash}/pulls`,
+      "--jq",
+      ".[0].number",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  let outcome: PrRefOutcome;
+  try {
+    const out = await cmd.output();
+    if (!out.success) {
+      const reason = new TextDecoder().decode(out.stderr).trim() ||
+        `gh api commits/${hash}/pulls exited non-zero`;
+      console.warn(`gen-changelog: failed to resolve PR for ${hash} — ${reason}`);
+      outcome = { kind: "failed", reason };
+    } else {
+      const decoded = new TextDecoder().decode(out.stdout).trim();
+      const num = decoded === "" || decoded === "null" ? NaN : Number(decoded);
+      outcome = Number.isInteger(num) ? { kind: "resolved", prNum: num } : { kind: "absent" };
+    }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`gen-changelog: cannot run gh CLI (${reason}) — PR lookup failed for ${hash}`);
+    outcome = { kind: "failed", reason };
+  }
+  PR_SHA_CACHE.set(hash, outcome);
+  return outcome;
 }
 
 /**
@@ -231,7 +346,8 @@ export type AdoptionEntry = {
 /** Result of {@link assembleAdoptionEntries}: the guide entries plus any retrieval failures. */
 export type AdoptionAssembly = {
   entries: AdoptionEntry[];
-  failures: { prNum: number; reason: string }[];
+  /** `prNum` is `null` when the PR could not be resolved from the commit at all. */
+  failures: { prNum: number | null; hash?: string; reason: string }[];
 };
 
 const TRAILING_PR_REF_RE = /\s\(#\d+\)\s*$/;
@@ -242,8 +358,10 @@ const TRAILING_PR_REF_RE = /\s\(#\d+\)\s*$/;
  * keeping retrieval *failures* strictly separate from legitimate *absences*
  * (#363, FR-004). This is the unit-testable seam extracted from `main()`:
  *
- * - non-`feat` commit, or `feat` with no trailing `(#NNN)` ⇒ no entry, no
- *   failure (identical behaviour local and in CI).
+ * - non-`feat` commit ⇒ no entry, no failure.
+ * - `feat` with no trailing `(#NNN)` ⇒ resolved from its SHA via
+ *   `resolveFromSha` (this repo rebase-merges, so the ref is never in the
+ *   subject); `absent` is a quiet skip, `failed` is recorded like any other.
  * - `retrieved` ⇒ run `extractAdoption`; a valid block yields an entry, an
  *   invalid/missing block is a quiet informational skip.
  * - `absent` ⇒ quiet informational skip.
@@ -254,14 +372,34 @@ const TRAILING_PR_REF_RE = /\s\(#\d+\)\s*$/;
 export async function assembleAdoptionEntries(
   classified: Classified[],
   fetch: PrBodyFetcher,
+  resolveFromSha: PrNumberResolver = () => Promise.resolve({ kind: "absent" }),
 ): Promise<AdoptionAssembly> {
   const entries: AdoptionEntry[] = [];
-  const failures: { prNum: number; reason: string }[] = [];
+  const failures: { prNum: number | null; hash?: string; reason: string }[] = [];
 
   for (const c of classified) {
     if (c.category !== "feat") continue;
-    const prNum = extractPrNumber(c.subject);
-    if (prNum === null) continue;
+    let prNum = extractPrNumber(c.subject);
+    if (prNum === null) {
+      // No `(#NNN)` in the subject. Under squash-merge that means "no PR";
+      // under rebase-merge it means nothing at all, because the rebase never
+      // wrote one. Ask the forge before concluding the commit is unattached.
+      const ref = await resolveFromSha(c.hash);
+      if (ref.kind === "failed") {
+        failures.push({ prNum: null, hash: c.hash, reason: ref.reason });
+        continue;
+      }
+      if (ref.kind === "absent") {
+        // Under this repo's convention every feat lands through a PR, so this
+        // is worth a line even though it is not a failure. A skip nobody can
+        // see is how the guide stayed empty across a whole major release.
+        console.warn(
+          `gen-changelog: feat commit ${c.hash} resolves to no PR — skipping adoption`,
+        );
+        continue;
+      }
+      prNum = ref.prNum;
+    }
 
     const outcome = await fetch(prNum);
     if (outcome.kind === "failed") {
@@ -461,11 +599,12 @@ async function main() {
   const { entries: adoptionEntries, failures } = await assembleAdoptionEntries(
     classified,
     fetchPrBody,
+    resolvePrFromSha,
   );
 
   if (failures.length > 0) {
     for (const f of failures) {
-      console.error(`#${f.prNum}: ${f.reason}`);
+      console.error(`${f.prNum === null ? f.hash : `#${f.prNum}`}: ${f.reason}`);
     }
     if (strict) {
       console.error(

--- a/tests/scripts/gen_changelog_test.ts
+++ b/tests/scripts/gen_changelog_test.ts
@@ -726,3 +726,162 @@ Deno.test("the guard stays silent when it should", () => {
   const ordinary = [{ hash: "a1", subject: "feat: adds a phase" }].map(classifyCommit);
   assertEquals(breakingGuardWarning(ordinary, "v2.1.0"), null, "a minor needs no marker");
 });
+
+// ---------------------------------------------------------------------------
+// The Adoption guide has never actually been published.
+//
+// `extractPrNumber` only ever found a PR through a trailing `(#NNN)` in the
+// subject. GitHub writes that on a SQUASH merge; this repository REBASE-merges,
+// which writes nothing. So every `feat` commit took the documented
+// "no ref ⇒ no entry, no failure" path and its section was dropped in silence —
+// while CI kept rejecting `feat:` PRs that omitted the very section no release
+// body has ever carried. v2.0.0: seven feat commits, zero adoption entries.
+//
+// Two more defects surfaced only by reading the RENDERED output, not by
+// checking that a guide existed: the comment stripper deleted the fence markers
+// an adoption prompt was teaching, and a trailing section swallowed the PR
+// footer into the published notes.
+// ---------------------------------------------------------------------------
+
+import { type PrNumberResolver, type PrRefOutcome } from "../../scripts/gen-changelog.ts";
+
+/** A `feat` commit with NO trailing PR ref — what a rebase merge actually leaves. */
+function rebasedFeatCommit(subject: string, hash = "be14410"): Classified {
+  return {
+    hash,
+    subject,
+    category: "feat",
+    cleanedSubject: subject.charAt(0).toUpperCase() + subject.slice(1),
+  };
+}
+
+function fakeResolver(map: Map<string, PrRefOutcome>): PrNumberResolver {
+  return (hash: string) => Promise.resolve(map.get(hash) ?? { kind: "absent" });
+}
+
+Deno.test("assembleAdoptionEntries: a rebased feat commit is resolved from its SHA", async () => {
+  const commits = [rebasedFeatCommit("deliver the section to projects that upgrade")];
+  const bodies = new Map<number, PrBodyOutcome>([
+    [471, { kind: "retrieved", body: adoptionBody("move your rules out of the block") }],
+  ]);
+  const refs = new Map<string, PrRefOutcome>([["be14410", { kind: "resolved", prNum: 471 }]]);
+
+  const { entries, failures } = await assembleAdoptionEntries(
+    commits,
+    fakeFetcher(bodies),
+    fakeResolver(refs),
+  );
+  assertEquals(failures.length, 0);
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].prNum, 471);
+});
+
+Deno.test("assembleAdoptionEntries: a failed SHA lookup is a recorded failure, never a skip", async () => {
+  // The whole point: "this commit has no PR" and "we could not ask" must stay
+  // distinguishable, so --strict can refuse to publish a partial guide.
+  const commits = [rebasedFeatCommit("deliver the section", "cafe123")];
+  const refs = new Map<string, PrRefOutcome>([
+    ["cafe123", { kind: "failed", reason: "gh api: HTTP 403" }],
+  ]);
+
+  const { entries, failures } = await assembleAdoptionEntries(
+    commits,
+    fakeFetcher(new Map()),
+    fakeResolver(refs),
+  );
+  assertEquals(entries.length, 0);
+  assertEquals(failures.length, 1);
+  assertEquals(failures[0].prNum, null);
+  assertEquals(failures[0].hash, "cafe123");
+});
+
+Deno.test("assembleAdoptionEntries: a commit genuinely without a PR stays a quiet skip", async () => {
+  const commits = [rebasedFeatCommit("pushed straight to main", "0000001")];
+  const { entries, failures } = await assembleAdoptionEntries(
+    commits,
+    fakeFetcher(new Map()),
+    fakeResolver(new Map()),
+  );
+  assertEquals(entries.length, 0);
+  assertEquals(failures.length, 0);
+});
+
+Deno.test("extractAdoption: an HTML comment inside code is content, not markup", () => {
+  // Specnaut's own managed-section fence IS an HTML comment. Stripping it left
+  // the prompt telling agents to look for a block delimited by nothing.
+  const body = [
+    "## Agent adoption",
+    "",
+    "Find the block fenced by `<!-- --- Specnaut: chain-stops --- -->`.",
+    "",
+    "```prompt",
+    "Look for `<!-- --- End Specnaut: chain-stops --- -->` in AGENTS.md.",
+    "```",
+  ].join("\n");
+
+  const got = extractAdoption(body);
+  assert(got !== null);
+  assertStringIncludes(got!, "<!-- --- Specnaut: chain-stops --- -->");
+  assertStringIncludes(got!, "<!-- --- End Specnaut: chain-stops --- -->");
+});
+
+Deno.test("extractAdoption: still strips a bare template placeholder comment", () => {
+  const body = [
+    "## Agent adoption",
+    "",
+    "<!-- describe what existing projects must do -->",
+    "Real prose.",
+    "",
+    "```prompt",
+    "do the thing",
+    "```",
+  ].join("\n");
+
+  const got = extractAdoption(body);
+  assert(got !== null);
+  assert(!got!.includes("describe what existing projects"), "placeholders must still go");
+  assertStringIncludes(got!, "Real prose.");
+});
+
+Deno.test("extractAdoption: interleaved code spans and fences are restored in place", () => {
+  // Regression: the two lifting passes pushed in their own order while the
+  // placeholders sat interleaved, so a code span came back as a fenced block.
+  const body = [
+    "## Agent adoption",
+    "",
+    "First `ALPHA` then `BETA`.",
+    "",
+    "```prompt",
+    "GAMMA",
+    "```",
+  ].join("\n");
+
+  const got = extractAdoption(body);
+  assert(got !== null);
+  assertStringIncludes(got!, "First `ALPHA` then `BETA`.");
+  assertStringIncludes(got!, "GAMMA");
+});
+
+Deno.test("extractAdoption: a trailing section stops at the prompt, not at EOF", () => {
+  // Every PR body carries a tooling footer. When `## Agent adoption` is the
+  // last H2, "run to EOF" printed that footer inside the release notes.
+  const body = [
+    "## Agent adoption",
+    "",
+    "Prose.",
+    "",
+    "```prompt",
+    "do the thing",
+    "```",
+    "",
+    "🤖 Generated with [Some Tool](https://example.invalid)",
+    "",
+    "https://example.invalid/session/abc",
+  ].join("\n");
+
+  const got = extractAdoption(body);
+  assert(got !== null);
+  assertStringIncludes(got!, "do the thing");
+  assert(!got!.includes("Generated with"), "the footer must not reach the release body");
+  assert(!got!.includes("example.invalid"), "no session links in published notes");
+});


### PR DESCRIPTION
Found while previewing the v2.0.1 release notes, and confirmed by an independent advisory pass.

## The Adoption guide has never been published. Not once.

`extractPrNumber` resolves a PR only from a trailing `(#NNN)` in the commit subject. GitHub writes that on a **squash** merge. This repository **rebase**-merges — since `feat(459)`, deliberately — which writes nothing. So every `feat` commit took the documented `no ref ⇒ no entry, no failure` path and its `## Agent adoption` section was dropped in silence.

Measured, not inferred: **v2.0.0 shipped seven `feat` commits and zero adoption entries.**

Meanwhile CI rejects any `feat:` PR that omits the section. The repo has been enforcing a contract it could not honour, and `--strict` — added by #363 *specifically to stop the guide vanishing silently* — exited 0 the whole time, because the `prNum === null` branch was the one path that logged nothing at all.

GitHub keeps the PR association across a rebase (`repos/…/commits/be14410/pulls` → `471`), so the fix is to ask it when the subject has no ref.

## Two more defects, found only by reading the rendered output

Checking that a guide *existed* would have passed both.

**1 — the comment stripper deleted the thing the prompt was about.** Specnaut's own managed-section fence *is* an HTML comment. `stripHtmlComments` ran over the whole section, so #471's adoption prompt — which teaches users about `<!-- --- Specnaut: chain-stops --- -->` — rendered as:

> Find the block fenced by `` and ``.

An instruction to look for a block delimited by nothing. Code regions are now lifted out before stripping, and restored **by index**: the two lifting passes push in their own order while the placeholders sit interleaved, so restoring positionally hands a code span back a fenced block. That bug was live for one commit and is now pinned by a test.

**2 — a trailing section swallowed the PR footer.** `## Agent adoption` as the last `## ` ran to EOF, so the tooling attribution and session link were published inside the release notes as adoption guidance. The section now ends at the closing fence of its ```prompt block — which is exactly what `CONTRIBUTING.md` defines as its end.

## Rendered result

```
### Adoption guide

**#471 — Deliver the two-stop section to projects that upgrade**

`specnaut upgrade` now writes one fenced section into your existing `AGENTS.md`:
`<!-- --- Specnaut: chain-stops --- -->`. Everything outside those markers is yours…

```prompt
Open `AGENTS.md` … find the block fenced by
`<!-- --- Specnaut: chain-stops --- -->` and `<!-- --- End Specnaut: chain-stops --- -->`.
```
```

Fence markers intact, footer gone, prose and prompt in the right order.

## Also

Corrects a stale comment in `release.yml` naming the wrong Codex sync destination. The step never hardcoded it — `sync-to-codex-plugin.sh` owns the target — so nothing was mis-wired; it was misleading to a reader.

7 new tests. 1219 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
