### PR TITLE
fix: the three stale mirrors the migration audit found

### DIFF
--- a/.github/workflows/pr_adoption_lint.yml
+++ b/.github/workflows/pr_adoption_lint.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   lint:
@@ -15,18 +16,39 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -eu
 
-          # Only enforce on feat: and feat(scope): titles.
+          # Enforce when the PR *title* is feat:, OR when any COMMIT in it is.
+          #
+          # The title alone was the old rule, and it silently exempted the
+          # entire v2.0.0 feature set: those PRs carried prose titles
+          # ("Collapse the phase chain to five phases…") over `feat(456):`
+          # commits. `scripts/gen-changelog.ts` classifies by commit subject,
+          # so the release notes rendered a Features section for work CI had
+          # never asked to document. Two definitions of "a feature", and the
+          # laxer one guarded the gate.
+          needs_section=no
           case "$PR_TITLE" in
-            feat:*|"feat("*)
-              ;;
-            *)
-              echo "Title is not feat: — section optional. Skipping check."
-              exit 0
-              ;;
+            feat:*|"feat("*) needs_section=yes ;;
           esac
+
+          if [ "$needs_section" = no ]; then
+            if gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate \
+                 --jq '.[].commit.message | split("\n")[0]' \
+               | grep -qE '^feat(\([^)]+\))?!?:'; then
+              needs_section=yes
+              echo "A commit in this PR is feat: — section required even though the title is not."
+            fi
+          fi
+
+          if [ "$needs_section" = no ]; then
+            echo "No feat: title and no feat: commit — section optional. Skipping check."
+            exit 0
+          fi
 
           body_file="$(mktemp)"
           printf '%s' "$PR_BODY" > "$body_file"

--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -524,6 +524,29 @@ function formatBullet(c: Classified): string {
 const REPO_URL = "https://github.com/specnaut/specnaut-cli";
 const DEFAULT_OUT = "dist/release-notes.md";
 
+/**
+ * Does `ref` resolve in this repository?
+ *
+ * Used to decide the range end. When cutting a new release the target tag does
+ * not exist yet, so the range must run to `HEAD`. When regenerating the notes
+ * for a tag that already shipped, `HEAD` is the wrong end — it sweeps in every
+ * commit merged since. `--to` used to only *label* the output, which meant
+ * `--from v1.21.0 --to v2.0.0` silently produced notes for v2.0.0 containing
+ * work that was not in v2.0.0.
+ */
+async function refExists(ref: string): Promise<boolean> {
+  try {
+    const { success } = await new Deno.Command("git", {
+      args: ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`],
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    return success;
+  } catch {
+    return false;
+  }
+}
+
 async function getCommits(from: string | null, to: string): Promise<Commit[]> {
   const range = from ? `${from}..${to}` : to;
   const cmd = new Deno.Command("git", {
@@ -591,7 +614,10 @@ async function main() {
   const to = toArg ?? (await detectCurrentTag());
   const out = outArg ?? DEFAULT_OUT;
 
-  const commits = await getCommits(from, "HEAD");
+  // Bound the range to the target tag when it already exists (regenerating a
+  // published release); otherwise HEAD (cutting a new one, tag not yet made).
+  const rangeEnd = await refExists(to) ? to : "HEAD";
+  const commits = await getCommits(from, rangeEnd);
   const classified = commits
     .map(classifyCommit)
     .filter((c) => c.category !== "skip");
@@ -633,7 +659,7 @@ async function main() {
   await ensureDir(out);
   await Deno.writeTextFile(out, md);
   console.log(`✓ wrote ${out}`);
-  console.log(`  range: ${from ?? "<root>"}..HEAD (target ${to})`);
+  console.log(`  range: ${from ?? "<root>"}..${rangeEnd} (target ${to})`);
   console.log(
     `  commits: ${classified.length} kept (${commits.length - classified.length} skipped)`,
   );

--- a/src/domain/plugin_coverage.ts
+++ b/src/domain/plugin_coverage.ts
@@ -65,9 +65,19 @@ export function isPluginCoveredPath(
  * (either re-install the plugin or run `specnaut upgrade` to restore
  * the bundled snapshot).
  *
- * Kept in sync with `isPluginCoveredPath` above. Total: 37 paths
- * (15 agents excluding architect + 1 router skill + 20 phase docs +
- * specnaut-review alias).
+ * Kept in sync with `isPluginCoveredPath` above. Total: 33 paths
+ * (15 agents + 1 router skill + 16 phase docs + specnaut-review alias).
+ *
+ * This array is hand-written, and it drifted: #455 removed six phases and
+ * added two, and only the *other* hand-written mirror (`SYNC_PAIRS` in the
+ * plugin sync test) was updated. `specnaut check --project` reads this list,
+ * so every correctly-migrated project was told six files were "missing —
+ * restore via `specnaut upgrade`" — advice that cannot be followed, because
+ * `upgrade` is what removes them.
+ *
+ * `tests/domain/plugin_coverage_parity_test.ts` now pins this array against
+ * `CORE_BUNDLE`. Editing the manifest without editing this list turns that
+ * test red, which is the only reason a third mirror is tolerable at all.
  *
  * Phase docs include hyphenated names — the regex was widened in #303
  * after silently dropping `tag-version`, `release-version`, and
@@ -102,26 +112,22 @@ export const PLUGIN_COVERED_PATHS_CLAUDE: ReadonlyArray<string> = [
   ].map((name) => `.claude/agents/${name}.md`),
   ".claude/skills/specnaut/SKILL.md",
   ...[
-    "specify",
-    "clarify",
     "plan",
+    "plan-audits",
     "tasks",
-    "analyze",
     "implement",
     "review",
     "merge",
+    "auto-chain",
     "constitution",
-    "checklist",
     "groom",
     "tag-version",
     "release-version",
-    "list-skills",
     "audit-security",
     "audit-performance",
     "audit-accessibility",
     "audit-architecture",
     "audit-dependencies",
-    "lite-heuristic",
   ].map((name) => `.claude/skills/specnaut/phases/${name}.md`),
   ".claude/skills/specnaut-review/SKILL.md",
 ];

--- a/tests/domain/plugin_coverage_parity_test.ts
+++ b/tests/domain/plugin_coverage_parity_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "@std/assert";
+import { PLUGIN_COVERED_PATHS_CLAUDE } from "../../src/domain/plugin_coverage.ts";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+
+/**
+ * The coverage list must equal what actually ships.
+ *
+ * `PLUGIN_COVERED_PATHS_CLAUDE` is hand-written, and so is `SYNC_PAIRS` in the
+ * plugin sync test, and so is `templates/manifest.json`. Three mirrors of one
+ * fact. #455 removed six phases and added two; the manifest and SYNC_PAIRS were
+ * updated and this one was not, for two releases.
+ *
+ * The cost landed on users rather than on CI: `specnaut check --project` reads
+ * this list, so every correctly-migrated project reported six files "missing —
+ * restore via `specnaut upgrade` or install the plugin". Neither remedy works —
+ * `upgrade` is precisely what removes them — so it was a permanent warning
+ * state, and the one diagnostic a user runs to confirm the migration worked
+ * told them it had not.
+ *
+ * Nothing compared any mirror to the bundle. That is the actual defect; the
+ * stale names were the symptom. These two assertions are the comparison.
+ */
+
+function coveredNames(prefix: string): string[] {
+  return PLUGIN_COVERED_PATHS_CLAUDE
+    .filter((p) => p.startsWith(prefix) && p.endsWith(".md"))
+    .map((p) => p.slice(prefix.length, -".md".length))
+    .filter((n) => !n.includes("/"))
+    .sort();
+}
+
+function bundleNames(category: string): string[] {
+  return CORE_BUNDLE.filter((e) => e.category === category).map((e) => e.name).sort();
+}
+
+Deno.test("every phase the bundle ships is covered, and nothing else is", () => {
+  assertEquals(
+    coveredNames(".claude/skills/specnaut/phases/"),
+    bundleNames("phase"),
+    "coverage list and bundled phases disagree — `specnaut check` will report " +
+      "files as missing that were deliberately removed, or miss files that ship",
+  );
+});
+
+Deno.test("every agent the bundle ships is covered, and nothing else is", () => {
+  assertEquals(
+    coveredNames(".claude/agents/"),
+    bundleNames("agent"),
+    "coverage list and bundled agents disagree",
+  );
+});

--- a/tests/infrastructure/fs_project_inspector_test.ts
+++ b/tests/infrastructure/fs_project_inspector_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
+import { PLUGIN_COVERED_PATHS_CLAUDE } from "../../src/domain/plugin_coverage.ts";
 import { FsProjectInspector } from "../../src/infrastructure/fs_project_inspector.ts";
 
 const CONSTITUTION_FILLED = `# Project Constitution
@@ -790,15 +791,15 @@ Deno.test("inspect: plugin gap check warns for each missing covered path when pl
         o.name === ".claude/skills/specnaut-review/SKILL.md") &&
       o.status === "warn"
     );
-    // 15 agents (10 original + ui-ux-designer drift fix #321 +
-    // performance-auditor #304 + a11y-auditor #305 + architecture-auditor
-    // #321 + dependency-auditor #322) + 1 router skill + 20 phase docs
-    // (the 11 original + tag-version + release-version + list-skills +
-    // audit-security #303 + audit-performance #304 + audit-accessibility
-    // #305 + audit-architecture #321 + audit-dependencies #322 +
-    // lite-heuristic #346) + specnaut-review alias = 37 covered paths
-    // (specnaut-auto removed in #409).
-    assertEquals(gapOutcomes.length, 37);
+    // Derived, not hardcoded. This assertion used to read `37` under a comment
+    // enumerating the covered set by hand — so when #455 removed six phases and
+    // added two, the constant drifted and this test agreed with it. A magic
+    // number that has to be re-derived by a human on every change is a copy of
+    // the thing it is meant to check.
+    //
+    // `plugin_coverage_parity_test.ts` pins the constant to CORE_BUNDLE; this
+    // pins the inspector to the constant. Neither can drift alone.
+    assertEquals(gapOutcomes.length, PLUGIN_COVERED_PATHS_CLAUDE.length);
     for (const o of gapOutcomes) {
       assertEquals(o.message.includes("missing"), true);
       assertEquals(o.message.includes("specnaut upgrade"), true);


### PR DESCRIPTION
Closes #478, closes #480, closes #482. Children of the migration audit epic `specnaut/specnaut-monorepo#16`.

## #478 — `check --project` told every migrated user their project was broken

The 2.0.1 binary, against a correctly-migrated 2.0.1 project:

```
.claude/skills/specnaut/phases/specify.md  ⚠ missing — restore via `specnaut upgrade` or install the plugin
… clarify, analyze, checklist, list-skills, lite-heuristic
```

**Neither remedy exists.** `upgrade` is what removes those files, so the warning could not be cleared — a permanent failure state on the one diagnostic a user runs to confirm the migration worked. Exit 0 throughout, so nothing ever went red.

`PLUGIN_COVERED_PATHS_CLAUDE` is a hand-written mirror of the phase list that #455 missed. It named six removed phases and was missing `plan-audits` **and** `auto-chain`.

The stale names are the symptom. The defect is that **nothing compared any mirror to the bundle**, and there are three of them — this array, `SYNC_PAIRS`, `templates/manifest.json`. Two were updated, one was not.

So the list is corrected *and* pinned: a parity test asserts its phase and agent sets equal `CORE_BUNDLE`'s.

A fourth mirror surfaced during the fix. `fs_project_inspector_test.ts` asserted the covered-path count as a literal `37` under a comment enumerating the set by hand — it **agreed with the stale constant**, locking the drift in rather than catching it. It now derives from the constant. The chain is bundle → constant → inspector, with no hand-copied number in it.

## #482 — the gate and the classifier disagreed on what a feature is

`pr_adoption_lint.yml` enforced `## Agent adoption` on the PR **title**. `gen-changelog.ts` classifies by **commit subject**.

All eight v2.0.0 PRs carried prose titles over `feat(...)` commits. The gate printed *"Title is not feat: — section optional. Skipping check."* and went green, while the release notes rendered a Features section for that same work.

**That is why v2.0.0 has no Adoption guide** — a deeper cause than the SHA-lookup bug fixed in #472. Even had a section existed, the lookup could not have fetched it. Two independent defects, both required, both broken, neither visible on a green build.

Title stays a trigger; any `feat:` commit is now also one. Verified against #461, whose commits the new rule catches and the old one did not.

## #480 — `--to` labelled the notes without bounding them

`getCommits(from, "HEAD")`, hardcoded. Fine when cutting a release (the tag doesn't exist yet), wrong for regenerating a past one: `--from v1.21.0 --to v2.0.0` produced notes titled v2.0.0 containing everything merged since. Unblocks #479.

## Verification

`check --project` from this branch against the migrated monorepo: **All checks passed**, down from six warnings. 1225 tests pass.

Three commits, one per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
