### PR TITLE
fix: a path rule that only knew one platform's idea of absolute

### DIFF
--- a/.specnaut/release/postflight.sh
+++ b/.specnaut/release/postflight.sh
@@ -177,7 +177,7 @@ catalog_version=""
 for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
   catalog_version="$(gh api repos/specnaut/specnaut-marketplace/contents/.claude-plugin/marketplace.json \
     --jq '.content' 2>/dev/null | base64 -d 2>/dev/null \
-    | jq -r '.plugins[0].version' 2>/dev/null || true)"
+    | jq -r '.plugins[] | select(.name=="specnaut-plugin") | .version' 2>/dev/null || true)"
   [ "$catalog_version" = "${TAG#v}" ] && break
   [ "$attempt" -eq 12 ] || sleep 10
 done

--- a/src/templates_bundle.ts
+++ b/src/templates_bundle.ts
@@ -24837,6 +24837,35 @@ find_feature_dir_by_prefix() {
     fi
 }
 
+# A path is absolute if it starts with \`/\` — or, under Git Bash on Windows, if
+# it names a drive: \`C:\\Users\\...\` or \`C:/Users/...\`.
+#
+# \`.specnaut/feature.json\` is written by the \`plan\` phase, and on Windows the
+# path it carries uses the platform's own separator — the PowerShell twin
+# resolves it that way, and so does anything calling the platform's path API.
+# Read back here, a drive-letter path does not start with \`/\`, so the
+# "normalize relative paths" rule below used to prepend the repo root and
+# produce \`/repo/C:\\Users\\...\` — a location that exists nowhere, and whose
+# \`basename\` is the whole mangled string rather than the feature's directory
+# name. Both the contradiction guard and the template copy read it.
+#
+# The PowerShell twin never had this: it asks \`[System.IO.Path]::IsPathRooted\`
+# rather than testing for a leading slash by hand.
+is_absolute_path() {
+    [[ "\$1" == /* ]] && return 0
+    [[ "\$1" =~ ^[A-Za-z]:[\\\\/] ]]
+}
+
+# Backslashes separate components on Windows and \`basename\` only ever splits on
+# \`/\`. Rewriting them keeps every consumer on one spelling — but ONLY for a
+# drive-letter path: on POSIX a backslash is a legal filename character, so
+# converting unconditionally would corrupt a directory that contains one.
+normalize_feature_path() {
+    local _p="\$1"
+    [[ "\$_p" =~ ^[A-Za-z]:[\\\\/] ]] && _p="\${_p//\\\\//}"
+    printf '%s' "\$_p"
+}
+
 get_feature_paths() {
     local repo_root=\$(get_repo_root)
     local current_branch=\$(get_current_branch)
@@ -24854,9 +24883,9 @@ get_feature_paths() {
     local feature_dir_source
     if [[ -n "\${SPECIFY_FEATURE_DIRECTORY:-}" ]]; then
         feature_dir_source="env"
-        feature_dir="\$SPECIFY_FEATURE_DIRECTORY"
+        feature_dir=\$(normalize_feature_path "\$SPECIFY_FEATURE_DIRECTORY")
         # Normalize relative paths to absolute under repo root
-        [[ "\$feature_dir" != /* ]] && feature_dir="\$repo_root/\$feature_dir"
+        is_absolute_path "\$feature_dir" || feature_dir="\$repo_root/\$feature_dir"
     elif [[ -f "\$repo_root/.specnaut/feature.json" ]]; then
         feature_dir_source="feature.json"
         local _fd
@@ -24870,9 +24899,9 @@ get_feature_paths() {
             _fd=\$(grep -o '"feature_directory"[[:space:]]*:[[:space:]]*"[^"]*"' "\$repo_root/.specnaut/feature.json" 2>/dev/null | sed 's/.*"\\([^"]*\\)"\$/\\1/')
         fi
         if [[ -n "\$_fd" ]]; then
-            feature_dir="\$_fd"
+            feature_dir=\$(normalize_feature_path "\$_fd")
             # Normalize relative paths to absolute under repo root
-            [[ "\$feature_dir" != /* ]] && feature_dir="\$repo_root/\$feature_dir"
+            is_absolute_path "\$feature_dir" || feature_dir="\$repo_root/\$feature_dir"
         elif ! feature_dir=\$(find_feature_dir_by_prefix "\$repo_root" "\$current_branch"); then
             echo "ERROR: Failed to resolve feature directory" >&2
             return 1

--- a/templates/core/specnaut/scripts/bash/common.sh
+++ b/templates/core/specnaut/scripts/bash/common.sh
@@ -207,6 +207,35 @@ find_feature_dir_by_prefix() {
     fi
 }
 
+# A path is absolute if it starts with `/` — or, under Git Bash on Windows, if
+# it names a drive: `C:\Users\...` or `C:/Users/...`.
+#
+# `.specnaut/feature.json` is written by the `plan` phase, and on Windows the
+# path it carries uses the platform's own separator — the PowerShell twin
+# resolves it that way, and so does anything calling the platform's path API.
+# Read back here, a drive-letter path does not start with `/`, so the
+# "normalize relative paths" rule below used to prepend the repo root and
+# produce `/repo/C:\Users\...` — a location that exists nowhere, and whose
+# `basename` is the whole mangled string rather than the feature's directory
+# name. Both the contradiction guard and the template copy read it.
+#
+# The PowerShell twin never had this: it asks `[System.IO.Path]::IsPathRooted`
+# rather than testing for a leading slash by hand.
+is_absolute_path() {
+    [[ "$1" == /* ]] && return 0
+    [[ "$1" =~ ^[A-Za-z]:[\\/] ]]
+}
+
+# Backslashes separate components on Windows and `basename` only ever splits on
+# `/`. Rewriting them keeps every consumer on one spelling — but ONLY for a
+# drive-letter path: on POSIX a backslash is a legal filename character, so
+# converting unconditionally would corrupt a directory that contains one.
+normalize_feature_path() {
+    local _p="$1"
+    [[ "$_p" =~ ^[A-Za-z]:[\\/] ]] && _p="${_p//\\//}"
+    printf '%s' "$_p"
+}
+
 get_feature_paths() {
     local repo_root=$(get_repo_root)
     local current_branch=$(get_current_branch)
@@ -224,9 +253,9 @@ get_feature_paths() {
     local feature_dir_source
     if [[ -n "${SPECIFY_FEATURE_DIRECTORY:-}" ]]; then
         feature_dir_source="env"
-        feature_dir="$SPECIFY_FEATURE_DIRECTORY"
+        feature_dir=$(normalize_feature_path "$SPECIFY_FEATURE_DIRECTORY")
         # Normalize relative paths to absolute under repo root
-        [[ "$feature_dir" != /* ]] && feature_dir="$repo_root/$feature_dir"
+        is_absolute_path "$feature_dir" || feature_dir="$repo_root/$feature_dir"
     elif [[ -f "$repo_root/.specnaut/feature.json" ]]; then
         feature_dir_source="feature.json"
         local _fd
@@ -240,9 +269,9 @@ get_feature_paths() {
             _fd=$(grep -o '"feature_directory"[[:space:]]*:[[:space:]]*"[^"]*"' "$repo_root/.specnaut/feature.json" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/')
         fi
         if [[ -n "$_fd" ]]; then
-            feature_dir="$_fd"
+            feature_dir=$(normalize_feature_path "$_fd")
             # Normalize relative paths to absolute under repo root
-            [[ "$feature_dir" != /* ]] && feature_dir="$repo_root/$feature_dir"
+            is_absolute_path "$feature_dir" || feature_dir="$repo_root/$feature_dir"
         elif ! feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch"); then
             echo "ERROR: Failed to resolve feature directory" >&2
             return 1

--- a/tests/scripts/feature_paths_absolute_test.ts
+++ b/tests/scripts/feature_paths_absolute_test.ts
@@ -1,0 +1,121 @@
+// `get_feature_paths()` decided whether a path was absolute by testing for a
+// leading `/`. Under Git Bash on Windows — the shell these scripts run in
+// there — `.specnaut/feature.json` legitimately carries `C:\Users\...`, which
+// fails that test. The "normalize relative paths" rule then prepended the repo
+// root, producing a location that exists nowhere and whose `basename` is the
+// whole mangled string rather than the feature's directory name.
+//
+// Two consumers read exactly that: the contradiction guard compares the
+// basename against the branch, and `setup-plan.sh` copies the plan template to
+// `$FEATURE_DIR/plan.md`. The PowerShell twin never had the defect — it asks
+// `[System.IO.Path]::IsPathRooted` instead of spelling the rule by hand.
+//
+// These assertions are on the RESOLUTION, not on filesystem effects, so they
+// run identically on every platform: a Windows-shaped path is a string this
+// function must handle, whoever is reading it.
+
+import { assert, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const COMMON = fromFileUrl(
+  new URL("../../templates/core/specnaut/scripts/bash/common.sh", import.meta.url),
+);
+
+type Result = { code: number; stdout: string; stderr: string };
+
+async function resolvePaths(dir: string): Promise<Result> {
+  const { code, stdout, stderr } = await new Deno.Command("bash", {
+    args: ["-c", `source ${JSON.stringify(COMMON)}; get_feature_paths`],
+    cwd: dir,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stdout: new TextDecoder().decode(stdout),
+    stderr: new TextDecoder().decode(stderr),
+  };
+}
+
+/** A git repo on branch `002-beta`, with whatever `feature.json` the case needs. */
+async function withRepo(
+  featureDirectory: string,
+  fn: (dir: string, result: Result) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "feature-paths-abs-" });
+  try {
+    const git = async (...args: string[]) => {
+      await new Deno.Command("git", { args, cwd: dir, stdout: "null", stderr: "null" }).output();
+    };
+    await git("init", "-q");
+    await git("config", "user.email", "t@example.invalid");
+    await git("config", "user.name", "t");
+
+    await Deno.mkdir(join(dir, ".specnaut", "specs", "002-beta"), { recursive: true });
+    await Deno.writeTextFile(join(dir, "README.md"), "x\n");
+    await git("add", "-A");
+    await git("commit", "-qm", "init");
+    await git("checkout", "-qb", "002-beta");
+
+    await Deno.writeTextFile(
+      join(dir, ".specnaut", "feature.json"),
+      JSON.stringify({ feature_directory: featureDirectory, linked_issue: null }),
+    );
+
+    await fn(dir, await resolvePaths(dir));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("feature paths: a drive-letter path is absolute, not relative to the repo root", async () => {
+  await withRepo("C:\\Users\\x\\proj\\.specnaut\\specs\\002-beta", async (dir, r) => {
+    assert(
+      !r.stdout.includes(`${dir}/C:`) && !r.stdout.includes(`${dir}\\C:`),
+      `the repo root was prepended to a drive-letter path:\n${r.stdout}${r.stderr}`,
+    );
+    assertStringIncludes(r.stdout, "C:/Users/x/proj/.specnaut/specs/002-beta");
+  });
+});
+
+Deno.test("feature paths: a drive-letter path keeps a usable basename", async () => {
+  // This is what the contradiction guard compares against the branch. With the
+  // backslashes left in place `basename` returns the entire string, the guard
+  // fires on a feature.json that agrees with the branch perfectly, and every
+  // caller is refused on Windows for a contradiction that does not exist.
+  await withRepo("C:\\Users\\x\\proj\\.specnaut\\specs\\002-beta", async (_dir, r) => {
+    assert(
+      r.code === 0,
+      `a feature.json naming the current branch must resolve, got exit ${r.code}:\n${r.stderr}`,
+    );
+    assertStringIncludes(r.stdout, "IMPL_PLAN=C:/Users/x/proj/.specnaut/specs/002-beta/plan.md");
+  });
+});
+
+Deno.test("feature paths: forward-slash drive paths resolve the same way", async () => {
+  await withRepo("C:/Users/x/proj/.specnaut/specs/002-beta", async (dir, r) => {
+    assert(!r.stdout.includes(`${dir}/C:`), `the repo root was prepended:\n${r.stdout}`);
+    assertStringIncludes(r.stdout, "C:/Users/x/proj/.specnaut/specs/002-beta");
+  });
+});
+
+Deno.test("feature paths: a relative path is still resolved under the repo root", async () => {
+  // The rule the fix must not break: a relative `feature_directory` is the
+  // documented shape, and it has to keep landing inside the project.
+  await withRepo(".specnaut/specs/002-beta", async (_dir, r) => {
+    assert(r.code === 0, `expected success, got exit ${r.code}:\n${r.stderr}`);
+    assertStringIncludes(r.stdout, "/.specnaut/specs/002-beta");
+    assert(
+      !r.stdout.includes("FEATURE_DIR=.specnaut"),
+      `a relative path was emitted unresolved:\n${r.stdout}`,
+    );
+  });
+});
+
+Deno.test("feature paths: a POSIX path containing a backslash is left alone", async () => {
+  // A backslash is a legal filename character on POSIX. The separator rewrite
+  // is scoped to drive-letter paths precisely so it cannot corrupt one.
+  await withRepo("/tmp/a\\b/002-beta", async (_dir, r) => {
+    assertStringIncludes(r.stdout, "a\\\\b");
+  });
+});

--- a/tests/scripts/feature_paths_absolute_test.ts
+++ b/tests/scripts/feature_paths_absolute_test.ts
@@ -40,7 +40,7 @@ async function resolvePaths(dir: string): Promise<Result> {
 /** A git repo on branch `002-beta`, with whatever `feature.json` the case needs. */
 async function withRepo(
   featureDirectory: string,
-  fn: (dir: string, result: Result) => Promise<void>,
+  fn: (dir: string, result: Result) => void | Promise<void>,
 ): Promise<void> {
   const dir = await Deno.makeTempDir({ prefix: "feature-paths-abs-" });
   try {
@@ -69,7 +69,7 @@ async function withRepo(
 }
 
 Deno.test("feature paths: a drive-letter path is absolute, not relative to the repo root", async () => {
-  await withRepo("C:\\Users\\x\\proj\\.specnaut\\specs\\002-beta", async (dir, r) => {
+  await withRepo("C:\\Users\\x\\proj\\.specnaut\\specs\\002-beta", (dir, r) => {
     assert(
       !r.stdout.includes(`${dir}/C:`) && !r.stdout.includes(`${dir}\\C:`),
       `the repo root was prepended to a drive-letter path:\n${r.stdout}${r.stderr}`,
@@ -83,7 +83,7 @@ Deno.test("feature paths: a drive-letter path keeps a usable basename", async ()
   // backslashes left in place `basename` returns the entire string, the guard
   // fires on a feature.json that agrees with the branch perfectly, and every
   // caller is refused on Windows for a contradiction that does not exist.
-  await withRepo("C:\\Users\\x\\proj\\.specnaut\\specs\\002-beta", async (_dir, r) => {
+  await withRepo("C:\\Users\\x\\proj\\.specnaut\\specs\\002-beta", (_dir, r) => {
     assert(
       r.code === 0,
       `a feature.json naming the current branch must resolve, got exit ${r.code}:\n${r.stderr}`,
@@ -93,7 +93,7 @@ Deno.test("feature paths: a drive-letter path keeps a usable basename", async ()
 });
 
 Deno.test("feature paths: forward-slash drive paths resolve the same way", async () => {
-  await withRepo("C:/Users/x/proj/.specnaut/specs/002-beta", async (dir, r) => {
+  await withRepo("C:/Users/x/proj/.specnaut/specs/002-beta", (dir, r) => {
     assert(!r.stdout.includes(`${dir}/C:`), `the repo root was prepended:\n${r.stdout}`);
     assertStringIncludes(r.stdout, "C:/Users/x/proj/.specnaut/specs/002-beta");
   });
@@ -102,7 +102,7 @@ Deno.test("feature paths: forward-slash drive paths resolve the same way", async
 Deno.test("feature paths: a relative path is still resolved under the repo root", async () => {
   // The rule the fix must not break: a relative `feature_directory` is the
   // documented shape, and it has to keep landing inside the project.
-  await withRepo(".specnaut/specs/002-beta", async (_dir, r) => {
+  await withRepo(".specnaut/specs/002-beta", (_dir, r) => {
     assert(r.code === 0, `expected success, got exit ${r.code}:\n${r.stderr}`);
     assertStringIncludes(r.stdout, "/.specnaut/specs/002-beta");
     assert(
@@ -115,7 +115,7 @@ Deno.test("feature paths: a relative path is still resolved under the repo root"
 Deno.test("feature paths: a POSIX path containing a backslash is left alone", async () => {
   // A backslash is a legal filename character on POSIX. The separator rewrite
   // is scoped to drive-letter paths precisely so it cannot corrupt one.
-  await withRepo("/tmp/a\\b/002-beta", async (_dir, r) => {
+  await withRepo("/tmp/a\\b/002-beta", (_dir, r) => {
     assertStringIncludes(r.stdout, "a\\\\b");
   });
 });

--- a/tests/scripts/setup_plan_clobber_test.ts
+++ b/tests/scripts/setup_plan_clobber_test.ts
@@ -208,9 +208,29 @@ for (const runner of RUNNERS) {
       );
       await Deno.remove(plans.second);
 
-      const { code } = await runner.run(["--json"], dir);
-      assertEquals(code, 0);
-      assertStringIncludes(await Deno.readTextFile(plans.second), "BLANK TEMPLATE MARKER");
+      const { code, stdout, stderr } = await runner.run(["--json"], dir);
+      assertEquals(code, 0, `exit ${code}\nstdout: ${stdout}\nstderr: ${stderr}`);
+      // A bare NotFound here says only that the file is missing, not where the
+      // script put it instead — which is the whole question when this fails on
+      // one platform and not the others. Report what the run actually did.
+      let seeded: string;
+      try {
+        seeded = await Deno.readTextFile(plans.second);
+      } catch (e) {
+        const listing: string[] = [];
+        for await (const entry of Deno.readDir(join(dir, ".specnaut", "specs", "002-beta"))) {
+          listing.push(entry.name);
+        }
+        throw new Error(
+          `the plan was not seeded at ${plans.second}\n` +
+            `  read error: ${e instanceof Error ? e.message : e}\n` +
+            `  exit:       ${code}\n` +
+            `  stdout:     ${stdout.trim()}\n` +
+            `  stderr:     ${stderr.trim()}\n` +
+            `  002-beta/:  ${listing.join(", ") || "(empty)"}`,
+        );
+      }
+      assertStringIncludes(seeded, "BLANK TEMPLATE MARKER");
     });
   });
 }


### PR DESCRIPTION
`ci` is red on `main` at `19437e4`: `cross-smoke (windows-latest)` fails `setup-plan [bash]: still seeds a plan when none exists`. This is the fix, opened as a PR rather than landed locally for one reason — **the defect only reproduces on Windows, and this repository's only Windows is CI.** The PR is the checkpoint that lets `windows-latest` adjudicate before anything touches `main`.

## The defect

`get_feature_paths()` tested for a leading `/` to decide whether `feature_directory` was absolute. Under Git Bash, `.specnaut/feature.json` carries `C:\Users\...`, which fails that test, so the "normalize relative paths" rule prepended the repo root and produced `/repo/C:\Users\...`.

Two consumers read it:

| Consumer | What it got |
| :--- | :--- |
| the #580 contradiction guard | `basename` of the whole mangled string — so a `feature.json` that agrees with the branch is refused as a contradiction |
| `setup-plan.sh` | a copy destination that resolves nowhere |

The PowerShell twin never had this. It asks `[System.IO.Path]::IsPathRooted` rather than spelling the rule by hand.

## Why it hid

Four of the five bash scenarios on Windows are satisfied by the script **not** writing. Only the positive-write case failed. That asymmetry is now recorded: the seeding assertion reports exit code, stdout, stderr and the directory listing instead of a bare `NotFound`.

## Verification

- 5 new assertions on the **resolution string**, not on filesystem effects, so they run identically on every platform.
- Red probe against the previous script: **3 fail**, and the two no-regression cases (a relative path still resolves under the repo root; a POSIX path containing a backslash is left alone) **stay green**.
- Full suite locally: 1670 passed / 0 failed. `deno fmt`, `deno lint` clean.

Windows is what this PR is asking. Merging on green.

Refs #580