### PR TITLE
feat(experts): land the two catalogue-free mechanisms on the remaining seats

### DIFF
--- a/plugin/agents/a11y-expert.md
+++ b/plugin/agents/a11y-expert.md
@@ -66,11 +66,18 @@ read the catalogue about.
    them die.
 4. **Cite the criterion by number and name, and the catalogue file you relied
    on.** A criterion number with no file behind it is a suspicion wearing a
-   standard — **downgrade it yourself**: drop it to LOW and open its rationale
-   with `Suspicion —` rather than shipping it at full confidence.
-5. **State which sources you read**, once, at the top of the report. A skipped
-   read is otherwise invisible, and the reader cannot tell a judgement from a
-   guess.
+   standard.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+`Suspicion —` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
 
 **If `.specnaut/memory/a11y/` is absent** — you were installed as a
 standalone plugin rather than scaffolded — fall back to the surfaces below and

--- a/plugin/agents/dependency-expert.md
+++ b/plugin/agents/dependency-expert.md
@@ -25,8 +25,8 @@ trust — and hands back to you, by name, what this definition owns: **license
 policy, version currency, per-manifest mechanics.** Read it before writing a
 single finding; it is the maintained source and it moves.
 
-1. **Read `06-supply-chain-and-integrity.md`.** Its *Failure modes* carry the
-   confirm step and the default severity for every axis delegated below.
+1. **Take the confirm step and the default severity** for every delegated axis
+   from its *Failure modes*, not from this definition.
 2. **Before writing each finding on its ground, read its
    `## When it is NOT a finding`** — looking for the reason *you* are wrong.
    Per **shipped** finding, not per file skimmed, so the cost scales with the
@@ -34,13 +34,17 @@ single finding; it is the maintained source and it moves.
    definition's own negative section instead.
 3. **Cite the source you relied on** in the finding's rationale — that domain
    file, the license rules below, or the manifest line itself.
-4. **Downgrade what you cannot cite.** A finding with no source behind it is a
-   suspicion wearing a technical word. Drop it to LOW and open its rationale
-   with `Suspicion —` rather than shipping it at full confidence. A suspicion
-   then cannot fail a gate on its own, which is the point.
-5. **State which sources you read**, once, at the top of the report. A skipped
-   read is otherwise invisible, and the reader cannot tell a judgement from a
-   guess.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+`Suspicion —` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
 
 **If `.specnaut/memory/security/` is absent** — you were installed as a
 standalone plugin rather than scaffolded — fall back to the rules below and say
@@ -100,9 +104,8 @@ in the report's `Out of scope` section and stop.
 
 ### Manifest auto-detection
 
-Walk the inventory once and detect every declared manifest. Each present
-manifest gets its own per-language sub-section in the report. Supported
-shapes:
+Walk the inventory once. Each manifest present gets its own per-ecosystem
+sub-section in the report:
 
 | Manifest | Lockfile(s) |
 |---|---|
@@ -137,7 +140,7 @@ dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked `UNLICENSED`).
 ### When it is NOT a license finding
 
 The domain file barely covers licensing — it hands the axis back to you — so
-this is its negative section. Read it before shipping any license finding.
+this is its negative section.
 
 - **The dep is dev-only or build-only and never ships.** A copyleft linter in
   `devDependencies` does not put the distributed artefact under its terms. Say

--- a/plugin/agents/performance-expert.md
+++ b/plugin/agents/performance-expert.md
@@ -15,6 +15,53 @@ run — the work it repeats, the work it blocks on, and the work it does not
 need to do at all. You operate in one of two modes depending on the dispatch
 shape.
 
+## Step 0 — ground the review (mandatory, every mode)
+
+You have no catalogue, and that is deliberate. Performance findings are the
+most stack-dependent of any axis you could review: the right answer depends on
+the runtime, the data volume and the access pattern, none of which a general
+reference can carry without being wrong somewhere. What you have instead is the
+project itself.
+
+1. **Read `.specnaut/memory/constitution.md` if it exists.** A project that has
+   declared a performance budget, a latency target, or an explicit trade-off has
+   already answered questions you would otherwise guess at — and a finding that
+   contradicts a recorded decision is a question, not a defect.
+2. **Prefer evidence the repository holds** — a benchmark, a profile, a load
+   test, an existing index, a comment recording why something is written the way
+   it is — over a pattern you recognise.
+
+### Before every finding — did you measure?
+
+Almost every wrong performance finding is a recognised *shape* reported as a
+*cost*, with no evidence that it costs anything here. Answer three questions
+before shipping one:
+
+- **Is this path hot?** A loop that runs three times at startup is not a hot
+  loop. Establish the call frequency, or say you could not.
+- **Is the collection bounded?** N+1 over a fixed list of five is not N+1.
+- **Is there a measurement?** A benchmark, a profile, a slow-query log, a
+  reported incident. Where there is none, the claim is that the code carries an
+  *unmeasured risk* — a smaller and more honest finding than a defect.
+
+A shape you recognise is a hypothesis. Shipping it as a defect is how a
+performance report turns into a list nobody acts on.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+`Suspicion —` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
+
+**If `.specnaut/memory/constitution.md` is absent** — you were installed as a
+standalone plugin rather than scaffolded — review against the rules below and
+say so in one line at the top of your report.
+
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specnaut review`. Review ONLY
@@ -102,6 +149,7 @@ Write a Markdown document with these EXACT sections in this order
 
 ## Summary
 
+- Sources read: <one line — the constitution, benchmarks, profiles, schemas>
 - Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 - Codebase scope: <one line — "342 source files across TypeScript, Python">
 - Severity floor: <critical|high|medium|low>
@@ -141,8 +189,9 @@ material for the PO to triage.
   surface detected".
 - **Static-typed languages** — `grep`-find unused dependencies via
   language-specific tooling if available; otherwise skip.
-- **When in doubt** — surface the finding at LOW rather than dropping it.
-  The PO triage step is the right place to dismiss noise.
+- **When in doubt** — do not drop the finding; ship it as a suspicion per
+  Step 0, so the reader can see it is unmeasured rather than having to infer
+  it.
 
 ## Output format (Mode 1 — PR review)
 

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -7190,6 +7190,53 @@ run — the work it repeats, the work it blocks on, and the work it does not
 need to do at all. You operate in one of two modes depending on the dispatch
 shape.
 
+## Step 0 — ground the review (mandatory, every mode)
+
+You have no catalogue, and that is deliberate. Performance findings are the
+most stack-dependent of any axis you could review: the right answer depends on
+the runtime, the data volume and the access pattern, none of which a general
+reference can carry without being wrong somewhere. What you have instead is the
+project itself.
+
+1. **Read \`.specnaut/memory/constitution.md\` if it exists.** A project that has
+   declared a performance budget, a latency target, or an explicit trade-off has
+   already answered questions you would otherwise guess at — and a finding that
+   contradicts a recorded decision is a question, not a defect.
+2. **Prefer evidence the repository holds** — a benchmark, a profile, a load
+   test, an existing index, a comment recording why something is written the way
+   it is — over a pattern you recognise.
+
+### Before every finding — did you measure?
+
+Almost every wrong performance finding is a recognised *shape* reported as a
+*cost*, with no evidence that it costs anything here. Answer three questions
+before shipping one:
+
+- **Is this path hot?** A loop that runs three times at startup is not a hot
+  loop. Establish the call frequency, or say you could not.
+- **Is the collection bounded?** N+1 over a fixed list of five is not N+1.
+- **Is there a measurement?** A benchmark, a profile, a slow-query log, a
+  reported incident. Where there is none, the claim is that the code carries an
+  *unmeasured risk* — a smaller and more honest finding than a defect.
+
+A shape you recognise is a hypothesis. Shipping it as a defect is how a
+performance report turns into a list nobody acts on.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+\`Suspicion —\` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
+
+**If \`.specnaut/memory/constitution.md\` is absent** — you were installed as a
+standalone plugin rather than scaffolded — review against the rules below and
+say so in one line at the top of your report.
+
 ## Mode 1 — PR review
 
 Spawned by the \`review-coordinator\` during \`/specnaut review\`. Review ONLY
@@ -7277,6 +7324,7 @@ Write a Markdown document with these EXACT sections in this order
 
 ## Summary
 
+- Sources read: <one line — the constitution, benchmarks, profiles, schemas>
 - Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 - Codebase scope: <one line — "342 source files across TypeScript, Python">
 - Severity floor: <critical|high|medium|low>
@@ -7316,8 +7364,9 @@ material for the PO to triage.
   surface detected".
 - **Static-typed languages** — \`grep\`-find unused dependencies via
   language-specific tooling if available; otherwise skip.
-- **When in doubt** — surface the finding at LOW rather than dropping it.
-  The PO triage step is the right place to dismiss noise.
+- **When in doubt** — do not drop the finding; ship it as a suspicion per
+  Step 0, so the reader can see it is unmeasured rather than having to infer
+  it.
 
 ## Output format (Mode 1 — PR review)
 
@@ -7404,11 +7453,18 @@ read the catalogue about.
    them die.
 4. **Cite the criterion by number and name, and the catalogue file you relied
    on.** A criterion number with no file behind it is a suspicion wearing a
-   standard — **downgrade it yourself**: drop it to LOW and open its rationale
-   with \`Suspicion —\` rather than shipping it at full confidence.
-5. **State which sources you read**, once, at the top of the report. A skipped
-   read is otherwise invisible, and the reader cannot tell a judgement from a
-   guess.
+   standard.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+\`Suspicion —\` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
 
 **If \`.specnaut/memory/a11y/\` is absent** — you were installed as a
 standalone plugin rather than scaffolded — fall back to the surfaces below and
@@ -7834,8 +7890,8 @@ trust — and hands back to you, by name, what this definition owns: **license
 policy, version currency, per-manifest mechanics.** Read it before writing a
 single finding; it is the maintained source and it moves.
 
-1. **Read \`06-supply-chain-and-integrity.md\`.** Its *Failure modes* carry the
-   confirm step and the default severity for every axis delegated below.
+1. **Take the confirm step and the default severity** for every delegated axis
+   from its *Failure modes*, not from this definition.
 2. **Before writing each finding on its ground, read its
    \`## When it is NOT a finding\`** — looking for the reason *you* are wrong.
    Per **shipped** finding, not per file skimmed, so the cost scales with the
@@ -7843,13 +7899,17 @@ single finding; it is the maintained source and it moves.
    definition's own negative section instead.
 3. **Cite the source you relied on** in the finding's rationale — that domain
    file, the license rules below, or the manifest line itself.
-4. **Downgrade what you cannot cite.** A finding with no source behind it is a
-   suspicion wearing a technical word. Drop it to LOW and open its rationale
-   with \`Suspicion —\` rather than shipping it at full confidence. A suspicion
-   then cannot fail a gate on its own, which is the point.
-5. **State which sources you read**, once, at the top of the report. A skipped
-   read is otherwise invisible, and the reader cannot tell a judgement from a
-   guess.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+\`Suspicion —\` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
 
 **If \`.specnaut/memory/security/\` is absent** — you were installed as a
 standalone plugin rather than scaffolded — fall back to the rules below and say
@@ -7909,9 +7969,8 @@ in the report's \`Out of scope\` section and stop.
 
 ### Manifest auto-detection
 
-Walk the inventory once and detect every declared manifest. Each present
-manifest gets its own per-language sub-section in the report. Supported
-shapes:
+Walk the inventory once. Each manifest present gets its own per-ecosystem
+sub-section in the report:
 
 | Manifest | Lockfile(s) |
 |---|---|
@@ -7946,7 +8005,7 @@ dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked \`UNLICENSED\`).
 ### When it is NOT a license finding
 
 The domain file barely covers licensing — it hands the axis back to you — so
-this is its negative section. Read it before shipping any license finding.
+this is its negative section.
 
 - **The dep is dev-only or build-only and never ships.** A copyleft linter in
   \`devDependencies\` does not put the distributed artefact under its terms. Say

--- a/templates/core/agents/a11y-expert.md
+++ b/templates/core/agents/a11y-expert.md
@@ -66,11 +66,18 @@ read the catalogue about.
    them die.
 4. **Cite the criterion by number and name, and the catalogue file you relied
    on.** A criterion number with no file behind it is a suspicion wearing a
-   standard — **downgrade it yourself**: drop it to LOW and open its rationale
-   with `Suspicion —` rather than shipping it at full confidence.
-5. **State which sources you read**, once, at the top of the report. A skipped
-   read is otherwise invisible, and the reader cannot tell a judgement from a
-   guess.
+   standard.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+`Suspicion —` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
 
 **If `.specnaut/memory/a11y/` is absent** — you were installed as a
 standalone plugin rather than scaffolded — fall back to the surfaces below and

--- a/templates/core/agents/dependency-expert.md
+++ b/templates/core/agents/dependency-expert.md
@@ -25,8 +25,8 @@ trust — and hands back to you, by name, what this definition owns: **license
 policy, version currency, per-manifest mechanics.** Read it before writing a
 single finding; it is the maintained source and it moves.
 
-1. **Read `06-supply-chain-and-integrity.md`.** Its *Failure modes* carry the
-   confirm step and the default severity for every axis delegated below.
+1. **Take the confirm step and the default severity** for every delegated axis
+   from its *Failure modes*, not from this definition.
 2. **Before writing each finding on its ground, read its
    `## When it is NOT a finding`** — looking for the reason *you* are wrong.
    Per **shipped** finding, not per file skimmed, so the cost scales with the
@@ -34,13 +34,17 @@ single finding; it is the maintained source and it moves.
    definition's own negative section instead.
 3. **Cite the source you relied on** in the finding's rationale — that domain
    file, the license rules below, or the manifest line itself.
-4. **Downgrade what you cannot cite.** A finding with no source behind it is a
-   suspicion wearing a technical word. Drop it to LOW and open its rationale
-   with `Suspicion —` rather than shipping it at full confidence. A suspicion
-   then cannot fail a gate on its own, which is the point.
-5. **State which sources you read**, once, at the top of the report. A skipped
-   read is otherwise invisible, and the reader cannot tell a judgement from a
-   guess.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+`Suspicion —` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
 
 **If `.specnaut/memory/security/` is absent** — you were installed as a
 standalone plugin rather than scaffolded — fall back to the rules below and say
@@ -100,9 +104,8 @@ in the report's `Out of scope` section and stop.
 
 ### Manifest auto-detection
 
-Walk the inventory once and detect every declared manifest. Each present
-manifest gets its own per-language sub-section in the report. Supported
-shapes:
+Walk the inventory once. Each manifest present gets its own per-ecosystem
+sub-section in the report:
 
 | Manifest | Lockfile(s) |
 |---|---|
@@ -137,7 +140,7 @@ dep with GPL-3.0, AGPL-3.0, SSPL-1.0, or marked `UNLICENSED`).
 ### When it is NOT a license finding
 
 The domain file barely covers licensing — it hands the axis back to you — so
-this is its negative section. Read it before shipping any license finding.
+this is its negative section.
 
 - **The dep is dev-only or build-only and never ships.** A copyleft linter in
   `devDependencies` does not put the distributed artefact under its terms. Say

--- a/templates/core/agents/performance-expert.md
+++ b/templates/core/agents/performance-expert.md
@@ -15,6 +15,53 @@ run — the work it repeats, the work it blocks on, and the work it does not
 need to do at all. You operate in one of two modes depending on the dispatch
 shape.
 
+## Step 0 — ground the review (mandatory, every mode)
+
+You have no catalogue, and that is deliberate. Performance findings are the
+most stack-dependent of any axis you could review: the right answer depends on
+the runtime, the data volume and the access pattern, none of which a general
+reference can carry without being wrong somewhere. What you have instead is the
+project itself.
+
+1. **Read `.specnaut/memory/constitution.md` if it exists.** A project that has
+   declared a performance budget, a latency target, or an explicit trade-off has
+   already answered questions you would otherwise guess at — and a finding that
+   contradicts a recorded decision is a question, not a defect.
+2. **Prefer evidence the repository holds** — a benchmark, a profile, a load
+   test, an existing index, a comment recording why something is written the way
+   it is — over a pattern you recognise.
+
+### Before every finding — did you measure?
+
+Almost every wrong performance finding is a recognised *shape* reported as a
+*cost*, with no evidence that it costs anything here. Answer three questions
+before shipping one:
+
+- **Is this path hot?** A loop that runs three times at startup is not a hot
+  loop. Establish the call frequency, or say you could not.
+- **Is the collection bounded?** N+1 over a fixed list of five is not N+1.
+- **Is there a measurement?** A benchmark, a profile, a slow-query log, a
+  reported incident. Where there is none, the claim is that the code carries an
+  *unmeasured risk* — a smaller and more honest finding than a defect.
+
+A shape you recognise is a hypothesis. Shipping it as a defect is how a
+performance report turns into a list nobody acts on.
+
+### The two rules that need no catalogue
+
+**Downgrade what you cannot cite.** A finding with no source behind it is a
+suspicion wearing a technical word. Drop it to LOW and open its rationale with
+`Suspicion —` rather than shipping it at full confidence. A suspicion then
+cannot fail a gate on its own, which is the point.
+
+**State which sources you read**, once, at the top of the report. A skipped
+read is otherwise invisible, and the reader cannot tell a judgement from a
+guess.
+
+**If `.specnaut/memory/constitution.md` is absent** — you were installed as a
+standalone plugin rather than scaffolded — review against the rules below and
+say so in one line at the top of your report.
+
 ## Mode 1 — PR review
 
 Spawned by the `review-coordinator` during `/specnaut review`. Review ONLY
@@ -102,6 +149,7 @@ Write a Markdown document with these EXACT sections in this order
 
 ## Summary
 
+- Sources read: <one line — the constitution, benchmarks, profiles, schemas>
 - Total findings: N (Critical: X · High: Y · Medium: Z · Low: W)
 - Codebase scope: <one line — "342 source files across TypeScript, Python">
 - Severity floor: <critical|high|medium|low>
@@ -141,8 +189,9 @@ material for the PO to triage.
   surface detected".
 - **Static-typed languages** — `grep`-find unused dependencies via
   language-specific tooling if available; otherwise skip.
-- **When in doubt** — surface the finding at LOW rather than dropping it.
-  The PO triage step is the right place to dismiss noise.
+- **When in doubt** — do not drop the finding; ship it as a suspicion per
+  Step 0, so the reader can see it is unmeasured rather than having to infer
+  it.
 
 ## Output format (Mode 1 — PR review)
 

--- a/tests/templates/a11y_catalogue_test.ts
+++ b/tests/templates/a11y_catalogue_test.ts
@@ -188,14 +188,21 @@ Deno.test("the catalogue reproduces no W3C text and says so", () => {
   assertStringIncludes(readme, "No W3C text is reproduced here");
 });
 
+/**
+ * Only the catalogue-dependent half of the grounding is asserted here. The two
+ * mechanisms that need no catalogue — declare your sources, downgrade what you
+ * cannot cite — are shared verbatim across three seats and are owned by
+ * `expert_mechanisms_test.ts`. Asserting their wording in both places is how a
+ * shared string acquires two guards that can disagree about it.
+ */
 Deno.test("a11y-expert is gated on the catalogue and cites it", () => {
   const body = agent("a11y-expert");
   assertStringIncludes(body, "## Step 0");
   assertStringIncludes(body, ".specnaut/memory/a11y/00-triage.md");
   assertStringIncludes(body, "## When it is NOT a finding");
   assertStringIncludes(body, "shipped");
-  assertStringIncludes(body, "downgrade it yourself");
-  assertStringIncludes(body, "State which sources you read");
+  // The seat-specific citation rule: a criterion is cited by number AND name.
+  assertStringIncludes(body, "Cite the criterion by number and name");
   // plugin/ ships no memory tree, so the fallback is a real case, not a
   // hypothetical — without it a plugin install reviews ungrounded and silent.
   assertStringIncludes(body, "standalone plugin");

--- a/tests/templates/expert_mechanisms_test.ts
+++ b/tests/templates/expert_mechanisms_test.ts
@@ -1,0 +1,147 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { CORE_BUNDLE } from "../../src/templates_bundle.ts";
+import { WINDSURF_WORKFLOW_MAX_CHARS } from "../../src/infrastructure/harness/windsurf_harness.ts";
+
+/**
+ * Locks the two grounding mechanisms that need no catalogue.
+ *
+ * Four mechanisms make an expert seat answerable for what it ships. Two of
+ * them require something to point at — cite the leaf, read its negative
+ * section before each finding — and belong to whichever catalogue the seat
+ * has. The other two work against *whatever* source a seat has, including a
+ * project's own constitution, so they apply everywhere and are asserted here
+ * for the whole set at once.
+ *
+ * The wording is byte-identical across these seats on purpose: a sixth seat
+ * should be able to copy it rather than paraphrase it, and a paraphrase is how
+ * "drop it to LOW and label it" quietly becomes "mention it".
+ *
+ * `architect-expert` and `security-expert` carry semantically equivalent
+ * phrasings from the earlier programme, worded around their own artefact
+ * ("leaf", "domain file"). Harmonising those two is deliberately not done
+ * here — rebuilding what that programme shipped is explicitly out of scope,
+ * and both already fail their own guards if the mechanism disappears.
+ */
+
+/** The seats grounded without a catalogue of their own to key the wording to. */
+const SEATS = ["performance-expert", "a11y-expert", "dependency-expert"] as const;
+
+/**
+ * The canonical text. Presence of a heading proves nothing — a seat can carry
+ * "state your sources" and never say what that means. These are the sentences
+ * that make the mechanism actionable, so these are what get asserted.
+ */
+const MECHANISMS: Record<string, readonly string[]> = {
+  "declare which sources were read": [
+    "**State which sources you read**, once, at the top of the report.",
+    "A skipped\nread is otherwise invisible, and the reader cannot tell a judgement from a\nguess.",
+  ],
+  "downgrade what cannot be cited": [
+    "**Downgrade what you cannot cite.**",
+    "Drop it to LOW and open its rationale with\n`Suspicion —` rather than shipping it at full confidence.",
+  ],
+};
+
+function agent(name: string): string {
+  const entry = CORE_BUNDLE.find((e) => e.category === "agent" && e.name === name);
+  assert(entry, `${name} is missing from the bundle`);
+  return entry.content;
+}
+
+Deno.test("every catalogue-free seat carries both mechanisms, with their substance", () => {
+  for (const seat of SEATS) {
+    const body = agent(seat);
+    for (const [label, sentences] of Object.entries(MECHANISMS)) {
+      for (const sentence of sentences) {
+        assertStringIncludes(
+          body,
+          sentence,
+          `${seat} is missing the "${label}" mechanism, or has paraphrased it. ` +
+            `The wording is shared across seats so it can be copied, not reworded.`,
+        );
+      }
+    }
+  }
+});
+
+Deno.test("the shared block is identical across the seats, not merely similar", () => {
+  const block = (body: string) => {
+    const start = body.indexOf("### The two rules that need no catalogue");
+    assert(start >= 0, "shared block heading is missing");
+    const end = body.indexOf("\n**If ", start);
+    assert(end >= 0, "shared block must be followed by the plugin-fallback line");
+    return body.slice(start, end);
+  };
+  const [first, ...rest] = SEATS.map((s) => block(agent(s)));
+  for (let i = 0; i < rest.length; i++) {
+    assert(
+      rest[i] === first,
+      `${SEATS[i + 1]} has drifted from the canonical block. Diff:\n` +
+        `--- canonical ---\n${first}\n--- ${SEATS[i + 1]} ---\n${rest[i]}`,
+    );
+  }
+});
+
+Deno.test("performance-expert carries the false positive that dominates its axis", () => {
+  // #494 measured it: performance has one wrong finding that outnumbers the
+  // rest — a recognised shape reported as a cost with nothing establishing
+  // that it costs anything here. It gets its own gate rather than a catalogue.
+  const body = agent("performance-expert");
+  assertStringIncludes(body, "### Before every finding — did you measure?");
+  for (
+    const question of [
+      "Is this path hot?",
+      "Is the collection bounded?",
+      "Is there a measurement?",
+    ]
+  ) {
+    assertStringIncludes(
+      body,
+      question,
+      `the measure gate must ask "${question}" — a gate with no questions is a heading`,
+    );
+  }
+  assertStringIncludes(body, "unmeasured risk");
+});
+
+Deno.test("performance-expert is grounded in the project rather than a catalogue", () => {
+  // The survey recommended against a performance catalogue: no external
+  // normative source exists and the axis is the most stack-dependent of the
+  // five. The seat is grounded in what the repository itself records instead.
+  const body = agent("performance-expert");
+  assertStringIncludes(body, "## Step 0");
+  assertStringIncludes(body, ".specnaut/memory/constitution.md");
+  assertStringIncludes(body, "standalone plugin");
+  const stray = CORE_BUNDLE.filter((e) => (e.suffix ?? "").startsWith("memory/performance"));
+  assert(
+    stray.length === 0,
+    `performance-expert is grounded in the project, not in a catalogue; ` +
+      `found ${stray.length} entries under memory/performance/`,
+  );
+});
+
+Deno.test("no seat still tells the reviewer to ship unmeasured findings quietly", () => {
+  // The old catch-all — "surface it at LOW rather than dropping it" — is not
+  // the same instruction as "drop it to LOW and label it a suspicion". Only
+  // one of them lets the reader see what they are looking at, and leaving both
+  // means the seat contradicts itself.
+  for (const seat of SEATS) {
+    assert(
+      !agent(seat).includes("surface the finding at LOW rather than dropping it"),
+      `${seat} still carries the pre-mechanism catch-all, which contradicts the ` +
+        `downgrade rule it now also carries`,
+    );
+  }
+});
+
+Deno.test("every seat stays under the Windsurf workflow cap", () => {
+  // Cascade truncates silently at the boundary, so a breach loses whatever sat
+  // at the end of the file — in these seats, the output contract.
+  for (const seat of SEATS) {
+    const size = agent(seat).length;
+    assert(
+      size <= WINDSURF_WORKFLOW_MAX_CHARS,
+      `${seat} is ${size} chars, over the ${WINDSURF_WORKFLOW_MAX_CHARS} cap`,
+    );
+  }
+});


### PR DESCRIPTION
Closes #503. Completes epic #500.

## What lands

Two of the four grounding mechanisms need nothing to point at — **declare
which sources you read** and **downgrade what you cannot cite** — so they apply
to every seat regardless of whether it has a catalogue.

| Seat | Before | After |
|---|---|---|
| `performance-expert` | no grounding at all | Step 0 + measure gate + both mechanisms |
| `a11y-expert` | mechanisms in its own words (#505) | canonical block |
| `dependency-expert` | mechanisms in its own words (#504) | canonical block |

## Decisions worth reviewing

**"Identical wording" is enforced as identity, not as similarity.** The obvious
test is *does each seat contain something about declaring sources*. That check
passes on a paraphrase — and a paraphrase is exactly how *"drop it to LOW and
open its rationale with `Suspicion —`"* becomes *"mention the uncertainty"*,
which is a different instruction with the same summary. So the shared block is
extracted verbatim and compared **character by character** across the three
seats. The ticket's stated goal — a sixth seat can copy it — is only true if
the three that exist have not already drifted.

Achieving that meant reworking the wording already shipped in #504 and #505,
where the mechanisms sat as items 4 and 5 of a numbered list and were therefore
indented differently in each. They are now a standalone block in all three.

**`performance-expert` gets a Step 0 without a catalogue.** The survey
recommended against building one, but "no catalogue" and "no grounding" are
different things. Its Step 0 points at what the repository itself records: the
constitution's declared budgets and trade-offs, and any benchmark, profile,
index or explanatory comment already present. A finding that contradicts a
recorded decision is a question, not a defect.

**The measure gate is three questions, not a slogan.** *You did not measure* as
a single line is unfalsifiable advice. It is asked as: is this path hot, is the
collection bounded, is there a measurement — and where the answer is no, the
claim becomes *unmeasured risk*, which is smaller, honest, and still worth
shipping.

**One contradiction removed.** `performance-expert` carried *"when in doubt,
surface the finding at LOW rather than dropping it"*. That is not the same
instruction as *"drop it to LOW and label it a suspicion"* — the first hides
the uncertainty in a severity, the second shows it. Leaving both would have
left the seat contradicting itself. A guard asserts the old line stays gone.

**A shared string should not have two guards.** `a11y_catalogue_test.ts`
asserted the mechanism wording it shipped; that wording now lives in three
files and is owned by the new shared test. Those assertions were handed over
rather than duplicated — two guards over one string are two guards free to
disagree.

## Scope boundary

`architect-expert` and `security-expert` keep their own phrasings, worded
around their own artefact ("the leaf", "the domain file"). Harmonising them
would mean editing what #489 shipped, which #500 puts out of scope, and both
already fail their own guards if the mechanism disappears. Noting it as the
one place the fleet is consistent rather than identical.

## Verification

Five guards, each probed by breaking what it protects. All five fail without
their fix:

| Break | Guard fires |
|---|---|
| a seat paraphrases the downgrade rule instead of copying it | yes |
| a seat keeps the heading but drops the declare-sources sentence | yes |
| the measure gate becomes a heading with no questions | yes |
| the old contradictory catch-all comes back | yes |
| a seat breaches the Windsurf cap | yes |

Full suite **1278 passed / 0 failed**. `deno task test` leaves a clean tree.

**Windsurf cap** — `dependency-expert` 11,770 · `a11y-expert` 9,096 ·
`performance-expert` 8,936 (cap 12,000). The dependency seat is the tight one;
three further dedups inside it bought the margin back after the shared block
landed.

## Agent adoption

All five expert seats now declare what they read and refuse to ship a finding
they cannot attribute at full confidence. Concretely, after upgrading:

- Every report opens with the sources it opened, so a skipped read is visible
  instead of invisible.
- Anything unattributable is `Suspicion —` at LOW, which by the
  `review-findings-contract` verdict rules **cannot fail a gate on its own**.
- `performance-expert` stops reporting recognised shapes as costs. An N+1 over
  a bounded list of five, or a "hot loop" that runs three times at startup, now
  has to answer for itself before it reaches you.

No project action beyond `specnaut upgrade`.

```prompt
Dispatch performance-expert, a11y-expert and dependency-expert over this
repository in audit mode. Confirm each report opens by naming the sources it
read, and that every finding is either attributed to one or labelled
`Suspicion —` at LOW. For the performance report specifically, check that each
finding states whether the path is hot and whether the collection is bounded.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
