### PR TITLE
fix(changelog): read the adoption section CI refuses to merge without

### DIFF
--- a/scripts/gen-changelog.ts
+++ b/scripts/gen-changelog.ts
@@ -19,6 +19,14 @@ export type Classified = Commit & {
 };
 
 const FEATURE_PREFIXES = new Set(["feat"]);
+/**
+ * Categories whose PRs are walked for an `## Agent adoption` section.
+ *
+ * Kept in step with the `pr_adoption_lint.yml` gate: whatever CI refuses to
+ * merge without an adoption section must be read back out here, or the gate
+ * collects an artefact nothing consumes.
+ */
+const ADOPTION_CATEGORIES = new Set<Category>(["feat", "breaking"]);
 const FIX_PREFIXES = new Set(["fix"]);
 const CHORE_PREFIXES = new Set([
   "chore",
@@ -378,7 +386,15 @@ export async function assembleAdoptionEntries(
   const failures: { prNum: number | null; hash?: string; reason: string }[] = [];
 
   for (const c of classified) {
-    if (c.category !== "feat") continue;
+    // A breaking change IS a feature that also breaks something, and the CI
+    // gate already treats it as one: `pr_adoption_lint.yml` greps
+    // `^feat(\([^)]+\))?!?:`, so a `feat!:` PR cannot merge without an
+    // adoption section. But `classify()` returns "breaking" and returns early,
+    // before it ever tests FEATURE_PREFIXES — so a feat-only walk here threw
+    // away the adoption prompt of the one commit in a major release most
+    // likely to need one. Silently: no warning, and nothing for --strict to
+    // catch, because a category that is never visited cannot fail.
+    if (!ADOPTION_CATEGORIES.has(c.category)) continue;
     let prNum = extractPrNumber(c.subject);
     if (prNum === null) {
       // No `(#NNN)` in the subject. Under squash-merge that means "no PR";
@@ -394,7 +410,7 @@ export async function assembleAdoptionEntries(
         // is worth a line even though it is not a failure. A skip nobody can
         // see is how the guide stayed empty across a whole major release.
         console.warn(
-          `gen-changelog: feat commit ${c.hash} resolves to no PR — skipping adoption`,
+          `gen-changelog: ${c.category} commit ${c.hash} resolves to no PR — skipping adoption`,
         );
         continue;
       }
@@ -408,14 +424,14 @@ export async function assembleAdoptionEntries(
     }
     if (outcome.kind === "absent") {
       console.warn(
-        `gen-changelog: feat commit ${c.hash} (#${prNum}) has no PR body — skipping adoption`,
+        `gen-changelog: ${c.category} commit ${c.hash} (#${prNum}) has no PR body — skipping adoption`,
       );
       continue;
     }
     const adoption = extractAdoption(outcome.body);
     if (adoption === null) {
       console.warn(
-        `gen-changelog: feat commit ${c.hash} (#${prNum}) has no Agent adoption section — skipping`,
+        `gen-changelog: ${c.category} commit ${c.hash} (#${prNum}) has no Agent adoption section — skipping`,
       );
       continue;
     }

--- a/tests/scripts/gen_changelog_test.ts
+++ b/tests/scripts/gen_changelog_test.ts
@@ -911,3 +911,75 @@ Deno.test("assembleAdoptionEntries: a PR with two feat commits yields ONE entry"
   assertEquals(entries.length, 1);
   assertEquals(entries[0].prNum, 461);
 });
+
+// ---------------------------------------------------------------------------
+// A breaking change is a feature that also breaks something (#509).
+//
+// `classifyCommit` returns "breaking" and returns EARLY, before it ever tests
+// FEATURE_PREFIXES — so `feat(x)!:` never carries the "feat" category. A
+// feat-only adoption walk therefore dropped the adoption prompt of the one
+// commit in a major release most likely to need one, and dropped it with no
+// warning and nothing for --strict to catch.
+//
+// These are written through the real `classifyCommit` rather than a hand-built
+// fixture: the hole only exists because of how the two halves fit together, so
+// a guard that stubs the category cannot see it reopen.
+// ---------------------------------------------------------------------------
+
+Deno.test("the CI gate's own pattern and the adoption walk agree on what a feature is", async () => {
+  // Verbatim the shape `pr_adoption_lint.yml` refuses to merge without an
+  // adoption section: /^feat(\([^)]+\))?!?:/ — the `!?` is deliberate there.
+  const gated = [
+    "feat: plain (#601)",
+    "feat(scope): scoped (#602)",
+    "feat!: breaking (#603)",
+    "feat(agents)!: rename the five auditor seats to experts (#604)",
+  ];
+  const map = new Map<number, PrBodyOutcome>(
+    [601, 602, 603, 604].map((n) => [n, { kind: "retrieved", body: adoptionBody(`run ${n}`) }]),
+  );
+
+  const classified = gated.map((subject) =>
+    classifyCommit({ hash: `h${subject.length}`, subject })
+  );
+  const { entries, failures } = await assembleAdoptionEntries(classified, fakeFetcher(map));
+
+  assertEquals(failures.length, 0);
+  // Every subject CI demands a section for must come back out of the walk.
+  // Collecting an artefact nothing reads is the failure this guards.
+  assertEquals(entries.map((e) => e.prNum).sort(), [601, 602, 603, 604]);
+});
+
+Deno.test("a breaking commit's adoption prompt survives into the entry", async () => {
+  const c = classifyCommit({
+    hash: "caafccc",
+    subject: "feat(agents)!: rename the five auditor seats to experts (#497)",
+  });
+  // The premise of the bug, asserted rather than assumed: this is NOT "feat".
+  assertEquals(c.category, "breaking");
+
+  const map = new Map<number, PrBodyOutcome>([
+    [497, { kind: "retrieved", body: adoptionBody("update the agent names you reference") }],
+  ]);
+  const { entries } = await assembleAdoptionEntries([c], fakeFetcher(map));
+
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].prNum, 497);
+  assertEquals(entries[0].title, "Rename the five auditor seats to experts");
+  assertStringIncludes(entries[0].body, "update the agent names you reference");
+});
+
+Deno.test("widening the walk did not widen it to everything", async () => {
+  // fix/chore PRs are not gated by pr_adoption_lint and carry no section; if
+  // the walk visited them it would warn on every one of them and train the
+  // release operator to ignore the warnings that matter.
+  const subjects = ["fix: a bug (#701)", "chore: tidy (#702)", "docs: a note (#703)"];
+  const map = new Map<number, PrBodyOutcome>(
+    [701, 702, 703].map((n) => [n, { kind: "retrieved", body: adoptionBody(`run ${n}`) }]),
+  );
+  const classified = subjects.map((s, i) => classifyCommit({ hash: `f${i}`, subject: s }));
+  const { entries, failures } = await assembleAdoptionEntries(classified, fakeFetcher(map));
+
+  assertEquals(entries.length, 0);
+  assertEquals(failures.length, 0);
+});


### PR DESCRIPTION
Found during the `/release cli` advisory pass for v3.0.0, before tagging.

## The defect

`pr_adoption_lint.yml:42` greps `^feat(\([^)]+\))?!?:` — the `!?` is deliberate, so a **breaking** feature cannot merge without an `## Agent adoption` section.

`assembleAdoptionEntries` then walked `category === "feat"` only. And `classifyCommit` (`scripts/gen-changelog.ts:53-58`) returns `"breaking"` on an early return placed *before* it ever tests `FEATURE_PREFIXES` — so a `feat(x)!:` commit is **never** `"feat"`, and its adoption prompt was thrown away.

The gate demanded the artefact; the consumer never read it. Silently: no warning on that path, and nothing for `--strict` to catch, because a category the walk never visits cannot fail.

It bites hardest exactly where being wrong costs most. The breaking commit of a major release is the one most likely to need an adoption prompt — and `v3.0.0` was about to ship without #497's, the auditor→expert rename, which is the single change in the release that requires users to go edit their own files.

## The fix

- Walk `{feat, breaking}` through a named `ADOPTION_CATEGORIES` set rather than a bare string comparison, so the next reader sees a list to keep in step with the CI gate.
- The three skip warnings said `feat commit …`; they now name the actual category. Those lines exist so that a drop is visible, and one asserting the wrong category is half-useless.

## Guards

Written through the real `classifyCommit` rather than a hand-built `Classified` — the hole exists only in how the two halves fit together, so a test that stubs the category cannot watch it reopen.

1. **the CI gate's own pattern and the adoption walk agree on what a feature is** — feeds the four subject shapes `pr_adoption_lint` refuses to merge without a section and asserts all four come back out.
2. **a breaking commit's adoption prompt survives into the entry** — the real `#497` subject; asserts the premise (`category === "breaking"`) rather than assuming it.
3. **widening the walk did not widen it to everything** — `fix`/`chore`/`docs` still are not visited, so the walk does not start warning on every ungated PR and train the operator to ignore the warnings that matter.

Probed both directions: with the feat-only filter restored, **2 of the 3 fail**; the third is the inverse guard and correctly stays green.

## Verification

- `deno test -A tests/scripts/gen_changelog_test.ts` → **62 passed / 0 failed** (59 before)
- Full `bash .specnaut/release/preflight.sh` run below in checks

## Adoption

None required — this changes release-note generation, not anything a scaffolded project consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV