### PR TITLE
chore(473): converge on one identity for every automated commit

### DIFF
--- a/scripts/bump-tap-formula.ts
+++ b/scripts/bump-tap-formula.ts
@@ -143,6 +143,10 @@ async function main(): Promise<number> {
       return 0;
     }
 
+    // The one identity for every automated commit in this repo. Set inline
+    // rather than shared because `scripts/lib/sync-helpers.sh` is bash and
+    // this is TypeScript — the two cannot import each other, so they are kept
+    // in step by hand. Change one, change the other (#473).
     await run(["git", "config", "user.name", "github-actions[bot]"], workdir);
     await run(
       [

--- a/scripts/lib/sync-helpers.sh
+++ b/scripts/lib/sync-helpers.sh
@@ -72,12 +72,25 @@ mktemp_workdir() {
 
 # git_bot_identity
 #
-# Set the local git user.email and user.name to the Specnaut sync
-# bot identity. Must be called from inside the destination clone
-# (after `cd` into it).
+# Set the local git identity for an automated commit. Must be called from
+# inside the destination clone (after `cd` into it).
+#
+# THIS IS THE ONE IDENTITY FOR EVERY AUTOMATED COMMIT IN THIS REPO. If you
+# add another path that commits on our behalf, call this — do not invent a
+# third. `scripts/bump-tap-formula.ts` sets the same name and address
+# directly, because it is TypeScript and cannot source this file; keep the
+# two in step.
+#
+# It is GitHub's own bot identity, which is what makes it the right choice:
+# these commits are pushed to public repositories, the forge renders the
+# author as a bot rather than a person, and it needs no address that has to
+# be owned, routed or kept alive. The previous value was a hand-picked
+# address on a domain unrelated to any of the destination repos — nothing
+# was broken by it, but it meant two identities to recognise in `git log`
+# and two to allowlist wherever bot authorship is checked (#473).
 git_bot_identity() {
-  git config user.email "specnaut-bot@mkrlabs.dev"
-  git config user.name "Specnaut Sync Bot"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git config user.name "github-actions[bot]"
 }
 
 # wire_gh_token_to_remote
@@ -109,7 +122,7 @@ wire_gh_token_to_remote() {
 # (an earlier run already pushed the same content; nothing to do).
 #
 # Arguments:
-#   $1 — repo (e.g. mkrlabs/plugins)
+#   $1 — repo (e.g. specnaut/specnaut-plugins)
 #   $2 — branch (e.g. specnaut-sync/v1.8.0)
 #   $3 — PR title
 #   $4 — PR body (multi-line OK)


### PR DESCRIPTION
Closes #473.

Two bot paths committed under two identities: `git_bot_identity()` in `scripts/lib/sync-helpers.sh` (used by both sync scripts) and `scripts/bump-tap-formula.ts`. Nothing was broken by it — it meant two identities to recognise in `git log`, two to allowlist wherever bot authorship is checked, and a third waiting to be invented by whoever adds the next sync path.

## Why GitHub's bot identity, not the other one

Converged on the one `bump-tap-formula.ts` already used. That is a reasoned target rather than an arbitrary tiebreak: these commits are pushed to **public** repositories, the forge renders the author as a bot rather than a person, and it needs no address that has to be owned, routed, or kept alive by anyone.

## The pin, where a pin is possible

The two paths cannot share code — one is bash, the other TypeScript. So both now carry a comment stating this is *the* identity, that the other sets it directly for that reason, and that they change together.

That is weaker than the parity tests used elsewhere in this session, and deliberately so: when a language boundary rules out a shared constant, a stated constraint is the only pin left. Worth naming rather than pretending the duplication is now safe.

## Acceptance criteria

| Criterion | Status |
| :--- | :--- |
| Both paths resolve to the same name and address | ✔ |
| Repo-wide grep returns only that identity | ✔ — one name, one address across `scripts/`, `.github/`, `.specnaut/` |
| Documented on `git_bot_identity()` as the one identity | ✔ |
| Sync scripts still push; no behavioural change | Diff verified identity-and-comments only — `bash -n` clean, `shellcheck` findings unchanged from `main` (2 pre-existing `SC2148`) |

The last one is a structural check, not an executed one: the sync paths only run on a release tag against public forks, so I could not exercise them without publishing. What I could verify is that nothing they do changed — rsync sets, destination repos and trigger conditions are untouched.

## Also

`create_pr_idempotent`'s docstring named a destination org the scripts do not use; `FORK` in `sync-to-codex-plugin.sh` is the real one. Same family as the stale `release.yml` comment fixed earlier, and it would have been odd to leave it in the file being cleaned.

1239 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
