### PR TITLE
fix(479): one adoption entry per PR, not per commit

### DIFF
--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -419,6 +419,12 @@ export async function assembleAdoptionEntries(
       );
       continue;
     }
+    // One entry per PR, not per commit. The adoption section is a property of
+    // the PR, so a PR carrying two `feat:` commits was emitting the same prose
+    // and the same prompt twice — and `specnaut-expert review-upgrade` walks
+    // these entries one at a time, so the user would have been asked to run an
+    // identical prompt twice in a row.
+    if (entries.some((e) => e.prNum === prNum)) continue;
     // Title = the cleaned subject without the trailing PR ref.
     const title = c.cleanedSubject.replace(TRAILING_PR_REF_RE, "");
     entries.push({ prNum, title, body: adoption });

--- a/tests/scripts/gen_changelog_test.ts
+++ b/tests/scripts/gen_changelog_test.ts
@@ -885,3 +885,29 @@ Deno.test("extractAdoption: a trailing section stops at the prompt, not at EOF",
   assert(!got!.includes("Generated with"), "the footer must not reach the release body");
   assert(!got!.includes("example.invalid"), "no session links in published notes");
 });
+
+Deno.test("assembleAdoptionEntries: a PR with two feat commits yields ONE entry", async () => {
+  // The adoption section belongs to the PR, not to each commit inside it.
+  // `review-upgrade` walks entries one at a time, so a duplicate means the user
+  // is asked to run the identical prompt twice in a row.
+  const commits = [
+    rebasedFeatCommit("reduce the router to five phases", "aaa1111"),
+    rebasedFeatCommit("fold specify and clarify into plan", "bbb2222"),
+  ];
+  const bodies = new Map<number, PrBodyOutcome>([
+    [461, { kind: "retrieved", body: adoptionBody("rewrite your phase references") }],
+  ]);
+  const refs = new Map<string, PrRefOutcome>([
+    ["aaa1111", { kind: "resolved", prNum: 461 }],
+    ["bbb2222", { kind: "resolved", prNum: 461 }],
+  ]);
+
+  const { entries, failures } = await assembleAdoptionEntries(
+    commits,
+    fakeFetcher(bodies),
+    fakeResolver(refs),
+  );
+  assertEquals(failures.length, 0);
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].prNum, 461);
+});


### PR DESCRIPTION
Closes #479. Child of epic `specnaut/specnaut-monorepo#16`.

## The v2.0.0 release body now carries its Adoption guide

It never did. The cause was not a missing script run — **the content was never written**: the adoption gate matched on PR *title*, all eight v2.0.0 PRs had prose titles over `feat(...)` commits, so CI never asked for a section (fixed separately in #482).

So this was a back-fill, and I did it by **fixing the source rather than the artifact**: `## Agent adoption` sections were authored onto PRs #461–#464, then the notes were regenerated with `gen-changelog --from v1.21.0 --to v2.0.0` (range bounding from #480) and the release body replaced with that output.

That matters for a reason beyond tidiness: **the published body is now exactly what the generator produces.** Re-running the command reproduces it byte for byte. A hand-edited release body would have been correct once and unverifiable forever after.

Verified before publishing that the regenerated body is a strict superset of the published one — every line of the old body survives; only the Adoption guide is added.

## The fix in this PR

Regenerating surfaced a real defect: **seven entries for four PRs.** `assembleAdoptionEntries` walked commits, but an adoption section belongs to the PR — so a PR with two `feat:` commits emitted the same prose and the same prompt twice.

That is not cosmetic. `specnaut-expert review-upgrade` walks these entries **one at a time**, prompting the user per entry, so a duplicate means being asked to run an identical prompt twice in a row.

## The four entries

| PR | What an upgrading project has to do |
| :--- | :--- |
| #461 | Rewrite references to the six retired phases and four retired flags |
| #462 | Nothing destructive — existing spec directories are left alone; the prompt only reports which use the old shape |
| #463 | Find wording in `AGENTS.md`/`CLAUDE.md` that tells an agent to pause between phases, and reconcile it with the two-stop rule |
| #464 | Check whether the default branch is protected, and **report** rather than change any repo setting |

Two of those prompts deliberately end in "report, don't change" — the branch-protection one especially. An adoption prompt that silently alters a repository setting is worse than one that does nothing.

1226 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
