### PR TITLE
fix(474): a declared preserve wins over the managed-section merge too

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -112,6 +112,9 @@ it stays byte-identical, the fences are Markdown comments so nothing renders, an
 line naming what it did. Re-running changes nothing. Delete the block and the next upgrade restores
 it — that is the only section on the file Specnaut claims.
 
+Declaring `AGENTS.md` in `.specnaut/preserve.yml` freezes it completely: the section is not
+delivered either, and `--force` does not change that. `--reset-preserved` is the only way through.
+
 One related fix: an upgrade no longer records a pre-existing `AGENTS.md` in
 `.specnaut/installed.lock`. It used to adopt the file it had just decided not to write, which made
 every later run report your own document as "customized locally" — and let `--force` replace it with

--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -174,6 +174,7 @@ export class UpgradeProjectUseCase {
       newShas.set(dest, await sha256Hex(shaInput));
     }
 
+    const isDeclaredPreserved = input.isDeclaredPreserved ?? (() => false);
     const pluginInstalled = this.deps.pluginDetector !== undefined &&
       await this.deps.pluginDetector.isPluginInstalled(PLUGIN_NAME);
     const plan = computeUpgradePlan(
@@ -185,7 +186,7 @@ export class UpgradeProjectUseCase {
         isPluginCovered: (dest) => isPluginCoveredPath(lock.harness, dest),
         isSkipIfExists: (dest) => bundle[dest]?.skipIfExists === true,
         resetBaseline: input.resetBaseline ?? false,
-        isDeclaredPreserved: input.isDeclaredPreserved ?? (() => false),
+        isDeclaredPreserved,
       },
     );
 
@@ -202,7 +203,11 @@ export class UpgradeProjectUseCase {
     // section that has to reach a project that upgrades rather than inits.
     // Merged in under their own fence, they never overwrite or reorder a line
     // the user wrote.
-    const plannedSections = await this.surveyManagedSections(bundle, input.projectDir);
+    const plannedSections = await this.surveyManagedSections(
+      bundle,
+      input.projectDir,
+      isDeclaredPreserved,
+    );
 
     const hasActualWork = plan.some((a) =>
       a.kind === "auto-update" ||
@@ -303,7 +308,11 @@ export class UpgradeProjectUseCase {
     // rewritten the whole file from the bundle, in which case the section is
     // already there and the merge is a no-op. Re-reading is what keeps the
     // reported outcome honest instead of echoing back what we predicted.
-    const appliedSections = await this.applyManagedSections(bundle, input.projectDir);
+    const appliedSections = await this.applyManagedSections(
+      bundle,
+      input.projectDir,
+      isDeclaredPreserved,
+    );
 
     const cleanRemovals = plan
       .filter((a): a is Extract<typeof a, { kind: "remove" }> =>
@@ -410,9 +419,11 @@ export class UpgradeProjectUseCase {
   private async surveyManagedSections(
     bundle: Bundle,
     projectDir: string,
+    isDeclaredPreserved: (dest: string) => boolean,
   ): Promise<ManagedSectionOutcome[]> {
     const out: ManagedSectionOutcome[] = [];
     for (const [dest, label, body] of managedSectionEntries(bundle)) {
+      if (isDeclaredPreserved(dest)) continue;
       const existing = await this.deps.reader.readText(projectDir, dest);
       if (existing === null) continue;
       const current = extractBlock(existing, label, "html");
@@ -426,9 +437,17 @@ export class UpgradeProjectUseCase {
   private async applyManagedSections(
     bundle: Bundle,
     projectDir: string,
+    isDeclaredPreserved: (dest: string) => boolean,
   ): Promise<ManagedSectionOutcome[]> {
     const out: ManagedSectionOutcome[] = [];
     for (const [dest, label, body] of managedSectionEntries(bundle)) {
+      // A declared preserve wins over everything, `--force` included (spec 011
+      // / #367, FR-009). #466 grafted its section straight off the bundle and
+      // never consulted the predicate, so a file the maintainer had frozen was
+      // written anyway — and the same run printed both "preserved … declared"
+      // and "added the … section" for it. Only `--reset-preserved` lifts this,
+      // and it does so by flipping the predicate in the handler.
+      if (isDeclaredPreserved(dest)) continue;
       const existing = await this.deps.reader.readText(projectDir, dest);
       if (existing === null) continue;
       const current = extractBlock(existing, label, "html");

--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -375,7 +375,15 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     }
   }
 
-  const preserves = result.plan.filter((a) => a.kind === "preserve");
+  // `customized` only. A declared preserve already got its own line above, and
+  // the advice below does not apply to it: `--force` will NOT overwrite a
+  // declared path (only `--reset-preserved` lifts it), and `--reset-baseline`
+  // is irrelevant to a file nobody is claiming was edited. Printing a diff for
+  // it under that banner told the maintainer two different things about the
+  // same path in one run (#474).
+  const preserves = result.plan.filter(
+    (a) => a.kind === "preserve" && a.reason === "customized",
+  );
   if (preserves.length > 0 && !intent.force) {
     console.log(
       dim(

--- a/tests/integration/upgrade_declared_preserve_section_test.ts
+++ b/tests/integration/upgrade_declared_preserve_section_test.ts
@@ -1,0 +1,113 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+/**
+ * #474 — a declared preserve wins over the managed-section merge too.
+ *
+ * Spec 011 / #367: a path listed in `.specnaut/preserve.yml` beats every other
+ * branch of the plan, `--force` included; only `--reset-preserved` lifts it.
+ * #466's section merge iterated the bundle directly and never consulted that
+ * predicate, so a file the maintainer had frozen was written anyway — and the
+ * same run printed both "preserved … declared" and "added the … section" for
+ * it. Two statements about one file, in one output, contradicting each other.
+ *
+ * Found by dogfooding v2.0.1 on the workspace that ships it, not by a report.
+ */
+
+const HEADING = "## The Specnaut chain has exactly two stops";
+const OWN = "# AGENTS.md\n\n## House rules\n\nWe rebase, never merge commits.\n";
+const PRESERVE_YML = "preserved:\n  - AGENTS.md\n";
+
+async function runSpecnaut(args: string[], cwd: string) {
+  const { code, stdout, stderr } = await new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", "--allow-run", "--allow-env", MAIN, ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+const INIT = ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"];
+
+/** Scaffolds a project whose own AGENTS.md is declared frozen. */
+async function frozenProject(): Promise<string> {
+  const dir = await Deno.makeTempDir({ prefix: "specnaut-declared-section-" });
+  await Deno.writeTextFile(join(dir, "AGENTS.md"), OWN);
+  const init = await runSpecnaut(INIT, dir);
+  assertEquals(init.code, 0, `init failed: ${init.stderr}`);
+  await Deno.writeTextFile(join(dir, ".specnaut/preserve.yml"), PRESERVE_YML);
+  return dir;
+}
+
+Deno.test("a declared AGENTS.md does not receive the managed section", async () => {
+  const dir = await frozenProject();
+  try {
+    const up = await runSpecnaut(["upgrade"], dir);
+    assertEquals(up.code, 0, `upgrade failed: ${up.stderr}`);
+    assertEquals(
+      await Deno.readTextFile(join(dir, "AGENTS.md")),
+      OWN,
+      "a frozen file must come back byte-identical",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("--force does not lift the declaration either", async () => {
+  // FR-009: only --reset-preserved overrides a declaration. --force is for
+  // *customized* preserves, which is a different thing entirely.
+  const dir = await frozenProject();
+  try {
+    const up = await runSpecnaut(["upgrade", "--force"], dir);
+    assertEquals(up.code, 0, `forced upgrade failed: ${up.stderr}`);
+    assertEquals(await Deno.readTextFile(join(dir, "AGENTS.md")), OWN);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("--reset-preserved does deliver the section", async () => {
+  // The escape hatch has to actually work, or the fix above is just a wall.
+  const dir = await frozenProject();
+  try {
+    const up = await runSpecnaut(["upgrade", "--reset-preserved"], dir);
+    assertEquals(up.code, 0, `upgrade failed: ${up.stderr}`);
+    const after = await Deno.readTextFile(join(dir, "AGENTS.md"));
+    assert(after.startsWith(OWN.trimEnd()), "the user's content is still the prefix");
+    assert(after.includes(HEADING), "lifting the declaration must deliver the section");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("one run never claims a path is both preserved and modified", async () => {
+  const dir = await frozenProject();
+  try {
+    const up = await runSpecnaut(["upgrade"], dir);
+    assert(
+      up.stdout.includes("preserved AGENTS.md"),
+      "a declared path must still be reported as preserved",
+    );
+    // The merge notice must be absent — that is the contradiction the fix removes.
+    assert(
+      !up.stdout.includes("Specnaut-managed"),
+      "a frozen file must not also be announced as having a section added",
+    );
+    // ...and so must the diff, whose banner offers --force and --reset-baseline,
+    // neither of which does anything to a declared path.
+    assert(
+      !up.stdout.includes("---- diff: AGENTS.md ----"),
+      "a declared preserve must not be diffed under the customized-file advice",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #474. Found by dogfooding v2.0.1 on the workspace that ships it — migrating this monorepo from templates 1.12.0, not by a user report.

## The contradiction

One run, one file, two statements:

```
preserved AGENTS.md — declared in .specnaut/preserve.yml
added the Specnaut-managed "chain-stops" section in AGENTS.md
```

Spec 011 / #367 says a declared path beats **every** branch of the plan — unchanged, auto-update, plugin-migration, removal — and that `--force` cannot override it; only `--reset-preserved` can. #466's section merge iterated the bundle directly and never consulted `isDeclaredPreserved`, so it bypassed the plan that carries the guarantee.

**No content was ever lost.** The write is an append inside its own fence: on this monorepo the diff was 44 insertions, 0 deletions. This is a broken promise, not a broken file — but it is the promise the whole preserve feature rests on.

## A third statement, and the only actionable one was wrong

While testing the output I found the handler also diffs declared paths under this banner:

> For customized files, review the diff below and merge manually if desired.
> Re-run with `--force` to overwrite them… If you never edited these files, the lock baseline is stale — re-run with `--reset-baseline`…

Neither flag does anything to a declared path. A maintainer who froze a file was being handed two remedies that silently do nothing to it. The block is now scoped to `customized` preserves; declared paths already get their own line.

## Guards

| Test | Fails on `main` |
| :--- | :--- |
| declared `AGENTS.md` comes back byte-identical after `upgrade` | ✔ |
| `--force` does not lift the declaration | ✔ |
| `--reset-preserved` **does** deliver the section | — (passes both ways; it guards the escape hatch, not the bug) |
| one run never claims a path is both preserved and modified | ✔ |

Verified by reverting the fix and re-running: 3 of 4 fail, the fourth is the escape-hatch guard and is expected to pass either way. A wall with no door would also have passed the first three.

1223 tests pass.

## Agent adoption

Nothing changes unless you use `.specnaut/preserve.yml`. If you declared `AGENTS.md` there and were relying on the two-stop section arriving anyway, it will now be skipped — that is the fix, not a regression. Run `specnaut upgrade --reset-preserved` once if you want the section, or paste the fenced block in yourself and keep the file frozen.

```prompt
Check whether `.specnaut/preserve.yml` exists at the repository root and lists
`AGENTS.md`.

If it does, open `AGENTS.md` and look for a block fenced by
`<!-- --- Specnaut: chain-stops --- -->`.

  - Block present → nothing to do.
  - Block absent → the file is frozen, so `specnaut upgrade` will not add it.
    Tell me both options rather than picking one: run
    `specnaut upgrade --reset-preserved` (delivers the section, and lifts the
    declaration for every other declared path too), or paste the block in by
    hand from a fresh scaffold and keep the file frozen.

If `preserve.yml` does not exist or does not list `AGENTS.md`, report that
nothing needs doing.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
