### PR TITLE
feat(481): name the migration guide when an upgrade crosses a major

### DIFF
--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -1,6 +1,11 @@
 import { resolve } from "@std/path";
 import { bold, cyan, dim, green, red, yellow } from "@std/fmt/colors";
 import { FsUpgradeMarkerStore } from "../../infrastructure/fs_upgrade_marker_store.ts";
+import {
+  crossesMajorBoundary,
+  MIGRATION_GUIDE_PATH,
+  MIGRATION_GUIDE_URL,
+} from "../../domain/major_boundary.ts";
 import { mergeMarker } from "../../domain/upgrade_marker.ts";
 import { UpgradeProjectUseCase } from "../../application/upgrade_project.ts";
 import { findHarness } from "../harnesses.ts";
@@ -434,6 +439,19 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
   }
   console.log();
   console.log(green(`✓ upgraded to templates ${result.fromVersion} → ${result.toVersion}`));
+
+  // A breaking upgrade is the one moment `UPGRADING.md` exists for, and until
+  // now the binary never named it — the only inbound links were the README and
+  // one published release body, neither of which somebody mid-upgrade is
+  // reading (#481). Printed only when the major actually changes, so it stays
+  // meaningful instead of becoming a line people learn to skip.
+  if (crossesMajorBoundary(result.fromVersion, result.toVersion)) {
+    console.log();
+    console.log(
+      yellow(`⚠ this crossed a major version — read the migration guide before you continue:`),
+    );
+    console.log(`  ${MIGRATION_GUIDE_PATH}  ·  ${MIGRATION_GUIDE_URL}`);
+  }
 
   // Write the upgrade-pending marker (preserves original `from` if a
   // marker already exists from a previous unreconciled upgrade).

--- a/src/domain/major_boundary.ts
+++ b/src/domain/major_boundary.ts
@@ -1,0 +1,33 @@
+/**
+ * Does an upgrade from `from` to `to` cross a major-version boundary?
+ *
+ * `UPGRADING.md` is the only document that explains a breaking release, and
+ * nothing put it in front of the person living through one: the CLI never
+ * named it, and the two places that link it — the README and one published
+ * release body — are not where somebody mid-upgrade is looking (#481).
+ *
+ * Pure, and deliberately conservative: an unparseable version on either side
+ * returns `false`. A pointer that fails to print is a missed opportunity; a
+ * pointer printed on every routine patch bump is noise that trains people to
+ * skip the line, which costs more than it saves.
+ */
+const SEMVER_MAJOR = /^v?(\d+)\./;
+
+function majorOf(version: string): number | null {
+  const m = version.trim().match(SEMVER_MAJOR);
+  if (m === null) return null;
+  const n = Number(m[1]);
+  return Number.isInteger(n) ? n : null;
+}
+
+export function crossesMajorBoundary(from: string, to: string): boolean {
+  const a = majorOf(from);
+  const b = majorOf(to);
+  if (a === null || b === null) return false;
+  return b > a;
+}
+
+/** Where the migration guide lives, for both the repo copy and the published one. */
+export const MIGRATION_GUIDE_PATH = "UPGRADING.md";
+export const MIGRATION_GUIDE_URL =
+  "https://github.com/specnaut/specnaut-cli/blob/main/UPGRADING.md";

--- a/tests/domain/major_boundary_test.ts
+++ b/tests/domain/major_boundary_test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from "@std/assert";
+import { crossesMajorBoundary } from "../../src/domain/major_boundary.ts";
+
+/**
+ * #481 — the pointer to `UPGRADING.md` must fire on a breaking upgrade and
+ * stay quiet on every other one.
+ *
+ * Both halves are load-bearing. A pointer that never prints leaves the user
+ * where they already were; a pointer on every patch bump trains them to skip
+ * the line, so it is not there when it matters.
+ */
+
+Deno.test("crossing a major fires", () => {
+  assertEquals(crossesMajorBoundary("1.21.0", "2.0.1"), true);
+  assertEquals(crossesMajorBoundary("1.0.0", "3.0.0"), true);
+  assertEquals(crossesMajorBoundary("v1.21.0", "v2.0.0"), true, "a leading v must not defeat it");
+});
+
+Deno.test("staying within a major stays quiet", () => {
+  assertEquals(crossesMajorBoundary("2.0.0", "2.0.1"), false);
+  assertEquals(crossesMajorBoundary("2.0.1", "2.4.0"), false);
+  assertEquals(crossesMajorBoundary("1.2.3", "1.99.0"), false);
+});
+
+Deno.test("a downgrade is not a crossing", () => {
+  // Reinstalling an older binary should not lecture the user about migrating.
+  assertEquals(crossesMajorBoundary("2.0.0", "1.21.0"), false);
+});
+
+Deno.test("an unparseable version is silence, not a guess", () => {
+  assertEquals(crossesMajorBoundary("", "2.0.0"), false);
+  assertEquals(crossesMajorBoundary("1.0.0", "not-a-version"), false);
+  assertEquals(crossesMajorBoundary("main", "2.0.0"), false);
+});

--- a/tests/integration/upgrade_major_pointer_test.ts
+++ b/tests/integration/upgrade_major_pointer_test.ts
@@ -1,0 +1,69 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+/**
+ * #481 — end to end: a major-crossing upgrade names the migration guide, a
+ * same-major one does not.
+ *
+ * The predicate is unit-tested; this pins the wiring, which is the half that
+ * actually reaches a user. A correct predicate nobody calls prints nothing.
+ */
+
+async function runSpecnaut(args: string[], cwd: string) {
+  const { code, stdout, stderr } = await new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", "--allow-run", "--allow-env", MAIN, ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+const INIT = ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"];
+
+/** Rewrites the lock's recorded templates version, faking an older install. */
+async function setLockVersion(dir: string, version: string) {
+  const path = join(dir, ".specnaut/installed.lock");
+  const lock = await Deno.readTextFile(path);
+  await Deno.writeTextFile(
+    path,
+    lock.replace(/^templates_version: .*$/m, `templates_version: ${version}`),
+  );
+}
+
+async function upgradeFrom(version: string) {
+  const dir = await Deno.makeTempDir({ prefix: "specnaut-major-pointer-" });
+  try {
+    assertEquals((await runSpecnaut(INIT, dir)).code, 0);
+    await setLockVersion(dir, version);
+    // Rewriting the recorded version alone leaves every file byte-identical, so
+    // the plan is all-unchanged and `upgrade` short-circuits to "already up to
+    // date" before any of this is reached. Remove a managed file so the run has
+    // real work, which is also what a genuine 1.x → 2.x upgrade looks like.
+    await Deno.remove(join(dir, ".claude/skills/specnaut/phases/tasks.md"));
+    const up = await runSpecnaut(["upgrade", "--force"], dir);
+    assertEquals(up.code, 0, `upgrade failed: ${up.stderr}`);
+    return up.stdout;
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("a major-crossing upgrade names the migration guide", async () => {
+  const out = await upgradeFrom("1.21.0");
+  assert(out.includes("UPGRADING.md"), "the guide's path must appear in the output");
+  assert(out.includes("major version"), "and the reason it is being shown");
+});
+
+Deno.test("a same-major upgrade says nothing about it", async () => {
+  // The quiet half. A pointer on every patch bump is a line people learn to
+  // skip, and then it is not there when it matters.
+  const out = await upgradeFrom("2.0.0");
+  assert(!out.includes("UPGRADING.md"), "no migration pointer on a routine bump");
+});


### PR DESCRIPTION
Closes #481. Child of epic `specnaut/specnaut-monorepo#16`.

`UPGRADING.md` is the only document that explains a breaking release, and nothing put it in front of the person living through one. The binary never mentioned it; the two inbound links are `README.md:17` and one already-published release body — neither of which somebody mid-upgrade is looking at.

```
✓ upgraded to templates 1.21.0 → 2.0.1

⚠ this crossed a major version — read the migration guide before you continue:
  UPGRADING.md  ·  https://github.com/specnaut/specnaut-cli/blob/main/UPGRADING.md
```

**The quiet half is load-bearing.** A pointer on every patch bump is a line people learn to skip, so it would not be there when it matters. `crossesMajorBoundary` is conservative by design: an unparseable version on either side returns `false`, and a downgrade is not a crossing — reinstalling an older binary should not lecture you about migrating.

## Tested at both levels

The predicate is unit-tested; the **wiring** is tested end to end, because a correct predicate nobody calls prints nothing.

Building that second test surfaced something worth recording: rewriting the lock's recorded version leaves every file byte-identical, so the run short-circuits to *"already up to date"* before reaching any of this. The test now removes a managed file first — which is also what a genuine 1.x → 2.x upgrade actually looks like.

1231 tests pass.

## Agent adoption

Nothing to do in your project. This only adds a line to `specnaut upgrade`'s output when the major version changes.

```prompt
No action is needed for this change itself. One thing to confirm: if this
project has a runbook, wrapper script, or CI job that parses `specnaut upgrade`
output, note that a major-crossing upgrade now prints two extra lines after the
success line — one beginning `⚠ this crossed a major version`, and one naming
`UPGRADING.md`.

Search the repo for anything that consumes that output (grep for `specnaut
upgrade` in scripts, CI workflows and docs). Report whether any of it matches on
an exact line count, on the last line of the output, or on the success line
being final. If nothing does, say so and change nothing.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
