### PR TITLE
feat(upgrade): report when a skipped file froze, and stop calling it a success

### DIFF
--- a/src/cli/handlers/upgrade_handler.ts
+++ b/src/cli/handlers/upgrade_handler.ts
@@ -187,15 +187,61 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
     for (const a of groups.added) console.log(green(`    + ${a.dest}`));
     console.log();
   }
-  if (groups.preserve.length > 0) {
+  // Customized files split into two states that read identically today and
+  // need opposite responses. One is settled — you edited it, upstream has not
+  // moved, nothing is missing. The other is an update that was published and
+  // never arrived, and will never arrive on its own: the lock entry froze with
+  // the file, so every later run reaches the same verdict. Reporting both as
+  // "customized locally" is what let five files in this project's own install
+  // sit three months behind, referencing agents that had been deleted, while
+  // every run printed a clean success.
+  const settled = groups.preserve.filter((a) => a.kind === "preserve" && !a.staleSince);
+  const behind = groups.preserve.filter((a) => a.kind === "preserve" && a.staleSince);
+
+  if (settled.length > 0) {
     console.log(bold("  customized locally (not touched)"));
-    for (const a of groups.preserve) {
+    for (const a of settled) {
       const tag = a.kind === "preserve" && a.pluginAvailable
         ? ` ${dim("[plugin available — reconcile manually]")}`
         : "";
       console.log(yellow(`    ⚠ ${a.dest}${tag}`));
     }
     console.log();
+  }
+  if (behind.length > 0) {
+    console.log(bold("  customized, and behind — an update was published and never applied"));
+    // Grouped by the version each file froze at, not listed flat. Files rarely
+    // freeze one at a time: a single out-of-band edit — a repo-wide rename, a
+    // bulk sed — strands a whole set at the same version on the same day. Seeing
+    // them share a freeze point names the event that caused it, which a flat
+    // list repeating the same date on every line actively hides.
+    const byFreeze = new Map<string, typeof behind>();
+    for (const a of behind) {
+      if (a.kind !== "preserve" || !a.staleSince) continue;
+      const key = `${a.staleSince.templatesVersion}\u0000${a.staleSince.installedAt.slice(0, 10)}`;
+      const bucket = byFreeze.get(key);
+      if (bucket) bucket.push(a);
+      else byFreeze.set(key, [a]);
+    }
+    for (const [key, files] of byFreeze) {
+      const [version, day] = key.split("\u0000");
+      console.log(
+        dim(
+          `    last written by v${version} on ${day} — every upgrade since has skipped ` +
+            `${files.length === 1 ? "it" : `these ${files.length}`}:`,
+        ),
+      );
+      for (const a of files) {
+        console.log(yellow(`      ⚠ ${a.dest}`));
+        console.log(dim(`          specnaut reconcile ${a.dest} --accept-upstream`));
+      }
+    }
+    console.log(
+      dim(
+        `    All ${behind.length} at once: specnaut upgrade --reset-baseline` +
+          ` (keeps a .specnaut.bak of each).\n`,
+      ),
+    );
   }
   if (groups.removed.length > 0) {
     console.log(bold("  removed (no longer in templates)"));
@@ -220,7 +266,8 @@ function renderSummary(plan: UpgradePlan, from: string, to: string) {
 
   console.log(
     dim(
-      `  ${groups.auto.length} auto-update, ${groups.preserve.length} preserved, ` +
+      `  ${groups.auto.length} auto-update, ${settled.length} preserved, ` +
+        `${behind.length} behind, ` +
         `${groups.added.length} added, ${groups.removed.length} removed, ` +
         `${groups.orphanPreserved.length} orphan-preserved, ${groups.migrated.length} migrated, ` +
         `${groups.deferred.length} deferred, ${groups.unchanged.length} unchanged`,
@@ -393,10 +440,7 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
     console.log(
       dim(
         "\nFor customized files, review the diff below and merge manually if desired.\n" +
-          "Re-run with --force to overwrite them (edits will be backed up to .specnaut.bak).\n" +
-          "If you never edited these files, the lock baseline is stale — re-run with\n" +
-          "`specnaut upgrade --reset-baseline` to trust the on-disk content as the new\n" +
-          "baseline and apply the upstream updates cleanly.\n",
+          "Re-run with --force to overwrite them (edits will be backed up to .specnaut.bak).\n",
       ),
     );
     // Resolve the harness from the lock to render diffs in the correct file tree.
@@ -439,6 +483,21 @@ export async function runUpgrade(intent: UpgradeIntent): Promise<number> {
   }
   console.log();
   console.log(green(`✓ upgraded to templates ${result.fromVersion} → ${result.toVersion}`));
+
+  // A run whose only outcome is skips still printed a bare green tick. That is
+  // the line people read, and it said the work was done. Name what was left,
+  // right where the eye lands, or the group above goes unread.
+  const leftBehind = result.plan.filter((a) => a.kind === "preserve" && a.staleSince);
+  if (leftBehind.length > 0) {
+    console.log(
+      yellow(
+        `⚠ ${leftBehind.length} file${leftBehind.length === 1 ? "" : "s"} did not receive ` +
+          `${leftBehind.length === 1 ? "an update" : "updates"} published for ` +
+          `${leftBehind.length === 1 ? "it" : "them"} — see "customized, and behind" above. ` +
+          `Nothing will deliver ${leftBehind.length === 1 ? "it" : "them"} on a later run.`,
+      ),
+    );
+  }
 
   // A breaking upgrade is the one moment `UPGRADING.md` exists for, and until
   // now the binary never named it — the only inbound links were the README and

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -56,9 +56,9 @@ ${bold("Flags (for upgrade):")}
   --force             Overwrite locally-customized files (existing content backed up to *.specnaut.bak)
   --backlog <name>    Switch the backlog backend (local | github | gitlab). Re-renders the backlog skill;
                       existing data in the previous backend is NOT migrated.
-  --reset-baseline    Trust the on-disk content as the new SHA baseline. Use when files are flagged
-                      "customized locally" but you never edited them (heals stale lock SHAs). Combine
-                      with --dry-run to preview what would change.
+  --reset-baseline    Take upstream for every file listed under "customized, and behind" — the ones
+                      an update was published for and never reached. Per-file: specnaut reconcile
+                      <path> --accept-upstream. Combine with --dry-run to preview what would change.
   --reset-preserved   Ignore .specnaut/preserve.yml for this run so declared files follow normal
                       upgrade rules (never the default; reported per overridden file).
 

--- a/src/domain/upgrade_plan.ts
+++ b/src/domain/upgrade_plan.ts
@@ -23,6 +23,26 @@ export type UpgradeAction =
      * untouched either way.
      */
     pluginAvailable: boolean;
+    /**
+     * Set when this file is **both** customized and behind upstream — the
+     * state that rots silently.
+     *
+     * Preserving a customized file is correct, but the lock entry is frozen
+     * along with it (`upgrade_project.ts`: `wrote` is false, so `sha256` and
+     * `templatesVersion` carry over verbatim). Every later run therefore
+     * reaches the same verdict and skips again, forever, while the summary
+     * says only "customized locally" — which reads as a settled fact rather
+     * than as an update that never arrived.
+     *
+     * The frozen field is what makes the gap reportable: it still holds the
+     * version that last wrote the file. Re-stamping it to "heal" the freeze
+     * would destroy the only record of when the divergence began, so this
+     * reads the freeze rather than repairing it.
+     *
+     * Absent when the file is customized but upstream has not moved since —
+     * nothing was missed there, and warning about it would be noise.
+     */
+    staleSince?: { templatesVersion: string; installedAt: string };
   }
   | { kind: "add-new"; dest: string }
   | { kind: "unchanged"; dest: string }
@@ -113,6 +133,39 @@ export type UpgradePlanOptions = {
    */
   isDeclaredPreserved?: (dest: string) => boolean;
 };
+
+/**
+ * Whether a customized file has also fallen behind upstream, and since when.
+ *
+ * Two conditions, and both are load-bearing:
+ *
+ *  - `lockSha !== newSha` — the template actually changed since this file was
+ *    last written. Without it, a file the user edited whose template never
+ *    moved would be reported as behind when nothing was missed.
+ *  - `entry.templatesVersion !== lock.templatesVersion` — this entry never
+ *    caught up. The lock's own version advances on every run, so an entry
+ *    lagging it was skipped by at least one completed upgrade.
+ *
+ * Together they mean: an update was published for this path, and it never
+ * landed. That is the state worth a warning; either alone is not.
+ */
+function staleSince(
+  lock: InstalledLock,
+  dest: string,
+  lockSha: string,
+  newSha: string,
+): { staleSince: { templatesVersion: string; installedAt: string } } | null {
+  if (lockSha === newSha) return null;
+  const entry = lock.entries.get(dest);
+  if (entry === undefined) return null;
+  if (entry.templatesVersion === lock.templatesVersion) return null;
+  return {
+    staleSince: {
+      templatesVersion: entry.templatesVersion,
+      installedAt: entry.installedAt,
+    },
+  };
+}
 
 export function computeUpgradePlan(
   diskShas: Map<string, string>,
@@ -214,6 +267,7 @@ export function computeUpgradePlan(
       dest,
       reason: "customized",
       pluginAvailable: covered,
+      ...(staleSince(lock, dest, lockSha, newSha) ?? {}),
     });
   }
 

--- a/tests/cli/handlers/upgrade_stale_report_test.ts
+++ b/tests/cli/handlers/upgrade_stale_report_test.ts
@@ -1,0 +1,177 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const MAIN = fromFileUrl(new URL("../../../src/main.ts", import.meta.url));
+
+async function specnaut(args: string[], cwd: string) {
+  const { code, stdout, stderr } = await new Deno.Command("deno", {
+    args: ["run", "-A", MAIN, ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    out: new TextDecoder().decode(stdout) + new TextDecoder().decode(stderr),
+  };
+}
+
+async function sandbox(): Promise<string> {
+  const dir = await Deno.makeTempDir({ prefix: "specnaut-stale-" });
+  await new Deno.Command("git", { args: ["init", "-q", "."], cwd: dir }).output();
+  await Deno.writeTextFile(join(dir, "package.json"), "{}");
+  const r = await specnaut(["init", "--here", "--ai", "claude", "--backlog", "local"], dir);
+  assert(r.code === 0, `init failed:\n${r.out}`);
+  return dir;
+}
+
+/**
+ * Puts one tracked file into the state the report exists for: diverged from its
+ * recorded baseline, and behind an upstream that has since moved.
+ *
+ * Both halves are forged deliberately. Editing the file alone only makes it
+ * "customized" — which is correct and unremarkable. Ageing the lock entry alone
+ * changes nothing, because a fresh install's recorded SHA still matches the
+ * bundle. It takes both for an update to have been published and missed, and
+ * that pairing is exactly what the report has to detect.
+ *
+ * @returns the doctored path.
+ */
+async function freeze(dir: string, opts: { upstreamMoved: boolean }): Promise<string> {
+  const lockPath = join(dir, ".specnaut", "installed.lock");
+  const lock = await Deno.readTextFile(lockPath);
+
+  const target = [...lock.matchAll(/^ {2}(\.claude\/agents\/[^\s:]+\.md):$/gm)]
+    .map((m) => m[1])[0];
+  assert(target, "expected the lock to track at least one agent file");
+
+  // Diverge on disk, or the plan short-circuits on `diskSha === newSha`.
+  const file = join(dir, target);
+  await Deno.writeTextFile(file, (await Deno.readTextFile(file)) + "\n<!-- local note -->\n");
+
+  const block = new RegExp(
+    `(^ {2}${target.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}:\\n` +
+      `    sha256: )([0-9a-f]+)(\\n    installed_at: '[^']+'\\n    templates_version: )(\\S+)`,
+    "m",
+  );
+  assert(block.test(lock), `could not locate the lock entry for ${target}`);
+  await Deno.writeTextFile(
+    lockPath,
+    lock.replace(
+      block,
+      // A recorded SHA that matches neither disk nor bundle is what "upstream
+      // published something since this file was last written" looks like.
+      // Hex with letters, not all-digits: YAML reads an unquoted `000…0` as the
+      // integer 0, and the lock parser rejects it for not being a string.
+      (_m, head, sha, mid) => `${head}${opts.upstreamMoved ? "f".repeat(64) : sha}${mid}1.12.0`,
+    ),
+  );
+  return target;
+}
+
+Deno.test("a file that missed a published update is named, dated, and made actionable", async () => {
+  const dir = await sandbox();
+  try {
+    const target = await freeze(dir, { upstreamMoved: true });
+    const { out } = await specnaut(["upgrade", "--dry-run"], dir);
+
+    assertStringIncludes(out, "customized, and behind");
+    assertStringIncludes(out, target);
+    // The version that last wrote it — the whole point of reading the frozen
+    // field rather than repairing it.
+    assertStringIncludes(out, "last written by v1.12.0");
+    // ...and the fact that this is not a one-off skip.
+    assertStringIncludes(out, "every upgrade since has skipped it");
+    // A command the reader can paste, for this path, not a generic trailer.
+    assertStringIncludes(out, `specnaut reconcile ${target} --accept-upstream`);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("the run does not present as an unqualified success", async () => {
+  const dir = await sandbox();
+  try {
+    await freeze(dir, { upstreamMoved: true });
+    const { out } = await specnaut(["upgrade"], dir);
+    // The green tick is the line people actually read. It stays — but it can no
+    // longer be the last word when an update was published and left unapplied.
+    assertStringIncludes(out, "✓ upgraded to templates");
+    assertStringIncludes(out, "did not receive");
+    assertStringIncludes(out, "Nothing will deliver");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a customization with nothing published against it stays quiet", async () => {
+  const dir = await sandbox();
+  try {
+    const target = await freeze(dir, { upstreamMoved: false });
+    const { out } = await specnaut(["upgrade", "--dry-run"], dir);
+
+    // Still preserved, still reported — just not as a missed update, because
+    // none was missed. Warning here would fire on every long-lived local edit
+    // and teach the reader to skip the section that matters.
+    assertStringIncludes(out, "customized locally (not touched)");
+    assertStringIncludes(out, target);
+    assert(
+      !out.includes("customized, and behind"),
+      "upstream never moved for this path; there is nothing behind to report",
+    );
+    assert(
+      !out.includes("did not receive"),
+      "the outcome line must stay clean when nothing was missed",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("files that froze together are reported together", async () => {
+  // Files rarely drift one at a time. A repo-wide rename or a bulk sed strands
+  // a whole set at the same version on the same day, and seeing them share a
+  // freeze point names the event that caused it. A flat list repeating the same
+  // date on every line hides exactly that.
+  const dir = await sandbox();
+  try {
+    const lockPath = join(dir, ".specnaut", "installed.lock");
+    let lock = await Deno.readTextFile(lockPath);
+    const targets = [...lock.matchAll(/^ {2}(\.claude\/agents\/[^\s:]+\.md):$/gm)]
+      .map((m) => m[1]).slice(0, 3);
+    assert(targets.length === 3, "need three tracked agent files");
+
+    // Two froze in one event, the third in a later one.
+    const freezes: [string, string][] = [
+      ["1.12.0", "2026-05-26"],
+      ["1.12.0", "2026-05-26"],
+      ["1.18.2", "2026-07-02"],
+    ];
+    for (let i = 0; i < targets.length; i++) {
+      const t = targets[i];
+      const f = join(dir, t);
+      await Deno.writeTextFile(f, (await Deno.readTextFile(f)) + "\n<!-- local -->\n");
+      const [version, day] = freezes[i];
+      lock = lock.replace(
+        new RegExp(
+          `(^ {2}${t.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}:\\n    sha256: )[0-9a-f]+` +
+            `(\\n    installed_at: ')[^']+('\\n    templates_version: )\\S+`,
+          "m",
+        ),
+        (_m, head, mid, tail) => `${head}${"f".repeat(64)}${mid}${day}T09:00:00Z${tail}${version}`,
+      );
+    }
+    await Deno.writeTextFile(lockPath, lock);
+
+    const { out } = await specnaut(["upgrade", "--dry-run"], dir);
+    assertStringIncludes(out, "last written by v1.12.0 on 2026-05-26");
+    assertStringIncludes(out, "skipped these 2");
+    assertStringIncludes(out, "last written by v1.18.2 on 2026-07-02");
+    // Singular for the lone file — a report that says "these 1" reads as a bug
+    // and costs the reader trust in everything around it.
+    assertStringIncludes(out, "skipped it:");
+    assertStringIncludes(out, "All 3 at once: specnaut upgrade --reset-baseline");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/domain/upgrade_stale_test.ts
+++ b/tests/domain/upgrade_stale_test.ts
@@ -1,0 +1,133 @@
+import { assert, assertEquals } from "@std/assert";
+import { computeUpgradePlan } from "../../src/domain/upgrade_plan.ts";
+import type { InstalledLock } from "../../src/domain/installed_lock.ts";
+
+/**
+ * A customized file that is also behind upstream.
+ *
+ * Preserving a customized file is right. Freezing its lock entry alongside it
+ * is what turns a single skip into a permanent one: `upgrade_project.ts` copies
+ * `sha256` and `templatesVersion` over verbatim whenever the file was not
+ * written, so every later run reaches the same verdict and skips again. The
+ * summary said only "customized locally", which reads as settled rather than as
+ * an update that never arrived.
+ *
+ * These lock the *discrimination*, which is the part that is easy to get wrong
+ * in the noisy direction: warning about every customized file would train the
+ * reader to skip the warning, and the one that matters would go with it.
+ */
+
+const DEST = ".claude/agents/product-owner.md";
+
+function lock(
+  entryVersion: string,
+  lockVersion: string,
+  sha = "lock-sha",
+): InstalledLock {
+  return {
+    version: 2,
+    harness: "claude",
+    backlogBackend: "local",
+    versionScheme: "semver",
+    specBackend: "local",
+    templatesVersion: lockVersion,
+    entries: new Map([[
+      DEST,
+      { sha256: sha, installedAt: "2026-05-26T10:00:00Z", templatesVersion: entryVersion },
+    ]]),
+  };
+}
+
+/** The customized `preserve` action for DEST, or null if the plan has none. */
+function preserved(plan: ReturnType<typeof computeUpgradePlan>) {
+  const a = plan.find((x) => x.kind === "preserve" && x.dest === DEST);
+  return a?.kind === "preserve" ? a : null;
+}
+
+Deno.test("a customized file whose template moved on, and never caught up, is flagged", () => {
+  // Entry frozen at 1.12.0 while the lock itself reached 2.0.1 — so at least
+  // one completed upgrade skipped it — and the template's SHA has moved, so
+  // there was something to deliver.
+  const plan = computeUpgradePlan(
+    new Map([[DEST, "edited-by-hand"]]),
+    lock("1.12.0", "2.0.1"),
+    new Map([[DEST, "upstream-moved"]]),
+  );
+  const a = preserved(plan);
+  assert(a, "expected a preserve action");
+  assertEquals(a.reason, "customized");
+  assert(a.staleSince, "an update was published for this path and never applied");
+  assertEquals(a.staleSince.templatesVersion, "1.12.0");
+  assertEquals(a.staleSince.installedAt, "2026-05-26T10:00:00Z");
+});
+
+Deno.test("a customized file whose template never moved is NOT flagged", () => {
+  // The lock entry lags — but `lockSha === newSha`, so nothing was published
+  // for this path. Reporting it as behind would be a false positive, and the
+  // noisy kind: it fires on every long-lived local edit in the project.
+  const plan = computeUpgradePlan(
+    new Map([[DEST, "edited-by-hand"]]),
+    lock("1.12.0", "2.0.1", "same-as-upstream"),
+    new Map([[DEST, "same-as-upstream"]]),
+  );
+  const a = preserved(plan);
+  assert(a, "expected a preserve action");
+  assertEquals(a.reason, "customized");
+  assertEquals(
+    a.staleSince,
+    undefined,
+    "upstream did not move, so nothing was missed and nothing should be warned about",
+  );
+});
+
+Deno.test("a customized file edited since the last upgrade is NOT flagged", () => {
+  // Entry version equals the lock's own: this file was current as of the most
+  // recent run, and the divergence is this cycle's. It is a normal preserve,
+  // not a file that has been silently skipped for releases.
+  const plan = computeUpgradePlan(
+    new Map([[DEST, "edited-by-hand"]]),
+    lock("2.0.1", "2.0.1"),
+    new Map([[DEST, "upstream-moved"]]),
+  );
+  const a = preserved(plan);
+  assert(a, "expected a preserve action");
+  assertEquals(a.staleSince, undefined, "no completed upgrade has skipped this file yet");
+});
+
+Deno.test("a declared preserve is never flagged as behind", () => {
+  // `.specnaut/preserve.yml` is the user saying "this one is mine". It is
+  // expected to diverge and expected to stay behind; that is the whole point
+  // of declaring it. Warning about it would be telling them their own
+  // instruction went wrong.
+  const plan = computeUpgradePlan(
+    new Map([[DEST, "edited-by-hand"]]),
+    lock("1.12.0", "2.0.1"),
+    new Map([[DEST, "upstream-moved"]]),
+    { isDeclaredPreserved: (d: string) => d === DEST },
+  );
+  const a = preserved(plan);
+  assert(a, "expected a preserve action");
+  assertEquals(a.reason, "declared");
+  assertEquals(a.staleSince, undefined, "a declared preserve is meant to stay put");
+});
+
+Deno.test("an untracked file has no lock entry and cannot be dated", () => {
+  // No entry means no recorded version, so there is nothing to compare and
+  // nothing honest to report. It must not guess.
+  const plan = computeUpgradePlan(
+    new Map([[DEST, "on-disk"]]),
+    {
+      version: 2,
+      harness: "claude",
+      backlogBackend: "local",
+      versionScheme: "semver",
+      specBackend: "local",
+      templatesVersion: "2.0.1",
+      entries: new Map(),
+    },
+    new Map([[DEST, "upstream"]]),
+  );
+  const a = preserved(plan);
+  assert(a, "expected a preserve action");
+  assertEquals(a.staleSince, undefined);
+});


### PR DESCRIPTION
Closes #507.

## The defect

Skipping a customized file is correct — it protects local edits. Freezing its
lock entry alongside it is not. `src/application/upgrade_project.ts` lines 408
and 412:

```ts
sha256:          wrote ? sha              : existing?.sha256 ?? sha,
templatesVersion: wrote ? templatesVersion : existing?.templatesVersion ?? templatesVersion,
```

`wrote` is false for every preserved file, so both fields carry over verbatim.
The next run makes the same comparison and reaches the same verdict. **The
first time a file diverges, it stops receiving updates permanently** — and the
summary reports it as `customized locally`, which reads as a settled fact
rather than as an update that never arrived.

Measured on this project's own lock: **34 of 238 entries frozen at `1.12.0`**
against a lock already at `2.0.1`. Five still named agents deleted three months
earlier. Every intervening run printed a clean green tick.

## What changed, and the one decision behind it

**The frozen field is the evidence.** It still holds the version that last
wrote the file. "Fixing" the freeze by re-stamping it would destroy the only
record of when the gap opened — so this **reads** the freeze instead of
repairing it. That is why there is no lock-format change and no bundler change.

**The signal is a conjunction, and both halves matter.** `staleSince` is set
only when the template actually moved (`lockSha !== newSha`) *and* the entry
never caught up (`templatesVersion !== lock.templatesVersion`).

| State | Reported |
|---|---|
| edited, template never changed since | `customized locally` — nothing was missed |
| edited this cycle, template changed | `customized locally` — no run has skipped it yet |
| edited, template changed, entry lagging | **`customized, and behind`** |
| declared in `preserve.yml` | `customized locally`, never flagged |

The first row is why the conjunction is load-bearing: warning on every
customized file would fire on every long-lived local edit, and the reader would
learn to skip the section that matters. Declared preserves are excluded because
`preserve.yml` is the user saying *this one is mine* — it is meant to stay
behind, and flagging it would be telling them their own instruction went wrong.

**Grouped by freeze point, not listed flat.** Files rarely drift one at a time:
a repo-wide rename or a bulk sed strands a whole set at the same version on the
same day. Sharing a freeze point names the event that caused it — a flat list
repeating the same date on every line hides exactly that.

```
  customized, and behind — an update was published and never applied
    last written by v1.12.0 on 2026-05-26 — every upgrade since has skipped these 3:
      ⚠ .claude/agents/README.md
          specnaut reconcile .claude/agents/README.md --accept-upstream
      ⚠ .claude/agents/a11y-expert.md
          specnaut reconcile .claude/agents/a11y-expert.md --accept-upstream
      ⚠ .claude/agents/architect-expert.md
          specnaut reconcile .claude/agents/architect-expert.md --accept-upstream
    last written by v1.18.2 on 2026-07-02 — every upgrade since has skipped it:
      ⚠ .claude/agents/code-reviewer.md
          specnaut reconcile .claude/agents/code-reviewer.md --accept-upstream
    All 4 at once: specnaut upgrade --reset-baseline (keeps a .specnaut.bak of each).

  0 auto-update, 0 preserved, 4 behind, 0 added, …

✓ upgraded to templates 2.0.1 → 2.1.0
⚠ 4 files did not receive updates published for them — see "customized, and
  behind" above. Nothing will deliver them on a later run.
```

`--reset-baseline` moved out of the generic trailer to the group it applies to,
and its `--help` entry now names that state instead of "you never edited them".

**Nothing is overwritten that was not overwritten before.** This is reporting
only.

## Verification

Nine tests — five on the discrimination, four end-to-end through the real
binary in a temp project. Five guards probed by breaking what they protect, all
five fail without their fix:

| Break | Guard fires |
|---|---|
| drop the "upstream moved" condition (warn on every customized file) | yes |
| drop the "never caught up" condition | yes |
| outcome line goes back to an unqualified tick | yes |
| per-file reconcile command replaced by a generic trailer | yes |
| declared preserves start getting flagged as behind | yes |

Full suite **1287 passed / 0 failed**; `deno task test` leaves a clean tree.

One thing the end-to-end tests taught, recorded in a comment so the next person
does not lose the hour: a forged SHA of 64 zeros is read by YAML as the integer
`0`, and `parseLock` then rejects it for not being a string.

## Agent adoption

None required — no config, no flag, no migration. The next `specnaut upgrade`
simply says more.

What to expect: if the project has been running a while and anyone has ever
edited a scaffolded file, the first run after upgrading may list files under
**customized, and behind**. Those are not new problems; they are problems that
were already there and invisible. Each line carries the command that resolves
it, or `--reset-baseline` takes them all at once.

```prompt
Run `specnaut upgrade --dry-run` and read the "customized, and behind" section
if one appears. For each file listed, decide whether the local edit is still
wanted: if not, run the `specnaut reconcile <path> --accept-upstream` command
printed beneath it. Report which files were behind and since which version.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV
