### PR TITLE
test(upgrade): derive the major-boundary fixtures instead of pinning them

### DIFF
--- a/tests/integration/upgrade_major_pointer_test.ts
+++ b/tests/integration/upgrade_major_pointer_test.ts
@@ -1,5 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { fromFileUrl, join } from "@std/path";
+import { VERSION } from "../../src/domain/version.ts";
+import { crossesMajorBoundary } from "../../src/domain/major_boundary.ts";
 
 const MAIN = fromFileUrl(new URL("../../src/main.ts", import.meta.url));
 
@@ -26,6 +28,31 @@ async function runSpecnaut(args: string[], cwd: string) {
 }
 
 const INIT = ["init", "--here", "--no-git", "--ai", "claude", "--backlog", "local"];
+
+/**
+ * Both fixtures are derived from the binary's own version rather than written
+ * down. A hardcoded same-major fixture stays same-major only until the binary
+ * reaches the next major — which happens on the day of the major release this
+ * test exists to protect, so it fails then, for a reason that has nothing to
+ * do with the behaviour under test. Deriving costs two lines and never expires.
+ */
+const CURRENT_MAJOR = Number(VERSION.split(".")[0]);
+const SAME_MAJOR = `${CURRENT_MAJOR}.0.0`;
+const PREVIOUS_MAJOR = `${CURRENT_MAJOR - 1}.0.0`;
+
+Deno.test("the fixtures straddle the boundary they claim to", () => {
+  // Without this, a bad derivation makes BOTH tests below vacuously pass: two
+  // same-major fixtures would print nothing, twice, and agree with each other.
+  assert(CURRENT_MAJOR >= 1, `cannot derive a previous major from ${VERSION}`);
+  assert(
+    crossesMajorBoundary(PREVIOUS_MAJOR, VERSION),
+    `${PREVIOUS_MAJOR} must cross into ${VERSION}`,
+  );
+  assert(
+    !crossesMajorBoundary(SAME_MAJOR, VERSION),
+    `${SAME_MAJOR} must not cross into ${VERSION}`,
+  );
+});
 
 /** Rewrites the lock's recorded templates version, faking an older install. */
 async function setLockVersion(dir: string, version: string) {
@@ -56,7 +83,7 @@ async function upgradeFrom(version: string) {
 }
 
 Deno.test("a major-crossing upgrade names the migration guide", async () => {
-  const out = await upgradeFrom("1.21.0");
+  const out = await upgradeFrom(PREVIOUS_MAJOR);
   assert(out.includes("UPGRADING.md"), "the guide's path must appear in the output");
   assert(out.includes("major version"), "and the reason it is being shown");
 });
@@ -64,6 +91,6 @@ Deno.test("a major-crossing upgrade names the migration guide", async () => {
 Deno.test("a same-major upgrade says nothing about it", async () => {
   // The quiet half. A pointer on every patch bump is a line people learn to
   // skip, and then it is not there when it matters.
-  const out = await upgradeFrom("2.0.0");
+  const out = await upgradeFrom(SAME_MAJOR);
   assert(!out.includes("UPGRADING.md"), "no migration pointer on a routine bump");
 });


### PR DESCRIPTION
Caught by `deno task test` during the `/release cli` run for v3.0.0, immediately after `bump-version.ts major` and **before** the tag was cut.

## The failure

`tests/integration/upgrade_major_pointer_test.ts` pinned its fixtures:

```ts
const out = await upgradeFrom("1.21.0");  // major-crossing
const out = await upgradeFrom("2.0.0");   // same-major
```

`2.0.0` is a same-major fixture only while the binary is 2.x. The moment `VERSION` becomes `3.0.0`, upgrading *from* 2.0.0 crosses a major, the pointer correctly fires, and `a same-major upgrade says nothing about it` fails.

So the test breaks on exactly the day it matters — during a major release — and it breaks for a reason that has nothing to do with the behaviour it guards. The `#481` wiring it pins is fine; only the fixture had expired. It would have done this again at v4.

## The fix

Both fixtures derive from `VERSION`: `SAME_MAJOR` is the current major at `.0.0`, `PREVIOUS_MAJOR` is the one below. Correct at every future major with no edit.

Deriving introduces a failure mode pinning did not have: a derivation that lands both fixtures on the same side of the boundary makes **both** tests vacuously pass — printing nothing twice and agreeing with each other. So a third test asserts the derivation's own premise against the real `crossesMajorBoundary` predicate before either behavioural test runs.

## Verification

- Green at **2.0.1** (this branch's merge base) — 3 passed / 0 failed
- Green at **3.0.0** (with the pending version bump applied) — 3 passed / 0 failed
- Probed: forcing both fixtures below the boundary → the straddle guard fails, as intended

## Adoption

None — test-only, nothing scaffolded changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV