### PR TITLE
docs: frame the agent rename as a 2.1.0 release, not a major

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ to drive a spec-driven workflow inside your project. It adds three things upstre
 - **Product backlog** — Markdown index + one file per task with structured frontmatter, a Product
   Owner agent for management, one-way sync to GitHub Issues/Project V2
 
-> **Crossing a major version?** Past majors have changed the phase chain and renamed agents — both
-> need edits `specnaut upgrade` cannot make for you. Read [UPGRADING.md](UPGRADING.md) first.
+> **Upgrading an existing project?** Some releases rename or remove things `specnaut upgrade` cannot
+> fix inside files you wrote — your `AGENTS.md`, your own skills, your saved prompts. Check
+> [UPGRADING.md](UPGRADING.md) for the version you are moving to.
 
 ## What Specnaut is not
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,10 @@
 # Upgrading Specnaut
 
-## 2.x → 3.0.0
+## 2.0.x → 2.1.0
+
+> This release renames the five expert agents. `specnaut upgrade` moves the files for you; it cannot
+> update references you wrote yourself, and there are no aliases — a stale name fails at dispatch
+> time, not at scaffold time. If you read one section below, read that one.
 
 ### The architect now reads a catalogue before it judges
 


### PR DESCRIPTION
Follow-up to #509, which was written on the assumption that this release would be `v3.0.0`. It ships as **2.1.0** instead — the five-seat rename is being released as a minor.

## What changes

- `UPGRADING.md` — section heading `2.x → 3.0.0` becomes `2.0.x → 2.1.0`.
- `UPGRADING.md` — a short lead note under the heading pointing straight at the rename section.
- `README.md` — the upgrade callout no longer keys on "crossing a major".

## Why the lead note and the README rewrite are not cosmetic

`#481`'s in-CLI pointer keys on `crossesMajorBoundary(from, to)` (`src/cli/handlers/upgrade_handler.ts:507`). That is **false** for `2.0.1 → 2.1.0`. So `specnaut upgrade` will not name `UPGRADING.md` on the one release where a user most needs it — the rename has no aliases, and a stale agent name fails at *dispatch* time, silently, until the moment the seat is needed.

That makes the README callout the primary discovery path, and it was itself conditional on a major (`> **Crossing a major version?**`) — inheriting the exact same blind spot. It now keys on what actually costs the reader something:

> **Upgrading an existing project?** Some releases rename or remove things `specnaut upgrade` cannot fix inside files you wrote — your `AGENTS.md`, your own skills, your saved prompts. Check [UPGRADING.md](UPGRADING.md) for the version you are moving to.

Durable, and no longer tied to a version shape.

## Not affected

The generated release notes still lead with `### ⚠ Breaking changes`, because that section keys on the **commit category** (`feat(agents)!:`), not on the tag. Verified: `breakingGuardWarning` only fires on a *major with no breaking marker*, so a minor carrying one passes `--strict` cleanly.

## Adoption

None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3t7DhMU299Fc7rSQ1KfV