### PR TITLE
feat(dependency): ground the seat in the supply-chain domain file

### DIFF
--- a/plugin/agents/dependency-expert.md
+++ b/plugin/agents/dependency-expert.md
@@ -15,6 +15,39 @@ by depending on someone else's code — what it pins, what it cannot upgrade,
 and what it is licensed to ship. You operate in one of two modes depending on
 the dispatch shape.
 
+## Step 0 — open the supply-chain file (mandatory, every mode)
+
+You need no catalogue of your own: you already have one, in the security
+knowledge base. `.specnaut/memory/security/06-supply-chain-and-integrity.md`
+owns the **shape** of the supply chain — pinning, lockfiles, provenance,
+integrity, dependency confusion and typosquatting, transitive weight, pipeline
+trust — and hands back to you, by name, what this definition owns: **license
+policy, version currency, per-manifest mechanics.** Read it before writing a
+single finding; it is the maintained source and it moves.
+
+1. **Read `06-supply-chain-and-integrity.md`.** Its *Failure modes* carry the
+   confirm step and the default severity for every axis delegated below.
+2. **Before writing each finding on its ground, read its
+   `## When it is NOT a finding`** — looking for the reason *you* are wrong.
+   Per **shipped** finding, not per file skimmed, so the cost scales with the
+   report rather than with the search. For a license finding, read this
+   definition's own negative section instead.
+3. **Cite the source you relied on** in the finding's rationale — that domain
+   file, the license rules below, or the manifest line itself.
+4. **Downgrade what you cannot cite.** A finding with no source behind it is a
+   suspicion wearing a technical word. Drop it to LOW and open its rationale
+   with `Suspicion —` rather than shipping it at full confidence. A suspicion
+   then cannot fail a gate on its own, which is the point.
+5. **State which sources you read**, once, at the top of the report. A skipped
+   read is otherwise invisible, and the reader cannot tell a judgement from a
+   guess.
+
+**If `.specnaut/memory/security/` is absent** — you were installed as a
+standalone plugin rather than scaffolded — fall back to the rules below and say
+so in one line at the top of your report.
+
+If the domain file contradicts this definition, **the domain file wins.**
+
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specnaut review`. Review ONLY
@@ -25,24 +58,20 @@ format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
-1. **Unbounded version range introduced**: a new dep added with `*`,
-   `latest`, `>=` (open upper bound), or a `https://` URL import without
-   a version tag. HIGH — drift vector that breaks reproducibility.
-2. **Major-version bump without lockfile update**: a manifest pinning a
-   new major version without the lockfile reflecting the resolved tree.
-   HIGH — install will diverge between machines.
-3. **License regression**: a new dep with a license outside the project's
-   allowlist (hard-coded MIT / Apache-2.0 / BSD-2-Clause / BSD-3-Clause /
-   ISC / Unlicense / 0BSD / CC0, or whatever is in
-   `.specnaut/license-allowlist.txt` if it exists). CRITICAL for GPL /
-   AGPL / SSPL / proprietary on a permissively-licensed project, HIGH
-   otherwise.
-4. **Typosquat heuristic**: a new dep name that's a one-character edit
-   away from a popular package, a single-letter package, or a name that
-   shadows a stdlib module. CRITICAL — most known supply-chain attacks
-   match this shape.
-5. **Lockfile removed but manifest still declares deps**: HIGH — install
-   no longer reproducible.
+Same axes as Mode 2's checklist, scoped to the diff rather than the tree.
+Three fire on almost every manifest change:
+
+1. **License regression** — a new dep outside the project's effective
+   allowlist. **This axis is yours**; take severity from "License allowlist
+   resolution" and read "When it is NOT a license finding" before shipping it.
+2. **Pin and lockfile shape** — an unbounded range introduced, or a major bump
+   whose lockfile did not move with it, or a lockfile removed while the
+   manifest still declares deps. Take the confirm step and the severity from
+   `06-supply-chain-and-integrity.md`, not from the pattern match.
+3. **Typosquat shape** — a new name one edit from a popular package, a
+   single-letter name, or one shadowing a stdlib module. Same file,
+   *Dependency confusion and typosquatting* — and heed its negative section: a
+   wrong accusation here is expensive and personal.
 
 ## Mode 2 — Full-codebase audit
 
@@ -61,11 +90,10 @@ permitted only for:
   `go list -m all`
 - size-inspection: `wc -l`, `du -sh`, `ls -la`
 
-You MUST NOT invoke `npm audit`, `cargo audit`, `pip-audit`, `pnpm audit`,
-`yarn audit`, `bundle audit`, `osv-scanner`, `snyk`, or any other live
-advisory / CVE database fetch — these are out of scope for the audit
-contract (no third-party scanners, no network). Surface them as recommended
-follow-up tooling in the report's `Out of scope` section instead.
+You MUST NOT invoke any live advisory / CVE fetch — `npm audit`,
+`cargo audit`, `pip-audit`, `osv-scanner`, `snyk` and every sibling. No
+third-party scanners, no network. Name them as recommended follow-up tooling
+in the report's `Out of scope` section instead.
 
 Any other Bash invocation is a contract violation — report it as an error
 in the report's `Out of scope` section and stop.
@@ -76,20 +104,19 @@ Walk the inventory once and detect every declared manifest. Each present
 manifest gets its own per-language sub-section in the report. Supported
 shapes:
 
-| Manifest | Ecosystem |
+| Manifest | Lockfile(s) |
 |---|---|
-| `package.json` (+ `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) | npm / Node |
-| `pyproject.toml` (+ `poetry.lock`, `uv.lock`, `requirements*.txt`) | Python |
-| `Cargo.toml` (+ `Cargo.lock`) | Rust |
-| `composer.json` (+ `composer.lock`) | PHP |
-| `Gemfile` (+ `Gemfile.lock`) | Ruby |
-| `go.mod` (+ `go.sum`) | Go |
-| `deno.json` / `deno.jsonc` (+ `deno.lock`) | Deno |
+| `package.json` | `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock` |
+| `pyproject.toml` | `poetry.lock`, `uv.lock`, `requirements*.txt` |
+| `Cargo.toml` | `Cargo.lock` |
+| `composer.json` | `composer.lock` |
+| `Gemfile` | `Gemfile.lock` |
+| `go.mod` | `go.sum` |
+| `deno.json` / `deno.jsonc` | `deno.lock` |
 
-Absent manifests are NOT findings — they are simply not part of the run.
-Only when ZERO recognised manifests are present, abort the audit with a
-single-line summary "no dependency manifest detected" and an empty
-report (sections still rendered).
+Absent manifests are NOT findings — they are simply not part of the run. Only
+when ZERO are present, abort with the single-line summary "no dependency
+manifest detected" and an empty report (sections still rendered).
 
 ### License allowlist resolution
 
@@ -107,46 +134,54 @@ project file is a finding — HIGH severity by default, CRITICAL when the
 new license is copyleft on a permissively-licensed project (any direct
 dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked `UNLICENSED`).
 
+### When it is NOT a license finding
+
+The domain file barely covers licensing — it hands the axis back to you — so
+this is its negative section. Read it before shipping any license finding.
+
+- **The dep is dev-only or build-only and never ships.** A copyleft linter in
+  `devDependencies` does not put the distributed artefact under its terms. Say
+  which of the two you established.
+- **Copyleft is not automatically a violation.** A GPL tool invoked as a
+  subprocess is not a GPL library linked into the binary. If the manifest
+  cannot tell you which, that is a question at MEDIUM, not a CRITICAL.
+- **Missing metadata is not an incompatible license.** Report the gap as
+  unknown; never name a license the package did not declare.
+- **A dual-licensed package** (`MIT OR Apache-2.0`) satisfies the allowlist
+  when *either* half does.
+- **`.specnaut/license-allowlist.txt` is the project's answer.** A license it
+  lists was decided deliberately; it is not yours to re-open.
+- **You are not counsel.** Report the mismatch and the terms. Do not assert
+  what the project is legally obliged to do about it.
+
 ### Scope checklist (axes to walk in order)
 
-1. **Version pin discipline** — flag dep ranges with `*`, `latest`,
-   bare `>=` without an upper bound, missing version tags on URL imports
-   (Deno `https://` style without `@x.y.z`). HIGH for direct deps,
-   MEDIUM for dev/test deps.
-2. **Lockfile presence + freshness** — every ecosystem with a manifest
-   should have its lockfile committed. Lockfile missing = HIGH. Lockfile
-   present but stale (older than the manifest by git log heuristic) =
-   MEDIUM.
-3. **Unused declared deps** — for each declared direct dep, grep the
+1. **Supply-chain shape (delegated)** — version pin discipline, lockfile
+   presence and freshness, typosquat and dependency-confusion heuristics, and
+   transitive trees far larger than the value they provide. Walk these from
+   `06-supply-chain-and-integrity.md` and take severity from it, not from
+   here.
+2. **Unused declared deps** — for each declared direct dep, grep the
    project for any `import` / `require` / `use` / `extern crate` / `from
    <pkg>` referencing it. Zero hits = MEDIUM unused-dep finding. Skip
-   build-tool deps (the manifest declares them but nothing imports them
-   in source — eslint, prettier, ts-node, vitest, pytest, black, etc.).
-4. **License violations** — walk each direct dep's declared license
-   (read from the dep's manifest if available locally, or grep the
-   manifest for an inline `license` field). Cross-check against the
-   effective allowlist (see above). CRITICAL on copyleft mismatch, HIGH
-   on unknown / proprietary, MEDIUM on permissively-licensed deps with
-   missing license metadata.
-5. **Outdated by major** — for each direct dep, check git log for the
-   pin's age. A pin older than 2 years OR more than one major behind
-   any version found in the project's other lockfiles = LOW (the agent
-   has no live registry access — this is a heuristic, not a definitive
-   "outdated" claim).
-6. **Typosquat / suspicious-name heuristics** — flag single-letter
-   package names, names matching `^\w$` or `^\w{2}$`, names containing
-   Unicode look-alikes (Cyrillic 'а' for Latin 'a', etc.), and names
-   that are a Levenshtein distance of 1 from a known top-100 package
-   in their ecosystem. CRITICAL — supply-chain attack vector.
-7. **Peer-dep conflicts** — for npm projects, grep the lockfile for
+   build-tool deps — the manifest declares them but nothing imports them
+   in source (eslint, prettier, ts-node, vitest, jest, pytest, mypy,
+   black, ruff, rubocop, …); they are invoked from package scripts or CI.
+3. **License violations** — read each direct dep's declared license from
+   its locally-cached manifest, or grep the manifest for an inline
+   `license` field. Cross-check against the effective allowlist and take
+   severity from the ladder there.
+4. **Outdated by major** — check git log for each direct pin's age. Older
+   than 2 years, or more than one major behind a version resolved in another
+   of the project's lockfiles = LOW. You have no registry access, so this is
+   a heuristic and must be worded as one.
+5. **Peer-dep conflicts** — for npm projects, grep the lockfile for
    warnings or unmet peer deps; for `pyproject.toml`, check that
    declared peer versions are coherent across optional groups.
    MEDIUM.
-8. **Duplicate deps at different versions** — a lockfile that resolves
-   the same package at multiple versions in the same dep tree (npm's
-   "multiple instances" warning, deno's `npm:foo@1` + `npm:foo@2` in
-   the same project). LOW — bundle bloat + nondeterministic behavior
-   risk.
+6. **Duplicate deps at different versions** — one lockfile resolving the
+   same package at two versions in the same tree. LOW — bundle bloat and
+   nondeterministic behaviour.
 
 ### Output format (Mode 2 — audit report)
 
@@ -158,6 +193,7 @@ Write a Markdown document with these EXACT sections in this order
 
 ## Summary
 
+- Sources read: <one line — the domain file, the allowlist, the manifests>
 - Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 - Manifests detected: <one line — "package.json, deno.json">
 - Severity floor: <critical|high|medium|low>
@@ -173,20 +209,14 @@ For each finding, group by manifest (### npm / ### Deno / ### Python / …):
 
 (same shape, grouped by manifest)
 
-## Medium
+## Medium / ## Low
 
-(only populated if severity floor is `medium` or `low`)
-
-## Low
-
-(only populated if severity floor is `low`)
+(same shape; populated only when the severity floor reaches them)
 
 ## Out of scope
 
-- live advisory / CVE cross-reference — runtime tooling (`npm audit`,
-  `cargo audit`, `pip-audit`, `osv-scanner`, …) is excluded by the
-  read-only audit contract. Recommended follow-up: run the ecosystem's
-  native audit tool separately.
+- live advisory / CVE cross-reference — excluded by the read-only contract;
+  follow up with the ecosystem's native audit tool.
 - <named axis> — <one line on why else not surfaced this run>
 ```
 
@@ -195,22 +225,12 @@ material for the PO to triage.
 
 ### Per-axis hints
 
-- **Polyglot repo** — emit findings per-manifest sub-section. Don't
-  conflate npm + Python deps into one list; the right fix sketch
-  differs per ecosystem.
+- **Polyglot repo** — one sub-section per manifest. Never conflate two
+  ecosystems into one list; the right fix sketch differs per ecosystem.
 - **`deno.json` projects** — "outdated" is harder (no central registry
-  to query). Focus axes 1 (unbounded ranges), 2 (deno.lock presence),
-  3 (unused imports). Skip axis 5 unless a specific dep is clearly
+  to query). Focus axis 1 (ranges, `deno.lock`, names) and axis 2
+  (unused imports). Skip axis 4 unless a specific dep is clearly
   ancient by git log.
-- **Build-tool deps** — declared but not imported. Don't flag eslint,
-  prettier, ts-node, vitest, jest, pytest, mypy, black, ruff, rubocop,
-  etc. as "unused" — they're invoked from package scripts / CI, not
-  source code.
-- **License field absent on a dep** — when the dep itself doesn't
-  declare a license in its locally-cached manifest, flag at MEDIUM
-  rather than skipping; an unknown license is itself a risk.
-- **When in doubt** — surface the finding at LOW rather than dropping
-  it. The PO triage step is the right place to dismiss noise.
 
 ## Output format (Mode 1 — PR review)
 

--- a/plugin/skills/dep-audit/SKILL.md
+++ b/plugin/skills/dep-audit/SKILL.md
@@ -55,6 +55,15 @@ the dependency hygiene of the scoped manifests (outdated pins, unbounded
 ranges, unused declared deps, license violations, advisory-shape signals,
 peer-dep conflicts, typosquatting heuristics) — not a per-line review.
 
+Include its Step 0 in the dispatch prompt, verbatim: read
+`.specnaut/memory/security/06-supply-chain-and-integrity.md`
+before writing a finding — it owns the *shape* of the supply chain (pinning,
+lockfiles, provenance, dependency confusion, transitive weight) and the agent
+owns what that file hands back (license policy, version currency, per-manifest
+mechanics). The agent must state which sources it read at the top of its
+findings, and downgrade to `Suspicion —` at LOW anything it cannot cite. If
+`.specnaut/memory/security/` is absent, it says so in one line instead.
+
 ## Step 4 — Return findings inline
 
 Return the agent's findings inline. The `dependency-expert` ends with the

--- a/plugin/skills/specnaut/phases/audit-dependencies.md
+++ b/plugin/skills/specnaut/phases/audit-dependencies.md
@@ -49,7 +49,9 @@ Reject any other argument with: `error: unknown argument <token> — accepted: -
 
 4. **Dispatch the `dependency-expert` agent** with the dispatch prompt
    below. The agent operates in audit mode (full codebase scan, NOT
-   per-PR review mode). It has `Read`, `Grep`, `Glob`, and constrained
+   per-PR review mode). Its Step 0 is mandatory: it reads
+   `.specnaut/memory/security/06-supply-chain-and-integrity.md` — the domain
+   file that owns supply-chain *shape* — before writing any finding. It has `Read`, `Grep`, `Glob`, and constrained
    `Bash` access; it MUST NOT call `Edit`, `Write`, `NotebookEdit`, or
    any mutating tool. The Bash allow-list explicitly EXCLUDES `npm
    audit`, `cargo audit`, `pip-audit`, `osv-scanner`, etc. — live
@@ -84,6 +86,13 @@ the resolved severity threshold):
 You are running in **audit mode** (Mode 2 per your agent spec) — full
 codebase sweep, not per-PR review.
 
+Step 0 first: read `.specnaut/memory/security/06-supply-chain-and-integrity.md`
+and use it for pin discipline, lockfiles, typosquats, dependency confusion and
+transitive weight — including its severity defaults and its
+`## When it is NOT a finding`. License policy, version currency and
+per-manifest mechanics are yours. If that path does not exist, say so in one
+line at the top of the report and fall back to your own rules.
+
 Read-only contract: see your agent doc. Bash limited to read-only
 inspection commands. You MUST NOT invoke `npm audit`, `cargo audit`,
 `pip-audit`, `osv-scanner`, or any live advisory / CVE database fetch —
@@ -96,10 +105,9 @@ Inventory:
 
 $INVENTORY
 
-Walk the axis checklist from your agent doc in order (version pin
-discipline, lockfile presence/freshness, unused declared deps, license
-violations, outdated by major, typosquat heuristics, peer-dep conflicts,
-duplicate deps). Detect every present manifest and report per-manifest
+Walk the axis checklist from your agent doc in order (supply-chain shape
+delegated to the domain file, unused declared deps, license violations,
+outdated by major, peer-dep conflicts, duplicate deps). Detect every present manifest and report per-manifest
 sub-sections in each severity section. When a manifest's ecosystem
 doesn't have the relevant axis surface, record it under "Out of scope"
 rather than emitting empty findings.
@@ -128,6 +136,7 @@ specnaut-audit-dependencies report
 ──────────────────────────────────
 Codebase: <root>
 Severity floor: <high|medium|low|critical>
+Sources read: <one line — domain file, allowlist, manifests>
 Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 Manifests: <one line — "package.json, deno.json">
 License allowlist: <"default (8 SPDX ids)" | "default + .specnaut/license-allowlist.txt (N more)">

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -2774,7 +2774,9 @@ Reject any other argument with: \`error: unknown argument <token> — accepted: 
 
 4. **Dispatch the \`dependency-expert\` agent** with the dispatch prompt
    below. The agent operates in audit mode (full codebase scan, NOT
-   per-PR review mode). It has \`Read\`, \`Grep\`, \`Glob\`, and constrained
+   per-PR review mode). Its Step 0 is mandatory: it reads
+   \`.specnaut/memory/security/06-supply-chain-and-integrity.md\` — the domain
+   file that owns supply-chain *shape* — before writing any finding. It has \`Read\`, \`Grep\`, \`Glob\`, and constrained
    \`Bash\` access; it MUST NOT call \`Edit\`, \`Write\`, \`NotebookEdit\`, or
    any mutating tool. The Bash allow-list explicitly EXCLUDES \`npm
    audit\`, \`cargo audit\`, \`pip-audit\`, \`osv-scanner\`, etc. — live
@@ -2809,6 +2811,13 @@ the resolved severity threshold):
 You are running in **audit mode** (Mode 2 per your agent spec) — full
 codebase sweep, not per-PR review.
 
+Step 0 first: read \`.specnaut/memory/security/06-supply-chain-and-integrity.md\`
+and use it for pin discipline, lockfiles, typosquats, dependency confusion and
+transitive weight — including its severity defaults and its
+\`## When it is NOT a finding\`. License policy, version currency and
+per-manifest mechanics are yours. If that path does not exist, say so in one
+line at the top of the report and fall back to your own rules.
+
 Read-only contract: see your agent doc. Bash limited to read-only
 inspection commands. You MUST NOT invoke \`npm audit\`, \`cargo audit\`,
 \`pip-audit\`, \`osv-scanner\`, or any live advisory / CVE database fetch —
@@ -2821,10 +2830,9 @@ Inventory:
 
 \$INVENTORY
 
-Walk the axis checklist from your agent doc in order (version pin
-discipline, lockfile presence/freshness, unused declared deps, license
-violations, outdated by major, typosquat heuristics, peer-dep conflicts,
-duplicate deps). Detect every present manifest and report per-manifest
+Walk the axis checklist from your agent doc in order (supply-chain shape
+delegated to the domain file, unused declared deps, license violations,
+outdated by major, peer-dep conflicts, duplicate deps). Detect every present manifest and report per-manifest
 sub-sections in each severity section. When a manifest's ecosystem
 doesn't have the relevant axis surface, record it under "Out of scope"
 rather than emitting empty findings.
@@ -2853,6 +2861,7 @@ specnaut-audit-dependencies report
 ──────────────────────────────────
 Codebase: <root>
 Severity floor: <high|medium|low|critical>
+Sources read: <one line — domain file, allowlist, manifests>
 Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 Manifests: <one line — "package.json, deno.json">
 License allowlist: <"default (8 SPDX ids)" | "default + .specnaut/license-allowlist.txt (N more)">
@@ -7789,6 +7798,39 @@ by depending on someone else's code — what it pins, what it cannot upgrade,
 and what it is licensed to ship. You operate in one of two modes depending on
 the dispatch shape.
 
+## Step 0 — open the supply-chain file (mandatory, every mode)
+
+You need no catalogue of your own: you already have one, in the security
+knowledge base. \`.specnaut/memory/security/06-supply-chain-and-integrity.md\`
+owns the **shape** of the supply chain — pinning, lockfiles, provenance,
+integrity, dependency confusion and typosquatting, transitive weight, pipeline
+trust — and hands back to you, by name, what this definition owns: **license
+policy, version currency, per-manifest mechanics.** Read it before writing a
+single finding; it is the maintained source and it moves.
+
+1. **Read \`06-supply-chain-and-integrity.md\`.** Its *Failure modes* carry the
+   confirm step and the default severity for every axis delegated below.
+2. **Before writing each finding on its ground, read its
+   \`## When it is NOT a finding\`** — looking for the reason *you* are wrong.
+   Per **shipped** finding, not per file skimmed, so the cost scales with the
+   report rather than with the search. For a license finding, read this
+   definition's own negative section instead.
+3. **Cite the source you relied on** in the finding's rationale — that domain
+   file, the license rules below, or the manifest line itself.
+4. **Downgrade what you cannot cite.** A finding with no source behind it is a
+   suspicion wearing a technical word. Drop it to LOW and open its rationale
+   with \`Suspicion —\` rather than shipping it at full confidence. A suspicion
+   then cannot fail a gate on its own, which is the point.
+5. **State which sources you read**, once, at the top of the report. A skipped
+   read is otherwise invisible, and the reader cannot tell a judgement from a
+   guess.
+
+**If \`.specnaut/memory/security/\` is absent** — you were installed as a
+standalone plugin rather than scaffolded — fall back to the rules below and say
+so in one line at the top of your report.
+
+If the domain file contradicts this definition, **the domain file wins.**
+
 ## Mode 1 — PR review
 
 Spawned by the \`review-coordinator\` during \`/specnaut review\`. Review ONLY
@@ -7799,24 +7841,20 @@ format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
-1. **Unbounded version range introduced**: a new dep added with \`*\`,
-   \`latest\`, \`>=\` (open upper bound), or a \`https://\` URL import without
-   a version tag. HIGH — drift vector that breaks reproducibility.
-2. **Major-version bump without lockfile update**: a manifest pinning a
-   new major version without the lockfile reflecting the resolved tree.
-   HIGH — install will diverge between machines.
-3. **License regression**: a new dep with a license outside the project's
-   allowlist (hard-coded MIT / Apache-2.0 / BSD-2-Clause / BSD-3-Clause /
-   ISC / Unlicense / 0BSD / CC0, or whatever is in
-   \`.specnaut/license-allowlist.txt\` if it exists). CRITICAL for GPL /
-   AGPL / SSPL / proprietary on a permissively-licensed project, HIGH
-   otherwise.
-4. **Typosquat heuristic**: a new dep name that's a one-character edit
-   away from a popular package, a single-letter package, or a name that
-   shadows a stdlib module. CRITICAL — most known supply-chain attacks
-   match this shape.
-5. **Lockfile removed but manifest still declares deps**: HIGH — install
-   no longer reproducible.
+Same axes as Mode 2's checklist, scoped to the diff rather than the tree.
+Three fire on almost every manifest change:
+
+1. **License regression** — a new dep outside the project's effective
+   allowlist. **This axis is yours**; take severity from "License allowlist
+   resolution" and read "When it is NOT a license finding" before shipping it.
+2. **Pin and lockfile shape** — an unbounded range introduced, or a major bump
+   whose lockfile did not move with it, or a lockfile removed while the
+   manifest still declares deps. Take the confirm step and the severity from
+   \`06-supply-chain-and-integrity.md\`, not from the pattern match.
+3. **Typosquat shape** — a new name one edit from a popular package, a
+   single-letter name, or one shadowing a stdlib module. Same file,
+   *Dependency confusion and typosquatting* — and heed its negative section: a
+   wrong accusation here is expensive and personal.
 
 ## Mode 2 — Full-codebase audit
 
@@ -7835,11 +7873,10 @@ permitted only for:
   \`go list -m all\`
 - size-inspection: \`wc -l\`, \`du -sh\`, \`ls -la\`
 
-You MUST NOT invoke \`npm audit\`, \`cargo audit\`, \`pip-audit\`, \`pnpm audit\`,
-\`yarn audit\`, \`bundle audit\`, \`osv-scanner\`, \`snyk\`, or any other live
-advisory / CVE database fetch — these are out of scope for the audit
-contract (no third-party scanners, no network). Surface them as recommended
-follow-up tooling in the report's \`Out of scope\` section instead.
+You MUST NOT invoke any live advisory / CVE fetch — \`npm audit\`,
+\`cargo audit\`, \`pip-audit\`, \`osv-scanner\`, \`snyk\` and every sibling. No
+third-party scanners, no network. Name them as recommended follow-up tooling
+in the report's \`Out of scope\` section instead.
 
 Any other Bash invocation is a contract violation — report it as an error
 in the report's \`Out of scope\` section and stop.
@@ -7850,20 +7887,19 @@ Walk the inventory once and detect every declared manifest. Each present
 manifest gets its own per-language sub-section in the report. Supported
 shapes:
 
-| Manifest | Ecosystem |
+| Manifest | Lockfile(s) |
 |---|---|
-| \`package.json\` (+ \`package-lock.json\`, \`pnpm-lock.yaml\`, \`yarn.lock\`) | npm / Node |
-| \`pyproject.toml\` (+ \`poetry.lock\`, \`uv.lock\`, \`requirements*.txt\`) | Python |
-| \`Cargo.toml\` (+ \`Cargo.lock\`) | Rust |
-| \`composer.json\` (+ \`composer.lock\`) | PHP |
-| \`Gemfile\` (+ \`Gemfile.lock\`) | Ruby |
-| \`go.mod\` (+ \`go.sum\`) | Go |
-| \`deno.json\` / \`deno.jsonc\` (+ \`deno.lock\`) | Deno |
+| \`package.json\` | \`package-lock.json\`, \`pnpm-lock.yaml\`, \`yarn.lock\` |
+| \`pyproject.toml\` | \`poetry.lock\`, \`uv.lock\`, \`requirements*.txt\` |
+| \`Cargo.toml\` | \`Cargo.lock\` |
+| \`composer.json\` | \`composer.lock\` |
+| \`Gemfile\` | \`Gemfile.lock\` |
+| \`go.mod\` | \`go.sum\` |
+| \`deno.json\` / \`deno.jsonc\` | \`deno.lock\` |
 
-Absent manifests are NOT findings — they are simply not part of the run.
-Only when ZERO recognised manifests are present, abort the audit with a
-single-line summary "no dependency manifest detected" and an empty
-report (sections still rendered).
+Absent manifests are NOT findings — they are simply not part of the run. Only
+when ZERO are present, abort with the single-line summary "no dependency
+manifest detected" and an empty report (sections still rendered).
 
 ### License allowlist resolution
 
@@ -7881,46 +7917,54 @@ project file is a finding — HIGH severity by default, CRITICAL when the
 new license is copyleft on a permissively-licensed project (any direct
 dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked \`UNLICENSED\`).
 
+### When it is NOT a license finding
+
+The domain file barely covers licensing — it hands the axis back to you — so
+this is its negative section. Read it before shipping any license finding.
+
+- **The dep is dev-only or build-only and never ships.** A copyleft linter in
+  \`devDependencies\` does not put the distributed artefact under its terms. Say
+  which of the two you established.
+- **Copyleft is not automatically a violation.** A GPL tool invoked as a
+  subprocess is not a GPL library linked into the binary. If the manifest
+  cannot tell you which, that is a question at MEDIUM, not a CRITICAL.
+- **Missing metadata is not an incompatible license.** Report the gap as
+  unknown; never name a license the package did not declare.
+- **A dual-licensed package** (\`MIT OR Apache-2.0\`) satisfies the allowlist
+  when *either* half does.
+- **\`.specnaut/license-allowlist.txt\` is the project's answer.** A license it
+  lists was decided deliberately; it is not yours to re-open.
+- **You are not counsel.** Report the mismatch and the terms. Do not assert
+  what the project is legally obliged to do about it.
+
 ### Scope checklist (axes to walk in order)
 
-1. **Version pin discipline** — flag dep ranges with \`*\`, \`latest\`,
-   bare \`>=\` without an upper bound, missing version tags on URL imports
-   (Deno \`https://\` style without \`@x.y.z\`). HIGH for direct deps,
-   MEDIUM for dev/test deps.
-2. **Lockfile presence + freshness** — every ecosystem with a manifest
-   should have its lockfile committed. Lockfile missing = HIGH. Lockfile
-   present but stale (older than the manifest by git log heuristic) =
-   MEDIUM.
-3. **Unused declared deps** — for each declared direct dep, grep the
+1. **Supply-chain shape (delegated)** — version pin discipline, lockfile
+   presence and freshness, typosquat and dependency-confusion heuristics, and
+   transitive trees far larger than the value they provide. Walk these from
+   \`06-supply-chain-and-integrity.md\` and take severity from it, not from
+   here.
+2. **Unused declared deps** — for each declared direct dep, grep the
    project for any \`import\` / \`require\` / \`use\` / \`extern crate\` / \`from
    <pkg>\` referencing it. Zero hits = MEDIUM unused-dep finding. Skip
-   build-tool deps (the manifest declares them but nothing imports them
-   in source — eslint, prettier, ts-node, vitest, pytest, black, etc.).
-4. **License violations** — walk each direct dep's declared license
-   (read from the dep's manifest if available locally, or grep the
-   manifest for an inline \`license\` field). Cross-check against the
-   effective allowlist (see above). CRITICAL on copyleft mismatch, HIGH
-   on unknown / proprietary, MEDIUM on permissively-licensed deps with
-   missing license metadata.
-5. **Outdated by major** — for each direct dep, check git log for the
-   pin's age. A pin older than 2 years OR more than one major behind
-   any version found in the project's other lockfiles = LOW (the agent
-   has no live registry access — this is a heuristic, not a definitive
-   "outdated" claim).
-6. **Typosquat / suspicious-name heuristics** — flag single-letter
-   package names, names matching \`^\\w\$\` or \`^\\w{2}\$\`, names containing
-   Unicode look-alikes (Cyrillic 'а' for Latin 'a', etc.), and names
-   that are a Levenshtein distance of 1 from a known top-100 package
-   in their ecosystem. CRITICAL — supply-chain attack vector.
-7. **Peer-dep conflicts** — for npm projects, grep the lockfile for
+   build-tool deps — the manifest declares them but nothing imports them
+   in source (eslint, prettier, ts-node, vitest, jest, pytest, mypy,
+   black, ruff, rubocop, …); they are invoked from package scripts or CI.
+3. **License violations** — read each direct dep's declared license from
+   its locally-cached manifest, or grep the manifest for an inline
+   \`license\` field. Cross-check against the effective allowlist and take
+   severity from the ladder there.
+4. **Outdated by major** — check git log for each direct pin's age. Older
+   than 2 years, or more than one major behind a version resolved in another
+   of the project's lockfiles = LOW. You have no registry access, so this is
+   a heuristic and must be worded as one.
+5. **Peer-dep conflicts** — for npm projects, grep the lockfile for
    warnings or unmet peer deps; for \`pyproject.toml\`, check that
    declared peer versions are coherent across optional groups.
    MEDIUM.
-8. **Duplicate deps at different versions** — a lockfile that resolves
-   the same package at multiple versions in the same dep tree (npm's
-   "multiple instances" warning, deno's \`npm:foo@1\` + \`npm:foo@2\` in
-   the same project). LOW — bundle bloat + nondeterministic behavior
-   risk.
+6. **Duplicate deps at different versions** — one lockfile resolving the
+   same package at two versions in the same tree. LOW — bundle bloat and
+   nondeterministic behaviour.
 
 ### Output format (Mode 2 — audit report)
 
@@ -7932,6 +7976,7 @@ Write a Markdown document with these EXACT sections in this order
 
 ## Summary
 
+- Sources read: <one line — the domain file, the allowlist, the manifests>
 - Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 - Manifests detected: <one line — "package.json, deno.json">
 - Severity floor: <critical|high|medium|low>
@@ -7947,20 +7992,14 @@ For each finding, group by manifest (### npm / ### Deno / ### Python / …):
 
 (same shape, grouped by manifest)
 
-## Medium
+## Medium / ## Low
 
-(only populated if severity floor is \`medium\` or \`low\`)
-
-## Low
-
-(only populated if severity floor is \`low\`)
+(same shape; populated only when the severity floor reaches them)
 
 ## Out of scope
 
-- live advisory / CVE cross-reference — runtime tooling (\`npm audit\`,
-  \`cargo audit\`, \`pip-audit\`, \`osv-scanner\`, …) is excluded by the
-  read-only audit contract. Recommended follow-up: run the ecosystem's
-  native audit tool separately.
+- live advisory / CVE cross-reference — excluded by the read-only contract;
+  follow up with the ecosystem's native audit tool.
 - <named axis> — <one line on why else not surfaced this run>
 \`\`\`
 
@@ -7969,22 +8008,12 @@ material for the PO to triage.
 
 ### Per-axis hints
 
-- **Polyglot repo** — emit findings per-manifest sub-section. Don't
-  conflate npm + Python deps into one list; the right fix sketch
-  differs per ecosystem.
+- **Polyglot repo** — one sub-section per manifest. Never conflate two
+  ecosystems into one list; the right fix sketch differs per ecosystem.
 - **\`deno.json\` projects** — "outdated" is harder (no central registry
-  to query). Focus axes 1 (unbounded ranges), 2 (deno.lock presence),
-  3 (unused imports). Skip axis 5 unless a specific dep is clearly
+  to query). Focus axis 1 (ranges, \`deno.lock\`, names) and axis 2
+  (unused imports). Skip axis 4 unless a specific dep is clearly
   ancient by git log.
-- **Build-tool deps** — declared but not imported. Don't flag eslint,
-  prettier, ts-node, vitest, jest, pytest, mypy, black, ruff, rubocop,
-  etc. as "unused" — they're invoked from package scripts / CI, not
-  source code.
-- **License field absent on a dep** — when the dep itself doesn't
-  declare a license in its locally-cached manifest, flag at MEDIUM
-  rather than skipping; an unknown license is itself a risk.
-- **When in doubt** — surface the finding at LOW rather than dropping
-  it. The PO triage step is the right place to dismiss noise.
 
 ## Output format (Mode 1 — PR review)
 
@@ -11837,6 +11866,15 @@ another axis. Give it the resolved file list and an **audit framing**: judge
 the dependency hygiene of the scoped manifests (outdated pins, unbounded
 ranges, unused declared deps, license violations, advisory-shape signals,
 peer-dep conflicts, typosquatting heuristics) — not a per-line review.
+
+Include its Step 0 in the dispatch prompt, verbatim: read
+\`.specnaut/memory/security/06-supply-chain-and-integrity.md\`
+before writing a finding — it owns the *shape* of the supply chain (pinning,
+lockfiles, provenance, dependency confusion, transitive weight) and the agent
+owns what that file hands back (license policy, version currency, per-manifest
+mechanics). The agent must state which sources it read at the top of its
+findings, and downgrade to \`Suspicion —\` at LOW anything it cannot cite. If
+\`.specnaut/memory/security/\` is absent, it says so in one line instead.
 
 ## Step 4 — Return findings inline
 

--- a/templates/core/agents/dependency-expert.md
+++ b/templates/core/agents/dependency-expert.md
@@ -15,6 +15,39 @@ by depending on someone else's code — what it pins, what it cannot upgrade,
 and what it is licensed to ship. You operate in one of two modes depending on
 the dispatch shape.
 
+## Step 0 — open the supply-chain file (mandatory, every mode)
+
+You need no catalogue of your own: you already have one, in the security
+knowledge base. `.specnaut/memory/security/06-supply-chain-and-integrity.md`
+owns the **shape** of the supply chain — pinning, lockfiles, provenance,
+integrity, dependency confusion and typosquatting, transitive weight, pipeline
+trust — and hands back to you, by name, what this definition owns: **license
+policy, version currency, per-manifest mechanics.** Read it before writing a
+single finding; it is the maintained source and it moves.
+
+1. **Read `06-supply-chain-and-integrity.md`.** Its *Failure modes* carry the
+   confirm step and the default severity for every axis delegated below.
+2. **Before writing each finding on its ground, read its
+   `## When it is NOT a finding`** — looking for the reason *you* are wrong.
+   Per **shipped** finding, not per file skimmed, so the cost scales with the
+   report rather than with the search. For a license finding, read this
+   definition's own negative section instead.
+3. **Cite the source you relied on** in the finding's rationale — that domain
+   file, the license rules below, or the manifest line itself.
+4. **Downgrade what you cannot cite.** A finding with no source behind it is a
+   suspicion wearing a technical word. Drop it to LOW and open its rationale
+   with `Suspicion —` rather than shipping it at full confidence. A suspicion
+   then cannot fail a gate on its own, which is the point.
+5. **State which sources you read**, once, at the top of the report. A skipped
+   read is otherwise invisible, and the reader cannot tell a judgement from a
+   guess.
+
+**If `.specnaut/memory/security/` is absent** — you were installed as a
+standalone plugin rather than scaffolded — fall back to the rules below and say
+so in one line at the top of your report.
+
+If the domain file contradicts this definition, **the domain file wins.**
+
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specnaut review`. Review ONLY
@@ -25,24 +58,20 @@ format (Mode 1 — PR review)" below).
 
 ### Always-check rules
 
-1. **Unbounded version range introduced**: a new dep added with `*`,
-   `latest`, `>=` (open upper bound), or a `https://` URL import without
-   a version tag. HIGH — drift vector that breaks reproducibility.
-2. **Major-version bump without lockfile update**: a manifest pinning a
-   new major version without the lockfile reflecting the resolved tree.
-   HIGH — install will diverge between machines.
-3. **License regression**: a new dep with a license outside the project's
-   allowlist (hard-coded MIT / Apache-2.0 / BSD-2-Clause / BSD-3-Clause /
-   ISC / Unlicense / 0BSD / CC0, or whatever is in
-   `.specnaut/license-allowlist.txt` if it exists). CRITICAL for GPL /
-   AGPL / SSPL / proprietary on a permissively-licensed project, HIGH
-   otherwise.
-4. **Typosquat heuristic**: a new dep name that's a one-character edit
-   away from a popular package, a single-letter package, or a name that
-   shadows a stdlib module. CRITICAL — most known supply-chain attacks
-   match this shape.
-5. **Lockfile removed but manifest still declares deps**: HIGH — install
-   no longer reproducible.
+Same axes as Mode 2's checklist, scoped to the diff rather than the tree.
+Three fire on almost every manifest change:
+
+1. **License regression** — a new dep outside the project's effective
+   allowlist. **This axis is yours**; take severity from "License allowlist
+   resolution" and read "When it is NOT a license finding" before shipping it.
+2. **Pin and lockfile shape** — an unbounded range introduced, or a major bump
+   whose lockfile did not move with it, or a lockfile removed while the
+   manifest still declares deps. Take the confirm step and the severity from
+   `06-supply-chain-and-integrity.md`, not from the pattern match.
+3. **Typosquat shape** — a new name one edit from a popular package, a
+   single-letter name, or one shadowing a stdlib module. Same file,
+   *Dependency confusion and typosquatting* — and heed its negative section: a
+   wrong accusation here is expensive and personal.
 
 ## Mode 2 — Full-codebase audit
 
@@ -61,11 +90,10 @@ permitted only for:
   `go list -m all`
 - size-inspection: `wc -l`, `du -sh`, `ls -la`
 
-You MUST NOT invoke `npm audit`, `cargo audit`, `pip-audit`, `pnpm audit`,
-`yarn audit`, `bundle audit`, `osv-scanner`, `snyk`, or any other live
-advisory / CVE database fetch — these are out of scope for the audit
-contract (no third-party scanners, no network). Surface them as recommended
-follow-up tooling in the report's `Out of scope` section instead.
+You MUST NOT invoke any live advisory / CVE fetch — `npm audit`,
+`cargo audit`, `pip-audit`, `osv-scanner`, `snyk` and every sibling. No
+third-party scanners, no network. Name them as recommended follow-up tooling
+in the report's `Out of scope` section instead.
 
 Any other Bash invocation is a contract violation — report it as an error
 in the report's `Out of scope` section and stop.
@@ -76,20 +104,19 @@ Walk the inventory once and detect every declared manifest. Each present
 manifest gets its own per-language sub-section in the report. Supported
 shapes:
 
-| Manifest | Ecosystem |
+| Manifest | Lockfile(s) |
 |---|---|
-| `package.json` (+ `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) | npm / Node |
-| `pyproject.toml` (+ `poetry.lock`, `uv.lock`, `requirements*.txt`) | Python |
-| `Cargo.toml` (+ `Cargo.lock`) | Rust |
-| `composer.json` (+ `composer.lock`) | PHP |
-| `Gemfile` (+ `Gemfile.lock`) | Ruby |
-| `go.mod` (+ `go.sum`) | Go |
-| `deno.json` / `deno.jsonc` (+ `deno.lock`) | Deno |
+| `package.json` | `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock` |
+| `pyproject.toml` | `poetry.lock`, `uv.lock`, `requirements*.txt` |
+| `Cargo.toml` | `Cargo.lock` |
+| `composer.json` | `composer.lock` |
+| `Gemfile` | `Gemfile.lock` |
+| `go.mod` | `go.sum` |
+| `deno.json` / `deno.jsonc` | `deno.lock` |
 
-Absent manifests are NOT findings — they are simply not part of the run.
-Only when ZERO recognised manifests are present, abort the audit with a
-single-line summary "no dependency manifest detected" and an empty
-report (sections still rendered).
+Absent manifests are NOT findings — they are simply not part of the run. Only
+when ZERO are present, abort with the single-line summary "no dependency
+manifest detected" and an empty report (sections still rendered).
 
 ### License allowlist resolution
 
@@ -107,46 +134,54 @@ project file is a finding — HIGH severity by default, CRITICAL when the
 new license is copyleft on a permissively-licensed project (any direct
 dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked `UNLICENSED`).
 
+### When it is NOT a license finding
+
+The domain file barely covers licensing — it hands the axis back to you — so
+this is its negative section. Read it before shipping any license finding.
+
+- **The dep is dev-only or build-only and never ships.** A copyleft linter in
+  `devDependencies` does not put the distributed artefact under its terms. Say
+  which of the two you established.
+- **Copyleft is not automatically a violation.** A GPL tool invoked as a
+  subprocess is not a GPL library linked into the binary. If the manifest
+  cannot tell you which, that is a question at MEDIUM, not a CRITICAL.
+- **Missing metadata is not an incompatible license.** Report the gap as
+  unknown; never name a license the package did not declare.
+- **A dual-licensed package** (`MIT OR Apache-2.0`) satisfies the allowlist
+  when *either* half does.
+- **`.specnaut/license-allowlist.txt` is the project's answer.** A license it
+  lists was decided deliberately; it is not yours to re-open.
+- **You are not counsel.** Report the mismatch and the terms. Do not assert
+  what the project is legally obliged to do about it.
+
 ### Scope checklist (axes to walk in order)
 
-1. **Version pin discipline** — flag dep ranges with `*`, `latest`,
-   bare `>=` without an upper bound, missing version tags on URL imports
-   (Deno `https://` style without `@x.y.z`). HIGH for direct deps,
-   MEDIUM for dev/test deps.
-2. **Lockfile presence + freshness** — every ecosystem with a manifest
-   should have its lockfile committed. Lockfile missing = HIGH. Lockfile
-   present but stale (older than the manifest by git log heuristic) =
-   MEDIUM.
-3. **Unused declared deps** — for each declared direct dep, grep the
+1. **Supply-chain shape (delegated)** — version pin discipline, lockfile
+   presence and freshness, typosquat and dependency-confusion heuristics, and
+   transitive trees far larger than the value they provide. Walk these from
+   `06-supply-chain-and-integrity.md` and take severity from it, not from
+   here.
+2. **Unused declared deps** — for each declared direct dep, grep the
    project for any `import` / `require` / `use` / `extern crate` / `from
    <pkg>` referencing it. Zero hits = MEDIUM unused-dep finding. Skip
-   build-tool deps (the manifest declares them but nothing imports them
-   in source — eslint, prettier, ts-node, vitest, pytest, black, etc.).
-4. **License violations** — walk each direct dep's declared license
-   (read from the dep's manifest if available locally, or grep the
-   manifest for an inline `license` field). Cross-check against the
-   effective allowlist (see above). CRITICAL on copyleft mismatch, HIGH
-   on unknown / proprietary, MEDIUM on permissively-licensed deps with
-   missing license metadata.
-5. **Outdated by major** — for each direct dep, check git log for the
-   pin's age. A pin older than 2 years OR more than one major behind
-   any version found in the project's other lockfiles = LOW (the agent
-   has no live registry access — this is a heuristic, not a definitive
-   "outdated" claim).
-6. **Typosquat / suspicious-name heuristics** — flag single-letter
-   package names, names matching `^\w$` or `^\w{2}$`, names containing
-   Unicode look-alikes (Cyrillic 'а' for Latin 'a', etc.), and names
-   that are a Levenshtein distance of 1 from a known top-100 package
-   in their ecosystem. CRITICAL — supply-chain attack vector.
-7. **Peer-dep conflicts** — for npm projects, grep the lockfile for
+   build-tool deps — the manifest declares them but nothing imports them
+   in source (eslint, prettier, ts-node, vitest, jest, pytest, mypy,
+   black, ruff, rubocop, …); they are invoked from package scripts or CI.
+3. **License violations** — read each direct dep's declared license from
+   its locally-cached manifest, or grep the manifest for an inline
+   `license` field. Cross-check against the effective allowlist and take
+   severity from the ladder there.
+4. **Outdated by major** — check git log for each direct pin's age. Older
+   than 2 years, or more than one major behind a version resolved in another
+   of the project's lockfiles = LOW. You have no registry access, so this is
+   a heuristic and must be worded as one.
+5. **Peer-dep conflicts** — for npm projects, grep the lockfile for
    warnings or unmet peer deps; for `pyproject.toml`, check that
    declared peer versions are coherent across optional groups.
    MEDIUM.
-8. **Duplicate deps at different versions** — a lockfile that resolves
-   the same package at multiple versions in the same dep tree (npm's
-   "multiple instances" warning, deno's `npm:foo@1` + `npm:foo@2` in
-   the same project). LOW — bundle bloat + nondeterministic behavior
-   risk.
+6. **Duplicate deps at different versions** — one lockfile resolving the
+   same package at two versions in the same tree. LOW — bundle bloat and
+   nondeterministic behaviour.
 
 ### Output format (Mode 2 — audit report)
 
@@ -158,6 +193,7 @@ Write a Markdown document with these EXACT sections in this order
 
 ## Summary
 
+- Sources read: <one line — the domain file, the allowlist, the manifests>
 - Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 - Manifests detected: <one line — "package.json, deno.json">
 - Severity floor: <critical|high|medium|low>
@@ -173,20 +209,14 @@ For each finding, group by manifest (### npm / ### Deno / ### Python / …):
 
 (same shape, grouped by manifest)
 
-## Medium
+## Medium / ## Low
 
-(only populated if severity floor is `medium` or `low`)
-
-## Low
-
-(only populated if severity floor is `low`)
+(same shape; populated only when the severity floor reaches them)
 
 ## Out of scope
 
-- live advisory / CVE cross-reference — runtime tooling (`npm audit`,
-  `cargo audit`, `pip-audit`, `osv-scanner`, …) is excluded by the
-  read-only audit contract. Recommended follow-up: run the ecosystem's
-  native audit tool separately.
+- live advisory / CVE cross-reference — excluded by the read-only contract;
+  follow up with the ecosystem's native audit tool.
 - <named axis> — <one line on why else not surfaced this run>
 ```
 
@@ -195,22 +225,12 @@ material for the PO to triage.
 
 ### Per-axis hints
 
-- **Polyglot repo** — emit findings per-manifest sub-section. Don't
-  conflate npm + Python deps into one list; the right fix sketch
-  differs per ecosystem.
+- **Polyglot repo** — one sub-section per manifest. Never conflate two
+  ecosystems into one list; the right fix sketch differs per ecosystem.
 - **`deno.json` projects** — "outdated" is harder (no central registry
-  to query). Focus axes 1 (unbounded ranges), 2 (deno.lock presence),
-  3 (unused imports). Skip axis 5 unless a specific dep is clearly
+  to query). Focus axis 1 (ranges, `deno.lock`, names) and axis 2
+  (unused imports). Skip axis 4 unless a specific dep is clearly
   ancient by git log.
-- **Build-tool deps** — declared but not imported. Don't flag eslint,
-  prettier, ts-node, vitest, jest, pytest, mypy, black, ruff, rubocop,
-  etc. as "unused" — they're invoked from package scripts / CI, not
-  source code.
-- **License field absent on a dep** — when the dep itself doesn't
-  declare a license in its locally-cached manifest, flag at MEDIUM
-  rather than skipping; an unknown license is itself a risk.
-- **When in doubt** — surface the finding at LOW rather than dropping
-  it. The PO triage step is the right place to dismiss noise.
 
 ## Output format (Mode 1 — PR review)
 

--- a/templates/core/skills/dep-audit/SKILL.md
+++ b/templates/core/skills/dep-audit/SKILL.md
@@ -55,6 +55,15 @@ the dependency hygiene of the scoped manifests (outdated pins, unbounded
 ranges, unused declared deps, license violations, advisory-shape signals,
 peer-dep conflicts, typosquatting heuristics) — not a per-line review.
 
+Include its Step 0 in the dispatch prompt, verbatim: read
+`.specnaut/memory/security/06-supply-chain-and-integrity.md`
+before writing a finding — it owns the *shape* of the supply chain (pinning,
+lockfiles, provenance, dependency confusion, transitive weight) and the agent
+owns what that file hands back (license policy, version currency, per-manifest
+mechanics). The agent must state which sources it read at the top of its
+findings, and downgrade to `Suspicion —` at LOW anything it cannot cite. If
+`.specnaut/memory/security/` is absent, it says so in one line instead.
+
 ## Step 4 — Return findings inline
 
 Return the agent's findings inline. The `dependency-expert` ends with the

--- a/templates/core/skills/specnaut/phases/audit-dependencies.md
+++ b/templates/core/skills/specnaut/phases/audit-dependencies.md
@@ -49,7 +49,9 @@ Reject any other argument with: `error: unknown argument <token> — accepted: -
 
 4. **Dispatch the `dependency-expert` agent** with the dispatch prompt
    below. The agent operates in audit mode (full codebase scan, NOT
-   per-PR review mode). It has `Read`, `Grep`, `Glob`, and constrained
+   per-PR review mode). Its Step 0 is mandatory: it reads
+   `.specnaut/memory/security/06-supply-chain-and-integrity.md` — the domain
+   file that owns supply-chain *shape* — before writing any finding. It has `Read`, `Grep`, `Glob`, and constrained
    `Bash` access; it MUST NOT call `Edit`, `Write`, `NotebookEdit`, or
    any mutating tool. The Bash allow-list explicitly EXCLUDES `npm
    audit`, `cargo audit`, `pip-audit`, `osv-scanner`, etc. — live
@@ -84,6 +86,13 @@ the resolved severity threshold):
 You are running in **audit mode** (Mode 2 per your agent spec) — full
 codebase sweep, not per-PR review.
 
+Step 0 first: read `.specnaut/memory/security/06-supply-chain-and-integrity.md`
+and use it for pin discipline, lockfiles, typosquats, dependency confusion and
+transitive weight — including its severity defaults and its
+`## When it is NOT a finding`. License policy, version currency and
+per-manifest mechanics are yours. If that path does not exist, say so in one
+line at the top of the report and fall back to your own rules.
+
 Read-only contract: see your agent doc. Bash limited to read-only
 inspection commands. You MUST NOT invoke `npm audit`, `cargo audit`,
 `pip-audit`, `osv-scanner`, or any live advisory / CVE database fetch —
@@ -96,10 +105,9 @@ Inventory:
 
 $INVENTORY
 
-Walk the axis checklist from your agent doc in order (version pin
-discipline, lockfile presence/freshness, unused declared deps, license
-violations, outdated by major, typosquat heuristics, peer-dep conflicts,
-duplicate deps). Detect every present manifest and report per-manifest
+Walk the axis checklist from your agent doc in order (supply-chain shape
+delegated to the domain file, unused declared deps, license violations,
+outdated by major, peer-dep conflicts, duplicate deps). Detect every present manifest and report per-manifest
 sub-sections in each severity section. When a manifest's ecosystem
 doesn't have the relevant axis surface, record it under "Out of scope"
 rather than emitting empty findings.
@@ -128,6 +136,7 @@ specnaut-audit-dependencies report
 ──────────────────────────────────
 Codebase: <root>
 Severity floor: <high|medium|low|critical>
+Sources read: <one line — domain file, allowlist, manifests>
 Findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 Manifests: <one line — "package.json, deno.json">
 License allowlist: <"default (8 SPDX ids)" | "default + .specnaut/license-allowlist.txt (N more)">

--- a/tests/templates/dependency_grounding_test.ts
+++ b/tests/templates/dependency_grounding_test.ts
@@ -1,0 +1,147 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+
+/**
+ * Locks `dependency-expert` to the supply-chain domain file it used to
+ * duplicate.
+ *
+ * This seat is the one grounding case in the fleet that must NOT get a
+ * catalogue of its own. `06-supply-chain-and-integrity.md` already covered its
+ * ground at comparable depth — advisories, lockfiles, typosquats, transitive
+ * trees — and the two were free to drift because neither pointed at the other.
+ * A parallel `memory/dependency/` tree would have made that three sources
+ * instead of two.
+ *
+ * So the guards here are about *delegation*, not about coverage: the domain
+ * file is named, and the delegated axes carry no second opinion beside it.
+ */
+
+const DOMAIN_FILE = "06-supply-chain-and-integrity.md";
+
+function agent(name: string): string {
+  const entry = CORE_BUNDLE.find((e) => e.category === "agent" && e.name === name);
+  assert(entry, `${name} agent is missing from the bundle`);
+  return entry.content;
+}
+
+/** Text between two markers, used to scope a guard to one block of the file. */
+function slice(body: string, from: string, to: string): string {
+  const start = body.indexOf(from);
+  assert(start >= 0, `expected to find ${JSON.stringify(from)}`);
+  const end = body.indexOf(to, start + from.length);
+  assert(end >= 0, `expected to find ${JSON.stringify(to)} after ${JSON.stringify(from)}`);
+  return body.slice(start, end);
+}
+
+Deno.test("dependency-expert opens the supply-chain domain file before judging", () => {
+  const body = agent("dependency-expert");
+  assertStringIncludes(body, "## Step 0");
+  assertStringIncludes(body, `.specnaut/memory/security/${DOMAIN_FILE}`);
+  // The hand-off has to be stated in both directions, or the seat cannot tell
+  // which half of the ground is its own.
+  assertStringIncludes(body, "version currency");
+});
+
+/**
+ * The guard that actually catches a regression.
+ *
+ * "Point at the domain file" is cheap to satisfy while leaving the duplicated
+ * rules in place beside the pointer — which is worse than either alone, because
+ * the two can now disagree and the reader has no way to know which won. A
+ * restated rule is recognisable by the thing a rule carries and a pointer does
+ * not: **its own severity.**
+ */
+Deno.test("delegated axes carry no severity of their own", () => {
+  const body = agent("dependency-expert");
+  const blocks = {
+    "Mode 1 always-check rules": slice(body, "### Always-check rules", "## Mode 2"),
+    "Mode 2 axis 1 (supply-chain shape)": slice(
+      body,
+      "1. **Supply-chain shape (delegated)**",
+      "2. **Unused declared deps**",
+    ),
+  };
+  for (const [label, block] of Object.entries(blocks)) {
+    for (const severity of ["CRITICAL", "HIGH", "MEDIUM", "LOW"]) {
+      assert(
+        !block.includes(severity),
+        `${label} assigns ${severity} itself. Pin discipline, lockfiles and ` +
+          `typosquats are delegated to ${DOMAIN_FILE} — a severity here is a ` +
+          `second opinion free to drift from the file that owns the axis.`,
+      );
+    }
+    assertStringIncludes(
+      block,
+      DOMAIN_FILE,
+      `${label} must name the file it delegates to`,
+    );
+  }
+});
+
+Deno.test("licensing stays with the seat and carries its own negative section", () => {
+  const body = agent("dependency-expert");
+  // The domain file hands licence policy back by name, so this is the one axis
+  // whose negative section cannot live there.
+  assertStringIncludes(body, "### License allowlist resolution");
+  assertStringIncludes(body, "### When it is NOT a license finding");
+  const negative = slice(
+    body,
+    "### When it is NOT a license finding",
+    "### Scope checklist",
+  );
+  // Each bullet must kill a specific wrong licence finding, not restate the rule.
+  for (const kill of ["devDependencies", "subprocess", "dual-licensed", "not counsel"]) {
+    assertStringIncludes(
+      negative,
+      kill,
+      `the license negative section must cover "${kill}" — these are the false ` +
+        `positives that make a license finding expensive and wrong`,
+    );
+  }
+});
+
+Deno.test("no dependency catalogue was created", () => {
+  // Explicitly required by the ticket: this seat is grounded by a pointer, not
+  // by a parallel tree. A `memory/dependency/` catalogue would reintroduce the
+  // drift the pointer removes.
+  const stray = CORE_BUNDLE.filter((e) => (e.suffix ?? "").startsWith("memory/dependency"));
+  assert(
+    stray.length === 0,
+    `dependency-expert must be grounded by a pointer at ${DOMAIN_FILE}, not by ` +
+      `its own catalogue; found ${stray.length} entries under memory/dependency/`,
+  );
+});
+
+Deno.test("transitive-dependency ground is reachable through the pointer", () => {
+  // The seat carried zero transitive-dependency content and the domain file
+  // carried it already. The pointer closes that gap for free — assert the chain
+  // rather than a copy of the content.
+  const domain = CORE_BUNDLE.find(
+    (e) => e.suffix === `memory/security/${DOMAIN_FILE}`,
+  );
+  assert(domain, `${DOMAIN_FILE} is missing from the bundle`);
+  assertStringIncludes(domain.content, "transitive");
+  assertStringIncludes(agent("dependency-expert"), DOMAIN_FILE);
+});
+
+Deno.test("dependency-expert degrades cleanly when installed as a plugin", () => {
+  // plugin/ ships no memory tree, so the fallback is this seat's real case —
+  // not a hypothetical. Without it the review runs ungrounded and silent.
+  const body = agent("dependency-expert");
+  assertStringIncludes(body, "standalone plugin");
+  assertStringIncludes(body, "is absent");
+});
+
+Deno.test("both dependency dispatch surfaces name the domain file", () => {
+  // The agent can be entered from the skill or from the phase. A Step 0 the
+  // dispatch prompt never mentions is a Step 0 that gets skipped under load.
+  const skill = CORE_BUNDLE.find((e) => e.category === "skill" && e.name === "dep-audit");
+  assert(skill, "dep-audit skill is missing from the bundle");
+  assertStringIncludes(skill.content, `memory/security/${DOMAIN_FILE}`);
+
+  const phase = CORE_BUNDLE.find(
+    (e) => e.category === "phase" && e.name === "audit-dependencies",
+  );
+  assert(phase, "audit-dependencies phase is missing from the bundle");
+  assertStringIncludes(phase.content, `memory/security/${DOMAIN_FILE}`);
+});


### PR DESCRIPTION
Closes #502.

## The finding this implements

`dependency-expert` and `.specnaut/memory/security/06-supply-chain-and-integrity.md`
covered substantially the same ground at comparable depth — and **neither
pointed at the other**. Two sources free to drift is the exact defect class
this programme exists to remove; a parallel `memory/dependency/` catalogue
would have made it three.

One fact the survey did not have: the domain file **already declares the
hand-off** — *"per-dependency CVE triage, licence policy, and version currency
belong to the `dependency-expert`"*. The boundary was stated from one side and
never from the other. This PR states it from the seat's side and enforces it.

## Decisions worth reviewing

**Where the licensing negative section lives — the agent, not the domain file
and not a new leaf.** The ticket left this open. The domain file hands
licensing *away* by name, so putting the caveats there would make
`security-expert` read ground it was explicitly told not to own. A new leaf
would be the dependency catalogue the ticket forbids. Licensing is the one
axis this seat owns outright, so its negative section belongs where its
positive rules already are.

**How "duplication removed" is enforced.** *Point at the domain file* is cheap
to satisfy while leaving the old rules in place beside the pointer — which is
worse than either alone, because the two can now disagree and the reader cannot
tell which won. A restated rule is recognisable by the thing a pointer does not
have: **its own severity**. The guard asserts no `CRITICAL`/`HIGH`/`MEDIUM`/`LOW`
token appears in the two delegated blocks, and that each names the file it
delegates to.

**Term counts went up, not down — deliberately.** The ticket measured
lockfiles 9/8 and typosquats 3/2 as the duplication smell. After the fix the
seat mentions them *more* (10 and 5), because a pointer has to name what it
delegates. Counts were the smell, not the spec; the severity guard measures the
substance instead.

**Spelling.** The new prose arrived British (`licence`, from the domain file)
into a file whose frontmatter, headings and manifest key are all American.
Normalised to `license` — one spelling per file beats importing another file's.

## Verification

All four guards were probed by breaking the thing they protect, and all four
fail without their fix:

| Break | Guard fires |
|---|---|
| a severity re-added to a delegated rule | yes |
| `dep-audit/SKILL.md` stops naming the domain file | yes |
| a bullet drops out of the license negative section | yes |
| Step 0 removed entirely | yes |

Full suite: 1259 passed, 0 failed. `deno task test` leaves a clean tree.

**Windsurf cap:** 12,570 → **11,861** chars (cap 12,000). Step 0 alone would
have breached it; cutting the duplication an AC required anyway is what bought
the headroom — the one seat where the cap constraint and the correctness fix
pushed the same way.

## Agent adoption

`dependency-expert` now refuses to judge supply-chain shape from memory. After
upgrading, a dependency review will read
`.specnaut/memory/security/06-supply-chain-and-integrity.md` first, state which
sources it read at the top of the report, and ship anything it cannot attribute
as `Suspicion —` at LOW rather than at full confidence — so a suspicion can no
longer fail a gate on its own.

The knowledge base reaches existing projects through a plain `specnaut upgrade`
(`.specnaut/memory/` is not preserved). No project action is required beyond
upgrading. If you keep a local `.specnaut/license-allowlist.txt`, it is now
explicitly authoritative: a license it lists is settled and the seat will not
re-open it.

```prompt
Dispatch the dependency-expert over this repository in audit mode. Confirm the
report opens by naming which sources it read, that supply-chain findings cite
06-supply-chain-and-integrity.md rather than restating it, and that any finding
it cannot attribute is labelled `Suspicion —` at LOW.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
