### PR TITLE
feat(476): let a child declare itself parent-managed, and clean the lock

### DIFF
--- a/src/application/upgrade_project.ts
+++ b/src/application/upgrade_project.ts
@@ -10,7 +10,7 @@ import {
 } from "../domain/upgrade_plan.ts";
 import { canonicalBlockBody, extractBlock, mergeIntoFile } from "../domain/merge_block.ts";
 import { isPluginCoveredPath } from "../domain/plugin_coverage.ts";
-import { isAgenticPath } from "../domain/parent_managed.ts";
+import { isAgenticPath, pruneAgenticEntries } from "../domain/parent_managed.ts";
 
 /** The plugin name used for both the install probe and the cache directory. */
 export const PLUGIN_NAME = "specnaut-plugin";
@@ -229,7 +229,14 @@ export class UpgradeProjectUseCase {
       // write: no file operations, just the lock. The common case (lock
       // already carries the right value) keeps the no-op fast path.
       const lockParentManaged = lock.parentManaged ?? false;
-      if (parentManaged !== lockParentManaged) {
+      // Rewrite when the decision changed OR when a parent-managed lock still
+      // records agentic rows. The second case is the one that bites: a lock
+      // written before the flip keeps describing files this workspace does not
+      // own, and without it the resurrection only moves from "planned adds" to
+      // phantom rows nobody looks at until they mislead someone (#476).
+      const staleAgentic = parentManaged &&
+        [...lock.entries.keys()].some((dest) => isAgenticPath(dest));
+      if (parentManaged !== lockParentManaged || staleAgentic) {
         const correctedLock: InstalledLock = {
           version: 2,
           harness: lock.harness,
@@ -238,7 +245,7 @@ export class UpgradeProjectUseCase {
           specBackend: lock.specBackend,
           specAutogen: lock.specAutogen,
           templatesVersion: lock.templatesVersion,
-          entries: lock.entries,
+          entries: parentManaged ? pruneAgenticEntries(lock.entries) : lock.entries,
           ...(parentManaged ? { parentManaged: true as const } : {}),
         };
         await lockStore.write(input.projectDir, correctedLock);

--- a/src/domain/parent_managed.ts
+++ b/src/domain/parent_managed.ts
@@ -57,3 +57,35 @@ export function isAgenticPath(dest: string): boolean {
     dest.startsWith(".claude/agents/") ||
     dest.startsWith(".claude/commands/");
 }
+
+/**
+ * Marker a child writes to declare that its enclosing Specnaut workspace
+ * manages its agentic files.
+ *
+ * Detection originally had exactly one positive signal — membership of the
+ * parent's `deno.json` `workspace[]` — which quietly made "is a Deno workspace
+ * member" the definition of "inherits agentic files from the parent". A
+ * sub-repo on a different toolchain, kept out of that array precisely because
+ * including it breaks its own build, had no way to say so: there was a negative
+ * opt-out marker and no positive opt-in (#476).
+ *
+ * This is the missing counterpart to `standalone.yml`, in the same place and
+ * with the same shape. It does NOT bypass the ancestor check — a providing
+ * ancestor must still exist, or suppressing `.claude/` would leave the child
+ * with no agentic files at all and nothing providing them.
+ */
+export const PARENT_MANAGED_MARKER = "parent-managed.yml";
+
+/**
+ * Prunes agentic rows from a lock's entry map for a parent-managed target.
+ *
+ * Suppressing future writes is not enough. The metadata-only correction path
+ * rewrites `entries` verbatim, so rows recorded before the flip survive it —
+ * and the resurrection simply moves from "planned adds" to phantom rows that
+ * describe files the workspace deliberately does not own.
+ */
+export function pruneAgenticEntries<T>(
+  entries: ReadonlyMap<string, T>,
+): Map<string, T> {
+  return new Map([...entries].filter(([dest]) => !isAgenticPath(dest)));
+}

--- a/src/infrastructure/fs_parent_workspace_reader.ts
+++ b/src/infrastructure/fs_parent_workspace_reader.ts
@@ -1,5 +1,6 @@
 import { dirname, isAbsolute, join, resolve } from "@std/path";
 import type { ParentWorkspaceReader } from "../application/ports.ts";
+import { PARENT_MANAGED_MARKER } from "../domain/parent_managed.ts";
 
 /**
  * Filesystem-backed `ParentWorkspaceReader`.
@@ -23,11 +24,20 @@ export class FsParentWorkspaceReader implements ParentWorkspaceReader {
     const canonicalTarget = await tryRealPath(targetDir);
     if (canonicalTarget === null) return null;
 
+    // The child may declare membership itself. Workspace-array membership was
+    // the only positive signal, which made "is a Deno workspace member" the
+    // definition of "inherits agentic files" — unreachable for a sub-repo on a
+    // different toolchain, deliberately kept out of that array because
+    // including it breaks its own build tooling (#476).
+    const declaredByChild = await fileExists(
+      join(targetDir, ".specnaut", PARENT_MANAGED_MARKER),
+    );
+
     // Walk dirname upward; stop when `dirname` no longer changes (root).
     let current = dirname(canonicalTarget);
     let parent = dirname(current);
     while (parent !== current) {
-      if (await this.isProvidingWorkspace(current, canonicalTarget)) {
+      if (await this.isProvidingWorkspace(current, canonicalTarget, declaredByChild)) {
         // `current` is already canonical (derived from a canonical target via
         // repeated dirname), but normalise via realPath to be safe.
         return await tryRealPath(current) ?? current;
@@ -36,21 +46,30 @@ export class FsParentWorkspaceReader implements ParentWorkspaceReader {
       parent = dirname(current);
     }
     // `current` is now the filesystem root — check it too before giving up.
-    if (await this.isProvidingWorkspace(current, canonicalTarget)) {
+    if (await this.isProvidingWorkspace(current, canonicalTarget, declaredByChild)) {
       return await tryRealPath(current) ?? current;
     }
     return null;
   }
 
   /**
-   * True iff `ancestor/.specnaut/` exists AND `ancestor/deno.json` declares a
-   * workspace member canonically equal to `canonicalTarget`.
+   * True iff `ancestor/.specnaut/` exists AND either the child declared itself
+   * parent-managed, or `ancestor/deno.json` declares a workspace member
+   * canonically equal to `canonicalTarget`. The `workspace[]` signal is kept as
+   * a fallback so existing Deno-workspace children need no new file.
    */
   private async isProvidingWorkspace(
     ancestor: string,
     canonicalTarget: string,
+    declaredByChild: boolean,
   ): Promise<boolean> {
     if (!(await isDir(join(ancestor, ".specnaut")))) return false;
+
+    // The child's declaration still requires a providing ancestor — it says
+    // "my enclosing workspace manages me", not "provision nothing". Skipping
+    // this check would leave a child with `.claude/` suppressed and nothing
+    // supplying it.
+    if (declaredByChild) return true;
 
     const members = await readWorkspaceMembers(join(ancestor, "deno.json"));
     if (members === null) return false;

--- a/tests/integration/parent_managed_optin_test.ts
+++ b/tests/integration/parent_managed_optin_test.ts
@@ -1,0 +1,150 @@
+import { assert, assertEquals } from "@std/assert";
+import { exists } from "@std/fs/exists";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
+
+/**
+ * #476 — a child on a foreign toolchain must be able to declare itself
+ * parent-managed, and the flip must clean the lock rather than just stop
+ * writing.
+ *
+ * Detection had one positive signal: membership of the parent's `deno.json`
+ * `workspace[]`. That quietly made "is a Deno workspace member" the definition
+ * of "inherits agentic files from the parent" — unreachable for a sub-repo kept
+ * out of that array precisely because including it breaks its own build. There
+ * was a negative opt-out marker and no positive opt-in.
+ *
+ * The second half matters as much: suppressing future writes leaves rows in
+ * `installed.lock` describing files the workspace does not own. The
+ * resurrection would move from "planned adds" to phantom rows.
+ */
+
+async function runSpecnaut(args: string[], cwd: string) {
+  const { code, stdout, stderr } = await new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", "--allow-run", "--allow-env", MAIN, ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+const INIT = ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"];
+
+/**
+ * A providing workspace with a child that is NOT in its `workspace[]` — the
+ * shape of a sub-repo running a different toolchain.
+ */
+async function workspaceWithForeignChild(): Promise<{ root: string; child: string }> {
+  const root = await Deno.makeTempDir({ prefix: "specnaut-parent-optin-" });
+  await Deno.mkdir(join(root, ".specnaut"), { recursive: true });
+  // The parent is a Specnaut workspace, but its workspace array names only a
+  // sibling — the child below is deliberately absent from it.
+  await Deno.writeTextFile(
+    join(root, "deno.json"),
+    JSON.stringify({ workspace: ["./other-half"] }, null, 2),
+  );
+  const child = join(root, "apps", "foreign-half");
+  await Deno.mkdir(child, { recursive: true });
+  return { root, child };
+}
+
+Deno.test("without the marker, a non-member child is provisioned standalone", async () => {
+  // The baseline. Nothing about this changes: absent any declaration, a child
+  // the parent does not claim gets its own agentic files.
+  const { root, child } = await workspaceWithForeignChild();
+  try {
+    assertEquals((await runSpecnaut(INIT, child)).code, 0);
+    assertEquals(
+      await exists(join(child, ".claude/skills/specnaut/SKILL.md")),
+      true,
+      "an unclaimed child must still get its own agentic files",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("the child's marker makes it parent-managed without touching deno.json", async () => {
+  const { root, child } = await workspaceWithForeignChild();
+  try {
+    await Deno.mkdir(join(child, ".specnaut"), { recursive: true });
+    await Deno.writeTextFile(
+      join(child, ".specnaut/parent-managed.yml"),
+      "# agentic files come from the enclosing workspace\n",
+    );
+
+    const init = await runSpecnaut(INIT, child);
+    assertEquals(init.code, 0, `init failed: ${init.stderr}`);
+
+    assertEquals(
+      await exists(join(child, ".claude/skills/specnaut/SKILL.md")),
+      false,
+      "a declared child must not receive its own copy of the agentic files",
+    );
+    // ...while the toolkit itself is still provisioned.
+    assertEquals(await exists(join(child, ".specnaut/templates")), true);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("standalone.yml still wins over the new marker", async () => {
+  // The opt-out is the override and stays the override — a user must be able
+  // to refuse a layout that happens to look parent-managed.
+  const { root, child } = await workspaceWithForeignChild();
+  try {
+    await Deno.mkdir(join(child, ".specnaut"), { recursive: true });
+    await Deno.writeTextFile(join(child, ".specnaut/parent-managed.yml"), "\n");
+    await Deno.writeTextFile(join(child, ".specnaut/standalone.yml"), "\n");
+
+    assertEquals((await runSpecnaut(INIT, child)).code, 0);
+    assertEquals(
+      await exists(join(child, ".claude/skills/specnaut/SKILL.md")),
+      true,
+      "standalone.yml must defeat the parent-managed declaration",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("the flip prunes agentic rows from the lock and plans no agentic adds", async () => {
+  const { root, child } = await workspaceWithForeignChild();
+  try {
+    // Scaffold standalone first: the lock now records agentic files.
+    assertEquals((await runSpecnaut(INIT, child)).code, 0);
+    const lockPath = join(child, ".specnaut/installed.lock");
+    assert(
+      (await Deno.readTextFile(lockPath)).includes(".claude/skills/"),
+      "setup: the standalone lock must record agentic entries",
+    );
+
+    // Now the workspace claims it, and the local agentic files are removed —
+    // exactly what centralising them looks like.
+    await Deno.writeTextFile(join(child, ".specnaut/parent-managed.yml"), "\n");
+    await Deno.remove(join(child, ".claude"), { recursive: true });
+
+    const up = await runSpecnaut(["upgrade"], child);
+    assertEquals(up.code, 0, `upgrade failed: ${up.stderr}`);
+
+    const lock = await Deno.readTextFile(lockPath);
+    assert(
+      !lock.includes(".claude/skills/") && !lock.includes(".claude/agents/") &&
+        !lock.includes(".claude/commands/"),
+      "the lock must not keep describing files this workspace no longer owns",
+    );
+    assertEquals(
+      await exists(join(child, ".claude/skills/specnaut/SKILL.md")),
+      false,
+      "the upgrade must not re-add the agentic directory the workspace removed",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #476. The last of the two open upgrade tickets.

## The asymmetry was the defect

Parent-managed detection had exactly **one** positive signal: membership of the parent's `deno.json` `workspace[]`. That quietly made *"is a Deno workspace member"* the definition of *"inherits agentic files from the parent"* — which a sub-repo on a different toolchain cannot satisfy, because it is deliberately kept out of that array so that including it does not break its own build.

There was a negative opt-out marker (`standalone.yml`) and **no positive opt-in**. That is the bug; the observed symptom was a workspace whose lock still held ~61 `.claude/` paths and whose next `upgrade` planned to add 69 of them back, recreating the directory a centralisation had removed on purpose.

## `.specnaut/parent-managed.yml`

The missing counterpart to `standalone.yml` — same place, same shape, toolchain-neutral.

It does **not** bypass the ancestor check. A providing ancestor must still exist, or a child ends up with `.claude/` suppressed and nothing supplying it. `workspace[]` stays as a fallback, so existing Deno-workspace children need no new file, and `standalone.yml` still beats both.

## The half that makes it real

Suppressing future writes is not enough. The metadata-only correction path rewrote `entries: lock.entries` verbatim, so a lock written before the flip kept describing files the workspace does not own. **Without this, the resurrection does not go away — it moves from "planned adds" to phantom rows**, which are worse because nobody looks at them until they mislead someone.

The rewrite now also fires when a parent-managed lock still holds agentic rows, not only when the decision itself changed — otherwise a lock left over from an older run would never be cleaned.

## Test shape

| Test | Fails on parent |
| :--- | :--- |
| the child's marker makes it parent-managed without touching `deno.json` | ✔ |
| the flip prunes agentic rows from the lock and re-adds nothing | ✔ |
| an unclaimed child is still provisioned standalone | — |
| `standalone.yml` still wins over the new marker | — |

The two that pass either way are deliberate baselines. Over-correcting here means suppressing agentic files for a child nobody is providing for, which leaves that project with no skills at all — a worse outcome than the bug.

1239 tests pass.

## Agent adoption

Only relevant if you keep a Specnaut project nested inside a larger Specnaut workspace. If it is a Deno workspace member, nothing changes.

```prompt
Check whether this project sits inside an enclosing Specnaut workspace — an
ancestor directory containing `.specnaut/`.

If it does NOT, stop: nothing here applies.

If it does, report which of these is true:
  a) the ancestor's `deno.json` lists this project in its `workspace` array —
     nothing to do, detection already works;
  b) it does not list it, AND this project has its own `.claude/skills` or
     `.claude/agents` that duplicate the parent's — then this project can now
     opt in by creating an empty `.specnaut/parent-managed.yml`, after which
     `specnaut upgrade` stops writing agentic files here and prunes them from
     `.specnaut/installed.lock`;
  c) it does not list it and the local agentic files are genuinely this
     project's own — do nothing, the current behaviour is correct.

Report which case applies and why. Do not create the marker file yourself —
suppressing agentic files is a workspace-layout decision, not a cleanup.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
